### PR TITLE
Reimplement citus_update_table_statistics to detect dist. deadlocks

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -52,6 +52,7 @@
 #include "distributed/resource_lock.h"
 #include "distributed/remote_commands.h"
 #include "distributed/tuplestore.h"
+#include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/version_compat.h"
 #include "nodes/makefuncs.h"
@@ -77,13 +78,25 @@ static bool DistributedTableSize(Oid relationId, char *sizeQuery, bool failOnErr
 static bool DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId,
 										 char *sizeQuery, bool failOnError,
 										 uint64 *tableSize);
-static char * GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList);
-static char * GenerateAllShardNameAndSizeQueryForNode(WorkerNode *workerNode);
-static List * GenerateShardSizesQueryList(List *workerNodeList);
+static List * ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId);
+static char * GenerateShardStatisticsQueryForShardList(List *shardIntervalList, bool
+													   useShardMinMaxQuery);
+static char * GenerateAllShardStatisticsQueryForNode(WorkerNode *workerNode,
+													 List *citusTableIds, bool
+													 useShardMinMaxQuery);
+static List * GenerateShardStatisticsQueryList(List *workerNodeList, List *citusTableIds,
+											   bool useShardMinMaxQuery);
 static void ErrorIfNotSuitableToGetSize(Oid relationId);
+static List * OpenConnectionToNodes(List *workerNodeList);
 static void ReceiveShardNameAndSizeResults(List *connectionList,
 										   Tuplestorestate *tupleStore,
 										   TupleDesc tupleDescriptor);
+static void AppendShardSizeMinMaxQuery(StringInfo selectQuery, uint64 shardId,
+									   ShardInterval *
+									   shardInterval, char *shardName,
+									   char *quotedShardName);
+static void AppendShardSizeQuery(StringInfo selectQuery, ShardInterval *shardInterval,
+								 char *quotedShardName);
 
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(citus_table_size);
@@ -99,25 +112,16 @@ citus_shard_sizes(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 
-	List *workerNodeList = ActivePrimaryNodeList(NoLock);
+	List *allCitusTableIds = AllCitusTableIds();
 
-	List *shardSizesQueryList = GenerateShardSizesQueryList(workerNodeList);
+	/* we don't need a distributed transaction here */
+	bool useDistributedTransaction = false;
 
-	List *connectionList = OpenConnectionToNodes(workerNodeList);
-	FinishConnectionListEstablishment(connectionList);
-
-
-	/* send commands in parallel */
-	for (int i = 0; i < list_length(connectionList); i++)
-	{
-		MultiConnection *connection = (MultiConnection *) list_nth(connectionList, i);
-		char *shardSizesQuery = (char *) list_nth(shardSizesQueryList, i);
-		int querySent = SendRemoteCommand(connection, shardSizesQuery);
-		if (querySent == 0)
-		{
-			ReportConnectionError(connection, WARNING);
-		}
-	}
+	/* we only want the shard sizes here so useShardMinMaxQuery parameter is false */
+	bool useShardMinMaxQuery = false;
+	List *connectionList = SendShardStatisticsQueriesInParallel(allCitusTableIds,
+																useDistributedTransaction,
+																useShardMinMaxQuery);
 
 	TupleDesc tupleDescriptor = NULL;
 	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
@@ -223,10 +227,63 @@ citus_relation_size(PG_FUNCTION_ARGS)
 
 
 /*
+ * SendShardStatisticsQueriesInParallel generates query lists for obtaining shard
+ * statistics and then sends the commands in parallel by opening connections
+ * to available nodes. It returns the connection list.
+ */
+List *
+SendShardStatisticsQueriesInParallel(List *citusTableIds, bool useDistributedTransaction,
+									 bool
+									 useShardMinMaxQuery)
+{
+	List *workerNodeList = ActivePrimaryNodeList(NoLock);
+
+	List *shardSizesQueryList = GenerateShardStatisticsQueryList(workerNodeList,
+																 citusTableIds,
+																 useShardMinMaxQuery);
+
+	List *connectionList = OpenConnectionToNodes(workerNodeList);
+	FinishConnectionListEstablishment(connectionList);
+
+	if (useDistributedTransaction)
+	{
+		/*
+		 * For now, in the case we want to include shard min and max values, we also
+		 * want to update the entries in pg_dist_placement and pg_dist_shard with the
+		 * latest statistics. In order to detect distributed deadlocks, we assign a
+		 * distributed transaction ID to the current transaction
+		 */
+		UseCoordinatedTransaction();
+	}
+
+	/* send commands in parallel */
+	for (int i = 0; i < list_length(connectionList); i++)
+	{
+		MultiConnection *connection = (MultiConnection *) list_nth(connectionList, i);
+		char *shardSizesQuery = (char *) list_nth(shardSizesQueryList, i);
+
+		if (useDistributedTransaction)
+		{
+			/* run the size query in a distributed transaction */
+			RemoteTransactionBeginIfNecessary(connection);
+		}
+
+		int querySent = SendRemoteCommand(connection, shardSizesQuery);
+
+		if (querySent == 0)
+		{
+			ReportConnectionError(connection, WARNING);
+		}
+	}
+	return connectionList;
+}
+
+
+/*
  * OpenConnectionToNodes opens a single connection per node
  * for the given workerNodeList.
  */
-List *
+static List *
 OpenConnectionToNodes(List *workerNodeList)
 {
 	List *connectionList = NIL;
@@ -247,20 +304,25 @@ OpenConnectionToNodes(List *workerNodeList)
 
 
 /*
- * GenerateShardSizesQueryList generates a query per node that
- * will return all shard_name, shard_size pairs from the node.
+ * GenerateShardStatisticsQueryList generates a query per node that will return:
+ * - all shard_name, shard_size pairs from the node (if includeShardMinMax is false)
+ * - all shard_id, shard_minvalue, shard_maxvalue, shard_size quartuples from the node (if true)
  */
 static List *
-GenerateShardSizesQueryList(List *workerNodeList)
+GenerateShardStatisticsQueryList(List *workerNodeList, List *citusTableIds, bool
+								 useShardMinMaxQuery)
 {
-	List *shardSizesQueryList = NIL;
+	List *shardStatisticsQueryList = NIL;
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerNodeList)
 	{
-		char *shardSizesQuery = GenerateAllShardNameAndSizeQueryForNode(workerNode);
-		shardSizesQueryList = lappend(shardSizesQueryList, shardSizesQuery);
+		char *shardStatisticsQuery = GenerateAllShardStatisticsQueryForNode(workerNode,
+																			citusTableIds,
+																			useShardMinMaxQuery);
+		shardStatisticsQueryList = lappend(shardStatisticsQueryList,
+										   shardStatisticsQuery);
 	}
-	return shardSizesQueryList;
+	return shardStatisticsQueryList;
 }
 
 
@@ -495,7 +557,7 @@ GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId)
  * ShardIntervalsOnWorkerGroup accepts a WorkerNode and returns a list of the shard
  * intervals of the given table which are placed on the group the node is a part of.
  */
-List *
+static List *
 ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId)
 {
 	CitusTableCacheEntry *distTableCacheEntry = GetCitusTableCacheEntry(relationId);
@@ -569,37 +631,50 @@ GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList, char *sizeQuery)
 
 
 /*
- * GenerateAllShardNameAndSizeQueryForNode generates a query that returns all
- * shard_name, shard_size pairs for the given node.
+ * GenerateAllShardStatisticsQueryForNode generates a query that returns:
+ * - all shard_name, shard_size pairs for the given node (if useShardMinMaxQuery is false)
+ * - all shard_id, shard_minvalue, shard_maxvalue, shard_size quartuples (if true)
  */
 static char *
-GenerateAllShardNameAndSizeQueryForNode(WorkerNode *workerNode)
+GenerateAllShardStatisticsQueryForNode(WorkerNode *workerNode, List *citusTableIds, bool
+									   useShardMinMaxQuery)
 {
-	List *allCitusTableIds = AllCitusTableIds();
-
-	StringInfo allShardNameAndSizeQuery = makeStringInfo();
+	StringInfo allShardStatisticsQuery = makeStringInfo();
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, allCitusTableIds)
+	foreach_oid(relationId, citusTableIds)
 	{
 		List *shardIntervalsOnNode = ShardIntervalsOnWorkerGroup(workerNode, relationId);
-		char *shardNameAndSizeQuery =
-			GenerateShardNameAndSizeQueryForShardList(shardIntervalsOnNode);
-		appendStringInfoString(allShardNameAndSizeQuery, shardNameAndSizeQuery);
+		char *shardStatisticsQuery =
+			GenerateShardStatisticsQueryForShardList(shardIntervalsOnNode,
+													 useShardMinMaxQuery);
+		appendStringInfoString(allShardStatisticsQuery, shardStatisticsQuery);
 	}
 
 	/* Add a dummy entry so that UNION ALL doesn't complain */
-	appendStringInfo(allShardNameAndSizeQuery, "SELECT NULL::text, 0::bigint;");
-	return allShardNameAndSizeQuery->data;
+	if (useShardMinMaxQuery)
+	{
+		/* 0 for shard_id, NULL for min, NULL for text, 0 for shard_size */
+		appendStringInfo(allShardStatisticsQuery,
+						 "SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;");
+	}
+	else
+	{
+		/* NULL for shard_name, 0 for shard_size */
+		appendStringInfo(allShardStatisticsQuery, "SELECT NULL::text, 0::bigint;");
+	}
+	return allShardStatisticsQuery->data;
 }
 
 
 /*
- * GenerateShardNameAndSizeQueryForShardList generates a SELECT shard_name - shard_size query to get
- * size of multiple tables.
+ * GenerateShardStatisticsQueryForShardList generates one of the two types of queries:
+ * - SELECT shard_name - shard_size (if useShardMinMaxQuery is false)
+ * - SELECT shard_id, shard_minvalue, shard_maxvalue, shard_size (if true)
  */
 static char *
-GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList)
+GenerateShardStatisticsQueryForShardList(List *shardIntervalList, bool
+										 useShardMinMaxQuery)
 {
 	StringInfo selectQuery = makeStringInfo();
 
@@ -615,12 +690,67 @@ GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList)
 		char *shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
 		char *quotedShardName = quote_literal_cstr(shardQualifiedName);
 
-		appendStringInfo(selectQuery, "SELECT %s AS shard_name, ", quotedShardName);
-		appendStringInfo(selectQuery, PG_RELATION_SIZE_FUNCTION, quotedShardName);
+		if (useShardMinMaxQuery)
+		{
+			AppendShardSizeMinMaxQuery(selectQuery, shardId, shardInterval, shardName,
+									   quotedShardName);
+		}
+		else
+		{
+			AppendShardSizeQuery(selectQuery, shardInterval, quotedShardName);
+		}
 		appendStringInfo(selectQuery, " UNION ALL ");
 	}
 
 	return selectQuery->data;
+}
+
+
+/*
+ * AppendShardSizeMinMaxQuery appends a query in the following form to selectQuery
+ * SELECT shard_id, shard_minvalue, shard_maxvalue, shard_size
+ */
+static void
+AppendShardSizeMinMaxQuery(StringInfo selectQuery, uint64 shardId,
+						   ShardInterval *shardInterval, char *shardName,
+						   char *quotedShardName)
+{
+	if (IsCitusTableType(shardInterval->relationId, APPEND_DISTRIBUTED))
+	{
+		/* fill in the partition column name */
+		const uint32 unusedTableId = 1;
+		Var *partitionColumn = PartitionColumn(shardInterval->relationId,
+											   unusedTableId);
+		char *partitionColumnName = get_attname(shardInterval->relationId,
+												partitionColumn->varattno, false);
+		appendStringInfo(selectQuery,
+						 "SELECT " UINT64_FORMAT
+						 " AS shard_id, min(%s)::text AS shard_minvalue, max(%s)::text AS shard_maxvalue, pg_relation_size(%s) AS shard_size FROM %s ",
+						 shardId, partitionColumnName,
+						 partitionColumnName,
+						 quotedShardName, shardName);
+	}
+	else
+	{
+		/* we don't need to update min/max for non-append distributed tables because they don't change */
+		appendStringInfo(selectQuery,
+						 "SELECT " UINT64_FORMAT
+						 " AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size(%s) AS shard_size ",
+						 shardId, quotedShardName);
+	}
+}
+
+
+/*
+ * AppendShardSizeQuery appends a query in the following form to selectQuery
+ * SELECT shard_name, shard_size
+ */
+static void
+AppendShardSizeQuery(StringInfo selectQuery, ShardInterval *shardInterval,
+					 char *quotedShardName)
+{
+	appendStringInfo(selectQuery, "SELECT %s AS shard_name, ", quotedShardName);
+	appendStringInfo(selectQuery, PG_RELATION_SIZE_FUNCTION, quotedShardName);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -52,7 +52,6 @@
 #include "distributed/resource_lock.h"
 #include "distributed/remote_commands.h"
 #include "distributed/tuplestore.h"
-#include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/version_compat.h"
 #include "nodes/makefuncs.h"
@@ -78,12 +77,10 @@ static bool DistributedTableSize(Oid relationId, char *sizeQuery, bool failOnErr
 static bool DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId,
 										 char *sizeQuery, bool failOnError,
 										 uint64 *tableSize);
-static List * ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId);
 static char * GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList);
 static char * GenerateAllShardNameAndSizeQueryForNode(WorkerNode *workerNode);
 static List * GenerateShardSizesQueryList(List *workerNodeList);
 static void ErrorIfNotSuitableToGetSize(Oid relationId);
-static List * OpenConnectionToNodes(List *workerNodeList);
 static void ReceiveShardNameAndSizeResults(List *connectionList,
 										   Tuplestorestate *tupleStore,
 										   TupleDesc tupleDescriptor);
@@ -229,7 +226,7 @@ citus_relation_size(PG_FUNCTION_ARGS)
  * OpenConnectionToNodes opens a single connection per node
  * for the given workerNodeList.
  */
-static List *
+List *
 OpenConnectionToNodes(List *workerNodeList)
 {
 	List *connectionList = NIL;
@@ -498,7 +495,7 @@ GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId)
  * ShardIntervalsOnWorkerGroup accepts a WorkerNode and returns a list of the shard
  * intervals of the given table which are placed on the group the node is a part of.
  */
-static List *
+List *
 ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId)
 {
 	CitusTableCacheEntry *distTableCacheEntry = GetCitusTableCacheEntry(relationId);

--- a/src/backend/distributed/sql/citus--8.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.0-1.sql
@@ -1394,22 +1394,11 @@ COMMENT ON FUNCTION master_update_node(node_id int, new_node_name text, new_node
 
 -- shard statistics
 CREATE OR REPLACE FUNCTION master_update_table_statistics(relation regclass)
-RETURNS VOID AS $$
-DECLARE
-	colocated_tables regclass[];
-BEGIN
-	SELECT get_colocated_table_array(relation) INTO colocated_tables;
-
-	PERFORM
-		master_update_shard_statistics(shardid)
-	FROM
-		pg_dist_shard
-	WHERE
-		logicalrelid = ANY (colocated_tables);
-END;
-$$ LANGUAGE 'plpgsql';
-COMMENT ON FUNCTION master_update_table_statistics(regclass)
-	IS 'updates shard statistics of the given table and its colocated tables';
+RETURNS VOID
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
+COMMENT ON FUNCTION pg_catalog.master_update_table_statistics(regclass)
+	IS 'updates shard statistics of the given table';
 
 CREATE OR REPLACE FUNCTION get_colocated_shard_array(bigint)
 	RETURNS BIGINT[]

--- a/src/backend/distributed/sql/udfs/citus_update_table_statistics/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_update_table_statistics/10.0-1.sql
@@ -1,17 +1,6 @@
 CREATE FUNCTION pg_catalog.citus_update_table_statistics(relation regclass)
-RETURNS VOID AS $$
-DECLARE
-	colocated_tables regclass[];
-BEGIN
-	SELECT get_colocated_table_array(relation) INTO colocated_tables;
-
-	PERFORM
-		master_update_shard_statistics(shardid)
-	FROM
-		pg_dist_shard
-	WHERE
-		logicalrelid = ANY (colocated_tables);
-END;
-$$ LANGUAGE 'plpgsql';
+	RETURNS VOID
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
 COMMENT ON FUNCTION pg_catalog.citus_update_table_statistics(regclass)
 	IS 'updates shard statistics of the given table and its colocated tables';

--- a/src/backend/distributed/sql/udfs/citus_update_table_statistics/10.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_update_table_statistics/10.0-1.sql
@@ -3,4 +3,4 @@ CREATE FUNCTION pg_catalog.citus_update_table_statistics(relation regclass)
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
 COMMENT ON FUNCTION pg_catalog.citus_update_table_statistics(regclass)
-	IS 'updates shard statistics of the given table and its colocated tables';
+	IS 'updates shard statistics of the given table';

--- a/src/backend/distributed/sql/udfs/citus_update_table_statistics/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_update_table_statistics/latest.sql
@@ -1,17 +1,6 @@
 CREATE FUNCTION pg_catalog.citus_update_table_statistics(relation regclass)
-RETURNS VOID AS $$
-DECLARE
-	colocated_tables regclass[];
-BEGIN
-	SELECT get_colocated_table_array(relation) INTO colocated_tables;
-
-	PERFORM
-		master_update_shard_statistics(shardid)
-	FROM
-		pg_dist_shard
-	WHERE
-		logicalrelid = ANY (colocated_tables);
-END;
-$$ LANGUAGE 'plpgsql';
+	RETURNS VOID
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
 COMMENT ON FUNCTION pg_catalog.citus_update_table_statistics(regclass)
 	IS 'updates shard statistics of the given table and its colocated tables';

--- a/src/backend/distributed/sql/udfs/citus_update_table_statistics/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_update_table_statistics/latest.sql
@@ -3,4 +3,4 @@ CREATE FUNCTION pg_catalog.citus_update_table_statistics(relation regclass)
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
 COMMENT ON FUNCTION pg_catalog.citus_update_table_statistics(regclass)
-	IS 'updates shard statistics of the given table and its colocated tables';
+	IS 'updates shard statistics of the given table';

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -100,9 +100,6 @@ static ForeignConstraintRelationshipNode * CreateOrFindNode(HTAB *adjacencyLists
 															relid);
 static List * GetConnectedListHelper(ForeignConstraintRelationshipNode *node,
 									 bool isReferencing);
-static HTAB * CreateOidVisitedHashSet(void);
-static bool OidVisited(HTAB *oidVisitedMap, Oid oid);
-static void VisitOid(HTAB *oidVisitedMap, Oid oid);
 static List * GetForeignConstraintRelationshipHelper(Oid relationId, bool isReferencing);
 
 
@@ -442,7 +439,7 @@ GetConnectedListHelper(ForeignConstraintRelationshipNode *node, bool isReferenci
  * As hash_create allocates memory in heap, callers are responsible to call
  * hash_destroy when appropriate.
  */
-static HTAB *
+HTAB *
 CreateOidVisitedHashSet(void)
 {
 	HASHCTL info = { 0 };
@@ -464,7 +461,7 @@ CreateOidVisitedHashSet(void)
 /*
  * OidVisited returns true if given oid is visited according to given oid hash-set.
  */
-static bool
+bool
 OidVisited(HTAB *oidVisitedMap, Oid oid)
 {
 	bool found = false;
@@ -476,7 +473,7 @@ OidVisited(HTAB *oidVisitedMap, Oid oid)
 /*
  * VisitOid sets given oid as visited in given hash-set.
  */
-static void
+void
 VisitOid(HTAB *oidVisitedMap, Oid oid)
 {
 	bool found = false;

--- a/src/include/distributed/foreign_key_relationship.h
+++ b/src/include/distributed/foreign_key_relationship.h
@@ -22,5 +22,8 @@ extern List * ReferencingRelationIdList(Oid relationId);
 extern void SetForeignConstraintRelationshipGraphInvalid(void);
 extern bool IsForeignConstraintRelationshipGraphValid(void);
 extern void ClearForeignConstraintRelationshipGraphContext(void);
+extern HTAB * CreateOidVisitedHashSet(void);
+extern bool OidVisited(HTAB *oidVisitedMap, Oid oid);
+extern void VisitOid(HTAB *oidVisitedMap, Oid oid);
 
 #endif

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -23,7 +23,6 @@
 #include "catalog/objectaddress.h"
 #include "distributed/citus_nodes.h"
 #include "distributed/relay_utility.h"
-#include "distributed/worker_manager.h"
 #include "utils/acl.h"
 #include "utils/relcache.h"
 
@@ -37,7 +36,7 @@
 #define CSTORE_TABLE_SIZE_FUNCTION "cstore_table_size(%s)"
 
 #define SHARD_SIZES_COLUMN_COUNT 2
-#define SHARD_SIZES_MIN_MAX_COLUMN_COUNT 4
+#define UPDATE_SHARD_STATISTICS_COLUMN_COUNT 4
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval
@@ -208,7 +207,6 @@ extern StringInfo GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList,
 extern List * RemoveCoordinatorPlacementIfNotSingleNode(List *placementList);
 extern ShardPlacement * ShardPlacementOnGroup(uint64 shardId, int groupId);
 
-
 /* Function declarations to modify shard and shard placement data */
 extern void InsertShardRow(Oid relationId, uint64 shardId, char storageType,
 						   text *shardMinValue, text *shardMaxValue);
@@ -266,7 +264,8 @@ extern ShardInterval * DeformedDistShardTupleToShardInterval(Datum *datumArray,
 															 int32 intervalTypeMod);
 extern void GetIntervalTypeInfo(char partitionMethod, Var *partitionColumn,
 								Oid *intervalTypeId, int32 *intervalTypeMod);
-extern List * OpenConnectionToNodes(List *workerNodeList);
-extern List * ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId);
+extern List * SendShardStatisticsQueriesInParallel(List *citusTableIds, bool
+												   useDistributedTransaction, bool
+												   useShardMinMaxQuery);
 
 #endif   /* METADATA_UTILITY_H */

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -23,6 +23,7 @@
 #include "catalog/objectaddress.h"
 #include "distributed/citus_nodes.h"
 #include "distributed/relay_utility.h"
+#include "distributed/worker_manager.h"
 #include "utils/acl.h"
 #include "utils/relcache.h"
 
@@ -36,6 +37,7 @@
 #define CSTORE_TABLE_SIZE_FUNCTION "cstore_table_size(%s)"
 
 #define SHARD_SIZES_COLUMN_COUNT 2
+#define SHARD_SIZES_MIN_MAX_COLUMN_COUNT 4
 
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval
@@ -264,5 +266,7 @@ extern ShardInterval * DeformedDistShardTupleToShardInterval(Datum *datumArray,
 															 int32 intervalTypeMod);
 extern void GetIntervalTypeInfo(char partitionMethod, Var *partitionColumn,
 								Oid *intervalTypeId, int32 *intervalTypeMod);
+extern List * OpenConnectionToNodes(List *workerNodeList);
+extern List * ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId);
 
 #endif   /* METADATA_UTILITY_H */

--- a/src/test/regress/expected/citus_update_table_statistics.out
+++ b/src/test/regress/expected/citus_update_table_statistics.out
@@ -1,0 +1,157 @@
+--
+-- citus_update_table_statistics.sql
+--
+-- Test citus_update_table_statistics function on both
+-- hash and append distributed tables
+-- This function updates shardlength, shardminvalue and shardmaxvalue
+--
+SET citus.next_shard_id TO 981000;
+SET client_min_messages TO WARNING;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 2;
+-- test with a hash-distributed table
+-- here we update only shardlength, not shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_hash (id int);
+SELECT create_distributed_table('test_table_statistics_hash', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- populate table
+INSERT INTO test_table_statistics_hash SELECT i FROM generate_series(0, 10000)i;
+-- originally shardlength (size of the shard) is zero
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength AS shardsize,
+    ds.shardminvalue AS shardminvalue,
+    ds.shardmaxvalue AS shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+ORDER BY 2, 3;
+         tablename          | shardid | placementid |             shardname             | shardsize | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_hash |  981000 |        2197 | test_table_statistics_hash_981000 |         0 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |        2198 | test_table_statistics_hash_981000 |         0 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |        2199 | test_table_statistics_hash_981001 |         0 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |        2200 | test_table_statistics_hash_981001 |         0 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |        2201 | test_table_statistics_hash_981002 |         0 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |        2202 | test_table_statistics_hash_981002 |         0 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |        2203 | test_table_statistics_hash_981003 |         0 | -536870912    | -1
+ test_table_statistics_hash |  981003 |        2204 | test_table_statistics_hash_981003 |         0 | -536870912    | -1
+ test_table_statistics_hash |  981004 |        2205 | test_table_statistics_hash_981004 |         0 | 0             | 536870911
+ test_table_statistics_hash |  981004 |        2206 | test_table_statistics_hash_981004 |         0 | 0             | 536870911
+ test_table_statistics_hash |  981005 |        2207 | test_table_statistics_hash_981005 |         0 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |        2208 | test_table_statistics_hash_981005 |         0 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |        2209 | test_table_statistics_hash_981006 |         0 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |        2210 | test_table_statistics_hash_981006 |         0 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |        2211 | test_table_statistics_hash_981007 |         0 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |        2212 | test_table_statistics_hash_981007 |         0 | 1610612736    | 2147483647
+(16 rows)
+
+-- update table statistics and then check that shardlength has changed
+-- but shardminvalue and shardmaxvalue stay the same because this is
+-- a hash distributed table
+SELECT citus_update_table_statistics('test_table_statistics_hash');
+ citus_update_table_statistics
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+ORDER BY 2, 3;
+         tablename          | shardid | placementid |             shardname             | shardsize | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_hash |  981000 |        2197 | test_table_statistics_hash_981000 |     49152 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |        2198 | test_table_statistics_hash_981000 |     49152 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |        2199 | test_table_statistics_hash_981001 |     49152 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |        2200 | test_table_statistics_hash_981001 |     49152 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |        2201 | test_table_statistics_hash_981002 |     49152 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |        2202 | test_table_statistics_hash_981002 |     49152 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |        2203 | test_table_statistics_hash_981003 |     49152 | -536870912    | -1
+ test_table_statistics_hash |  981003 |        2204 | test_table_statistics_hash_981003 |     49152 | -536870912    | -1
+ test_table_statistics_hash |  981004 |        2205 | test_table_statistics_hash_981004 |     49152 | 0             | 536870911
+ test_table_statistics_hash |  981004 |        2206 | test_table_statistics_hash_981004 |     49152 | 0             | 536870911
+ test_table_statistics_hash |  981005 |        2207 | test_table_statistics_hash_981005 |     49152 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |        2208 | test_table_statistics_hash_981005 |     49152 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |        2209 | test_table_statistics_hash_981006 |     49152 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |        2210 | test_table_statistics_hash_981006 |     49152 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |        2211 | test_table_statistics_hash_981007 |     49152 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |        2212 | test_table_statistics_hash_981007 |     49152 | 1610612736    | 2147483647
+(16 rows)
+
+-- check with an append-distributed table
+-- here we update shardlength, shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_append (id int);
+SELECT create_distributed_table('test_table_statistics_append', 'id', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+COPY test_table_statistics_append FROM PROGRAM 'echo 0 && echo 1 && echo 2 && echo 3' WITH CSV;
+COPY test_table_statistics_append FROM PROGRAM 'echo 4 && echo 5 && echo 6 && echo 7' WITH CSV;
+-- originally shardminvalue and shardmaxvalue will be 0,3 and 4, 7
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+          tablename           | shardid | placementid |              shardname              | shardsize | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_append |  981008 |        2213 | test_table_statistics_append_981008 |      8192 | 0             | 3
+ test_table_statistics_append |  981008 |        2214 | test_table_statistics_append_981008 |      8192 | 0             | 3
+ test_table_statistics_append |  981009 |        2215 | test_table_statistics_append_981009 |      8192 | 4             | 7
+ test_table_statistics_append |  981009 |        2216 | test_table_statistics_append_981009 |      8192 | 4             | 7
+(4 rows)
+
+-- delete some data to change shardminvalues of a shards
+DELETE FROM test_table_statistics_append WHERE id = 0 OR id = 4;
+-- update table statistics and then check that shardminvalue has changed
+-- shardlength (shardsize) is still 8192 since there is very few data
+SELECT citus_update_table_statistics('test_table_statistics_append');
+ citus_update_table_statistics
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+          tablename           | shardid | placementid |              shardname              | shardsize | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_append |  981008 |        2213 | test_table_statistics_append_981008 |      8192 | 1             | 3
+ test_table_statistics_append |  981008 |        2214 | test_table_statistics_append_981008 |      8192 | 1             | 3
+ test_table_statistics_append |  981009 |        2215 | test_table_statistics_append_981009 |      8192 | 5             | 7
+ test_table_statistics_append |  981009 |        2216 | test_table_statistics_append_981009 |      8192 | 5             | 7
+(4 rows)
+
+DROP TABLE test_table_statistics_hash, test_table_statistics_append;
+ALTER SYSTEM RESET citus.shard_count;
+ALTER SYSTEM RESET citus.shard_replication_factor;

--- a/src/test/regress/expected/citus_update_table_statistics.out
+++ b/src/test/regress/expected/citus_update_table_statistics.out
@@ -6,7 +6,7 @@
 -- This function updates shardlength, shardminvalue and shardmaxvalue
 --
 SET citus.next_shard_id TO 981000;
-SET client_min_messages TO WARNING;
+SET citus.next_placement_id TO 982000;
 SET citus.shard_count TO 8;
 SET citus.shard_replication_factor TO 2;
 -- test with a hash-distributed table
@@ -26,70 +26,89 @@ SELECT
     ds.shardid AS shardid,
     dsp.placementid AS placementid,
     shard_name(ds.logicalrelid, ds.shardid) AS shardname,
-    dsp.shardlength AS shardsize,
     ds.shardminvalue AS shardminvalue,
     ds.shardmaxvalue AS shardmaxvalue
 FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
-WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength = 0
 ORDER BY 2, 3;
-         tablename          | shardid | placementid |             shardname             | shardsize | shardminvalue | shardmaxvalue
+         tablename          | shardid | placementid |             shardname             | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- test_table_statistics_hash |  981000 |        2197 | test_table_statistics_hash_981000 |         0 | -2147483648   | -1610612737
- test_table_statistics_hash |  981000 |        2198 | test_table_statistics_hash_981000 |         0 | -2147483648   | -1610612737
- test_table_statistics_hash |  981001 |        2199 | test_table_statistics_hash_981001 |         0 | -1610612736   | -1073741825
- test_table_statistics_hash |  981001 |        2200 | test_table_statistics_hash_981001 |         0 | -1610612736   | -1073741825
- test_table_statistics_hash |  981002 |        2201 | test_table_statistics_hash_981002 |         0 | -1073741824   | -536870913
- test_table_statistics_hash |  981002 |        2202 | test_table_statistics_hash_981002 |         0 | -1073741824   | -536870913
- test_table_statistics_hash |  981003 |        2203 | test_table_statistics_hash_981003 |         0 | -536870912    | -1
- test_table_statistics_hash |  981003 |        2204 | test_table_statistics_hash_981003 |         0 | -536870912    | -1
- test_table_statistics_hash |  981004 |        2205 | test_table_statistics_hash_981004 |         0 | 0             | 536870911
- test_table_statistics_hash |  981004 |        2206 | test_table_statistics_hash_981004 |         0 | 0             | 536870911
- test_table_statistics_hash |  981005 |        2207 | test_table_statistics_hash_981005 |         0 | 536870912     | 1073741823
- test_table_statistics_hash |  981005 |        2208 | test_table_statistics_hash_981005 |         0 | 536870912     | 1073741823
- test_table_statistics_hash |  981006 |        2209 | test_table_statistics_hash_981006 |         0 | 1073741824    | 1610612735
- test_table_statistics_hash |  981006 |        2210 | test_table_statistics_hash_981006 |         0 | 1073741824    | 1610612735
- test_table_statistics_hash |  981007 |        2211 | test_table_statistics_hash_981007 |         0 | 1610612736    | 2147483647
- test_table_statistics_hash |  981007 |        2212 | test_table_statistics_hash_981007 |         0 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981000 |      982000 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |      982001 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |      982002 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |      982003 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |      982004 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |      982005 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |      982006 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981003 |      982007 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981004 |      982008 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981004 |      982009 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981005 |      982010 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |      982011 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |      982012 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |      982013 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |      982014 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |      982015 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
 (16 rows)
 
+-- setting this to on in order to verify that we use a distributed transaction id
+-- to run the size queries from different connections
+-- this is going to help detect deadlocks
+SET citus.log_remote_commands TO ON;
+-- setting this to sequential in order to have a deterministic order
+-- in the output of citus.log_remote_commands
+SET citus.multi_shard_modify_mode TO sequential;
 -- update table statistics and then check that shardlength has changed
 -- but shardminvalue and shardmaxvalue stay the same because this is
 -- a hash distributed table
 SELECT citus_update_table_statistics('test_table_statistics_hash');
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981000 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981000') AS shard_size  UNION ALL SELECT 981001 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981001') AS shard_size  UNION ALL SELECT 981002 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981002') AS shard_size  UNION ALL SELECT 981003 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981003') AS shard_size  UNION ALL SELECT 981004 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981004') AS shard_size  UNION ALL SELECT 981005 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981005') AS shard_size  UNION ALL SELECT 981006 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981006') AS shard_size  UNION ALL SELECT 981007 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981007') AS shard_size  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981000 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981000') AS shard_size  UNION ALL SELECT 981001 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981001') AS shard_size  UNION ALL SELECT 981002 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981002') AS shard_size  UNION ALL SELECT 981003 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981003') AS shard_size  UNION ALL SELECT 981004 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981004') AS shard_size  UNION ALL SELECT 981005 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981005') AS shard_size  UNION ALL SELECT 981006 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981006') AS shard_size  UNION ALL SELECT 981007 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981007') AS shard_size  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
  citus_update_table_statistics
 ---------------------------------------------------------------------
 
 (1 row)
 
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
 SELECT
     ds.logicalrelid::regclass::text AS tablename,
     ds.shardid AS shardid,
     dsp.placementid AS placementid,
     shard_name(ds.logicalrelid, ds.shardid) AS shardname,
-    dsp.shardlength as shardsize,
     ds.shardminvalue as shardminvalue,
     ds.shardmaxvalue as shardmaxvalue
 FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
-WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength > 0
 ORDER BY 2, 3;
-         tablename          | shardid | placementid |             shardname             | shardsize | shardminvalue | shardmaxvalue
+         tablename          | shardid | placementid |             shardname             | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- test_table_statistics_hash |  981000 |        2197 | test_table_statistics_hash_981000 |     49152 | -2147483648   | -1610612737
- test_table_statistics_hash |  981000 |        2198 | test_table_statistics_hash_981000 |     49152 | -2147483648   | -1610612737
- test_table_statistics_hash |  981001 |        2199 | test_table_statistics_hash_981001 |     49152 | -1610612736   | -1073741825
- test_table_statistics_hash |  981001 |        2200 | test_table_statistics_hash_981001 |     49152 | -1610612736   | -1073741825
- test_table_statistics_hash |  981002 |        2201 | test_table_statistics_hash_981002 |     49152 | -1073741824   | -536870913
- test_table_statistics_hash |  981002 |        2202 | test_table_statistics_hash_981002 |     49152 | -1073741824   | -536870913
- test_table_statistics_hash |  981003 |        2203 | test_table_statistics_hash_981003 |     49152 | -536870912    | -1
- test_table_statistics_hash |  981003 |        2204 | test_table_statistics_hash_981003 |     49152 | -536870912    | -1
- test_table_statistics_hash |  981004 |        2205 | test_table_statistics_hash_981004 |     49152 | 0             | 536870911
- test_table_statistics_hash |  981004 |        2206 | test_table_statistics_hash_981004 |     49152 | 0             | 536870911
- test_table_statistics_hash |  981005 |        2207 | test_table_statistics_hash_981005 |     49152 | 536870912     | 1073741823
- test_table_statistics_hash |  981005 |        2208 | test_table_statistics_hash_981005 |     49152 | 536870912     | 1073741823
- test_table_statistics_hash |  981006 |        2209 | test_table_statistics_hash_981006 |     49152 | 1073741824    | 1610612735
- test_table_statistics_hash |  981006 |        2210 | test_table_statistics_hash_981006 |     49152 | 1073741824    | 1610612735
- test_table_statistics_hash |  981007 |        2211 | test_table_statistics_hash_981007 |     49152 | 1610612736    | 2147483647
- test_table_statistics_hash |  981007 |        2212 | test_table_statistics_hash_981007 |     49152 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981000 |      982000 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |      982001 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |      982002 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |      982003 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |      982004 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |      982005 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |      982006 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981003 |      982007 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981004 |      982008 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981004 |      982009 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981005 |      982010 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |      982011 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |      982012 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |      982013 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |      982014 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |      982015 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
 (16 rows)
 
 -- check with an append-distributed table
@@ -109,47 +128,61 @@ SELECT
     ds.shardid AS shardid,
     dsp.placementid AS placementid,
     shard_name(ds.logicalrelid, ds.shardid) AS shardname,
-    dsp.shardlength as shardsize,
     ds.shardminvalue as shardminvalue,
     ds.shardmaxvalue as shardmaxvalue
 FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
 WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
 ORDER BY 2, 3;
-          tablename           | shardid | placementid |              shardname              | shardsize | shardminvalue | shardmaxvalue
+          tablename           | shardid | placementid |              shardname              | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- test_table_statistics_append |  981008 |        2213 | test_table_statistics_append_981008 |      8192 | 0             | 3
- test_table_statistics_append |  981008 |        2214 | test_table_statistics_append_981008 |      8192 | 0             | 3
- test_table_statistics_append |  981009 |        2215 | test_table_statistics_append_981009 |      8192 | 4             | 7
- test_table_statistics_append |  981009 |        2216 | test_table_statistics_append_981009 |      8192 | 4             | 7
+ test_table_statistics_append |  981008 |      982016 | test_table_statistics_append_981008 | 0             | 3
+ test_table_statistics_append |  981008 |      982017 | test_table_statistics_append_981008 | 0             | 3
+ test_table_statistics_append |  981009 |      982018 | test_table_statistics_append_981009 | 4             | 7
+ test_table_statistics_append |  981009 |      982019 | test_table_statistics_append_981009 | 4             | 7
 (4 rows)
 
 -- delete some data to change shardminvalues of a shards
 DELETE FROM test_table_statistics_append WHERE id = 0 OR id = 4;
+SET citus.log_remote_commands TO ON;
+SET citus.multi_shard_modify_mode TO sequential;
 -- update table statistics and then check that shardminvalue has changed
 -- shardlength (shardsize) is still 8192 since there is very few data
 SELECT citus_update_table_statistics('test_table_statistics_append');
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981008 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981008') AS shard_size FROM test_table_statistics_append_981008  UNION ALL SELECT 981009 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981009') AS shard_size FROM test_table_statistics_append_981009  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981008 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981008') AS shard_size FROM test_table_statistics_append_981008  UNION ALL SELECT 981009 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981009') AS shard_size FROM test_table_statistics_append_981009  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
  citus_update_table_statistics
 ---------------------------------------------------------------------
 
 (1 row)
 
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
 SELECT
     ds.logicalrelid::regclass::text AS tablename,
     ds.shardid AS shardid,
     dsp.placementid AS placementid,
     shard_name(ds.logicalrelid, ds.shardid) AS shardname,
-    dsp.shardlength as shardsize,
     ds.shardminvalue as shardminvalue,
     ds.shardmaxvalue as shardmaxvalue
 FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
 WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
 ORDER BY 2, 3;
-          tablename           | shardid | placementid |              shardname              | shardsize | shardminvalue | shardmaxvalue
+          tablename           | shardid | placementid |              shardname              | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- test_table_statistics_append |  981008 |        2213 | test_table_statistics_append_981008 |      8192 | 1             | 3
- test_table_statistics_append |  981008 |        2214 | test_table_statistics_append_981008 |      8192 | 1             | 3
- test_table_statistics_append |  981009 |        2215 | test_table_statistics_append_981009 |      8192 | 5             | 7
- test_table_statistics_append |  981009 |        2216 | test_table_statistics_append_981009 |      8192 | 5             | 7
+ test_table_statistics_append |  981008 |      982016 | test_table_statistics_append_981008 | 1             | 3
+ test_table_statistics_append |  981008 |      982017 | test_table_statistics_append_981008 | 1             | 3
+ test_table_statistics_append |  981009 |      982018 | test_table_statistics_append_981009 | 5             | 7
+ test_table_statistics_append |  981009 |      982019 | test_table_statistics_append_981009 | 5             | 7
 (4 rows)
 
 DROP TABLE test_table_statistics_hash, test_table_statistics_append;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -98,6 +98,11 @@ test: propagate_statistics
 test: pg13_propagate_statistics
 
 # ----------
+# Test for updating table statistics
+# ----------
+test: citus_update_table_statistics
+
+# ----------
 # Miscellaneous tests to check our query planning behavior
 # ----------
 test: multi_deparse_shard_query multi_distributed_transaction_id intermediate_results limit_intermediate_size rollback_to_savepoint

--- a/src/test/regress/sql/citus_update_table_statistics.sql
+++ b/src/test/regress/sql/citus_update_table_statistics.sql
@@ -1,0 +1,92 @@
+--
+-- citus_update_table_statistics.sql
+--
+-- Test citus_update_table_statistics function on both
+-- hash and append distributed tables
+-- This function updates shardlength, shardminvalue and shardmaxvalue
+--
+SET citus.next_shard_id TO 981000;
+SET client_min_messages TO WARNING;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 2;
+
+-- test with a hash-distributed table
+-- here we update only shardlength, not shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_hash (id int);
+SELECT create_distributed_table('test_table_statistics_hash', 'id');
+
+-- populate table
+INSERT INTO test_table_statistics_hash SELECT i FROM generate_series(0, 10000)i;
+
+-- originally shardlength (size of the shard) is zero
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength AS shardsize,
+    ds.shardminvalue AS shardminvalue,
+    ds.shardmaxvalue AS shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+ORDER BY 2, 3;
+
+-- update table statistics and then check that shardlength has changed
+-- but shardminvalue and shardmaxvalue stay the same because this is
+-- a hash distributed table
+
+SELECT citus_update_table_statistics('test_table_statistics_hash');
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash')
+ORDER BY 2, 3;
+
+-- check with an append-distributed table
+-- here we update shardlength, shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_append (id int);
+SELECT create_distributed_table('test_table_statistics_append', 'id', 'append');
+COPY test_table_statistics_append FROM PROGRAM 'echo 0 && echo 1 && echo 2 && echo 3' WITH CSV;
+COPY test_table_statistics_append FROM PROGRAM 'echo 4 && echo 5 && echo 6 && echo 7' WITH CSV;
+
+-- originally shardminvalue and shardmaxvalue will be 0,3 and 4, 7
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+
+-- delete some data to change shardminvalues of a shards
+DELETE FROM test_table_statistics_append WHERE id = 0 OR id = 4;
+
+-- update table statistics and then check that shardminvalue has changed
+-- shardlength (shardsize) is still 8192 since there is very few data
+
+SELECT citus_update_table_statistics('test_table_statistics_append');
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    dsp.shardlength as shardsize,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+
+DROP TABLE test_table_statistics_hash, test_table_statistics_append;
+ALTER SYSTEM RESET citus.shard_count;
+ALTER SYSTEM RESET citus.shard_replication_factor;


### PR DESCRIPTION
DESCRIPTION: Improves citus_update_table_statistics and provides distributed deadlock detection

Reimplement `citus_update_table_statistics` to first get all the updated metadata (using similar logic to `citus_shard_sizes`), and then modify `pg_dist_placement` (and `pg_dist_shard` as well for append distributed tables). This is faster than previous implementation. Also now the function updates a single table, not the whole colocation group.

Also see https://github.com/citusdata/citus/issues/4749#issuecomment-786599740

TODO:
- [x] maybe remove some newly added functions and merge with existing functions implemented for `citus_shard_sizes`. The main differences are: looking one table, not all tables, _and_ also keeping track of shard min/max values for append distributed tables. Open to suggestions from reviewers.
- [x] add tests
- [x] detect deadlocks

Fixes #4749 


