### PR TITLE
Not use predicate_refuted_by when pruning chunks

### DIFF
--- a/src/include/distributed/shard_pruning.h
+++ b/src/include/distributed/shard_pruning.h
@@ -16,6 +16,55 @@
 
 #define INVALID_SHARD_INDEX -1
 
+/*
+ * A pruning instance is a set of ANDed constraints on a partition key.
+ */
+typedef struct PruningInstance
+{
+	/* Does this instance contain any prunable expressions? */
+	bool hasValidConstraint;
+
+	/*
+	 * This constraint never evaluates to true, i.e. pruning does not have to
+	 * be performed.
+	 */
+	bool evaluatesToFalse;
+
+	/*
+	 * Constraints on the partition column value. If multiple values are
+	 * found the more restrictive one should be stored here. Even for
+	 * a hash-partitioned table, actual column-values are stored here, *not*
+	 * hashed values.
+	 */
+	Const *lessConsts;
+	Const *lessEqualConsts;
+	Const *equalConsts;
+	Const *greaterEqualConsts;
+	Const *greaterConsts;
+
+	/*
+	 * Constraint using a pre-hashed column value. The constant will store the
+	 * hashed value, not the original value of the restriction.
+	 */
+	Const *hashedEqualConsts;
+
+	/*
+	 * Has this PruningInstance been added to
+	 * ClauseWalkerContext->pruningInstances? This is not done immediately,
+	 * but the first time a constraint (independent of us being able to handle
+	 * that constraint) is found.
+	 */
+	bool addedToPruningInstances;
+
+	/*
+	 * When OR clauses are found, the non-ORed part (think of a < 3 AND (a > 5
+	 * OR a > 7)) of the expression is stored in one PruningInstance which is
+	 * then copied for the ORed expressions. The original is marked as
+	 * isPartial, to avoid being used for pruning.
+	 */
+	bool isPartial;
+} PruningInstance;
+
 /* Function declarations for shard pruning */
 extern List * PruneShards(Oid relationId, Index rangeTableId, List *whereClauseList,
 						  Const **partitionValueConst);
@@ -25,5 +74,8 @@ extern Const * TransformPartitionRestrictionValue(Var *partitionColumn,
 												  Const *restrictionValue,
 												  bool missingOk);
 bool VarConstOpExprClause(OpExpr *opClause, Var **varClause, Const **constantClause);
+extern bool ExhaustivePruneOneWithMinMax(PruningInstance *prune,
+										 FunctionCallInfo compareFunctionCall,
+										 Datum minimumValue, Datum maximumValue);
 
 #endif /* SHARD_PRUNING_H_ */


### PR DESCRIPTION
DESCRIPTION: Avoids using `predicate_refuted_by` when pruning columnar table chunks

Closes https://github.com/citusdata/citus/issues/4670.

Opening for feedback.

Since `predicate_refuted_by` is extremely costly, we want to re-use the fast pruning logic in `shard_pruning.c`.
Looked into that file and seems that we have a 4-step logic to prune shards.
To me, the only step that applies to chunk pruning is the exhaustive pruning step (step-4) due to the nature of chunks.
```c
/*-------------------------------------------------------------------------
 *
 * shard_pruning.c
 ......
 * 4) If there are overlapping shards, exhaustively search all shards that are
 *    not excluded by constraints
```

Talked with Andres, he suggested that we could first sort chunks and then could do the chunk pruning via binary search on chunk boundaries but I'm not sure if it applies to chunk pruning since I think we can't actually have a good way of sorting the chunks.
Any ideas ? (cc: @jeff-davis)

---

Also, I didn't do much benchmarking but the chunk pruning logic proposed in this pr seems to be much faster than using `predicate_refuted_by` when accessing the columnar table in a selective way:

```sql
create table local (a int) using columnar;
insert into local values (generate_series(1, 250000000));

SELECT sum(a) FROM local WHERE a = 10000325 or a = 104356 or a = 765567;
-- on this branch: ~95ms
-- on master: ~400ms
```

Is there a better way to measure the improvement done in this pr ?

-----

First two commits are to partially re-use the pruning logic from `shard_pruning.c`.
In the second commit, note that I removed two shard pruning specific fields from `ClauseWalkerContext` (`partitionMethod` & `compareIntervalFunctionCall`). This is because:
a) To re-use the same logic in chunk pruning when generating prune instances
b) Those two fields anyway are not used when generating prune instances for shard pruning and the only place that makes sense to use `ClauseWalkerContext` was already `PrunableExpressions`

Summarized design considerations & TODO's:
- [ ] Look more into `postgres/partprune.c` to see if we could directly use postgres's partitioning logic
- [ ] Add regression tests to cover each case in `ExhaustivePruneOneWithMinMax` by columnar tables
- [ ] Do some reasonable benchmarking
- [ ] Another improvement: prune chunk groups at once (https://github.com/citusdata/citus/pull/4753#discussion_r584541765) (cc: @pykello)
- [ ] Could we have have a more advanced pruning logic in chunk pruning too ?
This pr only uses exhaustive pruning (step-4) as mentioned above.

