### PR TITLE
Normalize the ConvertTable notices

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1169,7 +1169,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 	{
 		if (!suppressNoticeMessages)
 		{
-			ereport(NOTICE, (errmsg("Moving the data of %s",
+			ereport(NOTICE, (errmsg("moving the data of %s",
 									quote_qualified_identifier(schemaName, sourceName))));
 		}
 
@@ -1242,7 +1242,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 
 	if (!suppressNoticeMessages)
 	{
-		ereport(NOTICE, (errmsg("Dropping the old %s",
+		ereport(NOTICE, (errmsg("dropping the old %s",
 								quote_qualified_identifier(schemaName, sourceName))));
 	}
 
@@ -1253,7 +1253,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 
 	if (!suppressNoticeMessages)
 	{
-		ereport(NOTICE, (errmsg("Renaming the new table to %s",
+		ereport(NOTICE, (errmsg("renaming the new table to %s",
 								quote_qualified_identifier(schemaName, sourceName))));
 	}
 

--- a/src/test/regress/expected/alter_distributed_table.out
+++ b/src/test/regress/expected/alter_distributed_table.out
@@ -53,9 +53,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering distribution column
 SELECT alter_distributed_table('dist_table', distribution_column := 'b');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -82,9 +82,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count
 SELECT alter_distributed_table('dist_table', shard_count := 6);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -111,9 +111,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering colocation, note that shard count will also change
 SELECT alter_distributed_table('dist_table', colocate_with := 'alter_distributed_table.colocation_table');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -139,13 +139,13 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count with cascading, note that the colocation will be kept
 SELECT alter_distributed_table('dist_table', shard_count := 8, cascade_to_colocated := true);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
 NOTICE:  creating a new table for alter_distributed_table.colocation_table
-NOTICE:  Moving the data of alter_distributed_table.colocation_table
-NOTICE:  Dropping the old alter_distributed_table.colocation_table
-NOTICE:  Renaming the new table to alter_distributed_table.colocation_table
+NOTICE:  moving the data of alter_distributed_table.colocation_table
+NOTICE:  dropping the old alter_distributed_table.colocation_table
+NOTICE:  renaming the new table to alter_distributed_table.colocation_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -171,9 +171,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count without cascading, note that the colocation will be broken
 SELECT alter_distributed_table('dist_table', shard_count := 10, cascade_to_colocated := false);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -261,16 +261,16 @@ SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
 SELECT alter_distributed_table('partitioned_table', shard_count := 10, distribution_column := 'a');
 NOTICE:  converting the partitions of alter_distributed_table.partitioned_table
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table_1_5
-NOTICE:  Moving the data of alter_distributed_table.partitioned_table_1_5
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table_1_5
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table_1_5
+NOTICE:  moving the data of alter_distributed_table.partitioned_table_1_5
+NOTICE:  dropping the old alter_distributed_table.partitioned_table_1_5
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table_1_5
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table_6_10
-NOTICE:  Moving the data of alter_distributed_table.partitioned_table_6_10
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table_6_10
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table_6_10
+NOTICE:  moving the data of alter_distributed_table.partitioned_table_6_10
+NOTICE:  dropping the old alter_distributed_table.partitioned_table_6_10
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table_6_10
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table
+NOTICE:  dropping the old alter_distributed_table.partitioned_table
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -658,12 +658,12 @@ ALTER TABLE par_table ATTACH PARTITION par_table_1 FOR VALUES FROM (1) TO (5);
 SELECT alter_distributed_table('par_table', distribution_column:='b', colocate_with:='col_table');
 NOTICE:  converting the partitions of alter_distributed_table.par_table
 NOTICE:  creating a new table for alter_distributed_table.par_table_1
-NOTICE:  Moving the data of alter_distributed_table.par_table_1
-NOTICE:  Dropping the old alter_distributed_table.par_table_1
-NOTICE:  Renaming the new table to alter_distributed_table.par_table_1
+NOTICE:  moving the data of alter_distributed_table.par_table_1
+NOTICE:  dropping the old alter_distributed_table.par_table_1
+NOTICE:  renaming the new table to alter_distributed_table.par_table_1
 NOTICE:  creating a new table for alter_distributed_table.par_table
-NOTICE:  Dropping the old alter_distributed_table.par_table
-NOTICE:  Renaming the new table to alter_distributed_table.par_table
+NOTICE:  dropping the old alter_distributed_table.par_table
+NOTICE:  renaming the new table to alter_distributed_table.par_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -685,9 +685,9 @@ HINT:  check citus_tables view to see current properties of the table
 -- first colocate the tables, then try to re-colococate
 SELECT alter_distributed_table('dist_table', colocate_with := 'colocation_table');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -701,9 +701,9 @@ HINT:  check citus_tables view to see current properties of the table
 SELECT alter_distributed_table('dist_table', distribution_column:='b', shard_count:=4, cascade_to_colocated:=false);
 NOTICE:  table is already distributed by b
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -712,9 +712,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 SELECT alter_distributed_table('dist_table', shard_count:=4, colocate_with:='colocation_table_2');
 NOTICE:  shard count of the table is already 4
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -723,9 +723,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 SELECT alter_distributed_table('dist_table', colocate_with:='colocation_table_2', distribution_column:='a');
 NOTICE:  table is already colocated with colocation_table_2
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -750,9 +750,9 @@ HINT:  cascade_to_colocated := false will break the current colocation, cascade_
 -- test changing shard count of a non-colocated table without cascade_to_colocated, shouldn't error
 SELECT alter_distributed_table('dist_table', colocate_with := 'none');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -760,9 +760,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 SELECT alter_distributed_table('dist_table', shard_count := 14);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -820,11 +820,11 @@ INSERT INTO mat_view_test VALUES (1,1), (2,2);
 CREATE MATERIALIZED VIEW mat_view AS SELECT * FROM mat_view_test;
 SELECT alter_distributed_table('mat_view_test', shard_count := 5, cascade_to_colocated := false);
 NOTICE:  creating a new table for alter_distributed_table.mat_view_test
-NOTICE:  Moving the data of alter_distributed_table.mat_view_test
-NOTICE:  Dropping the old alter_distributed_table.mat_view_test
+NOTICE:  moving the data of alter_distributed_table.mat_view_test
+NOTICE:  dropping the old alter_distributed_table.mat_view_test
 NOTICE:  drop cascades to materialized view mat_view
 CONTEXT:  SQL statement "DROP TABLE alter_distributed_table.mat_view_test CASCADE"
-NOTICE:  Renaming the new table to alter_distributed_table.mat_view_test
+NOTICE:  renaming the new table to alter_distributed_table.mat_view_test
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -850,15 +850,15 @@ SELECT create_distributed_table('abcde_01234567890123456789012345678901234567890
 SELECT alter_distributed_table('abcde_0123456789012345678901234567890123456789012345678901234567890123456789', distribution_column := 'y');
 DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f7ff6612_xxxxxx) for relation (abcde_012345678901234567890123456789012345678901234567890123456) is too long, switching to sequential and local execution mode to prevent self deadlocks
 NOTICE:  creating a new table for alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
-NOTICE:  Moving the data of alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  moving the data of alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 CONTEXT:  SQL statement "INSERT INTO alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 (x,y) SELECT x,y FROM alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456"
 DEBUG:  performing repartitioned INSERT ... SELECT
 CONTEXT:  SQL statement "INSERT INTO alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 (x,y) SELECT x,y FROM alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456"
-NOTICE:  Dropping the old alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  dropping the old alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 CONTEXT:  SQL statement "DROP TABLE alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456 CASCADE"
-NOTICE:  Renaming the new table to alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  renaming the new table to alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f7ff6612_xxxxxx) for relation (abcde_012345678901234567890123456789012345678901234567890123456) is too long, switching to sequential and local execution mode to prevent self deadlocks
 CONTEXT:  SQL statement "ALTER TABLE alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 RENAME TO abcde_012345678901234567890123456789012345678901234567890123456"
  alter_distributed_table
@@ -886,12 +886,12 @@ NOTICE:  identifier "partition_lengths_p2020_09_28_12345678901234567890123456789
 SELECT alter_distributed_table('partition_lengths', shard_count := 29, cascade_to_colocated := false);
 NOTICE:  converting the partitions of alter_distributed_table.partition_lengths
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Moving the data of alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  moving the data of alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths
+NOTICE:  dropping the old alter_distributed_table.partition_lengths
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -906,12 +906,12 @@ NOTICE:  identifier "partition_lengths_12345678901234567890123456789012345678901
 SELECT alter_distributed_table('partition_lengths_12345678901234567890123456789012345678901234567890', shard_count := 17, cascade_to_colocated := false);
 NOTICE:  converting the partitions of alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Moving the data of alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  moving the data of alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
  alter_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/alter_distributed_table_0.out
+++ b/src/test/regress/expected/alter_distributed_table_0.out
@@ -53,9 +53,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering distribution column
 SELECT alter_distributed_table('dist_table', distribution_column := 'b');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -82,9 +82,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count
 SELECT alter_distributed_table('dist_table', shard_count := 6);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -111,9 +111,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering colocation, note that shard count will also change
 SELECT alter_distributed_table('dist_table', colocate_with := 'alter_distributed_table.colocation_table');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -139,13 +139,13 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count with cascading, note that the colocation will be kept
 SELECT alter_distributed_table('dist_table', shard_count := 8, cascade_to_colocated := true);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
 NOTICE:  creating a new table for alter_distributed_table.colocation_table
-NOTICE:  Moving the data of alter_distributed_table.colocation_table
-NOTICE:  Dropping the old alter_distributed_table.colocation_table
-NOTICE:  Renaming the new table to alter_distributed_table.colocation_table
+NOTICE:  moving the data of alter_distributed_table.colocation_table
+NOTICE:  dropping the old alter_distributed_table.colocation_table
+NOTICE:  renaming the new table to alter_distributed_table.colocation_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -171,9 +171,9 @@ SELECT STRING_AGG(table_name::text, ', ' ORDER BY 1) AS "Colocation Groups" FROM
 -- test altering shard count without cascading, note that the colocation will be broken
 SELECT alter_distributed_table('dist_table', shard_count := 10, cascade_to_colocated := false);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -261,16 +261,16 @@ SELECT * FROM partitioned_table_6_10 ORDER BY 1, 2;
 SELECT alter_distributed_table('partitioned_table', shard_count := 10, distribution_column := 'a');
 NOTICE:  converting the partitions of alter_distributed_table.partitioned_table
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table_1_5
-NOTICE:  Moving the data of alter_distributed_table.partitioned_table_1_5
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table_1_5
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table_1_5
+NOTICE:  moving the data of alter_distributed_table.partitioned_table_1_5
+NOTICE:  dropping the old alter_distributed_table.partitioned_table_1_5
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table_1_5
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table_6_10
-NOTICE:  Moving the data of alter_distributed_table.partitioned_table_6_10
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table_6_10
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table_6_10
+NOTICE:  moving the data of alter_distributed_table.partitioned_table_6_10
+NOTICE:  dropping the old alter_distributed_table.partitioned_table_6_10
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table_6_10
 NOTICE:  creating a new table for alter_distributed_table.partitioned_table
-NOTICE:  Dropping the old alter_distributed_table.partitioned_table
-NOTICE:  Renaming the new table to alter_distributed_table.partitioned_table
+NOTICE:  dropping the old alter_distributed_table.partitioned_table
+NOTICE:  renaming the new table to alter_distributed_table.partitioned_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -637,12 +637,12 @@ ALTER TABLE par_table ATTACH PARTITION par_table_1 FOR VALUES FROM (1) TO (5);
 SELECT alter_distributed_table('par_table', distribution_column:='b', colocate_with:='col_table');
 NOTICE:  converting the partitions of alter_distributed_table.par_table
 NOTICE:  creating a new table for alter_distributed_table.par_table_1
-NOTICE:  Moving the data of alter_distributed_table.par_table_1
-NOTICE:  Dropping the old alter_distributed_table.par_table_1
-NOTICE:  Renaming the new table to alter_distributed_table.par_table_1
+NOTICE:  moving the data of alter_distributed_table.par_table_1
+NOTICE:  dropping the old alter_distributed_table.par_table_1
+NOTICE:  renaming the new table to alter_distributed_table.par_table_1
 NOTICE:  creating a new table for alter_distributed_table.par_table
-NOTICE:  Dropping the old alter_distributed_table.par_table
-NOTICE:  Renaming the new table to alter_distributed_table.par_table
+NOTICE:  dropping the old alter_distributed_table.par_table
+NOTICE:  renaming the new table to alter_distributed_table.par_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -664,9 +664,9 @@ HINT:  check citus_tables view to see current properties of the table
 -- first colocate the tables, then try to re-colococate
 SELECT alter_distributed_table('dist_table', colocate_with := 'colocation_table');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -680,9 +680,9 @@ HINT:  check citus_tables view to see current properties of the table
 SELECT alter_distributed_table('dist_table', distribution_column:='b', shard_count:=4, cascade_to_colocated:=false);
 NOTICE:  table is already distributed by b
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -691,9 +691,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 SELECT alter_distributed_table('dist_table', shard_count:=4, colocate_with:='colocation_table_2');
 NOTICE:  shard count of the table is already 4
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -702,9 +702,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 SELECT alter_distributed_table('dist_table', colocate_with:='colocation_table_2', distribution_column:='a');
 NOTICE:  table is already colocated with colocation_table_2
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -729,9 +729,9 @@ HINT:  cascade_to_colocated := false will break the current colocation, cascade_
 -- test changing shard count of a non-colocated table without cascade_to_colocated, shouldn't error
 SELECT alter_distributed_table('dist_table', colocate_with := 'none');
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -739,9 +739,9 @@ NOTICE:  Renaming the new table to alter_distributed_table.dist_table
 
 SELECT alter_distributed_table('dist_table', shard_count := 14);
 NOTICE:  creating a new table for alter_distributed_table.dist_table
-NOTICE:  Moving the data of alter_distributed_table.dist_table
-NOTICE:  Dropping the old alter_distributed_table.dist_table
-NOTICE:  Renaming the new table to alter_distributed_table.dist_table
+NOTICE:  moving the data of alter_distributed_table.dist_table
+NOTICE:  dropping the old alter_distributed_table.dist_table
+NOTICE:  renaming the new table to alter_distributed_table.dist_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -799,11 +799,11 @@ INSERT INTO mat_view_test VALUES (1,1), (2,2);
 CREATE MATERIALIZED VIEW mat_view AS SELECT * FROM mat_view_test;
 SELECT alter_distributed_table('mat_view_test', shard_count := 5, cascade_to_colocated := false);
 NOTICE:  creating a new table for alter_distributed_table.mat_view_test
-NOTICE:  Moving the data of alter_distributed_table.mat_view_test
-NOTICE:  Dropping the old alter_distributed_table.mat_view_test
+NOTICE:  moving the data of alter_distributed_table.mat_view_test
+NOTICE:  dropping the old alter_distributed_table.mat_view_test
 NOTICE:  drop cascades to materialized view mat_view
 CONTEXT:  SQL statement "DROP TABLE alter_distributed_table.mat_view_test CASCADE"
-NOTICE:  Renaming the new table to alter_distributed_table.mat_view_test
+NOTICE:  renaming the new table to alter_distributed_table.mat_view_test
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -829,15 +829,15 @@ SELECT create_distributed_table('abcde_01234567890123456789012345678901234567890
 SELECT alter_distributed_table('abcde_0123456789012345678901234567890123456789012345678901234567890123456789', distribution_column := 'y');
 DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f7ff6612_xxxxxx) for relation (abcde_012345678901234567890123456789012345678901234567890123456) is too long, switching to sequential and local execution mode to prevent self deadlocks
 NOTICE:  creating a new table for alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
-NOTICE:  Moving the data of alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  moving the data of alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  cannot perform distributed INSERT INTO ... SELECT because the partition columns in the source table and subquery do not match
 DETAIL:  The target table's partition column should correspond to a partition column in the subquery.
 CONTEXT:  SQL statement "INSERT INTO alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 (x,y) SELECT x,y FROM alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456"
 DEBUG:  performing repartitioned INSERT ... SELECT
 CONTEXT:  SQL statement "INSERT INTO alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 (x,y) SELECT x,y FROM alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456"
-NOTICE:  Dropping the old alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  dropping the old alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 CONTEXT:  SQL statement "DROP TABLE alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456 CASCADE"
-NOTICE:  Renaming the new table to alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  renaming the new table to alter_distributed_table.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f7ff6612_xxxxxx) for relation (abcde_012345678901234567890123456789012345678901234567890123456) is too long, switching to sequential and local execution mode to prevent self deadlocks
 CONTEXT:  SQL statement "ALTER TABLE alter_distributed_table.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 RENAME TO abcde_012345678901234567890123456789012345678901234567890123456"
  alter_distributed_table
@@ -865,12 +865,12 @@ NOTICE:  identifier "partition_lengths_p2020_09_28_12345678901234567890123456789
 SELECT alter_distributed_table('partition_lengths', shard_count := 29, cascade_to_colocated := false);
 NOTICE:  converting the partitions of alter_distributed_table.partition_lengths
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Moving the data of alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  moving the data of alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28_123456789012345678901234567890123
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths
+NOTICE:  dropping the old alter_distributed_table.partition_lengths
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -885,12 +885,12 @@ NOTICE:  identifier "partition_lengths_12345678901234567890123456789012345678901
 SELECT alter_distributed_table('partition_lengths_12345678901234567890123456789012345678901234567890', shard_count := 17, cascade_to_colocated := false);
 NOTICE:  converting the partitions of alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Moving the data of alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_p2020_09_28
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  moving the data of alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_p2020_09_28
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_p2020_09_28
 NOTICE:  creating a new table for alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
-NOTICE:  Dropping the old alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
-NOTICE:  Renaming the new table to alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
+NOTICE:  dropping the old alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
+NOTICE:  renaming the new table to alter_distributed_table.partition_lengths_123456789012345678901234567890123456789012345
  alter_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -3,9 +3,9 @@
 CREATE TABLE alter_am_pg_version_table (a INT);
 SELECT alter_table_set_access_method('alter_am_pg_version_table', 'columnar');
 NOTICE:  creating a new table for public.alter_am_pg_version_table
-NOTICE:  Moving the data of public.alter_am_pg_version_table
-NOTICE:  Dropping the old public.alter_am_pg_version_table
-NOTICE:  Renaming the new table to public.alter_am_pg_version_table
+NOTICE:  moving the data of public.alter_am_pg_version_table
+NOTICE:  dropping the old public.alter_am_pg_version_table
+NOTICE:  renaming the new table to public.alter_am_pg_version_table
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -51,9 +51,9 @@ SELECT table_name, access_method FROM public.citus_tables WHERE table_name::text
 
 SELECT alter_table_set_access_method('dist_table', 'columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.dist_table
-NOTICE:  Moving the data of alter_table_set_access_method.dist_table
-NOTICE:  Dropping the old alter_table_set_access_method.dist_table
-NOTICE:  Renaming the new table to alter_table_set_access_method.dist_table
+NOTICE:  moving the data of alter_table_set_access_method.dist_table
+NOTICE:  dropping the old alter_table_set_access_method.dist_table
+NOTICE:  renaming the new table to alter_table_set_access_method.dist_table
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -131,9 +131,9 @@ ERROR:  you cannot alter access method of a partitioned table
 -- test altering the partition's access method
 SELECT alter_table_set_access_method('partitioned_table_1_5', 'columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.partitioned_table_1_5
-NOTICE:  Moving the data of alter_table_set_access_method.partitioned_table_1_5
-NOTICE:  Dropping the old alter_table_set_access_method.partitioned_table_1_5
-NOTICE:  Renaming the new table to alter_table_set_access_method.partitioned_table_1_5
+NOTICE:  moving the data of alter_table_set_access_method.partitioned_table_1_5
+NOTICE:  dropping the old alter_table_set_access_method.partitioned_table_1_5
+NOTICE:  renaming the new table to alter_table_set_access_method.partitioned_table_1_5
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -228,14 +228,14 @@ SELECT event FROM time_partitioned ORDER BY 1;
 CALL alter_old_partitions_set_access_method('time_partitioned', '2021-01-01', 'columnar');
 NOTICE:  converting time_partitioned_d00 with start time Sat Jan 01 00:00:00 2000 and end time Thu Dec 31 00:00:00 2009
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Renaming the new table to alter_table_set_access_method.time_partitioned_d00
+NOTICE:  moving the data of alter_table_set_access_method.time_partitioned_d00
+NOTICE:  dropping the old alter_table_set_access_method.time_partitioned_d00
+NOTICE:  renaming the new table to alter_table_set_access_method.time_partitioned_d00
 NOTICE:  converting time_partitioned_d10 with start time Fri Jan 01 00:00:00 2010 and end time Tue Dec 31 00:00:00 2019
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Renaming the new table to alter_table_set_access_method.time_partitioned_d10
+NOTICE:  moving the data of alter_table_set_access_method.time_partitioned_d10
+NOTICE:  dropping the old alter_table_set_access_method.time_partitioned_d10
+NOTICE:  renaming the new table to alter_table_set_access_method.time_partitioned_d10
 SELECT partition, access_method FROM time_partitions WHERE parent_table = 'time_partitioned'::regclass ORDER BY partition::text;
       partition       | access_method
 ---------------------------------------------------------------------
@@ -274,14 +274,14 @@ SELECT event FROM time_partitioned ORDER BY 1;
 CALL alter_old_partitions_set_access_method('time_partitioned', '2021-01-01', 'heap');
 NOTICE:  converting time_partitioned_d00 with start time Sat Jan 01 00:00:00 2000 and end time Thu Dec 31 00:00:00 2009
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d00
-NOTICE:  Renaming the new table to alter_table_set_access_method.time_partitioned_d00
+NOTICE:  moving the data of alter_table_set_access_method.time_partitioned_d00
+NOTICE:  dropping the old alter_table_set_access_method.time_partitioned_d00
+NOTICE:  renaming the new table to alter_table_set_access_method.time_partitioned_d00
 NOTICE:  converting time_partitioned_d10 with start time Fri Jan 01 00:00:00 2010 and end time Tue Dec 31 00:00:00 2019
 NOTICE:  creating a new table for alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Moving the data of alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Dropping the old alter_table_set_access_method.time_partitioned_d10
-NOTICE:  Renaming the new table to alter_table_set_access_method.time_partitioned_d10
+NOTICE:  moving the data of alter_table_set_access_method.time_partitioned_d10
+NOTICE:  dropping the old alter_table_set_access_method.time_partitioned_d10
+NOTICE:  renaming the new table to alter_table_set_access_method.time_partitioned_d10
 SELECT partition, access_method FROM time_partitions WHERE parent_table = 'time_partitioned'::regclass ORDER BY partition::text;
       partition       | access_method
 ---------------------------------------------------------------------
@@ -324,9 +324,9 @@ SELECT alter_table_set_access_method('index_table', 'columnar');
 NOTICE:  the index idx1 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
 NOTICE:  the index idx2 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.index_table
-NOTICE:  Moving the data of alter_table_set_access_method.index_table
-NOTICE:  Dropping the old alter_table_set_access_method.index_table
-NOTICE:  Renaming the new table to alter_table_set_access_method.index_table
+NOTICE:  moving the data of alter_table_set_access_method.index_table
+NOTICE:  dropping the old alter_table_set_access_method.index_table
+NOTICE:  renaming the new table to alter_table_set_access_method.index_table
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -395,9 +395,9 @@ NOTICE:  creating a new table for alter_table_set_access_method.table_type_dist
 WARNING:  fake_scan_getnextslot
 CONTEXT:  SQL statement "SELECT EXISTS (SELECT 1 FROM alter_table_set_access_method.table_type_dist_1533505599)"
 WARNING:  fake_scan_getnextslot
-NOTICE:  Moving the data of alter_table_set_access_method.table_type_dist
-NOTICE:  Dropping the old alter_table_set_access_method.table_type_dist
-NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_dist
+NOTICE:  moving the data of alter_table_set_access_method.table_type_dist
+NOTICE:  dropping the old alter_table_set_access_method.table_type_dist
+NOTICE:  renaming the new table to alter_table_set_access_method.table_type_dist
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -408,9 +408,9 @@ NOTICE:  creating a new table for alter_table_set_access_method.table_type_ref
 WARNING:  fake_scan_getnextslot
 CONTEXT:  SQL statement "SELECT EXISTS (SELECT 1 FROM alter_table_set_access_method.table_type_ref_1037855087)"
 WARNING:  fake_scan_getnextslot
-NOTICE:  Moving the data of alter_table_set_access_method.table_type_ref
-NOTICE:  Dropping the old alter_table_set_access_method.table_type_ref
-NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_ref
+NOTICE:  moving the data of alter_table_set_access_method.table_type_ref
+NOTICE:  dropping the old alter_table_set_access_method.table_type_ref
+NOTICE:  renaming the new table to alter_table_set_access_method.table_type_ref
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -418,9 +418,9 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_ref
 
 SELECT alter_table_set_access_method('table_type_pg_local', 'fake_am');
 NOTICE:  creating a new table for alter_table_set_access_method.table_type_pg_local
-NOTICE:  Moving the data of alter_table_set_access_method.table_type_pg_local
-NOTICE:  Dropping the old alter_table_set_access_method.table_type_pg_local
-NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_pg_local
+NOTICE:  moving the data of alter_table_set_access_method.table_type_pg_local
+NOTICE:  dropping the old alter_table_set_access_method.table_type_pg_local
+NOTICE:  renaming the new table to alter_table_set_access_method.table_type_pg_local
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -428,9 +428,9 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_pg_l
 
 SELECT alter_table_set_access_method('table_type_citus_local', 'fake_am');
 NOTICE:  creating a new table for alter_table_set_access_method.table_type_citus_local
-NOTICE:  Moving the data of alter_table_set_access_method.table_type_citus_local
-NOTICE:  Dropping the old alter_table_set_access_method.table_type_citus_local
-NOTICE:  Renaming the new table to alter_table_set_access_method.table_type_citus_local
+NOTICE:  moving the data of alter_table_set_access_method.table_type_citus_local
+NOTICE:  dropping the old alter_table_set_access_method.table_type_citus_local
+NOTICE:  renaming the new table to alter_table_set_access_method.table_type_citus_local
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -459,9 +459,9 @@ create table test_fk_p0 partition of test_fk_p for values from (0) to (10);
 create table test_fk_p1 partition of test_fk_p for values from (10) to (20);
 select alter_table_set_access_method('test_fk_p1', 'columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.test_fk_p1
-NOTICE:  Moving the data of alter_table_set_access_method.test_fk_p1
-NOTICE:  Dropping the old alter_table_set_access_method.test_fk_p1
-NOTICE:  Renaming the new table to alter_table_set_access_method.test_fk_p1
+NOTICE:  moving the data of alter_table_set_access_method.test_fk_p1
+NOTICE:  dropping the old alter_table_set_access_method.test_fk_p1
+NOTICE:  renaming the new table to alter_table_set_access_method.test_fk_p1
 ERROR:  Foreign keys and AFTER ROW triggers are not supported for columnar tables
 HINT:  Consider an AFTER STATEMENT trigger instead.
 CONTEXT:  SQL statement "ALTER TABLE alter_table_set_access_method.test_fk_p ATTACH PARTITION alter_table_set_access_method.test_fk_p1 FOR VALUES FROM (10) TO (20);"
@@ -475,11 +475,11 @@ INSERT INTO mat_view_test VALUES (1), (2);
 CREATE MATERIALIZED VIEW mat_view AS SELECT * FROM mat_view_test;
 SELECT alter_table_set_access_method('mat_view_test','columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.mat_view_test
-NOTICE:  Moving the data of alter_table_set_access_method.mat_view_test
-NOTICE:  Dropping the old alter_table_set_access_method.mat_view_test
+NOTICE:  moving the data of alter_table_set_access_method.mat_view_test
+NOTICE:  dropping the old alter_table_set_access_method.mat_view_test
 NOTICE:  drop cascades to materialized view mat_view
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.mat_view_test CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.mat_view_test
+NOTICE:  renaming the new table to alter_table_set_access_method.mat_view_test
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -519,13 +519,13 @@ create materialized view m_dist as select * from dist;
 create view v_dist as select * from dist;
 select alter_table_set_access_method('local','columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.local
-NOTICE:  Moving the data of alter_table_set_access_method.local
-NOTICE:  Dropping the old alter_table_set_access_method.local
+NOTICE:  moving the data of alter_table_set_access_method.local
+NOTICE:  dropping the old alter_table_set_access_method.local
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_local
 drop cascades to view v_local
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.local CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.local
+NOTICE:  renaming the new table to alter_table_set_access_method.local
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -533,13 +533,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.local
 
 select alter_table_set_access_method('ref','columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.ref
-NOTICE:  Moving the data of alter_table_set_access_method.ref
-NOTICE:  Dropping the old alter_table_set_access_method.ref
+NOTICE:  moving the data of alter_table_set_access_method.ref
+NOTICE:  dropping the old alter_table_set_access_method.ref
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_ref
 drop cascades to view v_ref
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.ref CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.ref
+NOTICE:  renaming the new table to alter_table_set_access_method.ref
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -547,13 +547,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.ref
 
 select alter_table_set_access_method('dist','columnar');
 NOTICE:  creating a new table for alter_table_set_access_method.dist
-NOTICE:  Moving the data of alter_table_set_access_method.dist
-NOTICE:  Dropping the old alter_table_set_access_method.dist
+NOTICE:  moving the data of alter_table_set_access_method.dist
+NOTICE:  dropping the old alter_table_set_access_method.dist
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_dist
 drop cascades to view v_dist
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.dist CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.dist
+NOTICE:  renaming the new table to alter_table_set_access_method.dist
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -561,13 +561,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.dist
 
 SELECT alter_distributed_table('dist', shard_count:=1, cascade_to_colocated:=false);
 NOTICE:  creating a new table for alter_table_set_access_method.dist
-NOTICE:  Moving the data of alter_table_set_access_method.dist
-NOTICE:  Dropping the old alter_table_set_access_method.dist
+NOTICE:  moving the data of alter_table_set_access_method.dist
+NOTICE:  dropping the old alter_table_set_access_method.dist
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_dist
 drop cascades to view v_dist
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.dist CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.dist
+NOTICE:  renaming the new table to alter_table_set_access_method.dist
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -575,13 +575,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.dist
 
 select alter_table_set_access_method('local','heap');
 NOTICE:  creating a new table for alter_table_set_access_method.local
-NOTICE:  Moving the data of alter_table_set_access_method.local
-NOTICE:  Dropping the old alter_table_set_access_method.local
+NOTICE:  moving the data of alter_table_set_access_method.local
+NOTICE:  dropping the old alter_table_set_access_method.local
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_local
 drop cascades to view v_local
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.local CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.local
+NOTICE:  renaming the new table to alter_table_set_access_method.local
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -589,13 +589,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.local
 
 select alter_table_set_access_method('ref','heap');
 NOTICE:  creating a new table for alter_table_set_access_method.ref
-NOTICE:  Moving the data of alter_table_set_access_method.ref
-NOTICE:  Dropping the old alter_table_set_access_method.ref
+NOTICE:  moving the data of alter_table_set_access_method.ref
+NOTICE:  dropping the old alter_table_set_access_method.ref
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_ref
 drop cascades to view v_ref
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.ref CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.ref
+NOTICE:  renaming the new table to alter_table_set_access_method.ref
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -603,13 +603,13 @@ NOTICE:  Renaming the new table to alter_table_set_access_method.ref
 
 select alter_table_set_access_method('dist','heap');
 NOTICE:  creating a new table for alter_table_set_access_method.dist
-NOTICE:  Moving the data of alter_table_set_access_method.dist
-NOTICE:  Dropping the old alter_table_set_access_method.dist
+NOTICE:  moving the data of alter_table_set_access_method.dist
+NOTICE:  dropping the old alter_table_set_access_method.dist
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view m_dist
 drop cascades to view v_dist
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.dist CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.dist
+NOTICE:  renaming the new table to alter_table_set_access_method.dist
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -696,10 +696,10 @@ DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f
 NOTICE:  creating a new table for alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  pathlist hook for columnar table am
 CONTEXT:  SQL statement "SELECT EXISTS (SELECT 1 FROM alter_table_set_access_method.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162)"
-NOTICE:  Moving the data of alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
-NOTICE:  Dropping the old alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  moving the data of alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  dropping the old alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
 CONTEXT:  SQL statement "DROP TABLE alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456 CASCADE"
-NOTICE:  Renaming the new table to alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
+NOTICE:  renaming the new table to alter_table_set_access_method.abcde_012345678901234567890123456789012345678901234567890123456
 DEBUG:  the name of the shard (abcde_01234567890123456789012345678901234567890_f7ff6612_xxxxxx) for relation (abcde_012345678901234567890123456789012345678901234567890123456) is too long, switching to sequential and local execution mode to prevent self deadlocks
 CONTEXT:  SQL statement "ALTER TABLE alter_table_set_access_method.abcde_0123456789012345678901234567890123456_f7ff6612_4160710162 RENAME TO abcde_012345678901234567890123456789012345678901234567890123456"
  alter_table_set_access_method

--- a/src/test/regress/expected/citus_local_tables.out
+++ b/src/test/regress/expected/citus_local_tables.out
@@ -351,11 +351,11 @@ ERROR:  Table 'citus_local_table_1' is a local table. Replicating shard of a loc
 BEGIN;
   SELECT undistribute_table('citus_local_table_1');
 NOTICE:  creating a new table for citus_local_tables_test_schema.citus_local_table_1
-NOTICE:  Moving the data of citus_local_tables_test_schema.citus_local_table_1
+NOTICE:  moving the data of citus_local_tables_test_schema.citus_local_table_1
 NOTICE:  executing the command locally: SELECT a FROM citus_local_tables_test_schema.citus_local_table_1_1504027 citus_local_table_1
-NOTICE:  Dropping the old citus_local_tables_test_schema.citus_local_table_1
+NOTICE:  dropping the old citus_local_tables_test_schema.citus_local_table_1
 NOTICE:  executing the command locally: DROP TABLE IF EXISTS citus_local_tables_test_schema.citus_local_table_1_xxxxx CASCADE
-NOTICE:  Renaming the new table to citus_local_tables_test_schema.citus_local_table_1
+NOTICE:  renaming the new table to citus_local_tables_test_schema.citus_local_table_1
  undistribute_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/columnar_citus_integration.out
+++ b/src/test/regress/expected/columnar_citus_integration.out
@@ -250,9 +250,9 @@ $cmd$);
 -- verify undistribute works
 SELECT undistribute_table('table_option');
 NOTICE:  creating a new table for columnar_citus_integration.table_option
-NOTICE:  Moving the data of columnar_citus_integration.table_option
-NOTICE:  Dropping the old columnar_citus_integration.table_option
-NOTICE:  Renaming the new table to columnar_citus_integration.table_option
+NOTICE:  moving the data of columnar_citus_integration.table_option
+NOTICE:  dropping the old columnar_citus_integration.table_option
+NOTICE:  renaming the new table to columnar_citus_integration.table_option
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -569,9 +569,9 @@ $cmd$);
 -- verify undistribute works
 SELECT undistribute_table('table_option');
 NOTICE:  creating a new table for columnar_citus_integration.table_option
-NOTICE:  Moving the data of columnar_citus_integration.table_option
-NOTICE:  Dropping the old columnar_citus_integration.table_option
-NOTICE:  Renaming the new table to columnar_citus_integration.table_option
+NOTICE:  moving the data of columnar_citus_integration.table_option
+NOTICE:  dropping the old columnar_citus_integration.table_option
+NOTICE:  renaming the new table to columnar_citus_integration.table_option
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -808,9 +808,9 @@ $cmd$);
 -- verify undistribute works
 SELECT undistribute_table('table_option_reference');
 NOTICE:  creating a new table for columnar_citus_integration.table_option_reference
-NOTICE:  Moving the data of columnar_citus_integration.table_option_reference
-NOTICE:  Dropping the old columnar_citus_integration.table_option_reference
-NOTICE:  Renaming the new table to columnar_citus_integration.table_option_reference
+NOTICE:  moving the data of columnar_citus_integration.table_option_reference
+NOTICE:  dropping the old columnar_citus_integration.table_option_reference
+NOTICE:  renaming the new table to columnar_citus_integration.table_option_reference
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -1041,9 +1041,9 @@ $cmd$);
 -- verify undistribute works
 SELECT undistribute_table('table_option_citus_local');
 NOTICE:  creating a new table for columnar_citus_integration.table_option_citus_local
-NOTICE:  Moving the data of columnar_citus_integration.table_option_citus_local
-NOTICE:  Dropping the old columnar_citus_integration.table_option_citus_local
-NOTICE:  Renaming the new table to columnar_citus_integration.table_option_citus_local
+NOTICE:  moving the data of columnar_citus_integration.table_option_citus_local
+NOTICE:  dropping the old columnar_citus_integration.table_option_citus_local
+NOTICE:  renaming the new table to columnar_citus_integration.table_option_citus_local
  undistribute_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/columnar_partitioning.out
+++ b/src/test/regress/expected/columnar_partitioning.out
@@ -46,9 +46,9 @@ SELECT count(*), sum(i), min(i), max(i) FROM parent;
 -- set older partitions as columnar
 SELECT alter_table_set_access_method('p0','columnar');
 NOTICE:  creating a new table for public.p0
-NOTICE:  Moving the data of public.p0
-NOTICE:  Dropping the old public.p0
-NOTICE:  Renaming the new table to public.p0
+NOTICE:  moving the data of public.p0
+NOTICE:  dropping the old public.p0
+NOTICE:  renaming the new table to public.p0
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -56,9 +56,9 @@ NOTICE:  Renaming the new table to public.p0
 
 SELECT alter_table_set_access_method('p1','columnar');
 NOTICE:  creating a new table for public.p1
-NOTICE:  Moving the data of public.p1
-NOTICE:  Dropping the old public.p1
-NOTICE:  Renaming the new table to public.p1
+NOTICE:  moving the data of public.p1
+NOTICE:  dropping the old public.p1
+NOTICE:  renaming the new table to public.p1
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -66,9 +66,9 @@ NOTICE:  Renaming the new table to public.p1
 
 SELECT alter_table_set_access_method('p3','columnar');
 NOTICE:  creating a new table for public.p3
-NOTICE:  Moving the data of public.p3
-NOTICE:  Dropping the old public.p3
-NOTICE:  Renaming the new table to public.p3
+NOTICE:  moving the data of public.p3
+NOTICE:  dropping the old public.p3
+NOTICE:  renaming the new table to public.p3
  alter_table_set_access_method
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/columnar_partitioning_1.out
+++ b/src/test/regress/expected/columnar_partitioning_1.out
@@ -46,9 +46,9 @@ SELECT count(*), sum(i), min(i), max(i) FROM parent;
 -- set older partitions as columnar
 SELECT alter_table_set_access_method('p0','columnar');
 NOTICE:  creating a new table for public.p0
-NOTICE:  Moving the data of public.p0
-NOTICE:  Dropping the old public.p0
-NOTICE:  Renaming the new table to public.p0
+NOTICE:  moving the data of public.p0
+NOTICE:  dropping the old public.p0
+NOTICE:  renaming the new table to public.p0
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -56,9 +56,9 @@ NOTICE:  Renaming the new table to public.p0
 
 SELECT alter_table_set_access_method('p1','columnar');
 NOTICE:  creating a new table for public.p1
-NOTICE:  Moving the data of public.p1
-NOTICE:  Dropping the old public.p1
-NOTICE:  Renaming the new table to public.p1
+NOTICE:  moving the data of public.p1
+NOTICE:  dropping the old public.p1
+NOTICE:  renaming the new table to public.p1
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -66,9 +66,9 @@ NOTICE:  Renaming the new table to public.p1
 
 SELECT alter_table_set_access_method('p3','columnar');
 NOTICE:  creating a new table for public.p3
-NOTICE:  Moving the data of public.p3
-NOTICE:  Dropping the old public.p3
-NOTICE:  Renaming the new table to public.p3
+NOTICE:  moving the data of public.p3
+NOTICE:  dropping the old public.p3
+NOTICE:  renaming the new table to public.p3
  alter_table_set_access_method
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/coordinator_shouldhaveshards.out
+++ b/src/test/regress/expected/coordinator_shouldhaveshards.out
@@ -718,9 +718,9 @@ SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid
 
 SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_with:='none');
 NOTICE:  creating a new table for coordinator_shouldhaveshards.adt_table
-NOTICE:  Moving the data of coordinator_shouldhaveshards.adt_table
-NOTICE:  Dropping the old coordinator_shouldhaveshards.adt_table
-NOTICE:  Renaming the new table to coordinator_shouldhaveshards.adt_table
+NOTICE:  moving the data of coordinator_shouldhaveshards.adt_table
+NOTICE:  dropping the old coordinator_shouldhaveshards.adt_table
+NOTICE:  renaming the new table to coordinator_shouldhaveshards.adt_table
  alter_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -73,9 +73,9 @@ SELECT create_distributed_table('test_collate_pushed_down_aggregate', 'a');
 
 SELECT alter_distributed_table('test_collate_pushed_down_aggregate', shard_count := 2, cascade_to_colocated:=false);
 NOTICE:  creating a new table for collation_tests.test_collate_pushed_down_aggregate
-NOTICE:  Moving the data of collation_tests.test_collate_pushed_down_aggregate
-NOTICE:  Dropping the old collation_tests.test_collate_pushed_down_aggregate
-NOTICE:  Renaming the new table to collation_tests.test_collate_pushed_down_aggregate
+NOTICE:  moving the data of collation_tests.test_collate_pushed_down_aggregate
+NOTICE:  dropping the old collation_tests.test_collate_pushed_down_aggregate
+NOTICE:  renaming the new table to collation_tests.test_collate_pushed_down_aggregate
  alter_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/multi_mx_alter_distributed_table.out
+++ b/src/test/regress/expected/multi_mx_alter_distributed_table.out
@@ -82,9 +82,9 @@ SELECT conrelid::regclass::text AS "Referencing Table", pg_get_constraintdef(oid
 
 SELECT alter_distributed_table('adt_table', distribution_column:='b', colocate_with:='none');
 NOTICE:  creating a new table for mx_alter_distributed_table.adt_table
-NOTICE:  Moving the data of mx_alter_distributed_table.adt_table
-NOTICE:  Dropping the old mx_alter_distributed_table.adt_table
-NOTICE:  Renaming the new table to mx_alter_distributed_table.adt_table
+NOTICE:  moving the data of mx_alter_distributed_table.adt_table
+NOTICE:  dropping the old mx_alter_distributed_table.adt_table
+NOTICE:  renaming the new table to mx_alter_distributed_table.adt_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -140,9 +140,9 @@ BEGIN;
 INSERT INTO adt_table SELECT x, x+1 FROM generate_series(1, 1000) x;
 SELECT alter_distributed_table('adt_table', distribution_column:='a');
 NOTICE:  creating a new table for mx_alter_distributed_table.adt_table
-NOTICE:  Moving the data of mx_alter_distributed_table.adt_table
-NOTICE:  Dropping the old mx_alter_distributed_table.adt_table
-NOTICE:  Renaming the new table to mx_alter_distributed_table.adt_table
+NOTICE:  moving the data of mx_alter_distributed_table.adt_table
+NOTICE:  dropping the old mx_alter_distributed_table.adt_table
+NOTICE:  renaming the new table to mx_alter_distributed_table.adt_table
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -207,9 +207,9 @@ RESET client_min_messages;
 -- shardCount is not null && list_length(colocatedTableList) = 1
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 8);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -236,9 +236,9 @@ SELECT proname, colocationid FROM pg_proc JOIN citus.pg_dist_object ON pg_proc.o
 -- colocatewith is not null && list_length(colocatedTableList) = 1
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 4);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -253,9 +253,9 @@ SELECT create_distributed_table('test_proc_colocation_1', 'a', colocate_with := 
 
 SELECT alter_distributed_table('test_proc_colocation_0', colocate_with := 'test_proc_colocation_1');
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -282,13 +282,13 @@ SELECT proname, colocationid FROM pg_proc JOIN citus.pg_dist_object ON pg_proc.o
 -- shardCount is not null && cascade_to_colocated is true
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 8, cascade_to_colocated := true);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -315,13 +315,13 @@ SELECT proname, colocationid FROM pg_proc JOIN citus.pg_dist_object ON pg_proc.o
 -- colocatewith is not null && cascade_to_colocated is true
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 4, cascade_to_colocated := true);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -336,13 +336,13 @@ SELECT create_distributed_table('test_proc_colocation_2', 'a', colocate_with := 
 
 SELECT alter_distributed_table('test_proc_colocation_0', colocate_with := 'test_proc_colocation_2', cascade_to_colocated := true);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -409,17 +409,17 @@ DETAIL:  from localhost:xxxxx
 RESET client_min_messages;
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 8, cascade_to_colocated := true);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_2
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_2
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_2
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_2
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_2
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_2
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_2
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_1
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_1
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_1
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -452,9 +452,9 @@ SELECT proname, colocationid FROM pg_proc JOIN citus.pg_dist_object ON pg_proc.o
 -- shardCount is not null && cascade_to_colocated is false
 SELECT alter_distributed_table('test_proc_colocation_0', shard_count:= 18, cascade_to_colocated := false);
 NOTICE:  creating a new table for mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Moving the data of mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Dropping the old mx_alter_distributed_table.test_proc_colocation_0
-NOTICE:  Renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  moving the data of mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  dropping the old mx_alter_distributed_table.test_proc_colocation_0
+NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocation_0
  alter_distributed_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -472,9 +472,9 @@ SELECT * FROM generated_stored_dist ORDER BY 1,2,3;
 INSERT INTO generated_stored_dist VALUES (1, 'text_1'), (2, 'text_2');
 SELECT alter_distributed_table('generated_stored_dist', shard_count := 5, cascade_to_colocated := false);
 NOTICE:  creating a new table for test_pg12.generated_stored_dist
-NOTICE:  Moving the data of test_pg12.generated_stored_dist
-NOTICE:  Dropping the old test_pg12.generated_stored_dist
-NOTICE:  Renaming the new table to test_pg12.generated_stored_dist
+NOTICE:  moving the data of test_pg12.generated_stored_dist
+NOTICE:  dropping the old test_pg12.generated_stored_dist
+NOTICE:  renaming the new table to test_pg12.generated_stored_dist
  alter_distributed_table
 ---------------------------------------------------------------------
 
@@ -533,9 +533,9 @@ create table generated_stored_columnar_p0 partition of generated_stored_columnar
 create table generated_stored_columnar_p1 partition of generated_stored_columnar for values from (10) to (20);
 SELECT alter_table_set_access_method('generated_stored_columnar_p0', 'columnar');
 NOTICE:  creating a new table for test_pg12.generated_stored_columnar_p0
-NOTICE:  Moving the data of test_pg12.generated_stored_columnar_p0
-NOTICE:  Dropping the old test_pg12.generated_stored_columnar_p0
-NOTICE:  Renaming the new table to test_pg12.generated_stored_columnar_p0
+NOTICE:  moving the data of test_pg12.generated_stored_columnar_p0
+NOTICE:  dropping the old test_pg12.generated_stored_columnar_p0
+NOTICE:  renaming the new table to test_pg12.generated_stored_columnar_p0
  alter_table_set_access_method
 ---------------------------------------------------------------------
 
@@ -568,9 +568,9 @@ SELECT * FROM generated_stored_ref ORDER BY 1,2,3,4,5;
 BEGIN;
   SELECT undistribute_table('generated_stored_ref');
 NOTICE:  creating a new table for test_pg12.generated_stored_ref
-NOTICE:  Moving the data of test_pg12.generated_stored_ref
-NOTICE:  Dropping the old test_pg12.generated_stored_ref
-NOTICE:  Renaming the new table to test_pg12.generated_stored_ref
+NOTICE:  moving the data of test_pg12.generated_stored_ref
+NOTICE:  dropping the old test_pg12.generated_stored_ref
+NOTICE:  renaming the new table to test_pg12.generated_stored_ref
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -600,9 +600,9 @@ BEGIN;
   -- show that undistribute_table works fine
   SELECT undistribute_table('generated_stored_ref');
 NOTICE:  creating a new table for test_pg12.generated_stored_ref
-NOTICE:  Moving the data of test_pg12.generated_stored_ref
-NOTICE:  Dropping the old test_pg12.generated_stored_ref
-NOTICE:  Renaming the new table to test_pg12.generated_stored_ref
+NOTICE:  moving the data of test_pg12.generated_stored_ref
+NOTICE:  dropping the old test_pg12.generated_stored_ref
+NOTICE:  renaming the new table to test_pg12.generated_stored_ref
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -630,9 +630,9 @@ BEGIN;
   -- show that undistribute_table works fine
   SELECT undistribute_table('generated_stored_ref');
 NOTICE:  creating a new table for test_pg12.generated_stored_ref
-NOTICE:  Moving the data of test_pg12.generated_stored_ref
-NOTICE:  Dropping the old test_pg12.generated_stored_ref
-NOTICE:  Renaming the new table to test_pg12.generated_stored_ref
+NOTICE:  moving the data of test_pg12.generated_stored_ref
+NOTICE:  dropping the old test_pg12.generated_stored_ref
+NOTICE:  renaming the new table to test_pg12.generated_stored_ref
  undistribute_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/pg13_with_ties.out
+++ b/src/test/regress/expected/pg13_with_ties.out
@@ -155,9 +155,9 @@ TRUNCATE with_ties_table_2;
 -- test INSERT SELECTs into distributed table with a different distribution column
 SELECT undistribute_table('with_ties_table_2');
 NOTICE:  creating a new table for public.with_ties_table_2
-NOTICE:  Moving the data of public.with_ties_table_2
-NOTICE:  Dropping the old public.with_ties_table_2
-NOTICE:  Renaming the new table to public.with_ties_table_2
+NOTICE:  moving the data of public.with_ties_table_2
+NOTICE:  dropping the old public.with_ties_table_2
+NOTICE:  renaming the new table to public.with_ties_table_2
  undistribute_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -289,9 +289,9 @@ COMMIT;
 -- to test citus local tables
 select undistribute_table('upsert_test');
 NOTICE:  creating a new table for single_node.upsert_test
-NOTICE:  Moving the data of single_node.upsert_test
-NOTICE:  Dropping the old single_node.upsert_test
-NOTICE:  Renaming the new table to single_node.upsert_test
+NOTICE:  moving the data of single_node.upsert_test
+NOTICE:  dropping the old single_node.upsert_test
+NOTICE:  renaming the new table to single_node.upsert_test
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -1195,9 +1195,9 @@ RESET citus.task_executor_type;
 ALTER TABLE test DROP CONSTRAINT foreign_key;
 SELECT undistribute_table('test_2');
 NOTICE:  creating a new table for single_node.test_2
-NOTICE:  Moving the data of single_node.test_2
-NOTICE:  Dropping the old single_node.test_2
-NOTICE:  Renaming the new table to single_node.test_2
+NOTICE:  moving the data of single_node.test_2
+NOTICE:  dropping the old single_node.test_2
+NOTICE:  renaming the new table to single_node.test_2
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -1246,28 +1246,28 @@ ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_5 FOREIGN KEY (col_1) REFERE
 SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
 NOTICE:  converting the partitions of single_node.partitioned_table_1
 NOTICE:  creating a new table for single_node.partitioned_table_1_100_200
-NOTICE:  Moving the data of single_node.partitioned_table_1_100_200
-NOTICE:  Dropping the old single_node.partitioned_table_1_100_200
-NOTICE:  Renaming the new table to single_node.partitioned_table_1_100_200
+NOTICE:  moving the data of single_node.partitioned_table_1_100_200
+NOTICE:  dropping the old single_node.partitioned_table_1_100_200
+NOTICE:  renaming the new table to single_node.partitioned_table_1_100_200
 NOTICE:  creating a new table for single_node.partitioned_table_1_200_300
-NOTICE:  Moving the data of single_node.partitioned_table_1_200_300
-NOTICE:  Dropping the old single_node.partitioned_table_1_200_300
-NOTICE:  Renaming the new table to single_node.partitioned_table_1_200_300
+NOTICE:  moving the data of single_node.partitioned_table_1_200_300
+NOTICE:  dropping the old single_node.partitioned_table_1_200_300
+NOTICE:  renaming the new table to single_node.partitioned_table_1_200_300
 NOTICE:  creating a new table for single_node.partitioned_table_1
-NOTICE:  Dropping the old single_node.partitioned_table_1
-NOTICE:  Renaming the new table to single_node.partitioned_table_1
+NOTICE:  dropping the old single_node.partitioned_table_1
+NOTICE:  renaming the new table to single_node.partitioned_table_1
 NOTICE:  creating a new table for single_node.reference_table_1
-NOTICE:  Moving the data of single_node.reference_table_1
-NOTICE:  Dropping the old single_node.reference_table_1
-NOTICE:  Renaming the new table to single_node.reference_table_1
+NOTICE:  moving the data of single_node.reference_table_1
+NOTICE:  dropping the old single_node.reference_table_1
+NOTICE:  renaming the new table to single_node.reference_table_1
 NOTICE:  creating a new table for single_node.distributed_table_1
-NOTICE:  Moving the data of single_node.distributed_table_1
-NOTICE:  Dropping the old single_node.distributed_table_1
-NOTICE:  Renaming the new table to single_node.distributed_table_1
+NOTICE:  moving the data of single_node.distributed_table_1
+NOTICE:  dropping the old single_node.distributed_table_1
+NOTICE:  renaming the new table to single_node.distributed_table_1
 NOTICE:  creating a new table for single_node.citus_local_table_1
-NOTICE:  Moving the data of single_node.citus_local_table_1
-NOTICE:  Dropping the old single_node.citus_local_table_1
-NOTICE:  Renaming the new table to single_node.citus_local_table_1
+NOTICE:  moving the data of single_node.citus_local_table_1
+NOTICE:  dropping the old single_node.citus_local_table_1
+NOTICE:  renaming the new table to single_node.citus_local_table_1
  undistribute_table
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/undistribute_table.out
+++ b/src/test/regress/expected/undistribute_table.out
@@ -35,15 +35,15 @@ SELECT * FROM dist_table ORDER BY 1, 2, 3;
 -- the name->OID conversion happens at parse time.
 SELECT undistribute_table('dist_table'), create_distributed_table('dist_table', 'a');
 NOTICE:  creating a new table for undistribute_table.dist_table
-NOTICE:  Moving the data of undistribute_table.dist_table
-NOTICE:  Dropping the old undistribute_table.dist_table
-NOTICE:  Renaming the new table to undistribute_table.dist_table
+NOTICE:  moving the data of undistribute_table.dist_table
+NOTICE:  dropping the old undistribute_table.dist_table
+NOTICE:  renaming the new table to undistribute_table.dist_table
 ERROR:  relation with OID XXXX does not exist
 SELECT undistribute_table('dist_table');
 NOTICE:  creating a new table for undistribute_table.dist_table
-NOTICE:  Moving the data of undistribute_table.dist_table
-NOTICE:  Dropping the old undistribute_table.dist_table
-NOTICE:  Renaming the new table to undistribute_table.dist_table
+NOTICE:  moving the data of undistribute_table.dist_table
+NOTICE:  dropping the old undistribute_table.dist_table
+NOTICE:  renaming the new table to undistribute_table.dist_table
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -88,9 +88,9 @@ SELECT * FROM pg_indexes WHERE tablename = 'dist_table';
 
 SELECT undistribute_table('dist_table');
 NOTICE:  creating a new table for undistribute_table.dist_table
-NOTICE:  Moving the data of undistribute_table.dist_table
-NOTICE:  Dropping the old undistribute_table.dist_table
-NOTICE:  Renaming the new table to undistribute_table.dist_table
+NOTICE:  moving the data of undistribute_table.dist_table
+NOTICE:  dropping the old undistribute_table.dist_table
+NOTICE:  renaming the new table to undistribute_table.dist_table
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -204,16 +204,16 @@ HINT:  the parent table is "partitioned_table"
 SELECT undistribute_table('partitioned_table');
 NOTICE:  converting the partitions of undistribute_table.partitioned_table
 NOTICE:  creating a new table for undistribute_table.partitioned_table_1_5
-NOTICE:  Moving the data of undistribute_table.partitioned_table_1_5
-NOTICE:  Dropping the old undistribute_table.partitioned_table_1_5
-NOTICE:  Renaming the new table to undistribute_table.partitioned_table_1_5
+NOTICE:  moving the data of undistribute_table.partitioned_table_1_5
+NOTICE:  dropping the old undistribute_table.partitioned_table_1_5
+NOTICE:  renaming the new table to undistribute_table.partitioned_table_1_5
 NOTICE:  creating a new table for undistribute_table.partitioned_table_6_10
-NOTICE:  Moving the data of undistribute_table.partitioned_table_6_10
-NOTICE:  Dropping the old undistribute_table.partitioned_table_6_10
-NOTICE:  Renaming the new table to undistribute_table.partitioned_table_6_10
+NOTICE:  moving the data of undistribute_table.partitioned_table_6_10
+NOTICE:  dropping the old undistribute_table.partitioned_table_6_10
+NOTICE:  renaming the new table to undistribute_table.partitioned_table_6_10
 NOTICE:  creating a new table for undistribute_table.partitioned_table
-NOTICE:  Dropping the old undistribute_table.partitioned_table
-NOTICE:  Renaming the new table to undistribute_table.partitioned_table
+NOTICE:  dropping the old undistribute_table.partitioned_table
+NOTICE:  renaming the new table to undistribute_table.partitioned_table
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -283,9 +283,9 @@ SELECT * FROM seq_table ORDER BY a;
 
 SELECT undistribute_table('seq_table');
 NOTICE:  creating a new table for undistribute_table.seq_table
-NOTICE:  Moving the data of undistribute_table.seq_table
-NOTICE:  Dropping the old undistribute_table.seq_table
-NOTICE:  Renaming the new table to undistribute_table.seq_table
+NOTICE:  moving the data of undistribute_table.seq_table
+NOTICE:  dropping the old undistribute_table.seq_table
+NOTICE:  renaming the new table to undistribute_table.seq_table
  undistribute_table
 ---------------------------------------------------------------------
 
@@ -348,14 +348,14 @@ SELECT * FROM another_schema.undis_view3 ORDER BY 1, 2;
 
 SELECT undistribute_table('view_table');
 NOTICE:  creating a new table for undistribute_table.view_table
-NOTICE:  Moving the data of undistribute_table.view_table
-NOTICE:  Dropping the old undistribute_table.view_table
+NOTICE:  moving the data of undistribute_table.view_table
+NOTICE:  dropping the old undistribute_table.view_table
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to view undis_view1
 drop cascades to view undis_view2
 drop cascades to view another_schema.undis_view3
 CONTEXT:  SQL statement "DROP TABLE undistribute_table.view_table CASCADE"
-NOTICE:  Renaming the new table to undistribute_table.view_table
+NOTICE:  renaming the new table to undistribute_table.view_table
  undistribute_table
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
The formatting of these notices keeps annoying me:
```
NOTICE:  creating a new table for public.test
NOTICE:  Moving the data of public.test
NOTICE:  Dropping the old public.test
NOTICE:  Renaming the new table to public.test
```

Normalize them to the usual message format: lowercase.