### PR TITLE
Fix chunk_group_consistency regression test view

### DIFF
--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -63,7 +63,7 @@ WITH a as (
    SELECT storage_id, stripe_num, chunk_group_count
    FROM columnar.stripe
 ), f as (
-   (TABLE d EXCEPT TABLE d) UNION (TABLE e EXCEPT TABLE d)
+   (TABLE d EXCEPT TABLE e) UNION (TABLE e EXCEPT TABLE d)
 )
 SELECT (SELECT count(*) = 0 FROM c) AND
        (SELECT count(*) = 0 FROM f) as consistent;

--- a/src/test/regress/sql/columnar_create.sql
+++ b/src/test/regress/sql/columnar_create.sql
@@ -67,7 +67,7 @@ WITH a as (
    SELECT storage_id, stripe_num, chunk_group_count
    FROM columnar.stripe
 ), f as (
-   (TABLE d EXCEPT TABLE d) UNION (TABLE e EXCEPT TABLE d)
+   (TABLE d EXCEPT TABLE e) UNION (TABLE e EXCEPT TABLE d)
 )
 SELECT (SELECT count(*) = 0 FROM c) AND
        (SELECT count(*) = 0 FROM f) as consistent;


### PR DESCRIPTION
We actually want to test if `columnar.chunk_group` is consistent with `columnar.stripe` by using two-way set difference, but we were subtracting the given table from itself.