### PR TITLE
Do not use security flags by default

### DIFF
--- a/configure
+++ b/configure
@@ -1345,8 +1345,7 @@ Optional Packages:
                           and update checks
   --without-lz4           do not use lz4
   --without-zstd          do not use zstd
-  --without-security-flags
-                          do not use security flags
+  --with-security-flags   use security flags
 
 Some influential environment variables:
   PG_CONFIG   Location to find pg_config for target PostgreSQL instalation
@@ -4754,7 +4753,7 @@ if test "${with_security_flags+set}" = set; then :
   esac
 
 else
-  with_security_flags=yes
+  with_security_flags=no
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -266,8 +266,8 @@ if test "$HAS_TABLEAM" == 'yes'; then
 fi # test "$HAS_TABLEAM" == 'yes'
 
 
-PGAC_ARG_BOOL(with, security-flags, yes,
-              [do not use security flags])
+PGAC_ARG_BOOL(with, security-flags, no,
+              [use security flags])
 AC_SUBST(with_security_flags)
 
 if test "$with_security_flags" = yes; then


### PR DESCRIPTION
We decided to make the security flags opt-in instead of opt-out while we work out the kinks.

Related: #4760