### PR TITLE
Switch to sequential mode on long partition names

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1655,8 +1655,20 @@ SwitchToSequentialAndLocalExecutionIfRelationNameTooLong(Oid relationId,
 		}
 
 		char *longestPartitionName = get_rel_name(longestNamePartitionId);
-		char *longestPartitionShardName = GetLongestShardName(longestNamePartitionId,
-															  longestPartitionName);
+		char *longestPartitionShardName = NULL;
+
+		/* Use the shardId values of the partition if it is distributed, otherwise use those of the parent's */
+		if (IsCitusTable(longestNamePartitionId) && ShardIntervalCount(
+				longestNamePartitionId) > 0)
+		{
+			longestPartitionShardName = GetLongestShardName(longestNamePartitionId,
+															longestPartitionName);
+		}
+		else
+		{
+			longestPartitionShardName = GetLongestShardName(relationId,
+															longestPartitionName);
+		}
 
 		SwitchToSequentialAndLocalExecutionIfShardNameTooLong(longestPartitionName,
 															  longestPartitionShardName);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -324,6 +324,9 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 		char *parentRelationName = generate_qualified_relation_name(parentRelationId);
 		bool viaDeprecatedAPI = false;
 
+		SwitchToSequentialAndLocalExecutionIfRelationNameTooLong(
+			parentRelationId, get_rel_name(relationId));
+
 		CreateDistributedTable(relationId, parentDistributionColumn,
 							   parentDistributionMethod, ShardCount,
 							   parentRelationName, viaDeprecatedAPI);
@@ -397,6 +400,9 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 				char distributionMethod = DISTRIBUTE_BY_HASH;
 				char *parentRelationName = generate_qualified_relation_name(relationId);
 				bool viaDeprecatedAPI = false;
+
+				SwitchToSequentialAndLocalExecutionIfRelationNameTooLong(
+					relationId, get_rel_name(partitionRelationId));
 
 				CreateDistributedTable(partitionRelationId, distributionColumn,
 									   distributionMethod, ShardCount,

--- a/src/test/regress/expected/multi_name_lengths.out
+++ b/src/test/regress/expected/multi_name_lengths.out
@@ -186,42 +186,24 @@ NOTICE:  identifier "partition_lengths_12345678901234567890123456789012345678901
 -- verify that we can rename partitioned tables and partitions with too-long names
 ALTER TABLE partition_lengths_12345678901234567890123456789012345678901234567890 RENAME TO partition_lengths;
 NOTICE:  identifier "partition_lengths_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_123456789012345678901234567890123456789012345"
--- Placeholders for unsupported operations
-\set VERBOSITY TERSE
--- renaming distributed table partitions
-ALTER TABLE partition_lengths_p2020_09_28 RENAME TO partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890;
-NOTICE:  identifier "partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_28_123456789012345678901234567890123"
--- creating or attaching new partitions with long names create deadlocks
-CREATE TABLE partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890 (LIKE partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890);
+-- creating or attaching new partitions with long names
+CREATE TABLE partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890 (LIKE partition_lengths_p2020_09_28);
 NOTICE:  identifier "partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_29_123456789012345678901234567890123"
-NOTICE:  identifier "partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_28_123456789012345678901234567890123"
 ALTER TABLE partition_lengths
     ATTACH PARTITION partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890
     FOR VALUES FROM ('2020-09-29 00:00:00') TO ('2020-09-30 00:00:00');
 NOTICE:  identifier "partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_29_123456789012345678901234567890123"
-ERROR:  canceling the transaction since it was involved in a distributed deadlock
 CREATE TABLE partition_lengths_p2020_09_30_12345678901234567890123456789012345678901234567890
     PARTITION OF partition_lengths
     FOR VALUES FROM ('2020-09-30 00:00:00') TO ('2020-10-01 00:00:00');
 NOTICE:  identifier "partition_lengths_p2020_09_30_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_30_123456789012345678901234567890123"
-ERROR:  canceling the transaction since it was involved in a distributed deadlock
 DROP TABLE partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890;
 NOTICE:  identifier "partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_29_123456789012345678901234567890123"
--- creating or attaching new partitions with long names work when using sequential shard modify mode
-BEGIN;
-SET LOCAL citus.multi_shard_modify_mode = sequential;
-CREATE TABLE partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890 (LIKE partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890);
-NOTICE:  identifier "partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_29_123456789012345678901234567890123"
+-- Placeholders for unsupported operations
+\set VERBOSITY TERSE
+-- renaming distributed table partitions are not supported
+ALTER TABLE partition_lengths_p2020_09_28 RENAME TO partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890;
 NOTICE:  identifier "partition_lengths_p2020_09_28_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_28_123456789012345678901234567890123"
-ALTER TABLE partition_lengths
-    ATTACH PARTITION partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890
-    FOR VALUES FROM ('2020-09-29 00:00:00') TO ('2020-09-30 00:00:00');
-NOTICE:  identifier "partition_lengths_p2020_09_29_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_29_123456789012345678901234567890123"
-CREATE TABLE partition_lengths_p2020_09_30_12345678901234567890123456789012345678901234567890
-    PARTITION OF partition_lengths
-    FOR VALUES FROM ('2020-09-30 00:00:00') TO ('2020-10-01 00:00:00');
-NOTICE:  identifier "partition_lengths_p2020_09_30_12345678901234567890123456789012345678901234567890" will be truncated to "partition_lengths_p2020_09_30_123456789012345678901234567890123"
-ROLLBACK;
 -- renaming distributed table constraints are not supported
 ALTER TABLE name_lengths RENAME CONSTRAINT unique_12345678901234567890123456789012345678901234567890 TO unique2_12345678901234567890123456789012345678901234567890;
 ERROR:  renaming constraints belonging to distributed tables is currently unsupported
@@ -311,14 +293,14 @@ SELECT master_create_worker_shards('sneaky_name_lengths', '2', '2');
 (1 row)
 
 \c - - :public_worker_1_host :worker_1_port
-\di public.sneaky*225030
+\di public.sneaky*225022
                                                     List of relations
  Schema |                              Name                               | Type  |  Owner   |           Table
 ---------------------------------------------------------------------
- public | sneaky_name_lengths_int_col_1234567890123456789_6402d2cd_225030 | index | postgres | sneaky_name_lengths_225030
+ public | sneaky_name_lengths_int_col_1234567890123456789_6402d2cd_225022 | index | postgres | sneaky_name_lengths_225022
 (1 row)
 
-SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225030'::regclass ORDER BY 1 DESC, 2 DESC;
+SELECT "Constraint", "Definition" FROM table_checks WHERE relid='public.sneaky_name_lengths_225022'::regclass ORDER BY 1 DESC, 2 DESC;
                         Constraint                         |                                  Definition
 ---------------------------------------------------------------------
  checky_12345678901234567890123456789012345678901234567890 | CHECK (int_col_123456789012345678901234567890123456789012345678901234 > 100)
@@ -342,11 +324,11 @@ SELECT create_distributed_table('sneaky_name_lengths', 'col1', 'hash');
 (1 row)
 
 \c - - :public_worker_1_host :worker_1_port
-\di unique*225032
+\di unique*225024
                                                     List of relations
  Schema |                              Name                               | Type  |  Owner   |           Table
 ---------------------------------------------------------------------
- public | unique_1234567890123456789012345678901234567890_a5986f27_225032 | index | postgres | sneaky_name_lengths_225032
+ public | unique_1234567890123456789012345678901234567890_a5986f27_225024 | index | postgres | sneaky_name_lengths_225024
 (1 row)
 
 \c - - :master_host :master_port


### PR DESCRIPTION
DESCRIPTION: Removes limits around long partition names

Long partition table names can create distributed deadlocks. If we switch to sequential execution, then we can handle long partition names when creating or attaching partitions to distributed tables.

One problem with my current solution is that I use the shardId of the parent table if the partition is not distributed yet, and this creates some shard names that are not really correct. As long as the length of the constructed shard name is correct however, it should not be a problem.

A better solution would be to create a new and unused shardId and use that for our long name checks.

I'd like #4794 more than this one. However I opened 2 separate PR's to facilitate offline discussion.

Fixes: #4736
Closes: #4794