### PR TITLE
Ignore columnar generated test files

### DIFF
--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -30,3 +30,7 @@
 /fdw_create.out
 /fdw_data_types.out
 /fdw_load.out
+/columnar_chunk_filtering.out
+/columnar_copyto.out
+/columnar_data_types.out
+/columnar_load.out

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -29,3 +29,7 @@
 /fdw_create.sql
 /fdw_data_types.sql
 /fdw_load.sql
+/columnar_chunk_filtering.sql
+/columnar_copyto.sql
+/columnar_data_types.sql
+/columnar_load.sql


### PR DESCRIPTION
Sometimes I would clean these 4 generated files manually, and it seems that it was because we weren't ignoring them like other files.