### PR TITLE
Add GUC to set maximum connection lifetime

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1239,6 +1239,16 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
+		"citus.max_cached_connection_lifetime",
+		gettext_noop("Sets the maximum lifetime of cached connections to other nodes."),
+		NULL,
+		&MaxCachedConnectionLifetime,
+		10 * MS_PER_MINUTE, -1, INT_MAX,
+		PGC_USERSET,
+		GUC_UNIT_MS | GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
 		"citus.repartition_join_bucket_count_per_node",
 		gettext_noop("Sets the bucket size for repartition joins per node"),
 		gettext_noop("Repartition joins create buckets in each node and "

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -200,6 +200,9 @@ extern int NodeConnectionTimeout;
 /* maximum number of connections to cache per worker per session */
 extern int MaxCachedConnectionsPerWorker;
 
+/* maximum lifetime of connections in miliseconds */
+extern int MaxCachedConnectionLifetime;
+
 /* parameters used for outbound connections */
 extern char *NodeConninfo;
 

--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -807,6 +807,7 @@ SELECT pg_sleep(0.1);
 (1 row)
 
 -- cache connections to the nodes
+SET citus.force_max_query_parallelization TO ON;
 SELECT count(*) FROM test;
  count
 ---------------------------------------------------------------------
@@ -823,6 +824,28 @@ BEGIN;
 (0 rows)
 
 COMMIT;
+-- should close all connections
+SET citus.max_cached_connection_lifetime TO '0s';
+SELECT count(*) FROM test;
+ count
+---------------------------------------------------------------------
+   155
+(1 row)
+
+-- show that no connections are cached
+SELECT
+	connection_count_to_node
+FROM
+	citus_remote_connection_stats()
+WHERE
+	port IN (SELECT node_port FROM master_get_active_worker_nodes()) AND
+	database_name = 'regression'
+ORDER BY
+	hostname, port;
+ connection_count_to_node
+---------------------------------------------------------------------
+(0 rows)
+
 -- in case other tests relies on these setting, reset them
 ALTER SYSTEM RESET citus.distributed_deadlock_detection_factor;
 ALTER SYSTEM RESET citus.recover_2pc_interval;


### PR DESCRIPTION
DESCRIPTION: Add GUC to set maximum connection lifetime

To mitigate cache bloat, it would be useful to close connections older than 10 minutes (configurable).

Fixes #4783 
Fixes #4228