### PR TITLE
Remove unnecessary AtEOXact_Files call

### DIFF
--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -318,28 +318,8 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			/* stop propagating notices from workers, we know the query is failed */
 			DisableWorkerMessagePropagation();
 
-			/*
-			 * FIXME: Add warning for the COORD_TRANS_COMMITTED case. That
-			 * can be reached if this backend fails after the
-			 * XACT_EVENT_PRE_COMMIT state.
-			 */
+			RemoveIntermediateResultsDirectory();
 
-			/*
-			 * Call other parts of citus that need to integrate into
-			 * transaction management. Do so before doing other work, so the
-			 * callbacks still can perform work if needed.
-			 */
-			{
-				/*
-				 * On Windows it's not possible to delete a file before you've closed all
-				 * handles to it (rmdir will return success but not take effect). Since
-				 * we're in an ABORT handler it's very likely that not all handles have
-				 * been closed; force them closed here before running
-				 * RemoveIntermediateResultsDirectory.
-				 */
-				AtEOXact_Files(false);
-				RemoveIntermediateResultsDirectory();
-			}
 			ResetShardPlacementTransactionState();
 
 			/* handles both already prepared and open transactions */


### PR DESCRIPTION
DESCRIPTION: Remove open temporary file warning when cancelling a query with an open tuple store

A remnant of (long-deprecated) Windows support (https://github.com/citusdata/citus/pull/2115) caused warnings when aborting queries with open tuple stores. Remove the call to `AtEOXact_Files`, since PostgreSQL will call it after the abort handler in `AbortTransaction`.

Fixes #4802