### PR TITLE
Make sure that local execution starts coordinated transaction

### DIFF
--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -209,6 +209,19 @@ ExecuteLocalTaskListExtended(List *taskList,
 	Oid *parameterTypes = NULL;
 	uint64 totalRowsProcessed = 0;
 
+	/*
+	 * Even if we are executing local tasks, we still enable
+	 * coordinated transaction. This is because
+	 *  (a) we might be in a transaction, and the next commands may
+	 *      require coordinated transaction
+	 *  (b) we might be executing some tasks locally and the others
+	 *      via remote execution
+	 *
+	 * Also, there is no harm enabling coordinated transaction even if
+	 * we only deal with local tasks in the transaction.
+	 */
+	UseCoordinatedTransaction();
+
 	if (paramListInfo != NULL)
 	{
 		/* not used anywhere, so declare here */

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -1986,7 +1986,11 @@ ROLLBACK;
 WITH cte_1 AS (UPDATE another_schema_table SET b = b + 1 WHERE a = 1 RETURNING *)
 SELECT coordinated_transaction_should_use_2PC() FROM cte_1;
 NOTICE:  executing the command locally: WITH cte_1 AS (UPDATE single_node.another_schema_table_90630511 another_schema_table SET b = (another_schema_table.b OPERATOR(pg_catalog.+) 1) WHERE (another_schema_table.a OPERATOR(pg_catalog.=) 1) RETURNING another_schema_table.a, another_schema_table.b) SELECT single_node.coordinated_transaction_should_use_2pc() AS coordinated_transaction_should_use_2pc FROM cte_1
-ERROR:  The transaction is not a coordinated transaction
+ coordinated_transaction_should_use_2pc
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- if the local execution is disabled, we cannot failover to
 -- local execution and the queries would fail
 SET citus.enable_local_execution TO  false;


### PR DESCRIPTION
With https://github.com/citusdata/citus/pull/4806 we enabled
2PC for any non-read-only local task. However, if the execution
is a single task, enabling 2PC (CoordinatedTransactionShouldUse2PC)
hits an assertion as we are not in a coordinated transaction.

There is no downside of using a coordinated transaction for single
task local queries.

Fixes #4829

DESCRIPTION: Makes sure that local execution starts coordinated transaction