### PR TITLE
Add citus_partitioned_shard_total_size for shard rebalancing

### DIFF
--- a/src/backend/distributed/sql/citus--10.0-3--10.1-1.sql
+++ b/src/backend/distributed/sql/citus--10.0-3--10.1-1.sql
@@ -2,3 +2,4 @@
 
 #include "../../columnar/sql/columnar--10.0-3--10.1-1.sql"
 #include "udfs/create_distributed_table/10.1-1.sql";
+#include "udfs/citus_partitioned_shard_total_size/10.1-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--10.1-1--10.0-3.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.1-1--10.0-3.sql
@@ -1,4 +1,4 @@
--- citus--10.1-1--10.0-2
+-- citus--10.1-1--10.0-3
 
 #include "../../../columnar/sql/downgrades/columnar--10.1-1--10.0-3.sql"
 
@@ -15,3 +15,4 @@ COMMENT ON FUNCTION create_distributed_table(table_name regclass,
 											 distribution_type citus.distribution_type,
 											 colocate_with text)
     IS 'creates a distributed table';
+DROP FUNCTION pg_catalog.citus_partitioned_shard_total_size(text);

--- a/src/backend/distributed/sql/udfs/citus_partitioned_shard_total_size/10.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_partitioned_shard_total_size/10.1-1.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_partitioned_shard_total_size(text)
+    RETURNS bigint
+    AS 'MODULE_PATHNAME', $$citus_partitioned_shard_total_size$$
+    LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION pg_catalog.citus_partitioned_shard_total_size(text)
+    IS 'Finds and returns the total size of a partitioned shard';

--- a/src/backend/distributed/sql/udfs/citus_partitioned_shard_total_size/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_partitioned_shard_total_size/latest.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_partitioned_shard_total_size(text)
+    RETURNS bigint
+    AS 'MODULE_PATHNAME', $$citus_partitioned_shard_total_size$$
+    LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION pg_catalog.citus_partitioned_shard_total_size(text)
+    IS 'Finds and returns the total size of a partitioned shard';

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -23,6 +23,7 @@ extern bool ShardsColocated(ShardInterval *leftShardInterval,
 							ShardInterval *rightShardInterval);
 extern List * ColocatedTableList(Oid distributedTableId);
 extern List * ColocatedShardIntervalList(ShardInterval *shardInterval);
+extern List * ColocatedNonPartitionShardIntervalList(ShardInterval *shardInterval);
 extern Oid ColocatedTableId(Oid colocationId);
 extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
 uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType,

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -203,7 +203,8 @@ extern List * AllShardPlacementsOnNodeGroup(int32 groupId);
 extern List * AllShardPlacementsWithShardPlacementState(ShardState shardState);
 extern List * GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId);
 extern StringInfo GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList,
-														char *sizeQuery);
+														char *sizeQuery, bool
+														skipPartitions);
 extern List * RemoveCoordinatorPlacementIfNotSingleNode(List *placementList);
 extern ShardPlacement * ShardPlacementOnGroup(uint64 shardId, int groupId);
 

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -560,11 +560,12 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.1-1
 ALTER EXTENSION citus UPDATE TO '10.1-1';
 SELECT * FROM print_extension_changes();
- previous_object |              current_object
+                                previous_object                                |                                    current_object
 ---------------------------------------------------------------------
  function create_distributed_table(regclass,text,citus.distribution_type,text) |
+                                                                               | function citus_partitioned_shard_total_size(text)
                                                                                | function create_distributed_table(regclass,text,citus.distribution_type,text,integer)
-(2 rows)
+(3 rows)
 
 DROP TABLE prev_objects, extension_diff;
 -- show running version

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -417,6 +417,31 @@ SELECT * FROM partitioning_test WHERE id = 1 OR id = 2 ORDER BY 1;
   2 | 07-07-2010
 (2 rows)
 
+-- check the shard size
+SELECT * FROM citus_shard_cost_by_disk_size(1660000);
+ citus_shard_cost_by_disk_size
+---------------------------------------------------------------------
+                        499712
+(1 row)
+
+SELECT * FROM citus_shard_cost_by_disk_size(1660001);
+ citus_shard_cost_by_disk_size
+---------------------------------------------------------------------
+                        557056
+(1 row)
+
+SELECT * FROM citus_shard_cost_by_disk_size(1660002);
+ citus_shard_cost_by_disk_size
+---------------------------------------------------------------------
+                        270336
+(1 row)
+
+SELECT * FROM citus_shard_cost_by_disk_size(1660003);
+ citus_shard_cost_by_disk_size
+---------------------------------------------------------------------
+                        368640
+(1 row)
+
 -- test DELETE
 -- DELETE from partitioned table
 DELETE FROM partitioning_test WHERE id = 9;

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -72,6 +72,7 @@ ORDER BY 1;
  function citus_jsonb_concatenate_final(jsonb)
  function citus_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode)
  function citus_node_capacity_1(integer)
+ function citus_partitioned_shard_total_size(text)
  function citus_prepare_pg_upgrade()
  function citus_query_stats()
  function citus_relation_size(regclass)
@@ -243,5 +244,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(227 rows)
+(228 rows)
 

--- a/src/test/regress/expected/upgrade_list_citus_objects_0.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects_0.out
@@ -69,6 +69,7 @@ ORDER BY 1;
  function citus_jsonb_concatenate_final(jsonb)
  function citus_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode)
  function citus_node_capacity_1(integer)
+ function citus_partitioned_shard_total_size(text)
  function citus_prepare_pg_upgrade()
  function citus_query_stats()
  function citus_relation_size(regclass)
@@ -239,5 +240,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(223 rows)
+(224 rows)
 

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -268,6 +268,12 @@ WHERE
 -- see the data is updated
 SELECT * FROM partitioning_test WHERE id = 1 OR id = 2 ORDER BY 1;
 
+-- check the shard size
+SELECT * FROM citus_shard_cost_by_disk_size(1660000);
+SELECT * FROM citus_shard_cost_by_disk_size(1660001);
+SELECT * FROM citus_shard_cost_by_disk_size(1660002);
+SELECT * FROM citus_shard_cost_by_disk_size(1660003);
+
 -- test DELETE
 -- DELETE from partitioned table
 DELETE FROM partitioning_test WHERE id = 9;


### PR DESCRIPTION
DESCRIPTION: Adds new udf `citus_partitioned_shard_total_size` for shard rebalancer

fixes: #4740 

Created a new UDF named citus_partitioned_shard_total_size(text) which takes a shard name and returns the total size of it's partitions. We are doing this to avoid generating huge size queries. As seen on the [flamegraph](https://github.com/citusdata/citus/issues/4740#issuecomment-803058591), `GenerateSizeQueryOnMultiplePlacements` takes too much time to generate the size query. Therefore using the new UDF `citus_partitioned_shard_total_size` will speed up our shard rebalancing feature.