### PR TITLE
Keep more execution statistics

### DIFF
--- a/src/test/regress/expected/multi_mx_reference_table.out
+++ b/src/test/regress/expected/multi_mx_reference_table.out
@@ -918,26 +918,14 @@ SELECT create_reference_table('numbers');
 
 (1 row)
 
-SET client_min_messages TO debug4;
+SET log_min_messages TO debug4;
 INSERT INTO numbers VALUES (1), (2), (3), (4);
-DEBUG:  Creating router plan
-DEBUG:  query before rebuilding: (null)
-DEBUG:  query after rebuilding:  INSERT INTO public.numbers_1250015 AS citus_table_alias (a) VALUES (1), (2), (3), (4)
-DEBUG:  assigned task to node localhost:xxxxx
-DEBUG:  opening 1 new connections to localhost:xxxxx
-DEBUG:  established connection to localhost:xxxxx for session 4
-DEBUG:  opening 1 new connections to localhost:xxxxx
-DEBUG:  established connection to localhost:xxxxx for session 5
-DEBUG:  Total number of commands sent over the session 4: 1
-DEBUG:  Total number of commands sent over the session 5: 1
 SELECT count(*) FROM numbers;
-DEBUG:  Distributed planning for a fast-path router query
-DEBUG:  Creating router plan
  count
 ---------------------------------------------------------------------
      4
 (1 row)
 
-RESET client_min_messages;
+RESET log_min_messages;
 -- clean up tables
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, numbers;

--- a/src/test/regress/sql/multi_mx_reference_table.sql
+++ b/src/test/regress/sql/multi_mx_reference_table.sql
@@ -562,10 +562,10 @@ SET citus.log_multi_join_order TO FALSE;
 -- issue 3766
 CREATE TABLE numbers(a int);
 SELECT create_reference_table('numbers');
-SET client_min_messages TO debug4;
+SET log_min_messages TO debug4;
 INSERT INTO numbers VALUES (1), (2), (3), (4);
 SELECT count(*) FROM numbers;
-RESET client_min_messages;
+RESET log_min_messages;
 
 -- clean up tables
 DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, numbers;


### PR DESCRIPTION
DESCRIPTION: When DEBUG4 enabled, Citus prints per task execution times

(First of the series of 3 patches that fixes #4689, wait until all pieces are ready before review)