### PR TITLE
Fix shard not found issue for public schema

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4361,16 +4361,8 @@ FragmentAlias(RangeTblEntry *rangeTableEntry, RangeTableFragment *fragment)
 		Oid relationId = rangeTableEntry->relid;
 		char *relationName = get_rel_name(relationId);
 
-		/*
-		 * If the table is not in the default namespace (public), we include it in
-		 * the fragment alias.
-		 */
 		Oid schemaId = get_rel_namespace(relationId);
 		schemaName = get_namespace_name(schemaId);
-		if (strncmp(schemaName, "public", NAMEDATALEN) == 0)
-		{
-			schemaName = NULL;
-		}
 
 		aliasName = relationName;
 

--- a/src/test/regress/expected/alter_role_propagation.out
+++ b/src/test/regress/expected/alter_role_propagation.out
@@ -275,4 +275,22 @@ SELECT run_command_on_workers('SHOW enable_hashjoin');
  (localhost,57638,t,on)
 (2 rows)
 
-DROP SCHEMA alter_role, ",CitUs,.TeeN!?" CASCADE;
+-- check altering search path won't cause public shards being not found
+CREATE TABLE test_search_path(a int);
+SELECT create_distributed_table('test_search_path', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE SCHEMA test_sp;
+ALTER USER current_user SET search_path TO test_sp;
+SELECT COUNT(*) FROM public.test_search_path;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+ALTER USER current_user RESET search_path;
+DROP TABLE test_search_path;
+DROP SCHEMA alter_role, ",CitUs,.TeeN!?", test_sp CASCADE;

--- a/src/test/regress/expected/failure_1pc_copy_append.out
+++ b/src/test/regress/expected/failure_1pc_copy_append.out
@@ -52,7 +52,7 @@ SELECT citus.dump_network_traffic();
  (0,worker,"[""RowDescription(fieldcount=2,fields=['F(name=min,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=max,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)'])"", 'DataRow(columncount=2,columns=[""C(length=0,value=b\\'\\')"", ""C(length=1,value=b\\'0\\')""])', 'CommandComplete(command=SELECT 1)', 'ReadyForQuery(state=in_transaction_block)']")
  (0,coordinator,"['Query(query=COMMIT)']")
  (0,worker,"['CommandComplete(command=COMMIT)', 'ReadyForQuery(state=idle)']")
- (0,coordinator,"['Query(query=SELECT count(1) AS count FROM copy_test_100400 copy_test WHERE true)']")
+ (0,coordinator,"['Query(query=SELECT count(1) AS count FROM public.copy_test_XXXXXX copy_test WHERE true)']")
  (0,worker,"[""RowDescription(fieldcount=1,fields=['F(name=count,tableoid=0,colattrnum=0,typoid=20,typlen=8,typmod=-1,format_code=0)'])"", 'DataRow(columncount=1,columns=[""C(length=0,value=b\\'\\')""])', 'CommandComplete(command=SELECT 1)', 'ReadyForQuery(state=idle)']")
 (20 rows)
 

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -156,10 +156,10 @@ step s3-view-worker:
 
 query          query_hostname query_hostport distributed_query_host_namedistributed_query_host_portstate          wait_event_typewait_event     usename        datname
 
-SELECT count(*) AS count FROM test_table_1300014 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-SELECT count(*) AS count FROM test_table_1300013 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-SELECT count(*) AS count FROM test_table_1300012 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
-SELECT count(*) AS count FROM test_table_1300011 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+SELECT count(*) AS count FROM public.test_table_1300014 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+SELECT count(*) AS count FROM public.test_table_1300013 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+SELECT count(*) AS count FROM public.test_table_1300012 test_table WHERE truelocalhost      57638          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
+SELECT count(*) AS count FROM public.test_table_1300011 test_table WHERE truelocalhost      57637          coordinator_host57636          idle in transactionClient         ClientRead     postgres       regression
 step s2-rollback:
  ROLLBACK;
 

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -357,7 +357,7 @@ Sort (actual rows=50 loops=1)
               Tuple data received from nodes: 780 bytes
               Tasks Shown: One of 2
               ->  Task
-                    Query: SELECT l_quantity, count(*) AS count_quantity FROM lineitem_290000 lineitem WHERE true GROUP BY l_quantity
+                    Query: SELECT l_quantity, count(*) AS count_quantity FROM public.lineitem_290000 lineitem WHERE true GROUP BY l_quantity
                     Tuple data received from node: 390 bytes
                     Node: host=localhost port=xxxxx dbname=regression
                     ->  HashAggregate (actual rows=50 loops=1)
@@ -380,7 +380,7 @@ Sort
               Task Count: 2
               Tasks Shown: One of 2
               ->  Task
-                    Query: SELECT l_quantity, count(*) AS count_quantity FROM lineitem_290000 lineitem WHERE true GROUP BY l_quantity
+                    Query: SELECT l_quantity, count(*) AS count_quantity FROM public.lineitem_290000 lineitem WHERE true GROUP BY l_quantity
                     Node: host=localhost port=xxxxx dbname=regression
                     ->  HashAggregate
                           Output: l_quantity, count(*)
@@ -397,7 +397,7 @@ Aggregate
         Task Count: 2
         Tasks Shown: One of 2
         ->  Task
-              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity) FROM lineitem_290000 lineitem WHERE true
+              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity) FROM public.lineitem_290000 lineitem WHERE true
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
                     Output: sum(l_quantity), sum(l_quantity), count(l_quantity)
@@ -532,7 +532,7 @@ Aggregate
         Task Count: 2
         Tasks Shown: One of 2
         ->  Task
-              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity), sum(l_quantity) AS worker_column_4 FROM lineitem_290000 lineitem WHERE true
+              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity), sum(l_quantity) AS worker_column_4 FROM public.lineitem_290000 lineitem WHERE true
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
                     Output: sum(l_quantity), sum(l_quantity), count(l_quantity), sum(l_quantity)
@@ -552,7 +552,7 @@ HashAggregate
         Task Count: 2
         Tasks Shown: One of 2
         ->  Task
-              Query: SELECT l_quantity, l_quantity AS worker_column_2 FROM lineitem_290000 lineitem WHERE true GROUP BY l_quantity
+              Query: SELECT l_quantity, l_quantity AS worker_column_2 FROM public.lineitem_290000 lineitem WHERE true GROUP BY l_quantity
               Node: host=localhost port=xxxxx dbname=regression
               ->  HashAggregate
                     Output: l_quantity, l_quantity
@@ -1405,7 +1405,7 @@ Custom Scan (Citus Adaptive)
                     Task Count: 4
                     Tasks Shown: One of 4
                     ->  Task
-                          Query: SELECT DISTINCT l_orderkey FROM lineitem_hash_part_360041 lineitem_hash_part WHERE true
+                          Query: SELECT DISTINCT l_orderkey FROM public.lineitem_hash_part_360041 lineitem_hash_part WHERE true
                           Node: host=localhost port=xxxxx dbname=regression
                           ->  HashAggregate
                                 Output: l_orderkey

--- a/src/test/regress/expected/multi_mx_explain.out
+++ b/src/test/regress/expected/multi_mx_explain.out
@@ -291,7 +291,7 @@ Aggregate
         Task Count: 16
         Tasks Shown: One of 16
         ->  Task
-              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity) FROM lineitem_mx_1220052 lineitem_mx WHERE true
+              Query: SELECT sum(l_quantity), sum(l_quantity), count(l_quantity) FROM public.lineitem_mx_1220052 lineitem_mx WHERE true
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
                     Output: sum(l_quantity), sum(l_quantity), count(l_quantity)

--- a/src/test/regress/output/multi_complex_count_distinct.source
+++ b/src/test/regress/output/multi_complex_count_distinct.source
@@ -73,7 +73,7 @@ SELECT
                Task Count: 8
                Tasks Shown: One of 8
                ->  Task
-                     Query: SELECT l_orderkey, count(DISTINCT l_partkey) AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_partkey)) DESC, l_orderkey DESC LIMIT '10'::bigint
+                     Query: SELECT l_orderkey, count(DISTINCT l_partkey) AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_partkey)) DESC, l_orderkey DESC LIMIT '10'::bigint
                      Node: host=localhost port=xxxxx dbname=regression
                      ->  Limit
                            Output: l_orderkey, (count(DISTINCT l_partkey))
@@ -118,7 +118,7 @@ SELECT
                      Task Count: 8
                      Tasks Shown: One of 8
                      ->  Task
-                           Query: SELECT l_partkey AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_partkey
+                           Query: SELECT l_partkey AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_partkey
                            Node: host=localhost port=xxxxx dbname=regression
                            ->  HashAggregate
                                  Output: l_partkey
@@ -169,7 +169,7 @@ SELECT
                            Task Count: 8
                            Tasks Shown: One of 8
                            ->  Task
-                                 Query: SELECT l_shipmode, l_partkey AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_shipmode, l_partkey
+                                 Query: SELECT l_shipmode, l_partkey AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_shipmode, l_partkey
                                  Node: host=localhost port=xxxxx dbname=regression
                                  ->  HashAggregate
                                        Output: l_shipmode, l_partkey
@@ -218,7 +218,7 @@ SELECT
                Task Count: 8
                Tasks Shown: One of 8
                ->  Task
-                     Query: SELECT l_orderkey, count(DISTINCT l_partkey) AS count, count(DISTINCT l_shipmode) AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_shipmode)) DESC, (count(DISTINCT l_partkey)) DESC, l_orderkey LIMIT '10'::bigint
+                     Query: SELECT l_orderkey, count(DISTINCT l_partkey) AS count, count(DISTINCT l_shipmode) AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_shipmode)) DESC, (count(DISTINCT l_partkey)) DESC, l_orderkey LIMIT '10'::bigint
                      Node: host=localhost port=xxxxx dbname=regression
                      ->  Limit
                            Output: l_orderkey, (count(DISTINCT l_partkey)), (count(DISTINCT l_shipmode))
@@ -254,7 +254,7 @@ SELECT
          Task Count: 8
          Tasks Shown: One of 8
          ->  Task
-               Query: SELECT l_orderkey AS count, l_partkey AS count, l_shipmode AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey, l_partkey, l_shipmode
+               Query: SELECT l_orderkey AS count, l_partkey AS count, l_shipmode AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey, l_partkey, l_shipmode
                Node: host=localhost port=xxxxx dbname=regression
                ->  HashAggregate
                      Output: l_orderkey, l_partkey, l_shipmode
@@ -422,7 +422,7 @@ SELECT *
                      Task Count: 8
                      Tasks Shown: One of 8
                      ->  Task
-                           Query: SELECT l_partkey, count(DISTINCT l_orderkey) AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_partkey
+                           Query: SELECT l_partkey, count(DISTINCT l_orderkey) AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_partkey
                            Node: host=localhost port=xxxxx dbname=regression
                            ->  GroupAggregate
                                  Output: l_partkey, count(DISTINCT l_orderkey)
@@ -491,7 +491,7 @@ SELECT
                Task Count: 8
                Tasks Shown: One of 8
                ->  Task
-                     Query: SELECT l_orderkey, count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode OPERATOR(pg_catalog.=) 'AIR'::bpchar)) AS count, count(DISTINCT l_suppkey) AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode OPERATOR(pg_catalog.=) 'AIR'::bpchar))) DESC, (count(DISTINCT l_suppkey)) DESC, l_orderkey LIMIT '10'::bigint
+                     Query: SELECT l_orderkey, count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode OPERATOR(pg_catalog.=) 'AIR'::bpchar)) AS count, count(DISTINCT l_suppkey) AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_orderkey ORDER BY (count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode OPERATOR(pg_catalog.=) 'AIR'::bpchar))) DESC, (count(DISTINCT l_suppkey)) DESC, l_orderkey LIMIT '10'::bigint
                      Node: host=localhost port=xxxxx dbname=regression
                      ->  Limit
                            Output: l_orderkey, (count(DISTINCT l_suppkey) FILTER (WHERE (l_shipmode = 'AIR'::bpchar))), (count(DISTINCT l_suppkey))
@@ -552,7 +552,7 @@ SELECT
                            Task Count: 8
                            Tasks Shown: One of 8
                            ->  Task
-                                 Query: SELECT l_suppkey, l_partkey AS count, l_shipmode AS count FROM lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_suppkey, l_partkey, l_shipmode
+                                 Query: SELECT l_suppkey, l_partkey AS count, l_shipmode AS count FROM public.lineitem_hash_240000 lineitem_hash WHERE true GROUP BY l_suppkey, l_partkey, l_shipmode
                                  Node: host=localhost port=xxxxx dbname=regression
                                  ->  HashAggregate
                                        Output: l_suppkey, l_partkey, l_shipmode

--- a/src/test/regress/sql/alter_role_propagation.sql
+++ b/src/test/regress/sql/alter_role_propagation.sql
@@ -90,4 +90,13 @@ SELECT run_command_on_workers('SHOW enable_hashjoin');
 ALTER ROLE ALL RESET enable_hashjoin;
 SELECT run_command_on_workers('SHOW enable_hashjoin');
 
-DROP SCHEMA alter_role, ",CitUs,.TeeN!?" CASCADE;
+-- check altering search path won't cause public shards being not found
+CREATE TABLE test_search_path(a int);
+SELECT create_distributed_table('test_search_path', 'a');
+CREATE SCHEMA test_sp;
+ALTER USER current_user SET search_path TO test_sp;
+SELECT COUNT(*) FROM public.test_search_path;
+ALTER USER current_user RESET search_path;
+
+DROP TABLE test_search_path;
+DROP SCHEMA alter_role, ",CitUs,.TeeN!?", test_sp CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes issues caused by public schema being omitted in queries

We used to neglect `public` as a schema in the planner. Removing that if statement.

fixes: #4735 
fixes: #4857