### PR TITLE
Executor takes connection establishment and task execution costs into account

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -2454,6 +2454,9 @@ ManageWorkerPool(WorkerPool *workerPool)
 		return;
 	}
 
+	/* increase the open rate every cycle (like TCP slow start) */
+	workerPool->maxNewConnectionsPerCycle += 1;
+
 	OpenNewConnections(workerPool, newConnectionCount, execution->transactionProperties);
 
 	/*
@@ -2641,10 +2644,7 @@ CalculateNewConnectionCount(WorkerPool *workerPool)
 		 */
 		newConnectionCount = Min(newConnectionsForReadyTasks, maxNewConnectionCount);
 		if (newConnectionCount > 0)
-		{
-			/* increase the open rate every cycle (like TCP slow start) */
-			workerPool->maxNewConnectionsPerCycle += 1;
-		}
+		{ }
 	}
 	return newConnectionCount;
 }

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -966,6 +966,18 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_cost_based_connection_establishment",
+		gettext_noop("When enabled the connection establishment times "
+					 "and task execution times into account for deciding "
+					 "whether or not to establish new connections."),
+		NULL,
+		&EnableCostBasedConnectionEstablishment,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.explain_distributed_queries",
 		gettext_noop("Enables Explain for distributed queries."),
 		gettext_noop("When enabled, the Explain command shows remote and local "

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -8,8 +8,10 @@ extern bool ForceMaxQueryParallelization;
 extern int MaxAdaptiveExecutorPoolSize;
 extern bool EnableBinaryProtocol;
 
+
 /* GUC, number of ms to wait between opening connections to the same worker */
 extern int ExecutorSlowStartInterval;
+extern bool EnableCostBasedConnectionEstablishment;
 
 extern bool ShouldRunTasksSequentially(List *taskList);
 extern uint64 ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported);


### PR DESCRIPTION
With this commit, the executor becomes smarter about refrain to open
new connections. The very basic example is that, if the connection
establishments take 1000ms and task executions as 5 msecs, the executor
becomes smart enough to not establish new connections.

DESCRIPTION: Executor refrains from opening extra connections

TODO:

- [x] Benchmark on empty tables
- [x] Benchmark on tables where queries take 50msec, 100msecs, 200msec, 500msecs and 1000msecs
- [x] Benchmarks with -c 1,2,16,32,256
- [x] Benchmark on single node
- [x] All benchmarks should count the total number of connections established during the benchmark, the connection SSL errors, tps and latencies
- [x] Benchmark with different shard counts


Here are the benchmark results: https://microsoft-my.sharepoint.com/:x:/p/onderk/ES7sAIzx5K5NlHquVPLFT7IBsz2FFBTrJCazSBOKOWTuxA?e=GDEZue