### PR TITLE
Notice users about no shard moves in rebalance

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1102,6 +1102,7 @@ RebalanceTableShards(RebalanceOptions *options, Oid shardReplicationModeOid)
 
 	if (list_length(placementUpdateList) == 0)
 	{
+		ereport(NOTICE, (errmsg("There are no rebalance moves for your current cluster.")));
 		return;
 	}
 


### PR DESCRIPTION
When there are no shard moves during rebalancing, it doesn't give any message hence it is a bit confusing if rebalancing happened. I thought we could add a NOTICE message, any thoughts? (will update tests if agreed)