### PR TITLE
Fix data-race with concurrent calls of DropMarkedShards

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -644,7 +644,8 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 				 */
 				lastShardCleanTime = GetCurrentTimestamp();
 
-				numberOfDroppedShards = TryDropMarkedShards();
+				bool waitForCleanupLock = false;
+				numberOfDroppedShards = TryDropMarkedShards(waitForCleanupLock);
 			}
 
 			CommitTransactionCommand();

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -388,6 +388,37 @@ SetLocktagForShardDistributionMetadata(int64 shardId, LOCKTAG *tag)
 
 
 /*
+ * LockPlacementCleanup takes an exclusive lock to ensure that only one process
+ * can cleanup placements at the same time.
+ */
+void
+LockPlacementCleanup(void)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+	const bool dontWait = false;
+	SET_LOCKTAG_PLACEMENT_CLEANUP(tag);
+	(void) LockAcquire(&tag, ExclusiveLock, sessionLock, dontWait);
+}
+
+
+/*
+ * TryLockPlacementCleanup takes an exclusive lock to ensure that only one
+ * process can cleanup placements at the same time.
+ */
+bool
+TryLockPlacementCleanup(void)
+{
+	LOCKTAG tag;
+	const bool sessionLock = false;
+	const bool dontWait = true;
+	SET_LOCKTAG_PLACEMENT_CLEANUP(tag);
+	bool lockAcquired = LockAcquire(&tag, ExclusiveLock, sessionLock, dontWait);
+	return lockAcquired;
+}
+
+
+/*
  * LockReferencedReferenceShardDistributionMetadata acquires shard distribution
  * metadata locks with the given lock mode on the reference tables which has a
  * foreign key from the given relation.

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -39,10 +39,10 @@ typedef enum AdvisoryLocktagClass
 	ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION = 7,
 	ADV_LOCKTAG_CLASS_CITUS_COLOCATED_SHARDS_METADATA = 8,
 	ADV_LOCKTAG_CLASS_CITUS_OPERATIONS = 9,
-	ADV_LOCKTAG_CLASS_CITUS_PLACEMENT_CLEANUP = 11,
+	ADV_LOCKTAG_CLASS_CITUS_PLACEMENT_CLEANUP = 10,
 
 	/* Columnar lock types */
-	ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION = 10
+	ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION = 11
 } AdvisoryLocktagClass;
 
 /* CitusOperations has constants for citus operations */
@@ -109,7 +109,7 @@ typedef enum CitusOperations
 						 0, \
 						 ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION)
 
-/* reuse advisory lock, but with different, unused field 4 (11)
+/* reuse advisory lock, but with different, unused field 4 (10)
  * Also it has the database hardcoded to MyDatabaseId, to ensure the locks
  * are local to each database */
 #define SET_LOCKTAG_PLACEMENT_CLEANUP(tag) \

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -39,6 +39,7 @@ typedef enum AdvisoryLocktagClass
 	ADV_LOCKTAG_CLASS_CITUS_REBALANCE_COLOCATION = 7,
 	ADV_LOCKTAG_CLASS_CITUS_COLOCATED_SHARDS_METADATA = 8,
 	ADV_LOCKTAG_CLASS_CITUS_OPERATIONS = 9,
+	ADV_LOCKTAG_CLASS_CITUS_PLACEMENT_CLEANUP = 11,
 
 	/* Columnar lock types */
 	ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION = 10
@@ -108,8 +109,21 @@ typedef enum CitusOperations
 						 0, \
 						 ADV_LOCKTAG_CLASS_COLUMNAR_STRIPE_RESERVATION)
 
+/* reuse advisory lock, but with different, unused field 4 (11)
+ * Also it has the database hardcoded to MyDatabaseId, to ensure the locks
+ * are local to each database */
+#define SET_LOCKTAG_PLACEMENT_CLEANUP(tag) \
+	SET_LOCKTAG_ADVISORY(tag, \
+						 MyDatabaseId, \
+						 (uint32) 0, \
+						 (uint32) 0, \
+						 ADV_LOCKTAG_CLASS_CITUS_PLACEMENT_CLEANUP)
+
+
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
+extern void LockPlacementCleanup(void);
+extern bool TryLockPlacementCleanup(void);
 extern void LockShardListMetadataOnWorkers(LOCKMODE lockmode, List *shardIntervalList);
 extern void BlockWritesToShardList(List *shardList);
 

--- a/src/include/distributed/shard_cleaner.h
+++ b/src/include/distributed/shard_cleaner.h
@@ -15,6 +15,6 @@
 extern int DeferShardDeleteInterval;
 extern bool DeferShardDeleteOnMove;
 
-extern int TryDropMarkedShards(void);
+extern int TryDropMarkedShards(bool waitForCleanupLock);
 
 #endif /*CITUS_SHARD_CLEANER_H */

--- a/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
+++ b/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
@@ -1,0 +1,56 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-move-placement s1-drop-marked-shards s2-drop-marked-shards s1-commit
+step s1-begin:
+    BEGIN;
+
+step s1-move-placement:
+        SET citus.defer_drop_after_shard_move TO ON;
+     SELECT master_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57637, 'localhost', 57638);
+
+master_move_shard_placement
+
+
+step s1-drop-marked-shards:
+    SELECT public.master_defer_delete_shards();
+
+master_defer_delete_shards
+
+1
+step s2-drop-marked-shards:
+    SELECT public.master_defer_delete_shards();
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-drop-marked-shards: <... completed>
+master_defer_delete_shards
+
+0
+
+starting permutation: s1-begin s1-move-placement s2-drop-marked-shards s1-drop-marked-shards s1-commit
+step s1-begin:
+    BEGIN;
+
+step s1-move-placement:
+        SET citus.defer_drop_after_shard_move TO ON;
+     SELECT master_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57637, 'localhost', 57638);
+
+master_move_shard_placement
+
+
+step s2-drop-marked-shards:
+    SELECT public.master_defer_delete_shards();
+
+master_defer_delete_shards
+
+0
+step s1-drop-marked-shards:
+    SELECT public.master_defer_delete_shards();
+
+master_defer_delete_shards
+
+1
+step s1-commit:
+    COMMIT;
+

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -72,6 +72,7 @@ test: isolation_blocking_move_multi_shard_commands
 test: isolation_blocking_move_single_shard_commands_on_mx
 test: isolation_blocking_move_multi_shard_commands_on_mx
 test: isolation_shard_rebalancer
+test: isolation_rebalancer_deferred_drop
 
 # MX tests
 test: isolation_reference_on_mx

--- a/src/test/regress/spec/isolation_rebalancer_deferred_drop.spec
+++ b/src/test/regress/spec/isolation_rebalancer_deferred_drop.spec
@@ -1,0 +1,66 @@
+// we use 15 as the partition key value through out the test
+// so setting the corresponding shard here is useful
+setup
+{
+  SELECT citus_internal.replace_isolation_tester_func();
+  SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+
+CREATE OR REPLACE FUNCTION master_defer_delete_shards()
+    RETURNS int
+    LANGUAGE C STRICT
+    AS 'citus', $$master_defer_delete_shards$$;
+COMMENT ON FUNCTION master_defer_delete_shards()
+    IS 'remove orphaned shards';
+
+	SET citus.shard_count TO 8;
+	SET citus.shard_replication_factor TO 1;
+    SET citus.defer_drop_after_shard_move TO ON;
+	CREATE TABLE t1 (x int PRIMARY KEY, y int);
+	SELECT create_distributed_table('t1', 'x');
+
+	SELECT get_shard_id_for_distribution_column('t1', 15) INTO selected_shard;
+}
+
+teardown
+{
+  SELECT citus_internal.restore_isolation_tester_func();
+
+  DROP TABLE selected_shard;
+  DROP TABLE t1;
+}
+
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-move-placement"
+{
+        SET citus.defer_drop_after_shard_move TO ON;
+    	SELECT master_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57637, 'localhost', 57638);
+}
+
+step "s1-drop-marked-shards"
+{
+    SELECT public.master_defer_delete_shards();
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-drop-marked-shards"
+{
+    SELECT public.master_defer_delete_shards();
+}
+
+permutation "s1-begin" "s1-move-placement" "s1-drop-marked-shards" "s2-drop-marked-shards" "s1-commit"
+permutation "s1-begin" "s1-move-placement" "s2-drop-marked-shards" "s1-drop-marked-shards" "s1-commit"
+
+


### PR DESCRIPTION
When trying to enable `citus.defer_drop_after_shard_move` by default it
turned out that DropMarkedShards was not safe to call concurrently.
This could especially cause big problems when also moving shards at the
same time. During tests it was possible to trigger a state where a shard
that was moved would not be available on any of the nodes anymore after
the move.

Currently DropMarkedShards is only called in production by the
maintenaince deamon. Since this is only a single process triggering such
a race is currently impossible in production settings. In future changes
we will want to call DropMarkedShards from other places too though.

DESCRIPTION: Fixes problems with concurrent calls of DropMarkedShards

A possible example of problem:
- Shard 1 is moved from node A to node B
- Shard 1 is marked as "to-be-removed" in node A
- More than one DropMarkedShards calls are made for Shard 1 on node A because its state is "4" (to-be-removed). 
- The first drop call deletes "to-be-removed" Shard 1 Placement from node A
- Shard 1 is moved back to node A from node B
- The second drop call deletes the actual Shard 1 placement so we lost data now. Note that the shard placement of Shard 1 is different but it doesn't matter because the shard id is the same.