### PR TITLE
Preparation for adding citus 10.0 to upgrade tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
             # run make check-citus-upgrade for all citus versions
             # the image has ${CITUS_VERSIONS} set with all verions it contains the binaries of
             for citus_version in ${CITUS_VERSIONS}; do \
+              export upgrade_test_old_citus_version="$citus_version"; \
               gosu circleci \
                 make -C src/test/regress \
                   check-citus-upgrade \

--- a/src/test/regress/expected/upgrade_partition_constraints_after.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_after.out
@@ -1,3 +1,18 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
 -- test cases for #3970
 SET search_path = test_3970;
 --5. add a partition

--- a/src/test/regress/expected/upgrade_partition_constraints_after_0.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_after_0.out
@@ -1,0 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ f
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q

--- a/src/test/regress/expected/upgrade_partition_constraints_before.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_before.out
@@ -1,3 +1,18 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
 -- test cases for #3970
 CREATE SCHEMA test_3970;
 SET search_path = test_3970;

--- a/src/test/regress/expected/upgrade_partition_constraints_before_0.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_before_0.out
@@ -1,0 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ f
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
@@ -1,3 +1,18 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
 -- drop objects from previous test (uprade_basic_after.sql) for a clean test
 -- drop upgrade_basic schema and switch back to public schema
 SET search_path to public;

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after_0.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after_0.out
@@ -1,0 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ f
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
@@ -1,3 +1,18 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
 -- create some objects that we just included into distributed object
 -- infrastructure in 9.1 versions but not included in 9.0.2
 -- extension propagation --

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before_0.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before_0.out
@@ -1,0 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+ upgrade_test_old_citus_version_e_9_0
+---------------------------------------------------------------------
+ f
+(1 row)
+
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q

--- a/src/test/regress/sql/upgrade_partition_constraints_after.sql
+++ b/src/test/regress/sql/upgrade_partition_constraints_after.sql
@@ -1,3 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
+
 -- test cases for #3970
 SET search_path = test_3970;
 

--- a/src/test/regress/sql/upgrade_partition_constraints_before.sql
+++ b/src/test/regress/sql/upgrade_partition_constraints_before.sql
@@ -1,3 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
+
 -- test cases for #3970
 CREATE SCHEMA test_3970;
 SET search_path = test_3970;

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
@@ -1,3 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
+
 -- drop objects from previous test (uprade_basic_after.sql) for a clean test
 -- drop upgrade_basic schema and switch back to public schema
 SET search_path to public;

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
@@ -1,3 +1,14 @@
+-- run this test only when old citus version is 9.0
+\set upgrade_test_old_citus_version `echo "$upgrade_test_old_citus_version"`
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
+       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
+AS upgrade_test_old_citus_version_e_9_0;
+\gset
+\if :upgrade_test_old_citus_version_e_9_0
+\else
+\q
+\endif
+
 -- create some objects that we just included into distributed object
 -- infrastructure in 9.1 versions but not included in 9.0.2
 


### PR DESCRIPTION
For https://github.com/citusdata/citus/pull/4907, we needed to have citus 10.0 in upgrade-tester docker image.

In https://github.com/citusdata/the-process repo, I added v10.0.0 to citus versions and then pushed a temporary docker image for that.
In b39b1ec, we use that docker image temporarily.
After we merge https://github.com/citusdata/the-process/pull/57, we can remove that commit.

Since some of the upgrade tests should be run for specific citus versions (as in 3d2db86), we basically pass the `old citus version` being used during the current upgrade testing in a3118e1.

