### PR TITLE
Wait until all connections are successfully established

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1387,6 +1387,21 @@ RegisterCitusConfigVariables(void)
 		GUC_UNIT_KB | GUC_STANDARD,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.prevent_incomplete_connection_establishment",
+		gettext_noop("When enabled, the executor waits until all the connections "
+					 "are successfully established."),
+		gettext_noop("Under some load, the executor may decide to establish some "
+					 "extra connections to further parallelize the execution. However,"
+					 "before the connection establishment is done, the execution might "
+					 "have already finished. When this GUC is set to true, the execution "
+					 "waits for such connections to be established."),
+		&PreventIncompleteConnectionEstablishment,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomEnumVariable(
 		"citus.propagate_set_commands",
 		gettext_noop("Sets which SET commands are propagated to workers."),

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -12,6 +12,7 @@ extern bool EnableBinaryProtocol;
 /* GUC, number of ms to wait between opening connections to the same worker */
 extern int ExecutorSlowStartInterval;
 extern bool EnableCostBasedConnectionEstablishment;
+extern bool PreventIncompleteConnectionEstablishment;
 
 extern bool ShouldRunTasksSequentially(List *taskList);
 extern uint64 ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported);


### PR DESCRIPTION
Re-try of #4317. On #4317 we saw a significant performance penalty of waiting all the connections. With #4895 we decreased the performance penalty significantly by avoiding absolutely unnecessary connections.


Comment from the code:
```
/*
 * Iterate until all the tasks are finished. Once all the tasks
 * are finished, ensure that that all the connection initializations
 * are also finished. Otherwise, those connections are terminated
 * abruptly before they are established (or failed). Instead, we let
 * the ConnectionStateMachine() to properly handle them.
 *
 * Note that we could have the connections that are not established
 * as a side effect of slow-start algorithm. At the time the algorithm
 * decides to establish new connections, the execution might have tasks
 * to finish. But, the execution might finish before the new connections
 * are established.
 */
```
 Note that the abruptly terminated connections lead to the following errors:
```
2020-11-16 21:09:09.800 CET [16633] LOG:  could not accept SSL connection: Connection reset by peer
2020-11-16 21:09:09.872 CET [16657] LOG:  could not accept SSL connection: Undefined error: 0
2020-11-16 21:09:09.894 CET [16667] LOG:  could not accept SSL connection: Connection reset by peer
```
To easily reproduce the issue:

- Create a single node Citus
- Add the coordinator to the metadata
- Create a distributed table with shards on the coordinator
- f.sql:  select count(*) from test;
- pgbench -f /tmp/f.sql postgres -T 12 -c 40 -P 1  or pgbench -f /tmp/f.sql postgres -T 12 -c 40 -P 1 -C

DESCRIPTION: Prevent connection errors by properly terminating connections

TODO:
- [x] Perf benchmarks between Citus 10 and this branch: The results show that when the #clients  > 32, this patch has a significant performance gain. Else, this branch may drop the performance in a non-negligible manner: https://microsoft-my.sharepoint.com/:x:/p/onderk/ETSiWyHq-tdHk6zf4CpLvToBIgB36YZcqc34rx0S3Kf2lw?e=IT3LTk  
