### PR TITLE
Fix diff-filter to search the whole line for matches

### DIFF
--- a/src/test/regress/bin/diff-filter
+++ b/src/test/regress/bin/diff-filter
@@ -41,7 +41,7 @@ def main():
 		regexpipeline.append(re.compile(rule.group('rule')))
 
 	def sed(line):
-		if any(regex.match(line) for regex in regexpipeline):
+		if any(regex.search(line) for regex in regexpipeline):
 			return None
 		return line
 


### PR DESCRIPTION
Recently two new normalization line deletion rules have been added that
don't match the start of a line:
```
/local tables that are added to metadata but not chained with reference tables via foreign keys might be automatically converted back to postgres tables$/d
/Consider setting citus.enable_local_reference_table_foreign_keys to 'off' to disable this behavior$/d
```

Because `diff-filter` used `regex.match` these lines were not removed
when creating a new diff. This could cause some confusing diffs, where
the wrong lines were shown as changed. This fixes that by using
`regex.search` instead of `regex.match`.