### PR TITLE
Decrease memory usage with rebalancer

### DIFF
--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -700,6 +700,11 @@ CopyShardTables(List *shardIntervalList, char *sourceNodeName, int32 sourceNodeP
 {
 	ShardInterval *shardInterval = NULL;
 
+	MemoryContext localContext = AllocSetContextCreate(CurrentMemoryContext,
+													   "CopyShardTables",
+													   ALLOCSET_DEFAULT_SIZES);
+	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
+
 	/* iterate through the colocated shards and copy each */
 	foreach_ptr(shardInterval, shardIntervalList)
 	{
@@ -718,6 +723,8 @@ CopyShardTables(List *shardIntervalList, char *sourceNodeName, int32 sourceNodeP
 		SendCommandListToWorkerInSingleTransaction(targetNodeName, targetNodePort,
 												   tableOwner, ddlCommandList);
 	}
+
+	MemoryContextReset(localContext);
 
 
 	/*
@@ -750,7 +757,10 @@ CopyShardTables(List *shardIntervalList, char *sourceNodeName, int32 sourceNodeP
 
 		SendCommandListToWorkerInSingleTransaction(targetNodeName, targetNodePort,
 												   tableOwner, commandList);
+		MemoryContextReset(localContext);
 	}
+
+	MemoryContextSwitchTo(oldContext);
 }
 
 


### PR DESCRIPTION
We decrease memory usage by:
- Freeing temporary buffers
- Using separate memory context for blocks that uses "small" amount of
memory but can be repeated many times such as loops

DESCRIPTION: Reduces memory usage while rebalancing
