### PR TITLE
Bump PG versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
 
   check-merge-to-enterprise:
     docker:
-      - image: citus/extbuilder:13.0
+      - image: citus/extbuilder:13.2
     working_directory: /home/circleci/project
     steps:
       - checkout
@@ -430,11 +430,11 @@ workflows:
       - build:
           name: build-12
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
       - build:
           name: build-13
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
 
       - check-style
       - check-sql-snapshots
@@ -442,136 +442,136 @@ workflows:
       - test-citus:
           name: 'test-12_check-multi'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-multi
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-mx'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-multi-mx
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-vanilla'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-vanilla
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-isolation'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-isolation
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-worker'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-worker
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-operations'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-operations
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-follower-cluster'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-follower-cluster
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-columnar'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-columnar
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-columnar-isolation'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-columnar-isolation
           requires: [build-12]
       - tap-test-citus:
           name: 'test_12_tap-recovery'
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           suite: recovery
           requires: [build-12]
       - test-citus:
           name: 'test-12_check-failure'
           pg_major: 12
           image: citus/failtester
-          image_tag: '12.4'
+          image_tag: '12.6'
           make: check-failure
           requires: [build-12]
 
       - test-citus:
           name: 'test-13_check-multi'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-multi
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-mx'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-multi-mx
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-vanilla'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-vanilla
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-isolation'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-isolation
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-worker'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-worker
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-operations'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-operations
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-follower-cluster'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-follower-cluster
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-columnar'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-columnar
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-columnar-isolation'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-columnar-isolation
           requires: [build-13]
       - tap-test-citus:
           name: 'test_13_tap-recovery'
           pg_major: 13
-          image_tag: '13.0'
+          image_tag: '13.2'
           suite: recovery
           requires: [build-13]
       - test-citus:
           name: 'test-13_check-failure'
           pg_major: 13
           image: citus/failtester
-          image_tag: '13.0'
+          image_tag: '13.2'
           make: check-failure
           requires: [build-13]
 
@@ -585,7 +585,7 @@ workflows:
       - test-citus-upgrade:
           name: test-12_check-citus-upgrade
           pg_major: 12
-          image_tag: '12.4'
+          image_tag: '12.6'
           requires: [build-12]
 
       - ch_benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       image_tag:
         description: 'docker image tag to use'
         type: string
-        default: 11-12-13
+        default: 12-13
     docker:
       - image: '<< parameters.image >>:<< parameters.image_tag >>'
     working_directory: /home/circleci/project
@@ -579,7 +579,7 @@ workflows:
           name: 'test-12-13_check-pg-upgrade'
           old_pg_major: 12
           new_pg_major: 13
-          image_tag: 11-12-13
+          image_tag: 12-13
           requires: [build-12,build-13]
 
       - test-citus-upgrade:

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -111,6 +111,9 @@ s/partition ".*" would be violated by some row/partition would be violated by so
 s/of relation ".*" contains null values/contains null values/g
 s/of relation "t1" is violated by some row/is violated by some row/g
 
+# pg13.1 changes
+s/^ERROR:  insufficient columns in PRIMARY KEY constraint definition$/ERROR:  unique constraint on partitioned table must include all partitioning columns/g
+
 # intermediate_results
 s/(ERROR.*)pgsql_job_cache\/([0-9]+_[0-9]+_[0-9]+)\/(.*).data/\1pgsql_job_cache\/xx_x_xxx\/\3.data/g
 

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -641,7 +641,7 @@ SELECT name, type FROM table_attrs WHERE relid = 'partitioning_test_2010'::regcl
 -- test add PRIMARY KEY
 -- add PRIMARY KEY to partitioned table - this will error out
 ALTER TABLE partitioning_test ADD CONSTRAINT partitioning_primary PRIMARY KEY (id);
-ERROR:  insufficient columns in PRIMARY KEY constraint definition
+ERROR:  unique constraint on partitioned table must include all partitioning columns
 DETAIL:  PRIMARY KEY constraint on table "partitioning_test" lacks column "time" which is part of the partition key.
 -- ADD PRIMARY KEY to partition
 ALTER TABLE partitioning_test_2009 ADD CONSTRAINT partitioning_2009_primary PRIMARY KEY (id);


### PR DESCRIPTION
Some error messages have changed in PG 13.1. We need to introduce a new error message alternative to make the tests pass on recent PG versions.

For the future we can start running tests on more recent PG versions as well, just to make sure our tests are compatible with all supported PG versions

Related: #4932 