### PR TITLE
Propagate SET TRANSACTION commands when propagate_set_commands = 'local'

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -387,7 +387,10 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		parsetree = ProcessCreateSubscriptionStmt(createSubStmt);
 	}
 
-	/* process SET LOCAL stmts of allowed GUCs in multi-stmt xacts */
+	/*
+	 * Process SET LOCAL and SET TRANSACTION statements in multi-statement
+	 * transactions.
+	 */
 	if (IsA(parsetree, VariableSetStmt))
 	{
 		VariableSetStmt *setStmt = (VariableSetStmt *) parsetree;

--- a/src/backend/distributed/commands/variableset.c
+++ b/src/backend/distributed/commands/variableset.c
@@ -35,6 +35,7 @@ static bool IsSettingSafeToPropagate(char *name);
  *
  * We currently propagate:
  * - SET LOCAL (for allowed settings)
+ * - SET TRANSACTION
  * - RESET (for allowed settings)
  * - RESET ALL
  */
@@ -72,8 +73,8 @@ ShouldPropagateSetCommand(VariableSetStmt *setStmt)
 		case VAR_SET_MULTI:
 		default:
 		{
-			/* SET (LOCAL) TRANSACTION should be handled locally */
-			return false;
+			/* SET TRANSACTION is similar to SET LOCAL */
+			return strcmp(setStmt->name, "TRANSACTION") == 0;
 		}
 	}
 }
@@ -121,7 +122,7 @@ PostprocessVariableSetStmt(VariableSetStmt *setStmt, const char *setStmtString)
 	const bool raiseInterrupts = true;
 	List *connectionList = NIL;
 
-	/* at present we only support SET LOCAL */
+	/* at present we only support SET LOCAL and SET TRANSACTION */
 	AssertArg(ShouldPropagateSetCommand(setStmt));
 
 	/* haven't seen any SET stmts so far in this (sub-)xact: initialize StringInfo */

--- a/src/test/regress/expected/propagate_set_commands.out
+++ b/src/test/regress/expected/propagate_set_commands.out
@@ -19,9 +19,94 @@ SELECT current_setting('enable_hashagg') FROM test WHERE id = 1;
  on
 (1 row)
 
--- should not be propagated, error should be coming from coordinator
+-- triggers an error on the worker
 SET LOCAL TRANSACTION ISOLATION LEVEL REPEATABLE READ;
-ERROR:  SET TRANSACTION ISOLATION LEVEL must be called before any query
+WARNING:  SET TRANSACTION ISOLATION LEVEL must be called before any query
+CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  failure on connection marked as essential: localhost:xxxxx
+END;
+BEGIN;
+SET TRANSACTION READ ONLY;
+-- should fail after setting transaction to read only
+INSERT INTO test VALUES (2,2);
+ERROR:  cannot execute INSERT in a read-only transaction
+END;
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+-- should reflect new isolation level
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+BEGIN;
+SET TRANSACTION READ ONLY;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+BEGIN;
+SET LOCAL transaction_read_only TO on;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+BEGIN;
+SET TRANSACTION READ ONLY;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SAVEPOINT goback;
+SET TRANSACTION READ ONLY;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+ROLLBACK TO SAVEPOINT goback;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ off
+(1 row)
+
 END;
 BEGIN;
 -- set session commands are not propagated


### PR DESCRIPTION
DESCRIPTION: Propagate SET TRANSACTION commands when propagate_set_commands = 'local'

We incorrectly send SET LOCAL commands after SELECT assign_distributed_transaction_id, which causes #4944 and prevents SET TRANSACTION commands from being propagated.

This PR swaps the order of SET commands and assign_distributed_transaction_id and enables SET TRANSACTION propagation.

Fixes #4944