### PR TITLE
Fix nested select query with union bug

### DIFF
--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -2006,7 +2006,7 @@ RelationRestrictionForRelation(RangeTblEntry *rangeTableEntry,
 	List *filteredRelationRestrictionList =
 		filteredRelationRestrictionContext->relationRestrictionList;
 
-	if (list_length(filteredRelationRestrictionList) != 1)
+	if (list_length(filteredRelationRestrictionList) < 1)
 	{
 		return NULL;
 	}

--- a/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
+++ b/src/test/regress/expected/recursive_relation_planning_restriction_pushdown.out
@@ -470,7 +470,111 @@ DEBUG:  Wrapping relation "local_table" "u2" to a subquery
 DEBUG:  generating subplan XXX_1 for subquery SELECT value FROM push_down_filters.local_table u2 WHERE false
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM ((push_down_filters.distributed_table u1 JOIN (SELECT NULL::integer AS key, u2_1.value, NULL::timestamp with time zone AS "time" FROM (SELECT intermediate_result.value FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(value integer)) u2_1) u2 USING (value)) JOIN LATERAL (SELECT distributed_table.value, random() AS random FROM push_down_filters.distributed_table WHERE (u2.value OPERATOR(pg_catalog.=) 15)) u3 USING (value)) WHERE ((u2.value OPERATOR(pg_catalog.>) 2) AND false)
 ERROR:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+-- Test Nested Select Query with Union, with Reference Tables
+CREATE TABLE tbl1(a int);
+CREATE TABLE tbl2(b int);
+INSERT INTO tbl1 VALUES (1);
+INSERT INTO tbl2 VALUES (1);
+SELECT create_reference_table('tbl1');
+NOTICE:  Copying data from local table...
+DEBUG:  Copied 1 rows
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$push_down_filters.tbl1$$)
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT MAX(x) FROM (
+	SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE b > 0) AS s1 WHERE true
+	UNION ALL
+	SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE b > 0) AS s1 WHERE false
+) as res;
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT b FROM push_down_filters.tbl2 WHERE (b OPERATOR(pg_catalog.>) 0)
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT b FROM push_down_filters.tbl2 WHERE false
+DEBUG:  generating subplan XXX_3 for subquery SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT tbl2_1.b FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE true UNION ALL SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT tbl2_1.b FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE false
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT max(x) AS max FROM (SELECT intermediate_result.x FROM read_intermediate_result('XXX_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) res
+ max
+---------------------------------------------------------------------
+   1
+(1 row)
+
+DROP TABLE tbl1, tbl2;
+CREATE table tbl2(a int, b int, d int);
+CREATE table tbl1(a int, b int, c int);
+INSERT INTO tbl1 VALUES (1,1,1);
+INSERT INTO tbl2 VALUES (1,1,1);
+SELECT create_distributed_table('tbl1', 'a');
+NOTICE:  Copying data from local table...
+DEBUG:  Copied 1 rows
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$push_down_filters.tbl1$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT MAX(x) FROM (
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE true
+UNION ALL
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE false
+) as res;
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT b FROM push_down_filters.tbl2 WHERE (b OPERATOR(pg_catalog.>) 0)
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT b FROM push_down_filters.tbl2 WHERE false
+DEBUG:  generating subplan XXX_3 for subquery SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT NULL::integer AS a, tbl2_1.b, NULL::integer AS d FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE true
+DEBUG:  generating subplan XXX_4 for subquery SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT NULL::integer AS a, tbl2_1.b, NULL::integer AS d FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE false
+DEBUG:  generating subplan XXX_5 for subquery SELECT intermediate_result.x FROM read_intermediate_result('XXX_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer) UNION ALL SELECT intermediate_result.x FROM read_intermediate_result('XXX_4'::text, 'binary'::citus_copy_format) intermediate_result(x integer)
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT max(x) AS max FROM (SELECT intermediate_result.x FROM read_intermediate_result('XXX_5'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) res
+ max
+---------------------------------------------------------------------
+   1
+(1 row)
+
+SELECT undistribute_table('tbl1');
+NOTICE:  creating a new table for push_down_filters.tbl1
+NOTICE:  moving the data of push_down_filters.tbl1
+NOTICE:  dropping the old push_down_filters.tbl1
+CONTEXT:  SQL statement "DROP TABLE push_down_filters.tbl1 CASCADE"
+NOTICE:  renaming the new table to push_down_filters.tbl1
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_reference_table('tbl1');
+NOTICE:  Copying data from local table...
+DEBUG:  Copied 1 rows
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$push_down_filters.tbl1$$)
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT MAX(x) FROM (
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE true
+UNION ALL
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE false
+) as res;
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT b FROM push_down_filters.tbl2 WHERE (b OPERATOR(pg_catalog.>) 0)
+DEBUG:  Wrapping relation "tbl2" to a subquery
+DEBUG:  generating subplan XXX_2 for subquery SELECT b FROM push_down_filters.tbl2 WHERE false
+DEBUG:  generating subplan XXX_3 for subquery SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT NULL::integer AS a, tbl2_1.b, NULL::integer AS d FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE true UNION ALL SELECT 1 AS x FROM (SELECT 1 FROM push_down_filters.tbl1, (SELECT NULL::integer AS a, tbl2_1.b, NULL::integer AS d FROM (SELECT intermediate_result.b FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(b integer)) tbl2_1) tbl2 WHERE (tbl2.b OPERATOR(pg_catalog.>) 0)) s1("?column?") WHERE false
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT max(x) AS max FROM (SELECT intermediate_result.x FROM read_intermediate_result('XXX_3'::text, 'binary'::citus_copy_format) intermediate_result(x integer)) res
+ max
+---------------------------------------------------------------------
+   1
+(1 row)
+
 \set VERBOSITY terse
 RESET client_min_messages;
 DROP SCHEMA push_down_filters CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 7 other objects

--- a/src/test/regress/sql/recursive_relation_planning_restriction_pushdown.sql
+++ b/src/test/regress/sql/recursive_relation_planning_restriction_pushdown.sql
@@ -260,6 +260,36 @@ JOIN LATERAL
 WHERE (u2.value > 2
        AND FALSE);
 
+-- Test Nested Select Query with Union, with Reference Tables
+CREATE TABLE tbl1(a int);
+CREATE TABLE tbl2(b int);
+INSERT INTO tbl1 VALUES (1);
+INSERT INTO tbl2 VALUES (1);
+SELECT create_reference_table('tbl1');
+SELECT MAX(x) FROM (
+	SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE b > 0) AS s1 WHERE true
+	UNION ALL
+	SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE b > 0) AS s1 WHERE false
+) as res;
+DROP TABLE tbl1, tbl2;
+CREATE table tbl2(a int, b int, d int);
+CREATE table tbl1(a int, b int, c int);
+INSERT INTO tbl1 VALUES (1,1,1);
+INSERT INTO tbl2 VALUES (1,1,1);
+SELECT create_distributed_table('tbl1', 'a');
+SELECT MAX(x) FROM (
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE true
+UNION ALL
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE false
+) as res;
+SELECT undistribute_table('tbl1');
+SELECT create_reference_table('tbl1');
+SELECT MAX(x) FROM (
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE true
+UNION ALL
+SELECT 1 as x FROM (SELECT 1 FROM tbl1, tbl2 WHERE tbl2.b > 0) AS s1 WHERE false
+) as res;
+
 \set VERBOSITY terse
 RESET client_min_messages;
 DROP SCHEMA push_down_filters CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes nested select query with union bug

We used to return `NIL` at `RelationRestrictionForRelation`, if the filter count is not 1. Now we'll return `NIL` when it's 0, and return the first one of them (Probably any of them is OK) when it's greater than 0. 

fixes: #4804 