### PR TITLE
Run copy_modified in upgrade tests

### DIFF
--- a/src/test/regress/upgrade/upgrade_common.py
+++ b/src/test/regress/upgrade/upgrade_common.py
@@ -73,6 +73,7 @@ def run_pg_regress(pg_path, pg_srcdir, port, schedule):
         '--use-existing'
     ]
     exit_code = subprocess.call(command)
+    subprocess.run('bin/copy_modified', check=True)
     if exit_code != 0:
         sys.exit(exit_code)
 


### PR DESCRIPTION
This allows running the following command to update the expected files
with normalized output files for upgrade tests too:

```bash
cp src/test/regress/{results,expected}/upgrade_rebalance_strategy_before.out
```