### PR TITLE
Handle old versioned columnar metapage after binary upgrade

### DIFF
--- a/src/backend/columnar/columnar_storage.c
+++ b/src/backend/columnar/columnar_storage.c
@@ -626,9 +626,15 @@ ColumnarMetapageRead(Relation rel, bool force)
 						errhint(OLD_METAPAGE_VERSION_HINT)));
 	}
 
+	/*
+	 * Regardless of "force" parameter, always force read metapage block.
+	 * We will check metapage version in ColumnarMetapageCheckVersion
+	 * depending on "force".
+	 */
+	bool forceReadBlock = true;
 	ColumnarMetapage metapage;
 	ReadFromBlock(rel, COLUMNAR_METAPAGE_BLOCKNO, SizeOfPageHeaderData,
-				  (char *) &metapage, sizeof(ColumnarMetapage), force);
+				  (char *) &metapage, sizeof(ColumnarMetapage), forceReadBlock);
 
 	if (!force)
 	{

--- a/src/backend/columnar/columnar_storage.c
+++ b/src/backend/columnar/columnar_storage.c
@@ -329,7 +329,7 @@ ColumnarStorageGetReservedOffset(Relation rel, bool force)
 
 
 /*
- * ColumnarMetapageNeedsUpgrade - return true if metapage exists and is not
+ * ColumnarStorageIsCurrent - return true if metapage exists and is not
  * the current version.
  */
 bool

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -683,6 +683,14 @@ static void
 columnar_vacuum_rel(Relation rel, VacuumParams *params,
 					BufferAccessStrategy bstrategy)
 {
+	/*
+	 * If metapage version of relation is older, then we hint users to VACUUM
+	 * the relation in ColumnarMetapageCheckVersion. So if needed, upgrade
+	 * the metapage before doing anything.
+	 */
+	bool isUpgrade = true;
+	ColumnarStorageUpdateIfNeeded(rel, isUpgrade);
+
 	int elevel = (params->options & VACOPT_VERBOSE) ? INFO : DEBUG2;
 
 	/* this should have been resolved by vacuum.c until now */

--- a/src/backend/columnar/sql/downgrades/columnar--10.1-1--10.0-3.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.1-1--10.0-3.sql
@@ -12,7 +12,7 @@ REFERENCES columnar.stripe(storage_id, stripe_num) ON DELETE CASCADE;
 -- define columnar_ensure_objects_exist again
 #include "../udfs/columnar_ensure_objects_exist/10.0-1.sql"
 
--- upgrade storage for all columnar relations
+-- downgrade storage for all columnar relations
 SELECT citus_internal.downgrade_columnar_storage(c.oid) FROM pg_class c, pg_am a
   WHERE c.relam = a.oid AND amname = 'columnar';
 


### PR DESCRIPTION
Opened against https://github.com/citusdata/citus/tree/columnar-index branch.

There were some issues around the scenario where user installed new binary but didn't run `ALTER EXTENSION citus UPDATE` yet.
With this pr, we fix those cases:
https://github.com/citusdata/citus/pull/4907#discussion_r623246475
https://github.com/citusdata/citus/pull/4907#discussion_r623249079
