### PR TITLE
Log remote commands for shard cost func at multi_partitioninig

### DIFF
--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -1020,6 +1020,9 @@ ColocatedNonPartitionShardIntervalList(ShardInterval *shardInterval)
 		return colocatedShardList;
 	}
 
+	ereport(DEBUG1, (errmsg("skipping child tables for relation named: %s",
+							get_rel_name(distributedTableId))));
+
 	int shardIntervalIndex = ShardIndex(shardInterval);
 	List *colocatedTableList = ColocatedTableList(distributedTableId);
 

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -2156,12 +2156,15 @@ SELECT create_distributed_table('"events.Energy Added"', 'user_id', colocate_wit
 
 CREATE TABLE "Energy Added_17634"  PARTITION OF "events.Energy Added" FOR VALUES  FROM ('2018-04-13 00:00:00+00') TO ('2018-04-14 00:00:00+00');
 -- test shard cost by disk size function
+SET client_min_messages TO DEBUG1;
 SELECT citus_shard_cost_by_disk_size(shardid) FROM pg_dist_shard WHERE logicalrelid = '"events.Energy Added"'::regclass ORDER BY shardid LIMIT 1;
+DEBUG:  skipping child tables for relation named: events.Energy Added
  citus_shard_cost_by_disk_size
 ---------------------------------------------------------------------
                          16384
 (1 row)
 
+RESET client_min_messages;
 CREATE INDEX idx_btree_hobbies ON "events.Energy Added" USING BTREE ((data->>'location'));
  \c - - - :worker_1_port
 -- should not be zero because of TOAST, vm, fms

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -1285,7 +1285,9 @@ SELECT create_distributed_table('"events.Energy Added"', 'user_id', colocate_wit
 CREATE TABLE "Energy Added_17634"  PARTITION OF "events.Energy Added" FOR VALUES  FROM ('2018-04-13 00:00:00+00') TO ('2018-04-14 00:00:00+00');
 
 -- test shard cost by disk size function
+SET client_min_messages TO DEBUG1;
 SELECT citus_shard_cost_by_disk_size(shardid) FROM pg_dist_shard WHERE logicalrelid = '"events.Energy Added"'::regclass ORDER BY shardid LIMIT 1;
+RESET client_min_messages;
 CREATE INDEX idx_btree_hobbies ON "events.Energy Added" USING BTREE ((data->>'location'));
  \c - - - :worker_1_port
 -- should not be zero because of TOAST, vm, fms


### PR DESCRIPTION
Updating test for logging remote commands at multi_partitioning, for making sure that the optimized shard disk size calculation function is used