### PR TITLE
Improve error message if no target nodes found

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1523,8 +1523,8 @@ MoveShardsAwayFromDisallowedNodes(RebalanceState *state)
 		if (targetFillState == NULL)
 		{
 			ereport(WARNING, (errmsg(
-								  "Not allowed to move shard " UINT64_FORMAT
-								  " anywhere from %s:%d",
+								  "There is not any node to move shard " UINT64_FORMAT
+								  " from %s:%d",
 								  disallowedPlacement->shardCost->shardId,
 								  disallowedPlacement->fillState->node->workerName,
 								  disallowedPlacement->fillState->node->workerPort

--- a/src/test/regress/expected/shard_rebalancer_unit.out
+++ b/src/test/regress/expected/shard_rebalancer_unit.out
@@ -108,7 +108,7 @@ SELECT unnest(shard_placement_rebalance_array(
           '{"shardid":4, "nodename":"hostname2"}'
         ]::json[]
 ));
-WARNING:  Not allowed to move shard xxxxx anywhere from hostname2:5432
+WARNING:  There is not any node to move shard xxxxx from hostname2:5432
                                                        unnest
 ---------------------------------------------------------------------
  {"updatetype":1,"shardid":2,"sourcename":"hostname1","sourceport":5432,"targetname":"hostname2","targetport":5432}


### PR DESCRIPTION
The reason I thought of increasing this error message was:

![image](https://user-images.githubusercontent.com/17179875/117583383-817cd600-b10f-11eb-9080-bff67dd29bf5.png)


Here node `localhost:9702` is the last node in the cluster, but the error was a bit implicit.  