### PR TITLE
Close connection after each shard move

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1117,7 +1117,6 @@ UpdateShardPlacement(PlacementUpdateEvent *placementUpdateEvent,
 	WorkerNode *sourceNode = placementUpdateEvent->sourceNode;
 	WorkerNode *targetNode = placementUpdateEvent->targetNode;
 	const char *doRepair = "false";
-	int connectionFlag = FORCE_NEW_CONNECTION;
 
 	Datum shardTranferModeLabelDatum =
 		DirectFunctionCall1(enum_out, shardReplicationModeOid);
@@ -1189,6 +1188,7 @@ UpdateShardPlacement(PlacementUpdateEvent *placementUpdateEvent,
 										  sourceNode->workerPort,
 										  REBALANCE_PROGRESS_MOVING);
 
+	int connectionFlag = FORCE_NEW_CONNECTION;
 	MultiConnection *connection = GetNodeConnection(connectionFlag, LOCAL_HOST_NAME,
 													PostPortNumber);
 
@@ -1202,6 +1202,7 @@ UpdateShardPlacement(PlacementUpdateEvent *placementUpdateEvent,
 										  sourceNode->workerName,
 										  sourceNode->workerPort,
 										  REBALANCE_PROGRESS_MOVED);
+	CloseConnection(connection);
 
 	return true;
 }


### PR DESCRIPTION
DESCRIPTION: Closes connection after each shard move

I have manually tested this and I don't get the "too many connections error" now. In practice, I feel like this could be a bigger problem if we were moving many shards, because we would not release the connection slots for many hours possibly. Is that indeed the case here? 

Is there a downside of closing this connection (other than the overhead)?

Fixes #4928.
