### PR TITLE
Not block maintenance daemon

### DIFF
--- a/src/backend/distributed/test/shard_rebalancer.c
+++ b/src/backend/distributed/test/shard_rebalancer.c
@@ -21,6 +21,7 @@
 #include "distributed/connection_management.h"
 #include "distributed/listutils.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/shard_cleaner.h"
 #include "distributed/shard_rebalancer.h"
 #include "funcapi.h"
 #include "miscadmin.h"
@@ -50,6 +51,7 @@ static ShardCost GetShardCost(uint64 shardId, void *context);
 PG_FUNCTION_INFO_V1(shard_placement_rebalance_array);
 PG_FUNCTION_INFO_V1(shard_placement_replication_array);
 PG_FUNCTION_INFO_V1(worker_node_responsive);
+PG_FUNCTION_INFO_V1(run_try_drop_marked_shards);
 
 typedef struct ShardPlacementTestInfo
 {
@@ -70,6 +72,17 @@ typedef struct RebalancePlanContext
 	List *workerTestInfoList;
 	List *shardPlacementTestInfoList;
 } RebalancePlacementContext;
+
+/*
+ * run_try_drop_marked_shards is a wrapper to run TryDropMarkedShards.
+ */
+Datum
+run_try_drop_marked_shards(PG_FUNCTION_ARGS)
+{
+	bool waitForLocks = false;
+	TryDropMarkedShards(waitForLocks);
+	PG_RETURN_VOID();
+}
 
 
 /*

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -644,8 +644,8 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 				 */
 				lastShardCleanTime = GetCurrentTimestamp();
 
-				bool waitForCleanupLock = false;
-				numberOfDroppedShards = TryDropMarkedShards(waitForCleanupLock);
+				bool waitForLocks = false;
+				numberOfDroppedShards = TryDropMarkedShards(waitForLocks);
 			}
 
 			CommitTransactionCommand();

--- a/src/include/distributed/shard_cleaner.h
+++ b/src/include/distributed/shard_cleaner.h
@@ -17,7 +17,7 @@ extern bool DeferShardDeleteOnMove;
 extern double DesiredPercentFreeAfterMove;
 extern bool CheckAvailableSpaceBeforeMove;
 
-extern int TryDropMarkedShards(bool waitForCleanupLock);
-extern int DropMarkedShards(bool waitForCleanupLock);
+extern int TryDropMarkedShards(bool waitForLocks);
+extern int DropMarkedShards(bool waitForLocks);
 
 #endif /*CITUS_SHARD_CLEANER_H */

--- a/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
+++ b/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
@@ -18,6 +18,7 @@ master_defer_delete_shards
 
 1
 step s2-drop-marked-shards:
+    SET client_min_messages to DEBUG1;
     SELECT public.master_defer_delete_shards();
  <waiting ...>
 step s1-commit: 
@@ -40,6 +41,7 @@ master_move_shard_placement
 
 
 step s2-drop-marked-shards:
+    SET client_min_messages to DEBUG1;
     SELECT public.master_defer_delete_shards();
 
 master_defer_delete_shards
@@ -98,4 +100,22 @@ step s2-stop-connection:
 
 stop_session_level_connection_to_node
 
+
+
+starting permutation: s1-begin s1-lock-pg-dist-placement s2-drop-old-shards s1-commit
+step s1-begin:
+    BEGIN;
+
+step s1-lock-pg-dist-placement:
+    LOCK TABLE pg_dist_placement IN SHARE ROW EXCLUSIVE MODE;
+
+s2: DEBUG:  could not acquire shard lock to cleanup placements
+step s2-drop-old-shards:
+    SELECT run_try_drop_marked_shards();
+
+run_try_drop_marked_shards
+
+
+step s1-commit:
+    COMMIT;
 


### PR DESCRIPTION
It was possible to block maintenance daemon by taking an ACCESS
EXCLUSIVE lock on pg_dist_placement. Until the lock is released
maintenance daemon would be blocked.

We should not block the maintenance daemon under any case hence now we
try to get the pg_dist_placement lock without waiting, if we cannot get
it then we don't try to drop the old placements.
