### PR TITLE
Lookup hostname before execution

### DIFF
--- a/src/test/regress/expected/isolation_dump_global_wait_edges.out
+++ b/src/test/regress/expected/isolation_dump_global_wait_edges.out
@@ -13,7 +13,7 @@ step s1-update:
 step s2-update:
     UPDATE distributed_table SET y = 2 WHERE x = 1;
  <waiting ...>
-step detector-dump-wait-edges:
+step detector-dump-wait-edges: 
     SELECT
         waiting_transaction_num,
         blocking_transaction_num,
@@ -28,11 +28,11 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-395            394            f
+400            399            f
 transactionnumberwaitingtransactionnumbers
 
-394
-395            394
+399
+400            399
 step s1-abort:
     ABORT;
 
@@ -57,10 +57,10 @@ step s1-update:
 step s2-update:
     UPDATE distributed_table SET y = 2 WHERE x = 1;
  <waiting ...>
-step s3-update:
+step s3-update: 
     UPDATE distributed_table SET y = 3 WHERE x = 1;
  <waiting ...>
-step detector-dump-wait-edges:
+step detector-dump-wait-edges: 
     SELECT
         waiting_transaction_num,
         blocking_transaction_num,
@@ -75,14 +75,14 @@ step detector-dump-wait-edges:
 
 waiting_transaction_numblocking_transaction_numblocking_transaction_waiting
 
-399            398            f
-400            398            f
-400            399            t
+404            403            f
+405            403            f
+405            404            t
 transactionnumberwaitingtransactionnumbers
 
-398
-399            398
-400            398,399
+403
+404            403
+405            403,404
 step s1-abort:
     ABORT;
 

--- a/src/test/regress/expected/isolation_update_node.out
+++ b/src/test/regress/expected/isolation_update_node.out
@@ -191,6 +191,7 @@ count
 step s1-commit-prepared:
     COMMIT prepared 'label';
 
+s2: WARNING:  connection to the remote node non-existent:57637 failed with the following error: could not translate host name "non-existent" to address: Name or service not known
 step s2-execute-prepared:
     EXECUTE foo;
 

--- a/src/test/regress/expected/isolation_update_node.out
+++ b/src/test/regress/expected/isolation_update_node.out
@@ -6,7 +6,7 @@ nodeid         nodename       nodeport
 22             localhost      57637
 23             localhost      57638
 step s1-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-update-node-1:
     SELECT 1 FROM master_update_node(
@@ -23,8 +23,8 @@ step s2-update-node-2:
         'localhost',
         58638);
  <waiting ...>
-step s1-commit:
-	COMMIT;
+step s1-commit: 
+ COMMIT;
 
 step s2-update-node-2: <... completed>
 ?column?
@@ -48,7 +48,7 @@ nodeid         nodename       nodeport
 24             localhost      57637
 25             localhost      57638
 step s1-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-update-node-1:
     SELECT 1 FROM master_update_node(
@@ -60,7 +60,7 @@ step s1-update-node-1:
 
 1
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-update-node-1:
     SELECT 1 FROM master_update_node(
@@ -68,15 +68,15 @@ step s2-update-node-1:
         'localhost',
         58637);
  <waiting ...>
-step s1-commit:
-	COMMIT;
+step s1-commit: 
+ COMMIT;
 
 step s2-update-node-1: <... completed>
 ?column?
 
 1
 step s2-abort:
-	ABORT;
+ ABORT;
 
 step s1-show-nodes:
     SELECT nodeid, nodename, nodeport, isactive
@@ -96,7 +96,7 @@ nodeid         nodename       nodeport
 26             localhost      57637
 27             localhost      57638
 step s1-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-update-node-1:
     SELECT 1 FROM master_update_node(
@@ -110,8 +110,8 @@ step s1-update-node-1:
 step s2-start-metadata-sync-node-2:
     SELECT start_metadata_sync_to_node('localhost', 57638);
  <waiting ...>
-step s1-commit:
-	COMMIT;
+step s1-commit: 
+ COMMIT;
 
 step s2-start-metadata-sync-node-2: <... completed>
 start_metadata_sync_to_node
@@ -131,5 +131,83 @@ nodeid         groupid        nodename       nodeport
 master_run_on_worker
 
 (localhost,57638,t,"[{""f1"": 26, ""f2"": 26, ""f3"": ""localhost"", ""f4"": 58637}, {""f1"": 27, ""f2"": 27, ""f3"": ""localhost"", ""f4"": 57638}]")
+nodeid         nodename       nodeport
+
+
+starting permutation: s2-create-table s1-begin s1-update-node-nonexistent s1-prepare-transaction s2-cache-prepared-statement s1-commit-prepared s2-execute-prepared s1-update-node-existent s2-drop-table
+nodeid         nodename       nodeport
+
+28             localhost      57637
+29             localhost      57638
+step s2-create-table:
+    CREATE TABLE test (a int);
+    SELECT create_distributed_table('test','a');
+
+create_distributed_table
+
+
+step s1-begin:
+ BEGIN;
+
+step s1-update-node-nonexistent:
+    SELECT 1 FROM master_update_node(
+        (select nodeid from pg_dist_node where nodeport = 57637),
+        'non-existent',
+        57637);
+
+?column?
+
+1
+step s1-prepare-transaction:
+    PREPARE transaction 'label';
+
+step s2-cache-prepared-statement:
+    PREPARE foo AS SELECT COUNT(*) FROM test WHERE a = 3;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+
+count
+
+0
+count
+
+0
+count
+
+0
+count
+
+0
+count
+
+0
+count
+
+0
+step s1-commit-prepared:
+    COMMIT prepared 'label';
+
+step s2-execute-prepared:
+    EXECUTE foo;
+
+count
+
+0
+step s1-update-node-existent:
+    SELECT 1 FROM master_update_node(
+        (select nodeid from pg_dist_node where nodeport = 57637),
+        'localhost',
+        57637);
+
+?column?
+
+1
+step s2-drop-table:
+    DROP TABLE test;
+
 nodeid         nodename       nodeport
 

--- a/src/test/regress/expected/isolation_update_node_lock_writes.out
+++ b/src/test/regress/expected/isolation_update_node_lock_writes.out
@@ -5,7 +5,7 @@ create_distributed_table
 
 
 step s1-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-update-node-1:
     SELECT 1 FROM master_update_node(
@@ -17,20 +17,20 @@ step s1-update-node-1:
 
 1
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-insert:
     INSERT INTO update_node(id, f1)
          SELECT id, md5(id::text)
            FROM generate_series(1, 10) as t(id);
  <waiting ...>
-step s1-commit:
-	COMMIT;
+step s1-commit: 
+ COMMIT;
 
 step s2-insert: <... completed>
-error in steps s1-commit s2-insert: ERROR:  relation "public.update_node_102008" does not exist
+error in steps s1-commit s2-insert: ERROR:  relation "public.update_node_102012" does not exist
 step s2-abort:
-	ABORT;
+ ABORT;
 
 nodeid         nodename       nodeport
 
@@ -40,7 +40,7 @@ create_distributed_table
 
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-insert:
     INSERT INTO update_node(id, f1)
@@ -53,8 +53,8 @@ step s1-update-node-1:
         'localhost',
         57638);
  <waiting ...>
-step s2-commit:
-	COMMIT;
+step s2-commit: 
+ COMMIT;
 
 step s1-update-node-1: <... completed>
 ?column?

--- a/src/test/regress/spec/isolation_update_node.spec
+++ b/src/test/regress/spec/isolation_update_node.spec
@@ -137,7 +137,7 @@ permutation "s1-begin" "s1-update-node-1" "s2-begin" "s2-update-node-1" "s1-comm
 // testing the reverse order here.
 permutation "s1-begin" "s1-update-node-1" "s2-start-metadata-sync-node-2" "s1-commit" "s2-verify-metadata"
 
-// make sure we have entries in prepared statement cache 
+// make sure we have entries in prepared statement cache
 // then make sure that after we update pg_dist_node, the changes are visible to
 // the prepared statement
 permutation "s2-create-table" "s1-begin" "s1-update-node-nonexistent" "s1-prepare-transaction" "s2-cache-prepared-statement" "s1-commit-prepared" "s2-execute-prepared" "s1-update-node-existent" "s2-drop-table"

--- a/src/test/regress/spec/isolation_update_node.spec
+++ b/src/test/regress/spec/isolation_update_node.spec
@@ -19,12 +19,34 @@ step "s1-begin"
 	BEGIN;
 }
 
+step "s1-prepare-transaction" {
+    PREPARE transaction 'label';
+}
+
+step "s1-commit-prepared" {
+    COMMIT prepared 'label';
+}
+
 step "s1-update-node-1"
 {
     SELECT 1 FROM master_update_node(
         (select nodeid from pg_dist_node where nodeport = 57637),
         'localhost',
         58637);
+}
+
+step "s1-update-node-nonexistent" {
+    SELECT 1 FROM master_update_node(
+        (select nodeid from pg_dist_node where nodeport = 57637),
+        'non-existent',
+        57637);
+}
+
+step "s1-update-node-existent" {
+    SELECT 1 FROM master_update_node(
+        (select nodeid from pg_dist_node where nodeport = 57637),
+        'localhost',
+        57637);
 }
 
 step "s1-commit"
@@ -62,6 +84,25 @@ step "s2-update-node-2"
         58638);
 }
 
+step "s2-create-table" {
+    CREATE TABLE test (a int);
+    SELECT create_distributed_table('test','a');
+}
+
+step "s2-cache-prepared-statement" {
+    PREPARE foo AS SELECT COUNT(*) FROM test WHERE a = 3;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+    EXECUTE foo;
+}
+
+step "s2-execute-prepared" {
+    EXECUTE foo;
+}
+
 step "s2-verify-metadata"
 {
     SELECT nodeid, groupid, nodename, nodeport FROM pg_dist_node ORDER BY nodeid;
@@ -74,6 +115,10 @@ step "s2-verify-metadata"
 step "s2-start-metadata-sync-node-2"
 {
     SELECT start_metadata_sync_to_node('localhost', 57638);
+}
+
+step "s2-drop-table" {
+    DROP TABLE test;
 }
 
 step "s2-abort"
@@ -91,3 +136,8 @@ permutation "s1-begin" "s1-update-node-1" "s2-begin" "s2-update-node-1" "s1-comm
 // cannot run start_metadata_sync_to_node in a transaction, so we're not
 // testing the reverse order here.
 permutation "s1-begin" "s1-update-node-1" "s2-start-metadata-sync-node-2" "s1-commit" "s2-verify-metadata"
+
+// make sure we have entries in prepared statement cache 
+// then make sure that after we update pg_dist_node, the changes are visible to
+// the prepared statement
+permutation "s2-create-table" "s1-begin" "s1-update-node-nonexistent" "s1-prepare-transaction" "s2-cache-prepared-statement" "s1-commit-prepared" "s2-execute-prepared" "s1-update-node-existent" "s2-drop-table"


### PR DESCRIPTION
DESCRIPTION: Fixes a bug causing stale hostnames in prep. statements after master_update_node

We lookup the hostname just before the execution so that even if there are cached entries in the prepared statement cache we use the updated entries.

Fixes #4782.