### PR TITLE
Skip CI checks for enterprise merges on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,7 @@ workflows:
             branches:
               ignore:
                 - /release-[0-9]+\.[0-9]+.*/ # match with releaseX.Y.*
+                - master
 
       - build:
           name: build-12


### PR DESCRIPTION
We occasionally get failing `check-merge-to-enterprise` jobs on CI with the following error message:

```
ERROR: enterprise/master was not found and community PR branch could not be merged into enterprise-master
```

See below for more on a failing test example:
https://app.circleci.com/pipelines/github/citusdata/citus/15501/workflows/f4dec149-df44-417d-8ba7-7af698923cb9/jobs/312569