### PR TITLE
Make TransactionModifiedNodeMetadata volatile

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -73,7 +73,7 @@ char *CurrentCluster = "default";
 bool ReplicateReferenceTablesOnActivate = true;
 
 /* did current transaction modify pg_dist_node? */
-bool TransactionModifiedNodeMetadata = false;
+bool volatile TransactionModifiedNodeMetadata = false;
 
 typedef struct NodeMetadata
 {

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -104,7 +104,7 @@ extern int DoBlockLevel;
 extern StringInfo activeSetStmts;
 
 /* did current transaction modify pg_dist_node? */
-extern bool TransactionModifiedNodeMetadata;
+extern bool volatile TransactionModifiedNodeMetadata;
 
 /*
  * Coordinated transaction management.


### PR DESCRIPTION
I think flags like this one should be volatile to prevent dirty reads(even though the chance is small)