### PR TITLE
Include result type in upgrade diff test

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -52,7 +52,9 @@ BEGIN
 	TRUNCATE TABLE extension_diff;
 
 	CREATE TABLE current_objects AS
-	SELECT pg_catalog.pg_describe_object(classid, objid, 0) AS description
+	SELECT pg_catalog.pg_describe_object(classid, objid, 0)
+           || ' ' ||
+           coalesce(pg_catalog.pg_get_function_result(objid), '') AS description
 	FROM pg_catalog.pg_depend, pg_catalog.pg_extension e
 	WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
 		AND refobjid = e.oid
@@ -129,166 +131,166 @@ ALTER EXTENSION citus UPDATE TO '9.2-1';
 ALTER EXTENSION citus UPDATE TO '9.2-2';
 -- Snapshot of state at 9.2-2
 SELECT * FROM print_extension_changes();
- previous_object |                                              current_object
+ previous_object |                                                                                                        current_object
 ---------------------------------------------------------------------
                  | event trigger citus_cascade_to_partition
-                 | function alter_role_if_exists(text,text)
-                 | function any_value(anyelement)
-                 | function any_value_agg(anyelement,anyelement)
-                 | function array_cat_agg(anyarray)
-                 | function assign_distributed_transaction_id(integer,bigint,timestamp with time zone)
-                 | function authinfo_valid(text)
-                 | function broadcast_intermediate_result(text,text)
-                 | function check_distributed_deadlocks()
-                 | function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real)
-                 | function citus_blocking_pids(integer)
-                 | function citus_create_restore_point(text)
-                 | function citus_dist_stat_activity()
-                 | function citus_drop_trigger()
-                 | function citus_executor_name(integer)
-                 | function citus_extradata_container(internal)
-                 | function citus_finish_pg_upgrade()
-                 | function citus_internal.find_groupid_for_node(text,integer)
-                 | function citus_internal.pg_dist_node_trigger_func()
-                 | function citus_internal.pg_dist_rebalance_strategy_enterprise_check()
-                 | function citus_internal.pg_dist_rebalance_strategy_trigger_func()
-                 | function citus_internal.pg_dist_shard_placement_trigger_func()
-                 | function citus_internal.refresh_isolation_tester_prepared_statement()
-                 | function citus_internal.replace_isolation_tester_func()
-                 | function citus_internal.restore_isolation_tester_func()
-                 | function citus_isolation_test_session_is_blocked(integer,integer[])
-                 | function citus_json_concatenate(json,json)
-                 | function citus_json_concatenate_final(json)
-                 | function citus_jsonb_concatenate(jsonb,jsonb)
-                 | function citus_jsonb_concatenate_final(jsonb)
-                 | function citus_node_capacity_1(integer)
-                 | function citus_prepare_pg_upgrade()
-                 | function citus_query_stats()
-                 | function citus_relation_size(regclass)
-                 | function citus_server_id()
-                 | function citus_set_default_rebalance_strategy(text)
-                 | function citus_shard_allowed_on_node_true(bigint,integer)
-                 | function citus_shard_cost_1(bigint)
-                 | function citus_shard_cost_by_disk_size(bigint)
-                 | function citus_stat_statements()
-                 | function citus_stat_statements_reset()
-                 | function citus_table_is_visible(oid)
-                 | function citus_table_size(regclass)
-                 | function citus_text_send_as_jsonb(text)
-                 | function citus_total_relation_size(regclass)
-                 | function citus_truncate_trigger()
-                 | function citus_validate_rebalance_strategy_functions(regproc,regproc,regproc)
-                 | function citus_version()
-                 | function citus_worker_stat_activity()
-                 | function column_name_to_column(regclass,text)
-                 | function column_to_column_name(regclass,text)
-                 | function coord_combine_agg(oid,cstring,anyelement)
-                 | function coord_combine_agg_ffunc(internal,oid,cstring,anyelement)
-                 | function coord_combine_agg_sfunc(internal,oid,cstring,anyelement)
-                 | function create_distributed_function(regprocedure,text,text)
-                 | function create_distributed_table(regclass,text,citus.distribution_type,text)
-                 | function create_intermediate_result(text,text)
-                 | function create_reference_table(regclass)
-                 | function distributed_tables_colocated(regclass,regclass)
-                 | function dump_global_wait_edges()
-                 | function dump_local_wait_edges()
-                 | function fetch_intermediate_results(text[],text,integer)
-                 | function get_all_active_transactions()
-                 | function get_colocated_shard_array(bigint)
-                 | function get_colocated_table_array(regclass)
-                 | function get_current_transaction_id()
-                 | function get_global_active_transactions()
-                 | function get_rebalance_progress()
-                 | function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name)
-                 | function get_shard_id_for_distribution_column(regclass,"any")
-                 | function isolate_tenant_to_new_shard(regclass,"any",text)
-                 | function json_cat_agg(json)
-                 | function jsonb_cat_agg(jsonb)
-                 | function lock_relation_if_exists(text,text)
-                 | function lock_shard_metadata(integer,bigint[])
-                 | function lock_shard_resources(integer,bigint[])
-                 | function mark_tables_colocated(regclass,regclass[])
-                 | function master_activate_node(text,integer)
-                 | function master_add_inactive_node(text,integer,integer,noderole,name)
-                 | function master_add_node(text,integer,integer,noderole,name)
-                 | function master_add_secondary_node(text,integer,text,integer,name)
-                 | function master_append_table_to_shard(bigint,text,text,integer)
-                 | function master_apply_delete_command(text)
-                 | function master_conninfo_cache_invalidate()
-                 | function master_copy_shard_placement(bigint,text,integer,text,integer,boolean,citus.shard_transfer_mode)
-                 | function master_create_distributed_table(regclass,text,citus.distribution_type)
-                 | function master_create_empty_shard(text)
-                 | function master_create_worker_shards(text,integer,integer)
-                 | function master_disable_node(text,integer)
-                 | function master_dist_local_group_cache_invalidate()
-                 | function master_dist_node_cache_invalidate()
-                 | function master_dist_object_cache_invalidate()
-                 | function master_dist_partition_cache_invalidate()
-                 | function master_dist_placement_cache_invalidate()
-                 | function master_dist_shard_cache_invalidate()
-                 | function master_drain_node(text,integer,citus.shard_transfer_mode,name)
-                 | function master_drop_all_shards(regclass,text,text)
-                 | function master_drop_sequences(text[])
-                 | function master_get_active_worker_nodes()
-                 | function master_get_new_placementid()
-                 | function master_get_new_shardid()
-                 | function master_get_table_ddl_events(text)
-                 | function master_get_table_metadata(text)
-                 | function master_modify_multiple_shards(text)
-                 | function master_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode)
-                 | function master_remove_distributed_table_metadata_from_workers(regclass,text,text)
-                 | function master_remove_node(text,integer)
-                 | function master_remove_partition_metadata(regclass,text,text)
-                 | function master_run_on_worker(text[],integer[],text[],boolean)
-                 | function master_set_node_property(text,integer,text,boolean)
-                 | function master_unmark_object_distributed(oid,oid,integer)
-                 | function master_update_node(integer,text,integer,boolean,integer)
-                 | function master_update_shard_statistics(bigint)
-                 | function master_update_table_statistics(regclass)
-                 | function poolinfo_valid(text)
-                 | function read_intermediate_result(text,citus_copy_format)
-                 | function read_intermediate_results(text[],citus_copy_format)
-                 | function rebalance_table_shards(regclass,real,integer,bigint[],citus.shard_transfer_mode,boolean,name)
-                 | function recover_prepared_transactions()
-                 | function relation_is_a_known_shard(regclass)
-                 | function replicate_table_shards(regclass,integer,integer,bigint[],citus.shard_transfer_mode)
-                 | function role_exists(name)
-                 | function run_command_on_colocated_placements(regclass,regclass,text,boolean)
-                 | function run_command_on_placements(regclass,text,boolean)
-                 | function run_command_on_shards(regclass,text,boolean)
-                 | function run_command_on_workers(text,boolean)
-                 | function shard_name(regclass,bigint)
-                 | function start_metadata_sync_to_node(text,integer)
-                 | function stop_metadata_sync_to_node(text,integer)
-                 | function task_tracker_assign_task(bigint,integer,text)
-                 | function task_tracker_cleanup_job(bigint)
-                 | function task_tracker_conninfo_cache_invalidate()
-                 | function task_tracker_task_status(bigint,integer)
-                 | function upgrade_to_reference_table(regclass)
-                 | function worker_append_table_to_shard(text,text,text,integer)
-                 | function worker_apply_inter_shard_ddl_command(bigint,text,bigint,text,text)
-                 | function worker_apply_sequence_command(text)
-                 | function worker_apply_sequence_command(text,regtype)
-                 | function worker_apply_shard_ddl_command(bigint,text)
-                 | function worker_apply_shard_ddl_command(bigint,text,text)
-                 | function worker_cleanup_job_schema_cache()
-                 | function worker_create_or_replace_object(text)
-                 | function worker_create_schema(bigint,text)
-                 | function worker_create_truncate_trigger(regclass)
-                 | function worker_drop_distributed_table(text)
-                 | function worker_execute_sql_task(bigint,integer,text,boolean)
-                 | function worker_fetch_foreign_file(text,text,bigint,text[],integer[])
-                 | function worker_fetch_partition_file(bigint,integer,integer,integer,text,integer)
-                 | function worker_hash("any")
-                 | function worker_hash_partition_table(bigint,integer,text,text,oid,anyarray)
-                 | function worker_merge_files_and_run_query(bigint,integer,text,text)
-                 | function worker_merge_files_into_table(bigint,integer,text[],text[])
-                 | function worker_partial_agg(oid,anyelement)
-                 | function worker_partial_agg_ffunc(internal)
-                 | function worker_partial_agg_sfunc(internal,oid,anyelement)
-                 | function worker_partition_query_result(text,text,integer,citus.distribution_type,text[],text[],boolean)
-                 | function worker_range_partition_table(bigint,integer,text,text,oid,anyarray)
-                 | function worker_repartition_cleanup(bigint)
+                 | function alter_role_if_exists(text,text) boolean
+                 | function any_value(anyelement) anyelement
+                 | function any_value_agg(anyelement,anyelement) anyelement
+                 | function array_cat_agg(anyarray) anyarray
+                 | function assign_distributed_transaction_id(integer,bigint,timestamp with time zone) void
+                 | function authinfo_valid(text) boolean
+                 | function broadcast_intermediate_result(text,text) bigint
+                 | function check_distributed_deadlocks() boolean
+                 | function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real) void
+                 | function citus_blocking_pids(integer) integer[]
+                 | function citus_create_restore_point(text) pg_lsn
+                 | function citus_dist_stat_activity() SETOF record
+                 | function citus_drop_trigger() event_trigger
+                 | function citus_executor_name(integer) text
+                 | function citus_extradata_container(internal) void
+                 | function citus_finish_pg_upgrade() void
+                 | function citus_internal.find_groupid_for_node(text,integer) integer
+                 | function citus_internal.pg_dist_node_trigger_func() trigger
+                 | function citus_internal.pg_dist_rebalance_strategy_enterprise_check() trigger
+                 | function citus_internal.pg_dist_rebalance_strategy_trigger_func() trigger
+                 | function citus_internal.pg_dist_shard_placement_trigger_func() trigger
+                 | function citus_internal.refresh_isolation_tester_prepared_statement() void
+                 | function citus_internal.replace_isolation_tester_func() void
+                 | function citus_internal.restore_isolation_tester_func() void
+                 | function citus_isolation_test_session_is_blocked(integer,integer[]) boolean
+                 | function citus_json_concatenate(json,json) json
+                 | function citus_json_concatenate_final(json) json
+                 | function citus_jsonb_concatenate(jsonb,jsonb) jsonb
+                 | function citus_jsonb_concatenate_final(jsonb) jsonb
+                 | function citus_node_capacity_1(integer) real
+                 | function citus_prepare_pg_upgrade() void
+                 | function citus_query_stats() SETOF record
+                 | function citus_relation_size(regclass) bigint
+                 | function citus_server_id() uuid
+                 | function citus_set_default_rebalance_strategy(text) void
+                 | function citus_shard_allowed_on_node_true(bigint,integer) boolean
+                 | function citus_shard_cost_1(bigint) real
+                 | function citus_shard_cost_by_disk_size(bigint) real
+                 | function citus_stat_statements() SETOF record
+                 | function citus_stat_statements_reset() void
+                 | function citus_table_is_visible(oid) boolean
+                 | function citus_table_size(regclass) bigint
+                 | function citus_text_send_as_jsonb(text) bytea
+                 | function citus_total_relation_size(regclass) bigint
+                 | function citus_truncate_trigger() trigger
+                 | function citus_validate_rebalance_strategy_functions(regproc,regproc,regproc) void
+                 | function citus_version() text
+                 | function citus_worker_stat_activity() SETOF record
+                 | function column_name_to_column(regclass,text) text
+                 | function column_to_column_name(regclass,text) text
+                 | function coord_combine_agg(oid,cstring,anyelement) anyelement
+                 | function coord_combine_agg_ffunc(internal,oid,cstring,anyelement) anyelement
+                 | function coord_combine_agg_sfunc(internal,oid,cstring,anyelement) internal
+                 | function create_distributed_function(regprocedure,text,text) void
+                 | function create_distributed_table(regclass,text,citus.distribution_type,text) void
+                 | function create_intermediate_result(text,text) bigint
+                 | function create_reference_table(regclass) void
+                 | function distributed_tables_colocated(regclass,regclass) boolean
+                 | function dump_global_wait_edges() SETOF record
+                 | function dump_local_wait_edges() SETOF record
+                 | function fetch_intermediate_results(text[],text,integer) bigint
+                 | function get_all_active_transactions() SETOF record
+                 | function get_colocated_shard_array(bigint) bigint[]
+                 | function get_colocated_table_array(regclass) regclass[]
+                 | function get_current_transaction_id() record
+                 | function get_global_active_transactions() SETOF record
+                 | function get_rebalance_progress() TABLE(sessionid integer, table_name regclass, shardid bigint, shard_size bigint, sourcename text, sourceport integer, targetname text, targetport integer, progress bigint)
+                 | function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name) TABLE(table_name regclass, shardid bigint, shard_size bigint, sourcename text, sourceport integer, targetname text, targetport integer)
+                 | function get_shard_id_for_distribution_column(regclass,"any") bigint
+                 | function isolate_tenant_to_new_shard(regclass,"any",text) bigint
+                 | function json_cat_agg(json) json
+                 | function jsonb_cat_agg(jsonb) jsonb
+                 | function lock_relation_if_exists(text,text) boolean
+                 | function lock_shard_metadata(integer,bigint[]) void
+                 | function lock_shard_resources(integer,bigint[]) void
+                 | function mark_tables_colocated(regclass,regclass[]) void
+                 | function master_activate_node(text,integer) integer
+                 | function master_add_inactive_node(text,integer,integer,noderole,name) integer
+                 | function master_add_node(text,integer,integer,noderole,name) integer
+                 | function master_add_secondary_node(text,integer,text,integer,name) integer
+                 | function master_append_table_to_shard(bigint,text,text,integer) real
+                 | function master_apply_delete_command(text) integer
+                 | function master_conninfo_cache_invalidate() trigger
+                 | function master_copy_shard_placement(bigint,text,integer,text,integer,boolean,citus.shard_transfer_mode) void
+                 | function master_create_distributed_table(regclass,text,citus.distribution_type) void
+                 | function master_create_empty_shard(text) bigint
+                 | function master_create_worker_shards(text,integer,integer) void
+                 | function master_disable_node(text,integer) void
+                 | function master_dist_local_group_cache_invalidate() trigger
+                 | function master_dist_node_cache_invalidate() trigger
+                 | function master_dist_object_cache_invalidate() trigger
+                 | function master_dist_partition_cache_invalidate() trigger
+                 | function master_dist_placement_cache_invalidate() trigger
+                 | function master_dist_shard_cache_invalidate() trigger
+                 | function master_drain_node(text,integer,citus.shard_transfer_mode,name) void
+                 | function master_drop_all_shards(regclass,text,text) integer
+                 | function master_drop_sequences(text[]) void
+                 | function master_get_active_worker_nodes() SETOF record
+                 | function master_get_new_placementid() bigint
+                 | function master_get_new_shardid() bigint
+                 | function master_get_table_ddl_events(text) SETOF text
+                 | function master_get_table_metadata(text) record
+                 | function master_modify_multiple_shards(text) integer
+                 | function master_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode) void
+                 | function master_remove_distributed_table_metadata_from_workers(regclass,text,text) void
+                 | function master_remove_node(text,integer) void
+                 | function master_remove_partition_metadata(regclass,text,text) void
+                 | function master_run_on_worker(text[],integer[],text[],boolean) SETOF record
+                 | function master_set_node_property(text,integer,text,boolean) void
+                 | function master_unmark_object_distributed(oid,oid,integer) void
+                 | function master_update_node(integer,text,integer,boolean,integer) void
+                 | function master_update_shard_statistics(bigint) bigint
+                 | function master_update_table_statistics(regclass) void
+                 | function poolinfo_valid(text) boolean
+                 | function read_intermediate_result(text,citus_copy_format) SETOF record
+                 | function read_intermediate_results(text[],citus_copy_format) SETOF record
+                 | function rebalance_table_shards(regclass,real,integer,bigint[],citus.shard_transfer_mode,boolean,name) void
+                 | function recover_prepared_transactions() integer
+                 | function relation_is_a_known_shard(regclass) boolean
+                 | function replicate_table_shards(regclass,integer,integer,bigint[],citus.shard_transfer_mode) void
+                 | function role_exists(name) boolean
+                 | function run_command_on_colocated_placements(regclass,regclass,text,boolean) SETOF record
+                 | function run_command_on_placements(regclass,text,boolean) SETOF record
+                 | function run_command_on_shards(regclass,text,boolean) SETOF record
+                 | function run_command_on_workers(text,boolean) SETOF record
+                 | function shard_name(regclass,bigint) text
+                 | function start_metadata_sync_to_node(text,integer) void
+                 | function stop_metadata_sync_to_node(text,integer) void
+                 | function task_tracker_assign_task(bigint,integer,text) void
+                 | function task_tracker_cleanup_job(bigint) void
+                 | function task_tracker_conninfo_cache_invalidate() trigger
+                 | function task_tracker_task_status(bigint,integer) integer
+                 | function upgrade_to_reference_table(regclass) void
+                 | function worker_append_table_to_shard(text,text,text,integer) void
+                 | function worker_apply_inter_shard_ddl_command(bigint,text,bigint,text,text) void
+                 | function worker_apply_sequence_command(text) void
+                 | function worker_apply_sequence_command(text,regtype) void
+                 | function worker_apply_shard_ddl_command(bigint,text) void
+                 | function worker_apply_shard_ddl_command(bigint,text,text) void
+                 | function worker_cleanup_job_schema_cache() void
+                 | function worker_create_or_replace_object(text) boolean
+                 | function worker_create_schema(bigint,text) void
+                 | function worker_create_truncate_trigger(regclass) void
+                 | function worker_drop_distributed_table(text) void
+                 | function worker_execute_sql_task(bigint,integer,text,boolean) bigint
+                 | function worker_fetch_foreign_file(text,text,bigint,text[],integer[]) void
+                 | function worker_fetch_partition_file(bigint,integer,integer,integer,text,integer) void
+                 | function worker_hash("any") integer
+                 | function worker_hash_partition_table(bigint,integer,text,text,oid,anyarray) void
+                 | function worker_merge_files_and_run_query(bigint,integer,text,text) void
+                 | function worker_merge_files_into_table(bigint,integer,text[],text[]) void
+                 | function worker_partial_agg(oid,anyelement) cstring
+                 | function worker_partial_agg_ffunc(internal) cstring
+                 | function worker_partial_agg_sfunc(internal,oid,anyelement) internal
+                 | function worker_partition_query_result(text,text,integer,citus.distribution_type,text[],text[],boolean) SETOF record
+                 | function worker_range_partition_table(bigint,integer,text,text,oid,anyarray) void
+                 | function worker_repartition_cleanup(bigint) void
                  | schema citus
                  | schema citus_internal
                  | sequence pg_dist_colocationid_seq
@@ -357,14 +359,16 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 9.3-2
 ALTER EXTENSION citus UPDATE TO '9.3-2';
 SELECT * FROM print_extension_changes();
- previous_object |                         current_object
+                  previous_object                  |                            current_object
 ---------------------------------------------------------------------
-                 | function citus_remote_connection_stats()
-                 | function replicate_reference_tables()
-                 | function truncate_local_data_after_distributing_table(regclass)
-                 | function update_distributed_table_colocation(regclass,text)
-                 | function worker_create_or_alter_role(text,text,text)
-(5 rows)
+ function citus_extradata_container(internal) void |
+                                                   | function citus_extradata_container(internal) SETOF record
+                                                   | function citus_remote_connection_stats() SETOF record
+                                                   | function replicate_reference_tables() void
+                                                   | function truncate_local_data_after_distributing_table(regclass) void
+                                                   | function update_distributed_table_colocation(regclass,text) void
+                                                   | function worker_create_or_alter_role(text,text,text) boolean
+(7 rows)
 
 -- Test downgrade to 9.3-2 from 9.4-1
 ALTER EXTENSION citus UPDATE TO '9.4-1';
@@ -378,10 +382,10 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 9.4-1
 ALTER EXTENSION citus UPDATE TO '9.4-1';
 SELECT * FROM print_extension_changes();
- previous_object |                     current_object
+ previous_object |                                                    current_object
 ---------------------------------------------------------------------
-                 | function worker_last_saved_explain_analyze()
-                 | function worker_save_query_explain_analyze(text,jsonb)
+                 | function worker_last_saved_explain_analyze() TABLE(explain_analyze_output text, execution_duration double precision)
+                 | function worker_save_query_explain_analyze(text,jsonb) SETOF record
 (2 rows)
 
 -- Test downgrade to 9.4-1 from 9.5-1
@@ -418,18 +422,18 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 9.5-1
 ALTER EXTENSION citus UPDATE TO '9.5-1';
 SELECT * FROM print_extension_changes();
-                           previous_object                           |                           current_object
+                             previous_object                              |                             current_object
 ---------------------------------------------------------------------
- function master_drop_sequences(text[])                              |
- function task_tracker_assign_task(bigint,integer,text)              |
- function task_tracker_cleanup_job(bigint)                           |
- function task_tracker_conninfo_cache_invalidate()                   |
- function task_tracker_task_status(bigint,integer)                   |
- function worker_execute_sql_task(bigint,integer,text,boolean)       |
- function worker_merge_files_and_run_query(bigint,integer,text,text) |
-                                                                     | function create_citus_local_table(regclass)
-                                                                     | function undistribute_table(regclass)
-                                                                     | function worker_record_sequence_dependency(regclass,regclass,name)
+ function master_drop_sequences(text[]) void                              |
+ function task_tracker_assign_task(bigint,integer,text) void              |
+ function task_tracker_cleanup_job(bigint) void                           |
+ function task_tracker_conninfo_cache_invalidate() trigger                |
+ function task_tracker_task_status(bigint,integer) integer                |
+ function worker_execute_sql_task(bigint,integer,text,boolean) bigint     |
+ function worker_merge_files_and_run_query(bigint,integer,text,text) void |
+                                                                          | function create_citus_local_table(regclass) void
+                                                                          | function undistribute_table(regclass) void
+                                                                          | function worker_record_sequence_dependency(regclass,regclass,name) void
 (10 rows)
 
 -- Test downgrade to 9.5-1 from 10.0-1
@@ -444,75 +448,75 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.0-1
 ALTER EXTENSION citus UPDATE TO '10.0-1';
 SELECT * FROM print_extension_changes();
-                                 previous_object                                 |                                             current_object
+                                   previous_object                                    |                                                current_object
 ---------------------------------------------------------------------
- function citus_total_relation_size(regclass)                                    |
- function create_citus_local_table(regclass)                                     |
- function mark_tables_colocated(regclass,regclass[])                             |
- function master_conninfo_cache_invalidate()                                     |
- function master_create_distributed_table(regclass,text,citus.distribution_type) |
- function master_create_worker_shards(text,integer,integer)                      |
- function master_dist_local_group_cache_invalidate()                             |
- function master_dist_node_cache_invalidate()                                    |
- function master_dist_object_cache_invalidate()                                  |
- function master_dist_partition_cache_invalidate()                               |
- function master_dist_placement_cache_invalidate()                               |
- function master_dist_shard_cache_invalidate()                                   |
- function master_drop_all_shards(regclass,text,text)                             |
- function master_modify_multiple_shards(text)                                    |
- function undistribute_table(regclass)                                           |
- function upgrade_to_reference_table(regclass)                                   |
-                                                                                 | access method columnar
-                                                                                 | function alter_columnar_table_reset(regclass,boolean,boolean,boolean,boolean)
-                                                                                 | function alter_columnar_table_set(regclass,integer,integer,name,integer)
-                                                                                 | function alter_distributed_table(regclass,text,integer,text,boolean)
-                                                                                 | function alter_old_partitions_set_access_method(regclass,timestamp with time zone,name)
-                                                                                 | function alter_table_set_access_method(regclass,text)
-                                                                                 | function citus_activate_node(text,integer)
-                                                                                 | function citus_add_inactive_node(text,integer,integer,noderole,name)
-                                                                                 | function citus_add_local_table_to_metadata(regclass,boolean)
-                                                                                 | function citus_add_node(text,integer,integer,noderole,name)
-                                                                                 | function citus_add_secondary_node(text,integer,text,integer,name)
-                                                                                 | function citus_conninfo_cache_invalidate()
-                                                                                 | function citus_copy_shard_placement(bigint,text,integer,text,integer,boolean,citus.shard_transfer_mode)
-                                                                                 | function citus_disable_node(text,integer)
-                                                                                 | function citus_dist_local_group_cache_invalidate()
-                                                                                 | function citus_dist_node_cache_invalidate()
-                                                                                 | function citus_dist_object_cache_invalidate()
-                                                                                 | function citus_dist_partition_cache_invalidate()
-                                                                                 | function citus_dist_placement_cache_invalidate()
-                                                                                 | function citus_dist_shard_cache_invalidate()
-                                                                                 | function citus_drain_node(text,integer,citus.shard_transfer_mode,name)
-                                                                                 | function citus_drop_all_shards(regclass,text,text)
-                                                                                 | function citus_internal.columnar_ensure_objects_exist()
-                                                                                 | function citus_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode)
-                                                                                 | function citus_remove_node(text,integer)
-                                                                                 | function citus_set_coordinator_host(text,integer,noderole,name)
-                                                                                 | function citus_set_node_property(text,integer,text,boolean)
-                                                                                 | function citus_shard_sizes()
-                                                                                 | function citus_total_relation_size(regclass,boolean)
-                                                                                 | function citus_unmark_object_distributed(oid,oid,integer)
-                                                                                 | function citus_update_node(integer,text,integer,boolean,integer)
-                                                                                 | function citus_update_shard_statistics(bigint)
-                                                                                 | function citus_update_table_statistics(regclass)
-                                                                                 | function columnar.columnar_handler(internal)
-                                                                                 | function fix_pre_citus10_partitioned_table_constraint_names()
-                                                                                 | function fix_pre_citus10_partitioned_table_constraint_names(regclass)
-                                                                                 | function notify_constraint_dropped()
-                                                                                 | function remove_local_tables_from_metadata()
-                                                                                 | function time_partition_range(regclass)
-                                                                                 | function undistribute_table(regclass,boolean)
-                                                                                 | function worker_change_sequence_dependency(regclass,regclass,regclass)
-                                                                                 | function worker_fix_pre_citus10_partitioned_table_constraint_names(regclass,bigint,text)
-                                                                                 | schema columnar
-                                                                                 | sequence columnar.storageid_seq
-                                                                                 | table columnar.chunk
-                                                                                 | table columnar.chunk_group
-                                                                                 | table columnar.options
-                                                                                 | table columnar.stripe
-                                                                                 | view citus_shards
-                                                                                 | view citus_tables
-                                                                                 | view time_partitions
+ function citus_total_relation_size(regclass) bigint                                  |
+ function create_citus_local_table(regclass) void                                     |
+ function mark_tables_colocated(regclass,regclass[]) void                             |
+ function master_conninfo_cache_invalidate() trigger                                  |
+ function master_create_distributed_table(regclass,text,citus.distribution_type) void |
+ function master_create_worker_shards(text,integer,integer) void                      |
+ function master_dist_local_group_cache_invalidate() trigger                          |
+ function master_dist_node_cache_invalidate() trigger                                 |
+ function master_dist_object_cache_invalidate() trigger                               |
+ function master_dist_partition_cache_invalidate() trigger                            |
+ function master_dist_placement_cache_invalidate() trigger                            |
+ function master_dist_shard_cache_invalidate() trigger                                |
+ function master_drop_all_shards(regclass,text,text) integer                          |
+ function master_modify_multiple_shards(text) integer                                 |
+ function undistribute_table(regclass) void                                           |
+ function upgrade_to_reference_table(regclass) void                                   |
+                                                                                      | access method columnar
+                                                                                      | function alter_columnar_table_reset(regclass,boolean,boolean,boolean,boolean) void
+                                                                                      | function alter_columnar_table_set(regclass,integer,integer,name,integer) void
+                                                                                      | function alter_distributed_table(regclass,text,integer,text,boolean) void
+                                                                                      | function alter_old_partitions_set_access_method(regclass,timestamp with time zone,name)
+                                                                                      | function alter_table_set_access_method(regclass,text) void
+                                                                                      | function citus_activate_node(text,integer) integer
+                                                                                      | function citus_add_inactive_node(text,integer,integer,noderole,name) integer
+                                                                                      | function citus_add_local_table_to_metadata(regclass,boolean) void
+                                                                                      | function citus_add_node(text,integer,integer,noderole,name) integer
+                                                                                      | function citus_add_secondary_node(text,integer,text,integer,name) integer
+                                                                                      | function citus_conninfo_cache_invalidate() trigger
+                                                                                      | function citus_copy_shard_placement(bigint,text,integer,text,integer,boolean,citus.shard_transfer_mode) void
+                                                                                      | function citus_disable_node(text,integer) void
+                                                                                      | function citus_dist_local_group_cache_invalidate() trigger
+                                                                                      | function citus_dist_node_cache_invalidate() trigger
+                                                                                      | function citus_dist_object_cache_invalidate() trigger
+                                                                                      | function citus_dist_partition_cache_invalidate() trigger
+                                                                                      | function citus_dist_placement_cache_invalidate() trigger
+                                                                                      | function citus_dist_shard_cache_invalidate() trigger
+                                                                                      | function citus_drain_node(text,integer,citus.shard_transfer_mode,name) void
+                                                                                      | function citus_drop_all_shards(regclass,text,text) integer
+                                                                                      | function citus_internal.columnar_ensure_objects_exist() void
+                                                                                      | function citus_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode) void
+                                                                                      | function citus_remove_node(text,integer) void
+                                                                                      | function citus_set_coordinator_host(text,integer,noderole,name) void
+                                                                                      | function citus_set_node_property(text,integer,text,boolean) void
+                                                                                      | function citus_shard_sizes() SETOF record
+                                                                                      | function citus_total_relation_size(regclass,boolean) bigint
+                                                                                      | function citus_unmark_object_distributed(oid,oid,integer) void
+                                                                                      | function citus_update_node(integer,text,integer,boolean,integer) void
+                                                                                      | function citus_update_shard_statistics(bigint) bigint
+                                                                                      | function citus_update_table_statistics(regclass) void
+                                                                                      | function columnar.columnar_handler(internal) table_am_handler
+                                                                                      | function fix_pre_citus10_partitioned_table_constraint_names() SETOF regclass
+                                                                                      | function fix_pre_citus10_partitioned_table_constraint_names(regclass) void
+                                                                                      | function notify_constraint_dropped() void
+                                                                                      | function remove_local_tables_from_metadata() void
+                                                                                      | function time_partition_range(regclass) record
+                                                                                      | function undistribute_table(regclass,boolean) void
+                                                                                      | function worker_change_sequence_dependency(regclass,regclass,regclass) void
+                                                                                      | function worker_fix_pre_citus10_partitioned_table_constraint_names(regclass,bigint,text) void
+                                                                                      | schema columnar
+                                                                                      | sequence columnar.storageid_seq
+                                                                                      | table columnar.chunk
+                                                                                      | table columnar.chunk_group
+                                                                                      | table columnar.options
+                                                                                      | table columnar.stripe
+                                                                                      | view citus_shards
+                                                                                      | view citus_tables
+                                                                                      | view time_partitions
 (67 rows)
 
 -- Test downgrade to 10.0-1 from 10.0-2
@@ -543,9 +547,9 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.0-3
 ALTER EXTENSION citus UPDATE TO '10.0-3';
 SELECT * FROM print_extension_changes();
- previous_object |              current_object
+ previous_object |                    current_object
 ---------------------------------------------------------------------
-                 | function citus_get_active_worker_nodes()
+                 | function citus_get_active_worker_nodes() SETOF record
 (1 row)
 
 -- Test downgrade to 10.0-3 from 10.1-1
@@ -560,19 +564,19 @@ SELECT * FROM print_extension_changes();
 -- Snapshot of state at 10.1-1
 ALTER EXTENSION citus UPDATE TO '10.1-1';
 SELECT * FROM print_extension_changes();
-                                    previous_object                                    |                                       current_object
+                                                                                                        previous_object                                                                                                        |                                                                                                           current_object
 ---------------------------------------------------------------------
- function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real)         |
- function citus_internal.columnar_ensure_objects_exist()                               |
- function create_distributed_table(regclass,text,citus.distribution_type,text)         |
- function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name) |
-                                                                                       | function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real,real)
-                                                                                       | function citus_local_disk_space_stats()
-                                                                                       | function create_distributed_table(regclass,text,citus.distribution_type,text,integer)
-                                                                                       | function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name,real)
-                                                                                       | function worker_partitioned_relation_size(regclass)
-                                                                                       | function worker_partitioned_relation_total_size(regclass)
-                                                                                       | function worker_partitioned_table_size(regclass)
+ function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real) void                                                                                                                                            |
+ function citus_internal.columnar_ensure_objects_exist() void                                                                                                                                                                  |
+ function create_distributed_table(regclass,text,citus.distribution_type,text) void                                                                                                                                            |
+ function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name) TABLE(table_name regclass, shardid bigint, shard_size bigint, sourcename text, sourceport integer, targetname text, targetport integer) |
+                                                                                                                                                                                                                               | function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real,real) void
+                                                                                                                                                                                                                               | function citus_local_disk_space_stats() record
+                                                                                                                                                                                                                               | function create_distributed_table(regclass,text,citus.distribution_type,text,integer) void
+                                                                                                                                                                                                                               | function get_rebalance_table_shards_plan(regclass,real,integer,bigint[],boolean,name,real) TABLE(table_name regclass, shardid bigint, shard_size bigint, sourcename text, sourceport integer, targetname text, targetport integer)
+                                                                                                                                                                                                                               | function worker_partitioned_relation_size(regclass) bigint
+                                                                                                                                                                                                                               | function worker_partitioned_relation_total_size(regclass) bigint
+                                                                                                                                                                                                                               | function worker_partitioned_table_size(regclass) bigint
 (11 rows)
 
 DROP TABLE prev_objects, extension_diff;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -52,7 +52,9 @@ BEGIN
 	TRUNCATE TABLE extension_diff;
 
 	CREATE TABLE current_objects AS
-	SELECT pg_catalog.pg_describe_object(classid, objid, 0) AS description
+	SELECT pg_catalog.pg_describe_object(classid, objid, 0)
+           || ' ' ||
+           coalesce(pg_catalog.pg_get_function_result(objid), '') AS description
 	FROM pg_catalog.pg_depend, pg_catalog.pg_extension e
 	WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
 		AND refobjid = e.oid


### PR DESCRIPTION
We often change result types of functions slightly. Our downgrade tests
wouldn't notice these changes. This change adds them to the description
of these items.

An example of an SQL change that isn't caught without this change and is
caught with the get_rebalance_progress change in this PR:
https://github.com/citusdata/citus/pull/4963