### PR TITLE
Fix data race in get_rebalance_progress

### DIFF
--- a/src/include/distributed/shard_rebalancer.h
+++ b/src/include/distributed/shard_rebalancer.h
@@ -105,7 +105,7 @@ typedef struct PlacementUpdateEventProgress
 	int sourcePort;
 	char targetName[255];
 	int targetPort;
-	uint64 progress;
+	pg_atomic_uint64 progress;
 } PlacementUpdateEventProgress;
 
 typedef struct NodeFillState


### PR DESCRIPTION
DESCRIPTION: Fix data race in get_rebalance_progress

To be able to report progress of the rebalancer, the rebalancer updates
the state of a shard move in a shared memory segment. To then fetch the
progress, `get_rebalance_progress` can be called which reads this shared
memory.

Without this change it did so without using any synchronization
primitives, allowing for data races. This fixes that by using atomic
operations to update and read from the parts of the shared memory that
can be changed after initialization.