### PR TITLE
Remove function GenerateNewTargetEntriesForSortClauses

### DIFF
--- a/src/test/regress/expected/window_functions.out
+++ b/src/test/regress/expected/window_functions.out
@@ -95,6 +95,9 @@ ORDER BY
 
 -- window function operates on the results of
 -- a join
+-- we also want to verify that this doesn't crash
+-- when the logging level is DEBUG4
+SET log_min_messages TO DEBUG4;
 SELECT
 	us.user_id,
 	SUM(us.value_1) OVER (PARTITION BY us.user_id)
@@ -1592,4 +1595,58 @@ from public.users_table as ut limit 1;
 ---------------------------------------------------------------------
 
 (1 row)
+
+-- verify that this doesn't crash with DEBUG4
+SET log_min_messages TO DEBUG4;
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, value_1, random() as r1
+	FROM
+		users_table as us, events_table
+	WHERE
+		us.user_id = events_table.user_id AND event_type IN (1,2)
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+ user_id | max
+---------------------------------------------------------------------
+       1 |   5
+       3 |   5
+       3 |   5
+       4 |   5
+       5 |   5
+       5 |   5
+       6 |   5
+       6 |   5
+       1 |   4
+       2 |   4
+       3 |   4
+       3 |   4
+       3 |   4
+       4 |   4
+       4 |   4
+       5 |   4
+       5 |   4
+       1 |   3
+       2 |   3
+       2 |   3
+       2 |   3
+       6 |   3
+       2 |   2
+       4 |   2
+       4 |   2
+       4 |   2
+       6 |   2
+       1 |   1
+       3 |   1
+       5 |   1
+       6 |   1
+       5 |   0
+(32 rows)
 

--- a/src/test/regress/expected/window_functions_0.out
+++ b/src/test/regress/expected/window_functions_0.out
@@ -95,6 +95,9 @@ ORDER BY
 
 -- window function operates on the results of
 -- a join
+-- we also want to verify that this doesn't crash
+-- when the logging level is DEBUG4
+SET log_min_messages TO DEBUG4;
 SELECT
 	us.user_id,
 	SUM(us.value_1) OVER (PARTITION BY us.user_id)
@@ -1588,4 +1591,58 @@ from public.users_table as ut limit 1;
 ---------------------------------------------------------------------
 
 (1 row)
+
+-- verify that this doesn't crash with DEBUG4
+SET log_min_messages TO DEBUG4;
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, value_1, random() as r1
+	FROM
+		users_table as us, events_table
+	WHERE
+		us.user_id = events_table.user_id AND event_type IN (1,2)
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+ user_id | max
+---------------------------------------------------------------------
+       1 |   5
+       3 |   5
+       3 |   5
+       4 |   5
+       5 |   5
+       5 |   5
+       6 |   5
+       6 |   5
+       1 |   4
+       2 |   4
+       3 |   4
+       3 |   4
+       3 |   4
+       4 |   4
+       4 |   4
+       5 |   4
+       5 |   4
+       1 |   3
+       2 |   3
+       2 |   3
+       2 |   3
+       6 |   3
+       2 |   2
+       4 |   2
+       4 |   2
+       4 |   2
+       6 |   2
+       1 |   1
+       3 |   1
+       5 |   1
+       6 |   1
+       5 |   0
+(32 rows)
 


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that can cause a crash when DEBUG4 logging is enabled

This PR undoes the changes made in https://github.com/citusdata/citus/pull/2024 because they became obsolete after https://github.com/citusdata/citus/pull/3307