### PR TITLE
Accept invalidation before fk graph validity check

### DIFF
--- a/src/include/distributed/foreign_key_relationship.h
+++ b/src/include/distributed/foreign_key_relationship.h
@@ -20,7 +20,6 @@ extern bool ConnectedToReferenceTableViaFKey(Oid relationId);
 extern List * ReferencedRelationIdList(Oid relationId);
 extern List * ReferencingRelationIdList(Oid relationId);
 extern void SetForeignConstraintRelationshipGraphInvalid(void);
-extern bool IsForeignConstraintRelationshipGraphValid(void);
 extern void ClearForeignConstraintRelationshipGraphContext(void);
 extern HTAB * CreateOidVisitedHashSet(void);
 extern bool OidVisited(HTAB *oidVisitedMap, Oid oid);


### PR DESCRIPTION
InvalidateForeignKeyGraph sends an invalidation via shared memory to all
backends, including the current one.

However, we might not call AcceptInvalidationMessages before reading
from the cache below. It would be better to also add a call to
AcceptInvalidationMessages in IsForeignConstraintRelationshipGraphValid.

See https://github.com/citusdata/citus/pull/5012#discussion_r643264872 for more context
Related: #5012