### PR TITLE
Do not rely on fk cache when truncating local data

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -761,7 +761,7 @@ List *
 GetForeignKeysFromLocalTables(Oid relationId)
 {
 	int referencedFKeysFlag = INCLUDE_REFERENCED_CONSTRAINTS |
-							   INCLUDE_LOCAL_TABLES;
+							  INCLUDE_LOCAL_TABLES;
 	List *referencingFKeyList = GetForeignKeyOids(relationId, referencedFKeysFlag);
 
 	return referencingFKeyList;

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -216,13 +216,13 @@ EnsureLocalTableCanBeTruncated(Oid relationId)
 								  "tables.")));
 	}
 
-	/* make sure there are no foreign key references from a local table */
-	SetForeignConstraintRelationshipGraphInvalid();
-	List *referencingRelationList = ReferencingRelationIdList(relationId);
-
-	Oid referencingRelation = InvalidOid;
-	foreach_oid(referencingRelation, referencingRelationList)
+	List *referencingForeignConstaintsFromLocalTables =
+		GetForeignKeysFromLocalTables(relationId);
+	Oid foreignKeyId = InvalidOid;
+	foreach_oid(foreignKeyId, referencingForeignConstaintsFromLocalTables)
 	{
+		Oid referencingRelation = GetReferencingTableId(foreignKeyId);
+
 		/* we do not truncate a table if there is a local table referencing it */
 		if (!IsCitusTable(referencingRelation))
 		{

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -220,8 +220,7 @@ EnsureLocalTableCanBeTruncated(Oid relationId)
 		GetForeignKeysFromLocalTables(relationId);
 	if (list_length(referencingForeignConstaintsFromLocalTables) > 0)
 	{
-		Oid foreignKeyId = lfirst_oid(list_head(
-										  referencingForeignConstaintsFromLocalTables));
+		Oid foreignKeyId = linitial_oid(referencingForeignConstaintsFromLocalTables);
 		Oid referencingRelation = GetReferencingTableId(foreignKeyId);
 		char *referencedRelationName = get_rel_name(relationId);
 		char *referencingRelationName = get_rel_name(referencingRelation);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -207,6 +207,7 @@ extern bool AnyForeignKeyDependsOnIndex(Oid indexId);
 extern bool HasForeignKeyWithLocalTable(Oid relationId);
 extern bool HasForeignKeyToCitusLocalTable(Oid relationId);
 extern bool HasForeignKeyToReferenceTable(Oid relationOid);
+extern List * GetForeignKeysFromLocalTables(Oid relationId);
 extern bool TableReferenced(Oid relationOid);
 extern bool TableReferencing(Oid relationOid);
 extern bool ConstraintIsAUniquenessConstraint(char *inputConstaintName, Oid relationId);
@@ -217,6 +218,7 @@ extern bool ConstraintWithIdIsOfType(Oid constraintId, char targetConstraintType
 extern bool TableHasExternalForeignKeys(Oid relationId);
 extern List * GetForeignKeyOids(Oid relationId, int flags);
 extern Oid GetReferencedTableId(Oid foreignKeyId);
+extern Oid GetReferencingTableId(Oid foreignKeyId);
 extern bool RelationInvolvedInAnyNonInheritedForeignKeys(Oid relationId);
 
 


### PR DESCRIPTION
@onurctirtir advised me to not rely on foreign key constraints when ensuring that we support truncating local data after distributing a table. (See https://github.com/citusdata/citus/pull/5012#discussion_r643243085)

I'd prefer making sure that the foreign key graph is invalidated properly and do not directly access any heap tuples. However it is not trivial to fix all the missing places where we should have invalidated the caches, and thus we want to access heap tuples instead.

Related: #5017 #5012 