### PR TITLE
Disable dropping and truncating known shards

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -36,6 +36,7 @@
 #include "distributed/relation_access_tracking.h"
 #include "distributed/resource_lock.h"
 #include "distributed/version_compat.h"
+#include "distributed/worker_shard_visibility.h"
 #include "lib/stringinfo.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_expr.h"
@@ -124,6 +125,8 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 		bool missingOK = true;
 
 		Oid relationId = RangeVarGetRelid(tableRangeVar, AccessShareLock, missingOK);
+
+		ErrorIfIllegallyChangingKnownShard(relationId);
 
 		/* we're not interested in non-valid, non-distributed relations */
 		if (relationId == InvalidOid || !IsCitusTable(relationId))

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -32,6 +32,7 @@
 #include "distributed/resource_lock.h"
 #include "distributed/transaction_management.h"
 #include "distributed/worker_transaction.h"
+#include "distributed/worker_shard_visibility.h"
 #include "storage/lmgr.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -266,6 +267,9 @@ ErrorIfUnsupportedTruncateStmt(TruncateStmt *truncateStatement)
 	foreach_ptr(rangeVar, relationList)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
+
+		ErrorIfIllegallyChangingKnownShard(relationId);
+
 		char relationKind = get_rel_relkind(relationId);
 		if (IsCitusTable(relationId) &&
 			relationKind == RELKIND_FOREIGN_TABLE)

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -691,6 +691,18 @@ RegisterCitusConfigVariables(void)
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.enable_manual_changes_to_shards",
+		gettext_noop("Enables dropping and truncating known shards."),
+		gettext_noop("Set to false by default. If set to true, enables "
+					 "dropping and truncating shards on the coordinator "
+					 "(or the workers with metadata)"),
+		&EnableManualChangesToShards,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomRealVariable(
 		"citus.distributed_deadlock_detection_factor",
 		gettext_noop("Sets the time to wait before checking for distributed "

--- a/src/include/distributed/local_executor.h
+++ b/src/include/distributed/local_executor.h
@@ -19,6 +19,8 @@
 extern bool EnableLocalExecution;
 extern bool LogLocalCommands;
 
+extern int LocalExecutorLevel;
+
 typedef enum LocalExecutionStatus
 {
 	LOCAL_EXECUTION_REQUIRED,

--- a/src/include/distributed/worker_shard_visibility.h
+++ b/src/include/distributed/worker_shard_visibility.h
@@ -14,10 +14,12 @@
 #include "nodes/nodes.h"
 
 extern bool OverrideTableVisibility;
+extern bool EnableManualChangesToShards;
 
 
 extern void ReplaceTableVisibleFunction(Node *inputNode);
 extern void ErrorIfRelationIsAKnownShard(Oid relationId);
+extern void ErrorIfIllegallyChangingKnownShard(Oid relationId);
 extern bool RelationIsAKnownShard(Oid shardRelationId, bool onlySearchPath);
 
 

--- a/src/include/distributed/worker_shard_visibility.h
+++ b/src/include/distributed/worker_shard_visibility.h
@@ -20,7 +20,7 @@ extern bool EnableManualChangesToShards;
 extern void ReplaceTableVisibleFunction(Node *inputNode);
 extern void ErrorIfRelationIsAKnownShard(Oid relationId);
 extern void ErrorIfIllegallyChangingKnownShard(Oid relationId);
-extern bool RelationIsAKnownShard(Oid shardRelationId, bool onlySearchPath);
+extern bool RelationIsAKnownShard(Oid shardRelationId);
 
 
 #endif /* WORKER_SHARD_VISIBILITY_H */

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -1842,6 +1842,33 @@ NOTICE:  executing the command locally: SELECT count(DISTINCT (key)::text) AS co
   1001 |     0
 (1 row)
 
+-- test disabling drop and truncate for known shards
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE test_disabling_drop_and_truncate (a int);
+SELECT create_distributed_table('test_disabling_drop_and_truncate', 'a');
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (102040, 'single_node', 'CREATE TABLE single_node.test_disabling_drop_and_truncate (a integer) ');SELECT worker_apply_shard_ddl_command (102040, 'single_node', 'ALTER TABLE single_node.test_disabling_drop_and_truncate OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (102041, 'single_node', 'CREATE TABLE single_node.test_disabling_drop_and_truncate (a integer) ');SELECT worker_apply_shard_ddl_command (102041, 'single_node', 'ALTER TABLE single_node.test_disabling_drop_and_truncate OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (102042, 'single_node', 'CREATE TABLE single_node.test_disabling_drop_and_truncate (a integer) ');SELECT worker_apply_shard_ddl_command (102042, 'single_node', 'ALTER TABLE single_node.test_disabling_drop_and_truncate OWNER TO postgres')
+NOTICE:  executing the command locally: SELECT worker_apply_shard_ddl_command (102043, 'single_node', 'CREATE TABLE single_node.test_disabling_drop_and_truncate (a integer) ');SELECT worker_apply_shard_ddl_command (102043, 'single_node', 'ALTER TABLE single_node.test_disabling_drop_and_truncate OWNER TO postgres')
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.enable_manual_changes_to_shards TO off;
+-- these should error out
+DROP TABLE test_disabling_drop_and_truncate_102040;
+ERROR:  cannot modify "test_disabling_drop_and_truncate_102040" because it is a shard of a distributed table
+HINT:  Use the distributed table or set citus.enable_manual_changes_to_shards to on to modify shards directly
+TRUNCATE TABLE test_disabling_drop_and_truncate_102040;
+ERROR:  cannot modify "test_disabling_drop_and_truncate_102040" because it is a shard of a distributed table
+HINT:  Use the distributed table or set citus.enable_manual_changes_to_shards to on to modify shards directly
+RESET citus.enable_manual_changes_to_shards ;
+-- these should work as expected
+TRUNCATE TABLE test_disabling_drop_and_truncate_102040;
+DROP TABLE test_disabling_drop_and_truncate_102040;
+RESET citus.shard_replication_factor;
+DROP TABLE test_disabling_drop_and_truncate;
 -- lets flush the copy often to make sure everyhing is fine
 SET citus.local_copy_flush_threshold TO 1;
 TRUNCATE another_schema_table;

--- a/src/test/regress/expected/single_node_truncate.out
+++ b/src/test/regress/expected/single_node_truncate.out
@@ -31,9 +31,9 @@ SELECT * FROM table_sizes;
         name        | has_data
 ---------------------------------------------------------------------
  citus_local        | f
- citus_local_102041 | t
+ citus_local_102045 | t
  ref                | t
- ref_102040         | t
+ ref_102044         | t
 (4 rows)
 
 -- verify that this UDF is noop on Citus local tables
@@ -47,9 +47,9 @@ SELECT * FROM table_sizes;
         name        | has_data
 ---------------------------------------------------------------------
  citus_local        | f
- citus_local_102041 | t
+ citus_local_102045 | t
  ref                | t
- ref_102040         | t
+ ref_102044         | t
 (4 rows)
 
 -- test that we allow cascading truncates to citus local tables
@@ -65,9 +65,9 @@ SELECT * FROM table_sizes;
         name        | has_data
 ---------------------------------------------------------------------
  citus_local        | f
- citus_local_102041 | t
+ citus_local_102045 | t
  ref                | f
- ref_102040         | t
+ ref_102044         | t
 (4 rows)
 
 ROLLBACK;
@@ -98,14 +98,14 @@ SELECT * FROM table_sizes;
         name        | has_data
 ---------------------------------------------------------------------
  citus_local        | f
- citus_local_102041 | t
+ citus_local_102045 | t
  dist               | f
- dist_102043        | t
- dist_102044        | t
- dist_102045        | t
- dist_102046        | t
+ dist_102047        | t
+ dist_102048        | t
+ dist_102049        | t
+ dist_102050        | t
  ref                | f
- ref_102040         | t
+ ref_102044         | t
 (9 rows)
 
 ROLLBACK;
@@ -121,14 +121,14 @@ SELECT * FROM table_sizes;
         name        | has_data
 ---------------------------------------------------------------------
  citus_local        | f
- citus_local_102041 | t
+ citus_local_102045 | t
  dist               | f
- dist_102043        | t
- dist_102044        | t
- dist_102045        | t
- dist_102046        | t
+ dist_102047        | t
+ dist_102048        | t
+ dist_102049        | t
+ dist_102050        | t
  ref                | t
- ref_102040         | t
+ ref_102044         | t
 (9 rows)
 
 ROLLBACK;

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -448,6 +448,7 @@ push(@pgOptions, "citus.sort_returning='on'");
 push(@pgOptions, "citus.shard_replication_factor=2");
 push(@pgOptions, "citus.node_connection_timeout=${connectionTimeout}");
 push(@pgOptions, "citus.explain_analyze_sort_method='taskId'");
+push(@pgOptions, "citus.enable_manual_changes_to_shards=on");
 
 # we disable slow start by default to encourage parallelism within tests
 push(@pgOptions, "citus.executor_slow_start_interval=0ms");


### PR DESCRIPTION
DESCRIPTION: Prevents users from dropping&truncating known shards

Adds a new GUC to prevent users from dropping and truncating shards on the coordinator (or MX workers). Set to `true` by default. If set to `false`, enables dropping and truncating the known shards.

fixes: #5002 