### PR TITLE
Only warn about reference tables when removing last node

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1292,7 +1292,7 @@ RemoveNodeFromCluster(char *nodeName, int32 nodePort)
 		}
 		if (NodeGroupHasLivePlacements(workerNode->groupId))
 		{
-			if (ClusterHasReferenceTable())
+			if (ActivePrimaryNodeCount() == 1 && ClusterHasReferenceTable())
 			{
 				ereport(ERROR, (errmsg(
 									"cannot remove the last worker node because there are reference "

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -136,6 +136,10 @@ SELECT create_reference_table('test_reference_table');
 (1 row)
 
 INSERT INTO test_reference_table VALUES (1, '1');
+-- try to remove a node with active placements and reference tables
+SELECT citus_remove_node('localhost', :worker_2_port);
+ERROR:  cannot remove the primary node of a node group which has shard placements
+HINT:  To proceed, either drop the distributed tables or use undistribute_table() function to convert them to local tables
 -- try to disable a node with active placements see that node is removed
 -- observe that a notification is displayed
 SELECT master_disable_node('localhost', :worker_2_port);

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -54,6 +54,9 @@ CREATE TABLE test_reference_table (y int primary key, name text);
 SELECT create_reference_table('test_reference_table');
 INSERT INTO test_reference_table VALUES (1, '1');
 
+-- try to remove a node with active placements and reference tables
+SELECT citus_remove_node('localhost', :worker_2_port);
+
 -- try to disable a node with active placements see that node is removed
 -- observe that a notification is displayed
 SELECT master_disable_node('localhost', :worker_2_port);


### PR DESCRIPTION
This error message keeps bugging me because it is thrown when there are placements on the node even when we are not removing the last node:
```sql
select nodename, nodeport from pg_dist_node;
┌───────────┬──────────┐
│ nodename  │ nodeport │
├───────────┼──────────┤
│ localhost │     1300 │
│ localhost │     1301 │
│ localhost │     1302 │
└───────────┴──────────┘
(3 rows)

select citus_remove_node('localhost', 1302);
ERROR:  cannot remove the last worker node because there are reference tables and it would cause data loss on reference tables
HINT:  To proceed, either drop the reference tables or use undistribute_table() function to convert them to local tables
```

This PR changes the behaviour of citus_remove_node to give the usual error message when there are >1 nodes.
```sql
select citus_remove_node('localhost', 1302);
ERROR:  cannot remove the primary node of a node group which has shard placements
HINT:  To proceed, either drop the distributed tables or use undistribute_table() function to convert them to local tables
```
