### PR TITLE
Enforce table opt constraints when using alter_columnar_table_set

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -1664,6 +1664,15 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(1))
 	{
 		options.chunkRowCount = PG_GETARG_INT32(1);
+		if (options.chunkRowCount < CHUNK_ROW_COUNT_MINIMUM ||
+			options.chunkRowCount > CHUNK_ROW_COUNT_MAXIMUM)
+		{
+			ereport(ERROR, (errmsg("chunk group row count limit out of range"),
+							errhint("chunk group row count limit must be between "
+									UINT64_FORMAT " and " UINT64_FORMAT,
+									(uint64) CHUNK_ROW_COUNT_MINIMUM,
+									(uint64) CHUNK_ROW_COUNT_MAXIMUM)));
+		}
 		ereport(DEBUG1,
 				(errmsg("updating chunk row count to %d", options.chunkRowCount)));
 	}
@@ -1672,6 +1681,15 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(2))
 	{
 		options.stripeRowCount = PG_GETARG_INT32(2);
+		if (options.stripeRowCount < STRIPE_ROW_COUNT_MINIMUM ||
+			options.stripeRowCount > STRIPE_ROW_COUNT_MAXIMUM)
+		{
+			ereport(ERROR, (errmsg("stripe row count limit out of range"),
+							errhint("stripe row count limit must be between "
+									UINT64_FORMAT " and " UINT64_FORMAT,
+									(uint64) STRIPE_ROW_COUNT_MINIMUM,
+									(uint64) STRIPE_ROW_COUNT_MAXIMUM)));
+		}
 		ereport(DEBUG1, (errmsg(
 							 "updating stripe row count to " UINT64_FORMAT,
 							 options.stripeRowCount)));

--- a/src/test/regress/expected/columnar_citus_integration.out
+++ b/src/test/regress/expected/columnar_citus_integration.out
@@ -129,7 +129,7 @@ $cmd$);
 (4 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -139,12 +139,12 @@ SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090000,t,100)
- (localhost,57638,20090001,t,100)
- (localhost,57637,20090002,t,100)
- (localhost,57638,20090003,t,100)
+ (localhost,57637,20090000,t,2000)
+ (localhost,57638,20090001,t,2000)
+ (localhost,57637,20090002,t,2000)
+ (localhost,57638,20090003,t,2000)
 (4 rows)
 
 -- reset setting
@@ -180,7 +180,7 @@ $cmd$);
 (4 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -190,12 +190,12 @@ SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090000,t,100)
- (localhost,57638,20090001,t,100)
- (localhost,57637,20090002,t,100)
- (localhost,57638,20090003,t,100)
+ (localhost,57637,20090000,t,2000)
+ (localhost,57638,20090001,t,2000)
+ (localhost,57637,20090002,t,2000)
+ (localhost,57638,20090003,t,2000)
 (4 rows)
 
 -- reset setting
@@ -220,8 +220,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 15);
  alter_columnar_table_set
@@ -239,12 +239,12 @@ SELECT create_distributed_table('table_option_2', 'a');
 SELECT run_command_on_placements('table_option_2',$cmd$
   SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-             run_command_on_placements
+              run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090004,t,"(100,1000,pglz,15)")
- (localhost,57638,20090005,t,"(100,1000,pglz,15)")
- (localhost,57637,20090006,t,"(100,1000,pglz,15)")
- (localhost,57638,20090007,t,"(100,1000,pglz,15)")
+ (localhost,57637,20090004,t,"(2000,20000,pglz,15)")
+ (localhost,57638,20090005,t,"(2000,20000,pglz,15)")
+ (localhost,57637,20090006,t,"(2000,20000,pglz,15)")
+ (localhost,57638,20090007,t,"(2000,20000,pglz,15)")
 (4 rows)
 
 -- verify undistribute works
@@ -424,7 +424,7 @@ $cmd$);
 (8 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -434,16 +434,16 @@ SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090008,t,100)
- (localhost,57638,20090008,t,100)
- (localhost,57637,20090009,t,100)
- (localhost,57638,20090009,t,100)
- (localhost,57637,20090010,t,100)
- (localhost,57638,20090010,t,100)
- (localhost,57637,20090011,t,100)
- (localhost,57638,20090011,t,100)
+ (localhost,57637,20090008,t,2000)
+ (localhost,57638,20090008,t,2000)
+ (localhost,57637,20090009,t,2000)
+ (localhost,57638,20090009,t,2000)
+ (localhost,57637,20090010,t,2000)
+ (localhost,57638,20090010,t,2000)
+ (localhost,57637,20090011,t,2000)
+ (localhost,57638,20090011,t,2000)
 (8 rows)
 
 -- reset setting
@@ -487,7 +487,7 @@ $cmd$);
 (8 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -497,16 +497,16 @@ SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090008,t,100)
- (localhost,57638,20090008,t,100)
- (localhost,57637,20090009,t,100)
- (localhost,57638,20090009,t,100)
- (localhost,57637,20090010,t,100)
- (localhost,57638,20090010,t,100)
- (localhost,57637,20090011,t,100)
- (localhost,57638,20090011,t,100)
+ (localhost,57637,20090008,t,2000)
+ (localhost,57638,20090008,t,2000)
+ (localhost,57637,20090009,t,2000)
+ (localhost,57638,20090009,t,2000)
+ (localhost,57637,20090010,t,2000)
+ (localhost,57638,20090010,t,2000)
+ (localhost,57637,20090011,t,2000)
+ (localhost,57638,20090011,t,2000)
 (8 rows)
 
 -- reset setting
@@ -535,8 +535,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 19);
  alter_columnar_table_set
@@ -554,16 +554,16 @@ SELECT create_distributed_table('table_option_2', 'a');
 SELECT run_command_on_placements('table_option_2',$cmd$
   SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-             run_command_on_placements
+              run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090012,t,"(100,1000,pglz,19)")
- (localhost,57638,20090012,t,"(100,1000,pglz,19)")
- (localhost,57637,20090013,t,"(100,1000,pglz,19)")
- (localhost,57638,20090013,t,"(100,1000,pglz,19)")
- (localhost,57637,20090014,t,"(100,1000,pglz,19)")
- (localhost,57638,20090014,t,"(100,1000,pglz,19)")
- (localhost,57637,20090015,t,"(100,1000,pglz,19)")
- (localhost,57638,20090015,t,"(100,1000,pglz,19)")
+ (localhost,57637,20090012,t,"(2000,20000,pglz,19)")
+ (localhost,57638,20090012,t,"(2000,20000,pglz,19)")
+ (localhost,57637,20090013,t,"(2000,20000,pglz,19)")
+ (localhost,57638,20090013,t,"(2000,20000,pglz,19)")
+ (localhost,57637,20090014,t,"(2000,20000,pglz,19)")
+ (localhost,57638,20090014,t,"(2000,20000,pglz,19)")
+ (localhost,57637,20090015,t,"(2000,20000,pglz,19)")
+ (localhost,57638,20090015,t,"(2000,20000,pglz,19)")
 (8 rows)
 
 -- verify undistribute works
@@ -699,7 +699,7 @@ $cmd$);
 (2 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -709,10 +709,10 @@ SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit 
 SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090016,t,100)
- (localhost,57638,20090016,t,100)
+ (localhost,57637,20090016,t,2000)
+ (localhost,57638,20090016,t,2000)
 (2 rows)
 
 -- reset setting
@@ -744,7 +744,7 @@ $cmd$);
 (2 rows)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -754,10 +754,10 @@ SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 10
 SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090016,t,100)
- (localhost,57638,20090016,t,100)
+ (localhost,57637,20090016,t,2000)
+ (localhost,57638,20090016,t,2000)
 (2 rows)
 
 -- reset setting
@@ -780,8 +780,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 9);
  alter_columnar_table_set
@@ -799,10 +799,10 @@ SELECT create_reference_table('table_option_reference_2');
 SELECT run_command_on_placements('table_option_reference_2',$cmd$
   SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-            run_command_on_placements
+             run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57637,20090017,t,"(100,1000,pglz,9)")
- (localhost,57638,20090017,t,"(100,1000,pglz,9)")
+ (localhost,57637,20090017,t,"(2000,20000,pglz,9)")
+ (localhost,57638,20090017,t,"(2000,20000,pglz,9)")
 (2 rows)
 
 -- verify undistribute works
@@ -938,7 +938,7 @@ $cmd$);
 (1 row)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -948,9 +948,9 @@ SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limi
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57636,20090018,t,100)
+ (localhost,57636,20090018,t,2000)
 (1 row)
 
 -- reset setting
@@ -980,7 +980,7 @@ $cmd$);
 (1 row)
 
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -990,9 +990,9 @@ SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-    run_command_on_placements
+     run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57636,20090018,t,100)
+ (localhost,57636,20090018,t,2000)
 (1 row)
 
 -- reset setting
@@ -1014,8 +1014,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 9);
  alter_columnar_table_set
@@ -1033,9 +1033,9 @@ SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');
 SELECT run_command_on_placements('table_option_citus_local_2',$cmd$
   SELECT ROW(chunk_group_row_limit, stripe_row_limit, compression, compression_level) FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
-            run_command_on_placements
+             run_command_on_placements
 ---------------------------------------------------------------------
- (localhost,57636,20090019,t,"(100,1000,pglz,9)")
+ (localhost,57636,20090019,t,"(2000,20000,pglz,9)")
 (1 row)
 
 -- verify undistribute works

--- a/src/test/regress/expected/columnar_empty.out
+++ b/src/test/regress/expected/columnar_empty.out
@@ -11,13 +11,13 @@ SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
 
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
    regclass   | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- t_compressed |             100 |              100 |                 3 | pglz
+ t_compressed |                  1000 |             2000 |                 3 | pglz
 (1 row)
 
 -- select

--- a/src/test/regress/expected/columnar_insert.out
+++ b/src/test/regress/expected/columnar_insert.out
@@ -153,7 +153,7 @@ DROP TABLE test_toast_columnar;
 -- We support writing into zero column tables, but not reading from them.
 -- We test that metadata makes sense so we can fix the read path in future.
 CREATE TABLE zero_col() USING columnar;
-SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 10);
+SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -182,7 +182,7 @@ ORDER BY 1,2,3,4;
  zero_col |          2 |                 1 |         1
  zero_col |          3 |                 1 |         1
  zero_col |          4 |                 1 |         1
- zero_col |          5 |                 7 |        64
+ zero_col |          5 |                 1 |        64
 (5 rows)
 
 SELECT relname, stripe_num, value_count FROM columnar.chunk a, pg_class b
@@ -201,13 +201,7 @@ ORDER BY 1,2,3,4;
  zero_col |          2 |               0 |         1
  zero_col |          3 |               0 |         1
  zero_col |          4 |               0 |         1
- zero_col |          5 |               0 |        10
- zero_col |          5 |               1 |        10
- zero_col |          5 |               2 |        10
- zero_col |          5 |               3 |        10
- zero_col |          5 |               4 |        10
- zero_col |          5 |               5 |        10
- zero_col |          5 |               6 |         4
-(11 rows)
+ zero_col |          5 |               0 |        64
+(5 rows)
 
 DROP TABLE zero_col;

--- a/src/test/regress/expected/columnar_tableoptions.out
+++ b/src/test/regress/expected/columnar_tableoptions.out
@@ -8,7 +8,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |           10000 |           150000 |                 3 | none
+ table_options |                 10000 |           150000 |                 3 | none
 (1 row)
 
 -- test changing the compression
@@ -23,7 +23,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |           10000 |           150000 |                 3 | pglz
+ table_options |                 10000 |           150000 |                 3 | pglz
 (1 row)
 
 -- test changing the compression level
@@ -38,11 +38,11 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |           10000 |           150000 |                 5 | pglz
+ table_options |                 10000 |           150000 |                 5 | pglz
 (1 row)
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 10);
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -53,11 +53,11 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |              10 |           150000 |                 5 | pglz
+ table_options |                  2000 |           150000 |                 5 | pglz
 (1 row)
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 4000);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -68,7 +68,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |              10 |              100 |                 5 | pglz
+ table_options |                  2000 |             4000 |                 5 | pglz
 (1 row)
 
 -- VACUUM FULL creates a new table, make sure it copies settings from the table you are vacuuming
@@ -78,11 +78,11 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |              10 |              100 |                 5 | pglz
+ table_options |                  2000 |             4000 |                 5 | pglz
 (1 row)
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
  alter_columnar_table_set
 ---------------------------------------------------------------------
 
@@ -93,7 +93,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 -- make sure table options are not changed when VACUUM a table
@@ -103,7 +103,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 -- make sure table options are not changed when VACUUM FULL a table
@@ -113,7 +113,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 -- make sure table options are not changed when truncating a table
@@ -123,7 +123,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 ALTER TABLE table_options ALTER COLUMN a TYPE bigint;
@@ -132,7 +132,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 -- reset settings one by one to the version of the GUC's
@@ -146,7 +146,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |             100 |             1000 |                 7 | none
+ table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
 SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
@@ -160,7 +160,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |            1000 |             1000 |                 7 | none
+ table_options |                  1000 |             8000 |                 7 | none
 (1 row)
 
 SELECT alter_columnar_table_reset('table_options', stripe_row_limit => true);
@@ -174,7 +174,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |            1000 |            10000 |                 7 | none
+ table_options |                  1000 |            10000 |                 7 | none
 (1 row)
 
 SELECT alter_columnar_table_reset('table_options', compression => true);
@@ -188,7 +188,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |            1000 |            10000 |                 7 | pglz
+ table_options |                  1000 |            10000 |                 7 | pglz
 (1 row)
 
 SELECT alter_columnar_table_reset('table_options', compression_level => true);
@@ -202,7 +202,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |            1000 |            10000 |                11 | pglz
+ table_options |                  1000 |            10000 |                11 | pglz
 (1 row)
 
 -- verify resetting all settings at once work
@@ -215,7 +215,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |            1000 |            10000 |                11 | pglz
+ table_options |                  1000 |            10000 |                11 | pglz
 (1 row)
 
 SELECT alter_columnar_table_reset(
@@ -234,7 +234,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
    regclass    | chunk_group_row_limit | stripe_row_limit | compression_level | compression
 ---------------------------------------------------------------------
- table_options |           10000 |           100000 |                13 | none
+ table_options |                 10000 |           100000 |                13 | none
 (1 row)
 
 -- verify edge cases
@@ -254,6 +254,23 @@ HINT:  compression level must be between 1 and 19
 SELECT alter_columnar_table_set('table_options', compression_level => 20);
 ERROR:  compression level out of range
 HINT:  compression level must be between 1 and 19
+-- verify cannot set out of range stripe_row_limit & chunk_group_row_limit options
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 999);
+ERROR:  stripe row count limit out of range
+HINT:  stripe row count limit must be between 1000 and 10000000
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
+ERROR:  stripe row count limit out of range
+HINT:  stripe row count limit must be between 1000 and 10000000
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
+ERROR:  chunk group row count limit out of range
+HINT:  chunk group row count limit must be between 1000 and 100000
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
+ERROR:  chunk group row count limit out of range
+HINT:  chunk group row count limit must be between 1000 and 100000
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
+ERROR:  chunk group row count limit out of range
+HINT:  chunk group row count limit must be between 1000 and 100000
+INSERT INTO table_options VALUES (1);
 -- verify options are removed when table is dropped
 DROP TABLE table_options;
 -- we expect no entries in çstore.options for anything not found int pg_class

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -272,7 +272,7 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
     -- create columnar table
     CREATE TABLE columnar_table (a int) USING columnar;
     -- alter a columnar table that is created by that unprivileged user
-    SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 100);
+    SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
     -- and drop it
     DROP TABLE columnar_table;
   $$;

--- a/src/test/regress/sql/columnar_citus_integration.sql
+++ b/src/test/regress/sql/columnar_citus_integration.sql
@@ -54,7 +54,7 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -72,7 +72,7 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -87,8 +87,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 15);
 SELECT create_distributed_table('table_option_2', 'a');
@@ -154,7 +154,7 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', chunk_group_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -172,7 +172,7 @@ SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option', stripe_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -187,8 +187,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 19);
 SELECT create_distributed_table('table_option_2', 'a');
@@ -251,7 +251,7 @@ SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_reference', chunk_group_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -269,7 +269,7 @@ SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_reference', stripe_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option_reference',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -284,8 +284,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_reference_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_reference_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 9);
 SELECT create_reference_table('table_option_reference_2');
@@ -351,7 +351,7 @@ SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', chunk_group_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT chunk_group_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -369,7 +369,7 @@ SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
 $cmd$);
 -- change setting
-SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_option_citus_local', stripe_row_limit => 2000);
 -- verify setting
 SELECT run_command_on_placements('table_option_citus_local',$cmd$
   SELECT stripe_row_limit FROM columnar.options WHERE regclass = '%s'::regclass;
@@ -384,8 +384,8 @@ $cmd$);
 -- verify settings are propagated when creating a table
 CREATE TABLE table_option_citus_local_2 (a int, b text) USING columnar;
 SELECT alter_columnar_table_set('table_option_citus_local_2',
-                                chunk_group_row_limit => 100,
-                                stripe_row_limit => 1000,
+                                chunk_group_row_limit => 2000,
+                                stripe_row_limit => 20000,
                                 compression => 'pglz',
                                 compression_level => 9);
 SELECT citus_add_local_table_to_metadata('table_option_citus_local_2');

--- a/src/test/regress/sql/columnar_empty.sql
+++ b/src/test/regress/sql/columnar_empty.sql
@@ -8,8 +8,8 @@ create table t_compressed(a int) using columnar;
 
 -- set options
 SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
-SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 100);
-SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 100);
+SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
+SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
 

--- a/src/test/regress/sql/columnar_insert.sql
+++ b/src/test/regress/sql/columnar_insert.sql
@@ -108,7 +108,7 @@ DROP TABLE test_toast_columnar;
 -- We support writing into zero column tables, but not reading from them.
 -- We test that metadata makes sense so we can fix the read path in future.
 CREATE TABLE zero_col() USING columnar;
-SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 10);
+SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
 
 INSERT INTO zero_col DEFAULT VALUES;
 INSERT INTO zero_col DEFAULT VALUES;

--- a/src/test/regress/sql/columnar_tableoptions.sql
+++ b/src/test/regress/sql/columnar_tableoptions.sql
@@ -24,14 +24,14 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 10);
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 100);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 4000);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -45,7 +45,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 1000, chunk_group_row_limit => 100, compression => 'none', compression_level => 7);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -141,6 +141,14 @@ SELECT alter_columnar_table_set('table_options', compression => 'foobar');
 -- verify cannot set out of range compression levels
 SELECT alter_columnar_table_set('table_options', compression_level => 0);
 SELECT alter_columnar_table_set('table_options', compression_level => 20);
+
+-- verify cannot set out of range stripe_row_limit & chunk_group_row_limit options
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 999);
+SELECT alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
+SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
+INSERT INTO table_options VALUES (1);
 
 -- verify options are removed when table is dropped
 DROP TABLE table_options;

--- a/src/test/regress/sql/multi_multiuser.sql
+++ b/src/test/regress/sql/multi_multiuser.sql
@@ -169,7 +169,7 @@ IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
     -- create columnar table
     CREATE TABLE columnar_table (a int) USING columnar;
     -- alter a columnar table that is created by that unprivileged user
-    SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 100);
+    SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
     -- and drop it
     DROP TABLE columnar_table;
   $$;


### PR DESCRIPTION
DESCRIPTION: `alter_columnar_table_set` enforces table option constraints for columnar tables

Realized that we were not enforcing constraints around `stripe_row_limit` & `chunk_group_row_limit` (like `CHUNK_ROW_COUNT_MINIMUM`) when using `alter_columnar_table_set`, although we were doing that when setting related GUC's (`columnar.chunk_group_row_limit` & `columnar.stripe_row_limit`).

Before this pr, following error was possible:
```sql
CREATE TABLE columnar_table(a int, b int) USING columnar;
SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 0);
INSERT INTO columnar_table select i, i*3 from generate_series(1, 100) i;
ERROR:  floating-point exception
DETAIL:  An invalid floating-point operation was signaled. This probably means an out-of-range result or an invalid operation, such as division by zero.
```
For the values other than `0`, I didn't see such errors but I think it would be nicer to enforce those constraints as we do for related GUC's.

----

If changes make sense, then I think we should merge this for 10.1.
Also applies to 10.0 but not sure if it's worth to backport.


