### PR TITLE
Fix a bug that causes worker_create_or_alter_role to crash with NULL input

### DIFF
--- a/src/backend/distributed/utils/role.c
+++ b/src/backend/distributed/utils/role.c
@@ -73,6 +73,11 @@ alter_role_if_exists(PG_FUNCTION_ARGS)
 Datum
 worker_create_or_alter_role(PG_FUNCTION_ARGS)
 {
+	if (PG_ARGISNULL(0))
+	{
+		ereport(ERROR, (errmsg("role name cannot be NULL")));
+	}
+
 	text *rolenameText = PG_GETARG_TEXT_P(0);
 	const char *rolename = text_to_cstring(rolenameText);
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -364,6 +364,11 @@ SELECT worker_hash('(1, 2)'::test_composite_type);
 
 SELECT citus_truncate_trigger();
 ERROR:  must be called as trigger
+-- make sure worker_create_or_alter_role does not crash with NULL input
+SELECT worker_create_or_alter_role(NULL, NULL, NULL);
+ERROR:  role name cannot be NULL
+SELECT worker_create_or_alter_role(NULL, 'create role dontcrash', NULL);
+ERROR:  role name cannot be NULL
 -- confirm that citus_create_restore_point works
 SELECT 1 FROM citus_create_restore_point('regression-test');
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -202,5 +202,9 @@ SELECT worker_hash('(1, 2)'::test_composite_type);
 
 SELECT citus_truncate_trigger();
 
+-- make sure worker_create_or_alter_role does not crash with NULL input
+SELECT worker_create_or_alter_role(NULL, NULL, NULL);
+SELECT worker_create_or_alter_role(NULL, 'create role dontcrash', NULL);
+
 -- confirm that citus_create_restore_point works
 SELECT 1 FROM citus_create_restore_point('regression-test');


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that caused worker_create_or_alter_role to crash with NULL input

Fixes #5047 