### PR TITLE
Set table size to zero if no size is read

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -644,7 +644,14 @@ DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId,
 	StringInfo tableSizeStringInfo = (StringInfo) linitial(sizeList);
 	char *tableSizeString = tableSizeStringInfo->data;
 
-	*tableSize = SafeStringToUint64(tableSizeString);
+	if (strlen(tableSizeString) > 0)
+	{
+		*tableSize = SafeStringToUint64(tableSizeString);
+	}
+	else
+	{
+		*tableSize = 0;
+	}
 
 	PQclear(result);
 	ClearResults(connection, failOnError);

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -650,6 +650,11 @@ DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId,
 	}
 	else
 	{
+		/*
+		 * This means the shard is moved or dropped while citus_total_relation_size is
+		 * being executed. For this case we get an empty string as table size.
+		 * We can take that as zero to prevent any unnecessary errors.
+		 */
 		*tableSize = 0;
 	}
 


### PR DESCRIPTION
DESCRIPTION: Fixes the relation size bug during rebalancing

If a shard is dropped or moved while `citus_total_relation_size()` is being executed, we get an empty string for table size. For that cases, converting an empty string to an unsigned long integer throws an unnecessary error. To prevent that, we can take these empty strings as zero.

Fixes #5041