### PR TITLE
Allow arbitrary (unsafe) triggers on Citus tables via a GUC

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1151,6 +1151,12 @@ EnsureTableNotDistributed(Oid relationId)
 static void
 EnsureRelationHasNoTriggers(Oid relationId)
 {
+	if (EnableUnsafeTriggers)
+	{
+		/* user really wants triggers */
+		return;
+	}
+
 	List *explicitTriggerIds = GetExplicitTriggerIdList(relationId);
 
 	if (list_length(explicitTriggerIds) > 0)

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -827,15 +827,9 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 		}
 		else if (AlterTableCommandTypeIsTrigger(alterTableType))
 		{
-			/*
-			 * We already error'ed out for ENABLE/DISABLE trigger commands for
-			 * other citus table types in ErrorIfUnsupportedAlterTableStmt.
-			 */
-			Assert(IsCitusTableType(leftRelationId, CITUS_LOCAL_TABLE));
-
 			char *triggerName = command->name;
-			return CitusLocalTableTriggerCommandDDLJob(leftRelationId, triggerName,
-													   alterTableCommand);
+			return CitusCreateTriggerCommandDDLJob(leftRelationId, triggerName,
+												   alterTableCommand);
 		}
 
 		/*

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -51,6 +51,10 @@ static void ErrorIfDropStmtDropsMultipleTriggers(DropStmt *dropTriggerStmt);
 static int16 GetTriggerTypeById(Oid triggerId);
 
 
+/* GUC that overrides trigger checks */
+bool EnableUnsafeTriggers = false;
+
+
 /*
  * GetExplicitTriggerCommandList returns the list of DDL commands to create
  * triggers that are explicitly created for the table with relationId. See
@@ -220,20 +224,14 @@ PostprocessCreateTriggerStmt(Node *node, const char *queryString)
 	}
 
 	EnsureCoordinator();
-
 	ErrorOutForTriggerIfNotCitusLocalTable(relationId);
 
-	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
-	{
-		ObjectAddress objectAddress = GetObjectAddressFromParseTree(node, missingOk);
-		EnsureDependenciesExistOnAllNodes(&objectAddress);
+	ObjectAddress objectAddress = GetObjectAddressFromParseTree(node, missingOk);
+	EnsureDependenciesExistOnAllNodes(&objectAddress);
 
-		char *triggerName = createTriggerStmt->trigname;
-		return CitusLocalTableTriggerCommandDDLJob(relationId, triggerName,
-												   queryString);
-	}
-
-	return NIL;
+	char *triggerName = createTriggerStmt->trigname;
+	return CitusCreateTriggerCommandDDLJob(relationId, triggerName,
+										   queryString);
 }
 
 
@@ -335,15 +333,10 @@ PostprocessAlterTriggerRenameStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 	ErrorOutForTriggerIfNotCitusLocalTable(relationId);
 
-	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
-	{
-		/* use newname as standard process utility already renamed it */
-		char *triggerName = renameTriggerStmt->newname;
-		return CitusLocalTableTriggerCommandDDLJob(relationId, triggerName,
-												   queryString);
-	}
-
-	return NIL;
+	/* use newname as standard process utility already renamed it */
+	char *triggerName = renameTriggerStmt->newname;
+	return CitusCreateTriggerCommandDDLJob(relationId, triggerName,
+										   queryString);
 }
 
 
@@ -399,15 +392,10 @@ PostprocessAlterTriggerDependsStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 	ErrorOutForTriggerIfNotCitusLocalTable(relationId);
 
-	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
-	{
-		Value *triggerNameValue =
-			GetAlterTriggerDependsTriggerNameValue(alterTriggerDependsStmt);
-		return CitusLocalTableTriggerCommandDDLJob(relationId, strVal(triggerNameValue),
-												   queryString);
-	}
-
-	return NIL;
+	Value *triggerNameValue =
+		GetAlterTriggerDependsTriggerNameValue(alterTriggerDependsStmt);
+	return CitusCreateTriggerCommandDDLJob(relationId, strVal(triggerNameValue),
+										   queryString);
 }
 
 
@@ -464,7 +452,7 @@ GetAlterTriggerDependsTriggerNameValue(AlterObjectDependsStmt *alterTriggerDepen
  * unsupported commands or creates ddl job for supported DROP TRIGGER commands.
  * The reason we process drop trigger commands before standard process utility
  * (unlike the other type of trigger commands) is that we act according to trigger
- * type in CitusLocalTableTriggerCommandDDLJob but trigger wouldn't exist after
+ * type in CitusCreateTriggerCommandDDLJob but trigger wouldn't exist after
  * standard process utility.
  */
 List *
@@ -492,15 +480,10 @@ PreprocessDropTriggerStmt(Node *node, const char *queryString,
 
 	ErrorIfUnsupportedDropTriggerCommand(dropTriggerStmt);
 
-	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
-	{
-		char *triggerName = NULL;
-		ExtractDropStmtTriggerAndRelationName(dropTriggerStmt, &triggerName, NULL);
-		return CitusLocalTableTriggerCommandDDLJob(relationId, triggerName,
-												   queryString);
-	}
-
-	return NIL;
+	char *triggerName = NULL;
+	ExtractDropStmtTriggerAndRelationName(dropTriggerStmt, &triggerName, NULL);
+	return CitusCreateTriggerCommandDDLJob(relationId, triggerName,
+										   queryString);
 }
 
 
@@ -533,13 +516,19 @@ ErrorIfUnsupportedDropTriggerCommand(DropStmt *dropTriggerStmt)
 void
 ErrorOutForTriggerIfNotCitusLocalTable(Oid relationId)
 {
-	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
+	if (EnableUnsafeTriggers)
 	{
+		/* user really wants triggers */
 		return;
 	}
-
-	ereport(ERROR, (errmsg("triggers are only supported for local tables added "
-						   "to metadata")));
+	else if (IsCitusTableType(relationId, REFERENCE_TABLE))
+	{
+		ereport(ERROR, (errmsg("triggers are not supported on reference tables")));
+	}
+	else if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
+	{
+		ereport(ERROR, (errmsg("triggers are not supported on distributed tables")));
+	}
 }
 
 
@@ -648,13 +637,13 @@ ErrorIfDropStmtDropsMultipleTriggers(DropStmt *dropTriggerStmt)
 
 
 /*
- * CitusLocalTableTriggerCommandDDLJob creates a ddl job to execute given
+ * CitusCreateTriggerCommandDDLJob creates a ddl job to execute given
  * queryString trigger command on shell relation(s) in mx worker(s) and to
  * execute necessary ddl task on citus local table shard (if needed).
  */
 List *
-CitusLocalTableTriggerCommandDDLJob(Oid relationId, char *triggerName,
-									const char *queryString)
+CitusCreateTriggerCommandDDLJob(Oid relationId, char *triggerName,
+								const char *queryString)
 {
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = relationId;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -928,6 +928,17 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_unsafe_triggers",
+		gettext_noop("Enables arbitrary triggers on distributed tables which may cause "
+					 "visibility and deadlock issues. Use at your own risk."),
+		NULL,
+		&EnableUnsafeTriggers,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.enable_version_checks",
 		gettext_noop("Enables version checks during CREATE/ALTER EXTENSION commands"),
 		NULL,

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -23,6 +23,8 @@
 
 /* controlled via GUC, should be accessed via EnableLocalReferenceForeignKeys() */
 extern bool EnableLocalReferenceForeignKeys;
+extern bool EnableUnsafeTriggers;
+
 
 extern void SwitchToSequentialAndLocalExecutionIfRelationNameTooLong(Oid relationId,
 																	 char *
@@ -485,13 +487,13 @@ extern List * PostprocessAlterTriggerDependsStmt(Node *node, const char *querySt
 extern void AlterTriggerDependsEventExtendNames(
 	AlterObjectDependsStmt *alterTriggerDependsStmt,
 	char *schemaName, uint64 shardId);
+extern void ErrorOutForTriggerIfNotCitusLocalTable(Oid relationId);
 extern List * PreprocessDropTriggerStmt(Node *node, const char *queryString,
 										ProcessUtilityContext processUtilityContext);
-extern void ErrorOutForTriggerIfNotCitusLocalTable(Oid relationId);
 extern void DropTriggerEventExtendNames(DropStmt *dropTriggerStmt, char *schemaName,
 										uint64 shardId);
-extern List * CitusLocalTableTriggerCommandDDLJob(Oid relationId, char *triggerName,
-												  const char *queryString);
+extern List * CitusCreateTriggerCommandDDLJob(Oid relationId, char *triggerName,
+											  const char *queryString);
 extern Oid GetTriggerFunctionId(Oid triggerId);
 
 /* cascade_table_operation_for_connected_relations.c */

--- a/src/test/regress/expected/citus_table_triggers.out
+++ b/src/test/regress/expected/citus_table_triggers.out
@@ -34,11 +34,11 @@ SELECT create_reference_table('reference_table');
 CREATE TRIGGER update_value_dist
 AFTER INSERT ON distributed_table
 FOR EACH ROW EXECUTE FUNCTION update_value();
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 CREATE TRIGGER update_value_ref
 AFTER INSERT ON reference_table
 FOR EACH ROW EXECUTE FUNCTION update_value();
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ---------------------------------------------------------------------
 -- show that we error out for trigger commands on distributed & reference tables
 ---------------------------------------------------------------------
@@ -56,42 +56,42 @@ SET citus.enable_ddl_propagation to ON;
 CREATE EXTENSION seg;
 -- below all should error out
 ALTER TRIGGER update_value_dist ON distributed_table RENAME TO update_value_dist1;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TRIGGER update_value_dist ON distributed_table DEPENDS ON EXTENSION seg;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 DROP TRIGGER update_value_dist ON distributed_table;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table DISABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table DISABLE TRIGGER USER;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table DISABLE TRIGGER update_value_dist;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table ENABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table ENABLE TRIGGER USER;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 ALTER TABLE distributed_table ENABLE TRIGGER update_value_dist;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 -- below all should error out
 ALTER TRIGGER update_value_ref ON reference_table RENAME TO update_value_ref1;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TRIGGER update_value_ref ON reference_table DEPENDS ON EXTENSION seg;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 DROP TRIGGER update_value_ref ON reference_table;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table DISABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table DISABLE TRIGGER USER;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table DISABLE TRIGGER update_value_ref;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table ENABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table ENABLE TRIGGER USER;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ALTER TABLE reference_table ENABLE TRIGGER update_value_ref;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on reference tables
 ---------------------------------------------------------------------
 -- show that we do not allow creating citus tables if the
 -- table has already triggers

--- a/src/test/regress/output/multi_alter_table_statements.source
+++ b/src/test/regress/output/multi_alter_table_statements.source
@@ -999,7 +999,7 @@ SELECT value, count(*) FROM trigger_table GROUP BY value ORDER BY value;
 (1 row)
 
 ALTER TABLE trigger_table DISABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 INSERT INTO trigger_table VALUES (1, 'trigger disabled');
 SELECT value, count(*) FROM trigger_table GROUP BY value ORDER BY value;
       value       | count 
@@ -1008,7 +1008,7 @@ SELECT value, count(*) FROM trigger_table GROUP BY value ORDER BY value;
 (1 row)
 
 ALTER TABLE trigger_table ENABLE TRIGGER ALL;
-ERROR:  triggers are only supported for local tables added to metadata
+ERROR:  triggers are not supported on distributed tables
 INSERT INTO trigger_table VALUES (1, 'trigger disabled');
 SELECT value, count(*) FROM trigger_table GROUP BY value ORDER BY value;
       value       | count 


### PR DESCRIPTION
Creating a branch to experiment with triggers.

When enabling `citus.enable_unsafe_triggers`, allow creation of triggers and propagate them to all shard placements. 

Trigger functions may do things that are invisible to or conflict with the outer distributed transaction.