### PR TITLE
fix regression tests to avoid any conflicts in enterprise

### DIFF
--- a/src/test/regress/expected/local_shard_execution_dropped_column.out
+++ b/src/test/regress/expected/local_shard_execution_dropped_column.out
@@ -196,7 +196,7 @@ NOTICE:  executing the command locally: UPDATE local_shard_execution_dropped_col
 -- has a dropped column but not the shard, via rebalance operation
 SET search_path TO local_shard_execution_dropped_column;
 ALTER TABLE t1 DROP COLUMN a;
-SELECT citus_move_shard_placement(2460000, 'localhost', :worker_1_port, 'localhost', :worker_2_port);
+SELECT citus_move_shard_placement(2460000, 'localhost', :worker_1_port, 'localhost', :worker_2_port, 'block_writes');
  citus_move_shard_placement
 ---------------------------------------------------------------------
 

--- a/src/test/regress/sql/local_shard_execution_dropped_column.sql
+++ b/src/test/regress/sql/local_shard_execution_dropped_column.sql
@@ -84,7 +84,7 @@ execute p4(8);
 SET search_path TO local_shard_execution_dropped_column;
 ALTER TABLE t1 DROP COLUMN a;
 
-SELECT citus_move_shard_placement(2460000, 'localhost', :worker_1_port, 'localhost', :worker_2_port);
+SELECT citus_move_shard_placement(2460000, 'localhost', :worker_1_port, 'localhost', :worker_2_port, 'block_writes');
 
 \c - - - :worker_2_port
 SET search_path TO local_shard_execution_dropped_column;


### PR DESCRIPTION
Trivial enough, merging without any reviews.

Without this fix, enterprise fails with:
```SQL
SELECT citus_move_shard_placement(2460000, 'localhost', :worker_1_port, 'localhost', :worker_2_port);
- citus_move_shard_placement
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  cannot use logical replication to transfer shards of the relation nation_hash since it doesn't have a REPLICA IDENTITY or PRIMARY KEY
+DETAIL:  UPDATE and DELETE commands on the shard will error out during logical replication unless there is a REPLICA IDENTITY or PRIMARY KEY.
+HINT:  If you wish to continue without a replica identity set the shard_transfer_mode to 'force_logical' or 'block_writes'.

``` 

However, we don't care about the replication mode in this test, so simply use `block_writes`