### PR TITLE
Synchronize hasmetadata flag on mx workers

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1110,7 +1110,8 @@ TriggerSyncMetadataToPrimaryNodes(void)
 			 * this because otherwise node activation might fail withing transaction blocks.
 			 */
 			LockRelationOid(DistNodeRelationId(), ExclusiveLock);
-			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
+			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_hasmetadata,
+									 BoolGetDatum(true));
 
 			triggerMetadataSync = true;
 		}

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1110,7 +1110,7 @@ TriggerSyncMetadataToPrimaryNodes(void)
 			 * this because otherwise node activation might fail withing transaction blocks.
 			 */
 			LockRelationOid(DistNodeRelationId(), ExclusiveLock);
-			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
+			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
 
 			triggerMetadataSync = true;
 		}

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -44,6 +44,7 @@
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_executor.h"
 #include "distributed/namespace_utils.h"
+#include "distributed/pg_dist_node.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/version_compat.h"
@@ -1109,7 +1110,8 @@ TriggerSyncMetadataToPrimaryNodes(void)
 			 * this because otherwise node activation might fail withing transaction blocks.
 			 */
 			LockRelationOid(DistNodeRelationId(), ExclusiveLock);
-			MarkNodeHasMetadata(workerNode->workerName, workerNode->workerPort, true);
+			bool localOnly = false;
+			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true, localOnly);
 
 			triggerMetadataSync = true;
 		}

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1110,8 +1110,7 @@ TriggerSyncMetadataToPrimaryNodes(void)
 			 * this because otherwise node activation might fail withing transaction blocks.
 			 */
 			LockRelationOid(DistNodeRelationId(), ExclusiveLock);
-			bool localOnly = false;
-			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true, localOnly);
+			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
 
 			triggerMetadataSync = true;
 		}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1773,20 +1773,23 @@ SyncMetadataToNodes(void)
 		if (workerNode->hasMetadata && !workerNode->metadataSynced)
 		{
 			bool raiseInterrupts = false;
-			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced,
-									 BoolGetDatum(true));
 			if (!SyncMetadataSnapshotToNode(workerNode, raiseInterrupts))
 			{
 				ereport(WARNING, (errmsg("failed to sync metadata to %s:%d",
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
+				break;
 			}
-			else
-			{
-				SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-								BoolGetDatum(true));
-			}
+		}
+	}
+
+	if (result == METADATA_SYNC_SUCCESS)
+	{
+		foreach_ptr(workerNode, workerList)
+		{
+			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
+								true));
 		}
 	}
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -208,8 +208,10 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	UseCoordinatedTransaction();
 
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true));
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
+								 BoolGetDatum(true));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
+									 true));
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -322,8 +324,10 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		}
 	}
 
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(false));
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(false));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
+									 false));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
+								 BoolGetDatum(false));
 
 	PG_RETURN_VOID();
 }
@@ -1813,7 +1817,8 @@ SyncMetadataToNodes(void)
 			}
 			else
 			{
-				SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true));
+				SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced,
+										 BoolGetDatum(true));
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -208,10 +208,11 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	UseCoordinatedTransaction();
 
+	bool raiseOnError = true;
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-								 BoolGetDatum(true));
+								 BoolGetDatum(true), raiseOnError);
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
-									 true));
+									 true), raiseOnError);
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -324,10 +325,11 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		}
 	}
 
+	bool raiseOnError = true;
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
-									 false));
+									 false), raiseOnError);
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-								 BoolGetDatum(false));
+								 BoolGetDatum(false), raiseOnError);
 
 	PG_RETURN_VOID();
 }
@@ -1788,9 +1790,10 @@ SyncMetadataToNodes(void)
 		}
 	}
 
+	bool raiseOnError = false;
 	foreach_ptr(workerNode, workerSuccess)
 	{
-		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true));
+		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true), raiseOnError);
 	}
 
 	return result;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -209,7 +209,9 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 	}
 
 	UseCoordinatedTransaction();
-	MarkNodeHasMetadata(nodeNameString, nodePort, true);
+
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true);
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -221,10 +223,6 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 	}
 
 	SyncMetadataSnapshotToNode(workerNode, raiseInterrupts);
-	MarkNodeMetadataSynced(workerNode->workerName, workerNode->workerPort, true);
-
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true);
 }
 
 
@@ -306,9 +304,6 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		PG_RETURN_VOID();
 	}
 
-	MarkNodeHasMetadata(nodeNameString, nodePort, false);
-	MarkNodeMetadataSynced(nodeNameString, nodePort, false);
-
 	if (clearMetadata)
 	{
 		if (NodeIsPrimary(workerNode))
@@ -329,8 +324,8 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		}
 	}
 
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1793,7 +1793,7 @@ SyncMetadataToNodes(void)
 			}
 		}
 
-		if(setMetadataSynced)
+		if (setMetadataSynced)
 		{
 			workerSuccess = lappend(workerSuccess, workerNode);
 		}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1775,14 +1775,7 @@ SyncMetadataToNodes(void)
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerList)
 	{
-		if (!workerNode->hasMetadata)
-		{
-			/* we have nothing to sync on workers with no metadata */
-			continue;
-		}
-
-		bool shouldSetMetadataSynced = true;
-		if (!workerNode->metadataSynced)
+		if (workerNode->hasMetadata && !workerNode->metadataSynced)
 		{
 			bool raiseInterrupts = false;
 			if (!SyncMetadataSnapshotToNode(workerNode, raiseInterrupts))
@@ -1792,14 +1785,11 @@ SyncMetadataToNodes(void)
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
 
-				/* we shouldn't send command to this worker, since the sync is failed */
-				shouldSetMetadataSynced = false;
 			}
-		}
-
-		if (shouldSetMetadataSynced)
-		{
-			syncedWorkerList = lappend(syncedWorkerList, workerNode);
+			else
+			{
+				syncedWorkerList = lappend(syncedWorkerList, workerNode);
+			}
 		}
 	}
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -205,7 +205,7 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	UseCoordinatedTransaction();
 
-	/* 
+	/*
 	 * We first set metadatasynced, and then hasmetadata; since setting columns for
 	 * nodes with metadatasynced==false could cause errors.
 	 * (See ErrorIfAnyMetadataNodeOutOfSync)
@@ -1791,6 +1791,7 @@ SyncMetadataToNodes(void)
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
+
 				/* we shouldn't send command to this worker, since the sync is failed */
 				shouldSetMetadataSynced = false;
 			}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1773,7 +1773,14 @@ SyncMetadataToNodes(void)
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerList)
 	{
-		if (workerNode->hasMetadata && !workerNode->metadataSynced)
+		if (!workerNode->hasMetadata)
+		{
+			/* we have nothing to sync on workers with no metadata */
+			continue;
+		}
+
+		bool setMetadataSynced = true;
+		if (!workerNode->metadataSynced)
 		{
 			bool raiseInterrupts = false;
 			if (!SyncMetadataSnapshotToNode(workerNode, raiseInterrupts))
@@ -1782,11 +1789,13 @@ SyncMetadataToNodes(void)
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
+				setMetadataSynced = false;
 			}
-			else
-			{
-				workerSuccess = lappend(workerSuccess, workerNode);
-			}
+		}
+
+		if(setMetadataSynced)
+		{
+			workerSuccess = lappend(workerSuccess, workerNode);
 		}
 	}
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -208,11 +208,10 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	UseCoordinatedTransaction();
 
-	bool raiseOnError = true;
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-								 BoolGetDatum(true), raiseOnError);
+								 BoolGetDatum(true));
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
-									 true), raiseOnError);
+									 true));
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -325,11 +324,10 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		}
 	}
 
-	bool raiseOnError = true;
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
-									 false), raiseOnError);
+									 false));
 	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-								 BoolGetDatum(false), raiseOnError);
+								 BoolGetDatum(false));
 
 	PG_RETURN_VOID();
 }
@@ -1799,11 +1797,10 @@ SyncMetadataToNodes(void)
 		}
 	}
 
-	bool raiseOnError = false;
 	foreach_ptr(workerNode, workerSuccess)
 	{
-		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true),
-						raiseOnError);
+		SetWorkerColumnOptional(workerNode, Anum_pg_dist_node_metadatasynced,
+								BoolGetDatum(true));
 	}
 
 	return result;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1779,6 +1779,7 @@ SyncMetadataToNodes(void)
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
+				break;
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -310,6 +310,9 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		PG_RETURN_VOID();
 	}
 
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
+
 	MarkNodeHasMetadata(nodeNameString, nodePort, false);
 	MarkNodeMetadataSynced(nodeNameString, nodePort, false);
 
@@ -332,9 +335,6 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 									nodeNameString, nodePort)));
 		}
 	}
-
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1784,7 +1784,6 @@ SyncMetadataToNodes(void)
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
-
 			}
 			else
 			{

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1779,7 +1779,6 @@ SyncMetadataToNodes(void)
 										 workerNode->workerName,
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
-				break;
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1793,7 +1793,8 @@ SyncMetadataToNodes(void)
 	bool raiseOnError = false;
 	foreach_ptr(workerNode, workerSuccess)
 	{
-		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true), raiseOnError);
+		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true),
+						raiseOnError);
 	}
 
 	return result;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1085,40 +1085,6 @@ ColocationIdUpdateCommand(Oid relationId, uint32 colocationId)
 
 
 /*
- * NodeHasmetadataUpdateCommand generates and returns a SQL UPDATE command
- * that updates the hasmetada column of pg_dist_node, for the given nodeid.
- */
-char *
-NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata)
-{
-	StringInfo updateCommand = makeStringInfo();
-	char *hasMetadataString = hasMetadata ? "TRUE" : "FALSE";
-	appendStringInfo(updateCommand,
-					 "UPDATE pg_dist_node SET hasmetadata = %s "
-					 "WHERE nodeid = %u",
-					 hasMetadataString, nodeId);
-	return updateCommand->data;
-}
-
-
-/*
- * NodeMetadataSyncedUpdateCommand generates and returns a SQL UPDATE command
- * that updates the metadataSynced column of pg_dist_node, for the given nodeid.
- */
-char *
-NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced)
-{
-	StringInfo updateCommand = makeStringInfo();
-	char *hasMetadataString = metadataSynced ? "TRUE" : "FALSE";
-	appendStringInfo(updateCommand,
-					 "UPDATE pg_dist_node SET metadatasynced = %s "
-					 "WHERE nodeid = %u",
-					 hasMetadataString, nodeId);
-	return updateCommand->data;
-}
-
-
-/*
  * PlacementUpsertCommand creates a SQL command for upserting a pg_dist_placment
  * entry with the given properties. In the case of a conflict on placementId, the command
  * updates all properties (excluding the placementId) with the given ones.

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -208,11 +208,7 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 		return;
 	}
 
-<<<<<<< HEAD
 	UseCoordinatedTransaction();
-	UpdateHasmetadataOnWorkersWithMetadata(nodeNameString, nodePort, "true");
-=======
->>>>>>> Use SetWorkerColumn
 	MarkNodeHasMetadata(nodeNameString, nodePort, true);
 
 	if (!NodeIsPrimary(workerNode))
@@ -310,9 +306,6 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		PG_RETURN_VOID();
 	}
 
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
-
 	MarkNodeHasMetadata(nodeNameString, nodePort, false);
 	MarkNodeMetadataSynced(nodeNameString, nodePort, false);
 
@@ -335,6 +328,9 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 									nodeNameString, nodePort)));
 		}
 	}
+
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1802,6 +1802,15 @@ SyncMetadataToNodes(void)
 	{
 		SetWorkerColumnOptional(workerNode, Anum_pg_dist_node_metadatasynced,
 								BoolGetDatum(true));
+
+		/* we fetch the same node again to check if it's synced or not */
+		WorkerNode *nodeUpdated = FindWorkerNode(workerNode->workerName,
+												 workerNode->workerPort);
+		if (!nodeUpdated->metadataSynced)
+		{
+			/* set the result to FAILED to trigger the sync again */
+			result = METADATA_SYNC_FAILED_SYNC;
+		}
 	}
 
 	return result;

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -211,8 +211,10 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 	UseCoordinatedTransaction();
 
 	bool localOnly = false;
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true, localOnly);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true, localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true,
+								 localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true,
+								 localOnly);
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -326,8 +328,10 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 	}
 
 	bool localOnly = false;
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false, localOnly);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false, localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false,
+								 localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false,
+								 localOnly);
 
 	PG_RETURN_VOID();
 }
@@ -1882,7 +1886,8 @@ SyncMetadataToNodes(void)
 			}
 			else
 			{
-				SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true, localOnly);
+				SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true,
+								localOnly);
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1157,19 +1157,6 @@ LocalGroupIdUpdateCommand(int32 groupId)
 
 
 /*
- * MarkNodeHasMetadata function sets the hasmetadata column of the specified worker in
- * pg_dist_node to hasMetadata.
- */
-void
-MarkNodeHasMetadata(const char *nodeName, int32 nodePort, bool hasMetadata)
-{
-	UpdateDistNodeBoolAttr(nodeName, nodePort,
-						   Anum_pg_dist_node_hasmetadata,
-						   hasMetadata);
-}
-
-
-/*
  * UpdateDistNodeBoolAttr updates a boolean attribute of the specified worker
  * to the given value.
  */

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -208,11 +208,8 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	UseCoordinatedTransaction();
 
-	bool localOnly = false;
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true,
-								 localOnly);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, true,
-								 localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
 
 	if (!NodeIsPrimary(workerNode))
 	{
@@ -325,11 +322,8 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 		}
 	}
 
-	bool localOnly = false;
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, false,
-								 localOnly);
-	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, false,
-								 localOnly);
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(false));
+	workerNode = SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(false));
 
 	PG_RETURN_VOID();
 }
@@ -1802,7 +1796,6 @@ SyncMetadataToNodes(void)
 		return METADATA_SYNC_FAILED_LOCK;
 	}
 
-	bool localOnly = true;
 	List *workerList = ActivePrimaryNonCoordinatorNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerList)
@@ -1820,8 +1813,7 @@ SyncMetadataToNodes(void)
 			}
 			else
 			{
-				SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, true,
-								localOnly);
+				SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(true));
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1773,7 +1773,8 @@ SyncMetadataToNodes(void)
 		if (workerNode->hasMetadata && !workerNode->metadataSynced)
 		{
 			bool raiseInterrupts = false;
-
+			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced,
+									 BoolGetDatum(true));
 			if (!SyncMetadataSnapshotToNode(workerNode, raiseInterrupts))
 			{
 				ereport(WARNING, (errmsg("failed to sync metadata to %s:%d",
@@ -1783,8 +1784,8 @@ SyncMetadataToNodes(void)
 			}
 			else
 			{
-				SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced,
-										 BoolGetDatum(true));
+				SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
+								BoolGetDatum(true));
 			}
 		}
 	}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1787,6 +1787,12 @@ SyncMetadataToNodes(void)
 	{
 		foreach_ptr(workerNode, workerList)
 		{
+			SetWorkerColumnLocalOnly(workerNode, Anum_pg_dist_node_metadatasynced,
+									 BoolGetDatum(true));
+		}
+
+		foreach_ptr(workerNode, workerList)
+		{
 			SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(
 								true));
 		}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1787,7 +1787,7 @@ SyncMetadataToNodes(void)
 	{
 		foreach_ptr(workerNode, workerList)
 		{
-			SetWorkerColumn(workerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(
+			SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced, BoolGetDatum(
 								true));
 		}
 	}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1608,7 +1608,13 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 		}
 	}
 
-	SendCommandToWorkersWithMetadata(metadataSyncCommand);
+	List *workerNodeList = TargetWorkerSetNodeList(NON_COORDINATOR_METADATA_NODES, ShareLock);
+	/* open connections in parallel */
+	WorkerNode *workerNodeIterate = NULL;
+	foreach_ptr(workerNodeIterate, workerNodeList)
+	{
+		SendOptionalCommandListToWorkerInCoordinatedTransaction(workerNodeIterate->workerName, workerNodeIterate->workerPort, CurrentUserName(), list_make1(metadataSyncCommand));
+	}
 
 	return workerNode;
 }

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -109,6 +109,8 @@ static bool NodeIsLocal(WorkerNode *worker);
 static void SetLockTimeoutLocally(int32 lock_cooldown);
 static void UpdateNodeLocation(int32 nodeId, char *newNodeName, int32 newNodePort);
 static bool UnsetMetadataSyncedForAll(void);
+static char * NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata);
+static char * NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced);
 static void ErrorIfCoordinatorMetadataSetFalse(WorkerNode *workerNode, Datum value,
 											   char *field);
 static WorkerNode * SetShouldHaveShards(WorkerNode *workerNode, bool shouldHaveShards);
@@ -1651,6 +1653,40 @@ SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex, Datum value)
 	table_close(pgDistNode, NoLock);
 
 	return newWorkerNode;
+}
+
+
+/*
+ * NodeHasmetadataUpdateCommand generates and returns a SQL UPDATE command
+ * that updates the hasmetada column of pg_dist_node, for the given nodeid.
+ */
+static char *
+NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata)
+{
+	StringInfo updateCommand = makeStringInfo();
+	char *hasMetadataString = hasMetadata ? "TRUE" : "FALSE";
+	appendStringInfo(updateCommand,
+					 "UPDATE pg_dist_node SET hasmetadata = %s "
+					 "WHERE nodeid = %u",
+					 hasMetadataString, nodeId);
+	return updateCommand->data;
+}
+
+
+/*
+ * NodeMetadataSyncedUpdateCommand generates and returns a SQL UPDATE command
+ * that updates the metadataSynced column of pg_dist_node, for the given nodeid.
+ */
+static char *
+NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced)
+{
+	StringInfo updateCommand = makeStringInfo();
+	char *hasMetadataString = metadataSynced ? "TRUE" : "FALSE";
+	appendStringInfo(updateCommand,
+					 "UPDATE pg_dist_node SET metadatasynced = %s "
+					 "WHERE nodeid = %u",
+					 hasMetadataString, nodeId);
+	return updateCommand->data;
 }
 
 

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1607,9 +1607,13 @@ SetWorkerColumnOptional(WorkerNode *workerNode, int columnIndex, Datum value)
 		if (!success)
 		{
 			/* metadata out of sync, mark the worker as not synced */
-			ereport(WARNING, (errmsg("Worker column failed to set for node: (%s,%d)."
-									 "Metadata out of sync.", worker->workerName,
-									 worker->workerPort)));
+			ereport(WARNING, (errmsg("Updating the metadata of the node %s:%d "
+									 "is failed on node %s:%d."
+									 "Metadata on %s:%d is marked as out of sync.",
+									 workerNode->workerName, workerNode->workerPort,
+									 worker->workerName, worker->workerPort,
+									 worker->workerName, worker->workerPort)));
+
 			SetWorkerColumnLocalOnly(worker, Anum_pg_dist_node_metadatasynced,
 									 BoolGetDatum(false));
 		}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1611,9 +1611,9 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value, bool raise
 
 	if (raiseOnError)
 	{
+		/* this function errors out if any metadata node is out of sync */
 		SendCommandToWorkersWithMetadata(metadataSyncCommand);
 	}
-
 	else
 	{
 		List *workerNodeList = TargetWorkerSetNodeList(NON_COORDINATOR_METADATA_NODES,

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -579,8 +579,9 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 		 */
 		if (ClusterHasDistributedFunctionWithDistArgument())
 		{
-			MarkNodeHasMetadata(newWorkerNode->workerName, newWorkerNode->workerPort,
-								true);
+			bool localOnly = false;
+			SetWorkerColumn(newWorkerNode, Anum_pg_dist_node_hasmetadata, true,
+							localOnly);
 			TriggerMetadataSyncOnCommit();
 		}
 	}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1556,7 +1556,7 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
  * SetWorkerColumn function sets the column with the specified index
  * (see pg_dist_node.h) on the worker in pg_dist_node.
  * It returns the new worker node after the modification.
- * It also sends commands for the same update on the other metadata nodes, 
+ * It also sends commands for the same update on the other metadata nodes,
  * unless localOnly is true.
  */
 WorkerNode *

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1557,7 +1557,7 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
  * (see pg_dist_node.h) on the worker in pg_dist_node.
  * It returns the new worker node after the modification.
  */
-static WorkerNode *
+WorkerNode *
 SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 {
 	Relation pgDistNode = table_open(DistNodeRelationId(), RowExclusiveLock);
@@ -1575,7 +1575,8 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 		case Anum_pg_dist_node_hasmetadata:
 		{
 			ErrorIfCoordinatorMetadataSetFalse(workerNode, value, "hasmetadata");
-
+			metadataSyncCommand = NodeHasmetadataUpdateCommand(workerNode->nodeId,
+															   DatumGetBool(value));
 			break;
 		}
 
@@ -1598,7 +1599,8 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 		case Anum_pg_dist_node_metadatasynced:
 		{
 			ErrorIfCoordinatorMetadataSetFalse(workerNode, value, "metadatasynced");
-
+			metadataSyncCommand = NodeMetadataSyncedUpdateCommand(workerNode->nodeId,
+																  DatumGetBool(value));
 			break;
 		}
 

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1608,12 +1608,17 @@ SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value)
 		}
 	}
 
-	List *workerNodeList = TargetWorkerSetNodeList(NON_COORDINATOR_METADATA_NODES, ShareLock);
+	List *workerNodeList = TargetWorkerSetNodeList(NON_COORDINATOR_METADATA_NODES,
+												   ShareLock);
+
 	/* open connections in parallel */
 	WorkerNode *workerNodeIterate = NULL;
 	foreach_ptr(workerNodeIterate, workerNodeList)
 	{
-		SendOptionalCommandListToWorkerInCoordinatedTransaction(workerNodeIterate->workerName, workerNodeIterate->workerPort, CurrentUserName(), list_make1(metadataSyncCommand));
+		SendOptionalCommandListToWorkerInCoordinatedTransaction(
+			workerNodeIterate->workerName, workerNodeIterate->workerPort,
+			CurrentUserName(),
+			list_make1(metadataSyncCommand));
 	}
 
 	return workerNode;

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1607,6 +1607,9 @@ SetWorkerColumnOptional(WorkerNode *workerNode, int columnIndex, Datum value)
 		if (!success)
 		{
 			/* metadata out of sync, mark the worker as not synced */
+			ereport(WARNING, (errmsg("Worker column failed to set for node: (%s,%d)."
+									 "Metadata out of sync.", worker->workerName,
+									 worker->workerPort)));
 			SetWorkerColumnLocalOnly(worker, Anum_pg_dist_node_metadatasynced,
 									 BoolGetDatum(false));
 		}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -579,7 +579,8 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 		 */
 		if (ClusterHasDistributedFunctionWithDistArgument())
 		{
-			SetWorkerColumnLocalOnly(newWorkerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
+			SetWorkerColumnLocalOnly(newWorkerNode, Anum_pg_dist_node_hasmetadata,
+									 BoolGetDatum(true));
 			TriggerMetadataSyncOnCommit();
 		}
 	}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -109,7 +109,8 @@ static bool NodeIsLocal(WorkerNode *worker);
 static void SetLockTimeoutLocally(int32 lock_cooldown);
 static void UpdateNodeLocation(int32 nodeId, char *newNodeName, int32 newNodePort);
 static bool UnsetMetadataSyncedForAll(void);
-static char * SetWorkerColumnInternal(WorkerNode *workerNode, int columnIndex, Datum value);
+static char * SetWorkerColumnInternal(WorkerNode *workerNode, int columnIndex, Datum
+									  value);
 static char * NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata);
 static char * NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced);
 static void ErrorIfCoordinatorMetadataSetFalse(WorkerNode *workerNode, Datum value,

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -579,7 +579,7 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 		 */
 		if (ClusterHasDistributedFunctionWithDistArgument())
 		{
-			SetWorkerColumn(newWorkerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
+			SetWorkerColumnLocalOnly(newWorkerNode, Anum_pg_dist_node_hasmetadata, BoolGetDatum(true));
 			TriggerMetadataSyncOnCommit();
 		}
 	}

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -51,7 +51,6 @@ extern char * PlacementUpsertCommand(uint64 shardId, uint64 placementId, int sha
 									 uint64 shardLength, int32 groupId);
 extern void CreateTableMetadataOnWorkers(Oid relationId);
 extern void MarkNodeHasMetadata(const char *nodeName, int32 nodePort, bool hasMetadata);
-extern void MarkNodeMetadataSynced(const char *nodeName, int32 nodePort, bool synced);
 extern BackgroundWorkerHandle * SpawnSyncMetadataToNodes(Oid database, Oid owner);
 extern void SyncMetadataToNodesMain(Datum main_arg);
 extern void SignalMetadataSyncDaemon(Oid database, int sig);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -50,7 +50,6 @@ extern List * GrantOnSchemaDDLCommands(Oid schemaId);
 extern char * PlacementUpsertCommand(uint64 shardId, uint64 placementId, int shardState,
 									 uint64 shardLength, int32 groupId);
 extern void CreateTableMetadataOnWorkers(Oid relationId);
-extern void MarkNodeHasMetadata(const char *nodeName, int32 nodePort, bool hasMetadata);
 extern BackgroundWorkerHandle * SpawnSyncMetadataToNodes(Oid database, Oid owner);
 extern void SyncMetadataToNodesMain(Datum main_arg);
 extern void SignalMetadataSyncDaemon(Oid database, int sig);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -42,8 +42,6 @@ extern List * ShardListInsertCommand(List *shardIntervalList);
 extern char * NodeDeleteCommand(uint32 nodeId);
 extern char * NodeStateUpdateCommand(uint32 nodeId, bool isActive);
 extern char * ShouldHaveShardsUpdateCommand(uint32 nodeId, bool shouldHaveShards);
-extern char * NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata);
-extern char * NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced);
 extern char * ColocationIdUpdateCommand(Oid relationId, uint32 colocationId);
 extern char * CreateSchemaDDLCommand(Oid schemaId);
 extern List * GrantOnSchemaDDLCommands(Oid schemaId);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -42,6 +42,8 @@ extern List * ShardListInsertCommand(List *shardIntervalList);
 extern char * NodeDeleteCommand(uint32 nodeId);
 extern char * NodeStateUpdateCommand(uint32 nodeId, bool isActive);
 extern char * ShouldHaveShardsUpdateCommand(uint32 nodeId, bool shouldHaveShards);
+extern char * NodeHasmetadataUpdateCommand(uint32 nodeId, bool hasMetadata);
+extern char * NodeMetadataSyncedUpdateCommand(uint32 nodeId, bool metadataSynced);
 extern char * ColocationIdUpdateCommand(Oid relationId, uint32 colocationId);
 extern char * CreateSchemaDDLCommand(Oid schemaId);
 extern List * GrantOnSchemaDDLCommands(Oid schemaId);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,7 +96,7 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value, bool raiseOnError);
 extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex,
 											 Datum value);
 extern uint32 CountPrimariesWithMetadata(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,7 +96,8 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value, bool localOnly);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value,
+									bool localOnly);
 extern uint32 CountPrimariesWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,7 +96,8 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value, bool raiseOnError);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value,
+									bool raiseOnError);
 extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex,
 											 Datum value);
 extern uint32 CountPrimariesWithMetadata(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,8 +96,9 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value,
-									bool raiseOnError);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
+extern WorkerNode * SetWorkerColumnOptional(WorkerNode *workerNode, int columnIndex, Datum
+											value);
 extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex,
 											 Datum value);
 extern uint32 CountPrimariesWithMetadata(void);

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,8 +96,8 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value,
-									bool localOnly);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
+extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex, Datum value);
 extern uint32 CountPrimariesWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -97,7 +97,8 @@ extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
 extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
-extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex, Datum value);
+extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex,
+											 Datum value);
 extern uint32 CountPrimariesWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,6 +96,7 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
 extern uint32 CountPrimariesWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -96,7 +96,7 @@ extern bool NodeIsPrimary(WorkerNode *worker);
 extern bool NodeIsSecondary(WorkerNode *worker);
 extern bool NodeIsReadable(WorkerNode *worker);
 extern bool NodeIsCoordinator(WorkerNode *node);
-extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value);
+extern WorkerNode * SetWorkerColumn(WorkerNode *workerNode, int columnIndex, Datum value, bool localOnly);
 extern uint32 CountPrimariesWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 

--- a/src/test/regress/expected/drop_column_partitioned_table.out
+++ b/src/test/regress/expected/drop_column_partitioned_table.out
@@ -248,7 +248,7 @@ EXPLAIN (COSTS FALSE) SELECT count(*) FROM sensors_2000 WHERE measureid = 3;
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
          ->  Aggregate
-               ->  Bitmap Heap Scan on sensors_2000_2580005 sensors_2000
+               ->  Bitmap Heap Scan on sensors_2000_2580005 sensors_xxx
                      Recheck Cond: (measureid = 3)
                      ->  Bitmap Index Scan on sensors_2000_pkey_2580005
                            Index Cond: (measureid = 3)
@@ -263,7 +263,7 @@ EXPLAIN (COSTS FALSE) SELECT count(*) FROM sensors_2001 WHERE measureid = 3;
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
          ->  Aggregate
-               ->  Bitmap Heap Scan on sensors_2001_2580009 sensors_2001
+               ->  Bitmap Heap Scan on sensors_2001_2580009 sensors_xxx
                      Recheck Cond: (measureid = 3)
                      ->  Bitmap Index Scan on sensors_2001_pkey_2580009
                            Index Cond: (measureid = 3)
@@ -278,7 +278,7 @@ EXPLAIN (COSTS FALSE) SELECT count(*) FROM sensors_2002 WHERE measureid = 3;
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
          ->  Aggregate
-               ->  Bitmap Heap Scan on sensors_2002_2580013 sensors_2002
+               ->  Bitmap Heap Scan on sensors_2002_2580013 sensors_xxx
                      Recheck Cond: (measureid = 3)
                      ->  Bitmap Index Scan on sensors_2002_pkey_2580013
                            Index Cond: (measureid = 3)
@@ -293,7 +293,7 @@ EXPLAIN (COSTS FALSE) SELECT count(*) FROM sensors_2003 WHERE measureid = 3;
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
          ->  Aggregate
-               ->  Bitmap Heap Scan on sensors_2003_2580017 sensors_2003
+               ->  Bitmap Heap Scan on sensors_2003_2580017 sensors_xxx
                      Recheck Cond: (measureid = 3)
                      ->  Bitmap Index Scan on sensors_2003_pkey_2580017
                            Index Cond: (measureid = 3)

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -266,7 +266,7 @@ SELECT * FROM pg_dist_local_group;
 SELECT * FROM pg_dist_node ORDER BY nodeid;
  nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive | noderole  |  nodecluster   | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
-      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | f              | t
+      1 |       1 | localhost |    57637 | default  | t           | t        | primary   | default        | t              | t
       2 |       2 | localhost |    57638 | default  | f           | t        | primary   | default        | f              | t
       4 |       1 | localhost |     8888 | default  | f           | t        | secondary | default        | f              | t
       5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f              | t

--- a/src/test/regress/expected/multi_test_helpers_superuser.out
+++ b/src/test/regress/expected/multi_test_helpers_superuser.out
@@ -26,7 +26,7 @@ WITH dist_node_summary AS (
                             ARRAY[dist_node_summary.query, dist_node_summary.query],
                             false)
 ), dist_placement_summary AS (
-    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY shardid) FROM pg_dist_placement' AS query
+    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY placementid) FROM pg_dist_placement' AS query
 ), dist_placement_check AS (
     SELECT count(distinct result) = 1 AS matches
     FROM dist_placement_summary CROSS JOIN LATERAL

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -271,7 +271,13 @@ SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'reference_table__' AND rel
 (1 row)
 
 \c - - - :master_port
--- test synchronization for hasmetadata flag
+-- test synchronization for pg_dist_node flags
+SELECT citus_set_node_property('localhost', :worker_2_port, 'shouldhaveshards', false);
+ citus_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node
 ---------------------------------------------------------------------
@@ -284,23 +290,35 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 
 (1 row)
 
-\c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT citus_set_node_property('localhost', :worker_1_port, 'shouldhaveshards', false);
+ citus_set_node_property
 ---------------------------------------------------------------------
- t           | t
- t           | t
+
+(1 row)
+
+\c - - - :worker_1_port
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
+---------------------------------------------------------------------
+ t           | t              | f
+ t           | t              | f
 (2 rows)
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
- t           | t
- t           | t
+ t           | t              | f
+ t           | t              | f
 (2 rows)
 
 \c - - - :master_port
+SELECT citus_set_node_property('localhost', :worker_2_port, 'shouldhaveshards', true);
+ citus_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
 NOTICE:  dropping metadata on the node (localhost,57637)
  stop_metadata_sync_to_node
@@ -308,18 +326,24 @@ NOTICE:  dropping metadata on the node (localhost,57637)
 
 (1 row)
 
+SELECT citus_set_node_property('localhost', :worker_1_port, 'shouldhaveshards', true);
+ citus_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
 \c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
 (0 rows)
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
- f           | f
- t           | t
+ f           | f              | t
+ t           | t              | t
 (2 rows)
 
 \c - - - :master_port
@@ -331,14 +355,14 @@ NOTICE:  dropping metadata on the node (localhost,57638)
 (1 row)
 
 \c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
 (0 rows)
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata | metadatasynced
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced | shouldhaveshards
 ---------------------------------------------------------------------
 (0 rows)
 

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -271,6 +271,36 @@ SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'reference_table__' AND rel
 (1 row)
 
 \c - - - :master_port
+-- test synchronization for hasmetadata flag
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :worker_1_port
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+\c - - - :worker_2_port
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+\c - - - :master_port
 SET search_path TO "start_stop_metadata_sync";
 -- both start & stop metadata sync operations can be transactional
 BEGIN;

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -308,6 +308,21 @@ NOTICE:  dropping metadata on the node (localhost,57637)
 
 (1 row)
 
+\c - - - :worker_1_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
+---------------------------------------------------------------------
+(0 rows)
+
+\c - - - :worker_2_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
+---------------------------------------------------------------------
+ f           | f
+ t           | t
+(2 rows)
+
+\c - - - :master_port
 SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
 NOTICE:  dropping metadata on the node (localhost,57638)
  stop_metadata_sync_to_node

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -285,20 +285,47 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 (1 row)
 
 \c - - - :worker_1_port
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
 ---------------------------------------------------------------------
- t
- t
+ t           | t
+ t           | t
 (2 rows)
 
 \c - - - :worker_2_port
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- hasmetadata
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
 ---------------------------------------------------------------------
- t
- t
+ t           | t
+ t           | t
 (2 rows)
+
+\c - - - :master_port
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+NOTICE:  dropping metadata on the node (localhost,57637)
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+NOTICE:  dropping metadata on the node (localhost,57638)
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :worker_1_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
+---------------------------------------------------------------------
+(0 rows)
+
+\c - - - :worker_2_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ hasmetadata | metadatasynced
+---------------------------------------------------------------------
+(0 rows)
 
 \c - - - :master_port
 SET search_path TO "start_stop_metadata_sync";

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -367,6 +367,52 @@ SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nod
 (0 rows)
 
 \c - - - :master_port
+-- verify that mx workers are updated when disabling/activating nodes
+SELECT citus_disable_node('localhost', :worker_1_port);
+NOTICE:  Node localhost:xxxxx has active shard placements. Some queries may fail after this operation. Use SELECT master_activate_node('localhost', 57637) to activate this node back.
+ citus_disable_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :worker_2_port
+SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ isactive
+---------------------------------------------------------------------
+ f
+ t
+(2 rows)
+
+\c - - - :master_port
+SET client_min_messages TO ERROR;
+SELECT citus_activate_node('localhost', :worker_1_port);
+ citus_activate_node
+---------------------------------------------------------------------
+                  17
+(1 row)
+
+\c - - - :worker_2_port
+SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ isactive
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+\c - - - :master_port
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+NOTICE:  dropping metadata on the node (localhost,57638)
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
 SET search_path TO "start_stop_metadata_sync";
 -- both start & stop metadata sync operations can be transactional
 BEGIN;

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -382,11 +382,11 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 (1 row)
 
 \c - - - :worker_2_port
-SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- isactive
+SELECT nodeport, isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ nodeport | isactive
 ---------------------------------------------------------------------
- f
- t
+    57637 | f
+    57638 | t
 (2 rows)
 
 \c - - - :master_port
@@ -398,11 +398,11 @@ SELECT citus_activate_node('localhost', :worker_1_port);
 (1 row)
 
 \c - - - :worker_2_port
-SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
- isactive
+SELECT nodeport, isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+ nodeport | isactive
 ---------------------------------------------------------------------
- t
- t
+    57637 | t
+    57638 | t
 (2 rows)
 
 \c - - - :master_port

--- a/src/test/regress/sql/multi_test_helpers_superuser.sql
+++ b/src/test/regress/sql/multi_test_helpers_superuser.sql
@@ -23,7 +23,7 @@ WITH dist_node_summary AS (
                             ARRAY[dist_node_summary.query, dist_node_summary.query],
                             false)
 ), dist_placement_summary AS (
-    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY shardid) FROM pg_dist_placement' AS query
+    SELECT 'SELECT jsonb_agg(pg_dist_placement ORDER BY placementid) FROM pg_dist_placement' AS query
 ), dist_placement_check AS (
     SELECT count(distinct result) = 1 AS matches
     FROM dist_placement_summary CROSS JOIN LATERAL

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -157,14 +157,14 @@ SELECT citus_disable_node('localhost', :worker_1_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 
 \c - - - :worker_2_port
-SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT nodeport, isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
 SET client_min_messages TO ERROR;
 SELECT citus_activate_node('localhost', :worker_1_port);
 
 \c - - - :worker_2_port
-SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT nodeport, isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
 SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -120,32 +120,36 @@ SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'distributed_table__' AND r
 SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'reference_table__' AND relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = 'start_stop_metadata_sync');
 
 \c - - - :master_port
--- test synchronization for hasmetadata flag
+-- test synchronization for pg_dist_node flags
+SELECT citus_set_node_property('localhost', :worker_2_port, 'shouldhaveshards', false);
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+SELECT citus_set_node_property('localhost', :worker_1_port, 'shouldhaveshards', false);
 
 \c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
+SELECT citus_set_node_property('localhost', :worker_2_port, 'shouldhaveshards', true);
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+SELECT citus_set_node_property('localhost', :worker_1_port, 'shouldhaveshards', true);
 \c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
 SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
 
 \c - - - :worker_1_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :worker_2_port
-SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
 SET search_path TO "start_stop_metadata_sync";

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -125,10 +125,19 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 
 \c - - - :worker_1_port
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :worker_2_port
-SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :master_port
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+\c - - - :worker_1_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :worker_2_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
 SET search_path TO "start_stop_metadata_sync";

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -120,6 +120,17 @@ SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'distributed_table__' AND r
 SELECT count(*) > 0 FROM pg_class WHERE relname LIKE 'reference_table__' AND relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = 'start_stop_metadata_sync');
 
 \c - - - :master_port
+-- test synchronization for hasmetadata flag
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+
+\c - - - :worker_1_port
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :worker_2_port
+SELECT hasmetadata FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :master_port
 SET search_path TO "start_stop_metadata_sync";
 
 -- both start & stop metadata sync operations can be transactional

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -152,6 +152,23 @@ SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nod
 SELECT hasmetadata, metadatasynced, shouldhaveshards FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 
 \c - - - :master_port
+-- verify that mx workers are updated when disabling/activating nodes
+SELECT citus_disable_node('localhost', :worker_1_port);
+SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+
+\c - - - :worker_2_port
+SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :master_port
+SET client_min_messages TO ERROR;
+SELECT citus_activate_node('localhost', :worker_1_port);
+
+\c - - - :worker_2_port
+SELECT isactive FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :master_port
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+
 SET search_path TO "start_stop_metadata_sync";
 
 -- both start & stop metadata sync operations can be transactional

--- a/src/test/regress/sql/start_stop_metadata_sync.sql
+++ b/src/test/regress/sql/start_stop_metadata_sync.sql
@@ -132,7 +132,15 @@ SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_
 
 \c - - - :master_port
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+\c - - - :worker_1_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :worker_2_port
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
+
+\c - - - :master_port
 SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+
 \c - - - :worker_1_port
 SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport IN (:worker_1_port, :worker_2_port) ORDER BY nodeport;
 


### PR DESCRIPTION
DESCRIPTION: Synchronizes hasmetadata flag on mx workers

1- In the beginning, this PR's target was to keep `hasmetadata` flag synced among the metadata nodes. However, we extended the scope and included other `pg_dist_node` fields such as `metadatasynced` and `shouldhaveshards`. We also refactored the API we used to update `pg_dist_node`. Removed/created/modified all these functions as explained below.

2- This PR removes the functions we used to update `pg_dist_node`. Namely, `MarkNodeHasMetadata`, `MarkNodeMetadataSynced` and `UpdateDistNodeBoolAttr`. Instead, we improved `SetWorkerColumn` API and used it in place of others. Now we have `SetWorkerColumn` to set a field of a worker, and then propagate it to other metadata workers to keep them synced. We also have `SetWorkerColumnLocalOnly` which does the same, but no propagation. Lastly, we have `SetWorkerColumnOptional` which, again, does the same, but with an optional transaction. We tried to avoid using `SetWorkerColumnLocalOnly` as much as possible, as we want to keep all metadata nodes updated.

3- This PR adds SQL commands generator functions for `UPDATE pg_dist_node SET ...` commands.

4- Added regression tests that verify we successfully start/stop metadata sync and keep different fields of `pg_dist_node` updated among the nodes. Also tested with activating/disabling node.

fixes: #2320