### PR TITLE
Fix a flaky test

### DIFF
--- a/src/test/regress/expected/shared_connection_stats.out
+++ b/src/test/regress/expected/shared_connection_stats.out
@@ -226,10 +226,11 @@ COMMIT;
 -- now, some of the optional connections would be skipped,
 -- and only 5 connections are used per node
 BEGIN;
-	SELECT count(*), pg_sleep(0.1) FROM test;
- count | pg_sleep
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
+	with cte_1 as (select pg_sleep(0.1) is null, a from test) SELECT a from cte_1 ORDER By 1 LIMIT 1;
+ a
 ---------------------------------------------------------------------
-   101 |
+ 0
 (1 row)
 
 	SELECT

--- a/src/test/regress/sql/shared_connection_stats.sql
+++ b/src/test/regress/sql/shared_connection_stats.sql
@@ -148,7 +148,8 @@ COMMIT;
 -- now, some of the optional connections would be skipped,
 -- and only 5 connections are used per node
 BEGIN;
-	SELECT count(*), pg_sleep(0.1) FROM test;
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 16;
+	with cte_1 as (select pg_sleep(0.1) is null, a from test) SELECT a from cte_1 ORDER By 1 LIMIT 1;
 	SELECT
 		connection_count_to_node
 	FROM


### PR DESCRIPTION
This is a backport of #4596.

The tests on pg11 on 9.5 seems to be so flaky, so we are backporting this.