### PR TITLE
Remove stripeList & currentStripe from ColumnarReadState

### DIFF
--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -447,8 +447,8 @@ AdvanceStripeRead(ColumnarReadState *readState)
 	readState->chunkGroupsFiltered +=
 		readState->stripeReadState->chunkGroupsFiltered;
 
-	uint64 lastReadRowNumber = readState->currentStripeMetadata->firstRowNumber +
-							   readState->currentStripeMetadata->rowCount - 1;
+	uint64 lastReadRowNumber =
+		StripeGetHighestRowNumber(readState->currentStripeMetadata);
 
 	EndStripeRead(readState->stripeReadState);
 

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -1295,8 +1295,7 @@ ColumnarGetHighestItemPointer(Relation relation, Snapshot snapshot)
 		return invalidItemPtr;
 	}
 
-	uint64 highestRowNumber = stripeWithHighestRowNumber->firstRowNumber +
-							  stripeWithHighestRowNumber->rowCount - 1;
+	uint64 highestRowNumber = StripeGetHighestRowNumber(stripeWithHighestRowNumber);
 	return row_number_to_tid(highestRowNumber);
 }
 

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -254,6 +254,8 @@ extern void SaveChunkGroups(RelFileNode relfilenode, uint64 stripe,
 extern StripeSkipList * ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 										   TupleDesc tupleDescriptor,
 										   uint32 chunkCount);
+extern StripeMetadata * FindNextStripeByRowNumber(Relation relation, uint64 rowNumber,
+												  Snapshot snapshot);
 extern StripeMetadata * FindStripeByRowNumber(Relation relation, uint64 rowNumber,
 											  Snapshot snapshot);
 extern StripeMetadata * FindStripeWithHighestRowNumber(Relation relation,

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -258,6 +258,7 @@ extern StripeMetadata * FindNextStripeByRowNumber(Relation relation, uint64 rowN
 												  Snapshot snapshot);
 extern StripeMetadata * FindStripeByRowNumber(Relation relation, uint64 rowNumber,
 											  Snapshot snapshot);
+extern uint64 StripeGetHighestRowNumber(StripeMetadata *stripeMetadata);
 extern StripeMetadata * FindStripeWithHighestRowNumber(Relation relation,
 													   Snapshot snapshot);
 extern Datum columnar_relation_storageid(PG_FUNCTION_ARGS);


### PR DESCRIPTION
In #5058, we optimize correlated index scan by caching the last read stripe.
However, each time `columnar_index_fetch_tuple` is called, we had to search our stripe in `stripeList` to properly set `currentStripe` for the cached stripe.

For this reason, we remove `stripeList` & `currentStripe (index)` fields from `ColumnarReadState` and introduce `currentStripeMetadata` with this pr.