### PR TITLE
Re-cost columnar table index scan paths

### DIFF
--- a/src/test/regress/columnar_schedule
+++ b/src/test/regress/columnar_schedule
@@ -9,7 +9,7 @@ test: columnar_analyze
 test: columnar_data_types
 test: columnar_drop
 test: columnar_indexes
-test: columnar_fallback_scan
+test: columnar_fallback_scan columnar_paths
 test: columnar_partitioning
 test: columnar_permissions
 test: columnar_empty

--- a/src/test/regress/expected/columnar_paths.out
+++ b/src/test/regress/expected/columnar_paths.out
@@ -1,0 +1,302 @@
+CREATE SCHEMA columnar_paths;
+SET search_path TO columnar_paths;
+CREATE TABLE full_correlated (a int, b text, c int, d int) USING columnar;
+INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000000) i;
+CREATE INDEX full_correlated_btree ON full_correlated (a);
+ANALYZE full_correlated;
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a=200;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a<0;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a>10 AND a<20;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a>1000000;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>900000;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a<1000;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b FROM full_correlated WHERE a<3000;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a<9000;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+BEGIN;
+  TRUNCATE full_correlated;
+  INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000) i;
+  -- Since we have much smaller number of rows, selectivity of below
+  -- query should be much higher. So we would choose columnar custom scan.
+  SELECT columnar_test_helpers.uses_custom_scan (
+  $$
+  SELECT a FROM full_correlated WHERE a=200;
+  $$
+  );
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- same filter used in above, but choosing multiple columns would increase
+-- custom scan cost, so we would prefer index scan this time
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b,c,d FROM full_correlated WHERE a<9000;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- again same filter used in above, but we would choose custom scan this
+-- time since it would read three less columns from disk
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT c FROM full_correlated WHERE a<10000;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>200;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=0 OR a=5;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP INDEX full_correlated_btree;
+CREATE INDEX full_correlated_hash ON full_correlated USING hash(a);
+ANALYZE full_correlated;
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a<10;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>1 AND a<10;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=0 OR a=5;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=1000;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,c FROM full_correlated WHERE a=1000;
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE full_anti_correlated (a int, b text) USING columnar;
+INSERT INTO full_anti_correlated SELECT i, i::text FROM generate_series(1, 500000) i;
+CREATE INDEX full_anti_correlated_hash ON full_anti_correlated USING hash(b);
+ANALYZE full_anti_correlated;
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE b='600';
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b FROM full_anti_correlated WHERE b='600';
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a,b FROM full_anti_correlated WHERE b='600' OR b='10';
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP INDEX full_anti_correlated_hash;
+CREATE INDEX full_anti_correlated_btree ON full_anti_correlated (a,b);
+ANALYZE full_anti_correlated;
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>6500 AND a<7000 AND b<'10000';
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>2000 AND a<7000;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>2000 AND a<7000 AND b='24';
+$$
+);
+ uses_index_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a<7000 AND b<'10000';
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE no_correlation (a int, b text) USING columnar;
+INSERT INTO no_correlation SELECT random()*5000, (random()*5000)::int::text FROM generate_series(1, 500000) i;
+CREATE INDEX no_correlation_btree ON no_correlation (a);
+ANALYZE no_correlation;
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM no_correlation WHERE a < 2;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM no_correlation WHERE a = 200;
+$$
+);
+ uses_custom_scan
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_paths CASCADE;

--- a/src/test/regress/expected/columnar_test_helpers.out
+++ b/src/test/regress/expected/columnar_test_helpers.out
@@ -77,3 +77,30 @@ CREATE FUNCTION top_memory_context_usage()
 	RETURNS BIGINT AS $$
 		SELECT TopMemoryContext FROM columnar_test_helpers.columnar_store_memory_stats();
 	$$ LANGUAGE SQL VOLATILE;
+CREATE OR REPLACE FUNCTION uses_index_scan(command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+  query_plan text;
+BEGIN
+  FOR query_plan IN EXECUTE 'EXPLAIN' || command LOOP
+    IF query_plan ILIKE '%Index Only Scan using%' OR
+       query_plan ILIKE '%Index Scan using%'
+    THEN
+        RETURN true;
+    END IF;
+  END LOOP;
+  RETURN false;
+END; $$ language plpgsql;
+CREATE OR REPLACE FUNCTION uses_custom_scan(command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+  query_plan text;
+BEGIN
+  FOR query_plan IN EXECUTE 'EXPLAIN' || command LOOP
+    IF query_plan ILIKE '%Custom Scan (ColumnarScan)%'
+    THEN
+        RETURN true;
+    END IF;
+  END LOOP;
+  RETURN false;
+END; $$ language plpgsql;

--- a/src/test/regress/sql/columnar_paths.sql
+++ b/src/test/regress/sql/columnar_paths.sql
@@ -1,0 +1,203 @@
+CREATE SCHEMA columnar_paths;
+SET search_path TO columnar_paths;
+
+CREATE TABLE full_correlated (a int, b text, c int, d int) USING columnar;
+INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000000) i;
+CREATE INDEX full_correlated_btree ON full_correlated (a);
+ANALYZE full_correlated;
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a=200;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a<0;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a>10 AND a<20;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a>1000000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>900000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_correlated WHERE a<1000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b FROM full_correlated WHERE a<3000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a<9000;
+$$
+);
+
+BEGIN;
+  TRUNCATE full_correlated;
+  INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000) i;
+
+  -- Since we have much smaller number of rows, selectivity of below
+  -- query should be much higher. So we would choose columnar custom scan.
+  SELECT columnar_test_helpers.uses_custom_scan (
+  $$
+  SELECT a FROM full_correlated WHERE a=200;
+  $$
+  );
+ROLLBACK;
+
+-- same filter used in above, but choosing multiple columns would increase
+-- custom scan cost, so we would prefer index scan this time
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b,c,d FROM full_correlated WHERE a<9000;
+$$
+);
+
+-- again same filter used in above, but we would choose custom scan this
+-- time since it would read three less columns from disk
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT c FROM full_correlated WHERE a<10000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>200;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=0 OR a=5;
+$$
+);
+
+DROP INDEX full_correlated_btree;
+
+CREATE INDEX full_correlated_hash ON full_correlated USING hash(a);
+ANALYZE full_correlated;
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a<10;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a>1 AND a<10;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=0 OR a=5;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_correlated WHERE a=1000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,c FROM full_correlated WHERE a=1000;
+$$
+);
+
+CREATE TABLE full_anti_correlated (a int, b text) USING columnar;
+INSERT INTO full_anti_correlated SELECT i, i::text FROM generate_series(1, 500000) i;
+CREATE INDEX full_anti_correlated_hash ON full_anti_correlated USING hash(b);
+ANALYZE full_anti_correlated;
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE b='600';
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a,b FROM full_anti_correlated WHERE b='600';
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a,b FROM full_anti_correlated WHERE b='600' OR b='10';
+$$
+);
+
+DROP INDEX full_anti_correlated_hash;
+
+CREATE INDEX full_anti_correlated_btree ON full_anti_correlated (a,b);
+ANALYZE full_anti_correlated;
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>6500 AND a<7000 AND b<'10000';
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>2000 AND a<7000;
+$$
+);
+
+SELECT columnar_test_helpers.uses_index_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a>2000 AND a<7000 AND b='24';
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM full_anti_correlated WHERE a<7000 AND b<'10000';
+$$
+);
+
+CREATE TABLE no_correlation (a int, b text) USING columnar;
+INSERT INTO no_correlation SELECT random()*5000, (random()*5000)::int::text FROM generate_series(1, 500000) i;
+CREATE INDEX no_correlation_btree ON no_correlation (a);
+ANALYZE no_correlation;
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM no_correlation WHERE a < 2;
+$$
+);
+
+SELECT columnar_test_helpers.uses_custom_scan (
+$$
+SELECT a FROM no_correlation WHERE a = 200;
+$$
+);
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_paths CASCADE;

--- a/src/test/regress/sql/columnar_test_helpers.sql
+++ b/src/test/regress/sql/columnar_test_helpers.sql
@@ -84,3 +84,32 @@ CREATE FUNCTION top_memory_context_usage()
 	RETURNS BIGINT AS $$
 		SELECT TopMemoryContext FROM columnar_test_helpers.columnar_store_memory_stats();
 	$$ LANGUAGE SQL VOLATILE;
+
+CREATE OR REPLACE FUNCTION uses_index_scan(command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+  query_plan text;
+BEGIN
+  FOR query_plan IN EXECUTE 'EXPLAIN' || command LOOP
+    IF query_plan ILIKE '%Index Only Scan using%' OR
+       query_plan ILIKE '%Index Scan using%'
+    THEN
+        RETURN true;
+    END IF;
+  END LOOP;
+  RETURN false;
+END; $$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION uses_custom_scan(command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+  query_plan text;
+BEGIN
+  FOR query_plan IN EXECUTE 'EXPLAIN' || command LOOP
+    IF query_plan ILIKE '%Custom Scan (ColumnarScan)%'
+    THEN
+        RETURN true;
+    END IF;
+  END LOOP;
+  RETURN false;
+END; $$ language plpgsql;


### PR DESCRIPTION
(Rebased onto #5058)

With the changes in this pr, we adjust the cost estimate done by indexAM for `IndexPath` according to columnar tables when the index is on a columnar table.
This is because, the way indexAM estimates the cost is not appropriate for indexes on columnar tables.
The most basic reason is that indexAM assumes we will only need to read single page to access a single tuple of the table.
On the other hand for columnar tables, we read the whole stripe from disk for a single tuple too, regardless of the optimization done in #5058.

Note that we don't simply assign startup / total costs but we add the cost estmated by us to the cost estimated by indexAM.
This is because we need to take "the cost due to index data-structure traversal" into account too.

Before explaining the logic that we follow for `IndexPath`, let's first summarize what we were / are doing for `ColumnarCustomScan`:
```math
X <- cost for reading single column of single stripe // 1
cost = X * (number of columns after projection pushdown) // 2
cost = cost * (number of stripes that relation has) // 3
```

The logic that we follow to calculate the additional cost for index scan is as follows:
```math
X <- cost for reading single column of single stripe // same as 1 above
cost = X * (number of columns that relation has) // index scan cannot do projection pushdown, so different than 2 above
cost = cost * (estimated number of stripes that we need to read)
```

where, we calculate `estimated number of stripes that we need to read` as follows:

```math
indexCorrelation, indexSelectivity <- calculate by using amcostestimate_function
estimatedReadRows = (relation row count) * indexSelectivity

minEstimateStripeReads = estimatedReadRows / (average stripe row count) // full correlation, we will not do any redundant stripe reads
maxEstimateStripeReads = estimatedReadRows // no correlation, we will read a different stripe for each tuple

complementCorrelation = 1 - abs(indexCorrelation)
estimatedStripeCount = minEstimateStripeReads +
                       complementCorrelation  * (maxEstimateStripeReads  - minEstimateStripeReads)
```

------

Note that this pr doesn't re-cost sequential scan paths, which we should do in another pr for the cases where `columnar.enable_custom_scan` is set to `'off'`.

------

TODO:
- [x] Add tests to show when we choose index scan / columnar custom scan