### PR TITLE
Fix: citus_prepare_pg_upgrade idempotency

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/10.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/10.1-1.sql
@@ -18,6 +18,7 @@ BEGIN
     DROP TABLE IF EXISTS public.pg_dist_authinfo;
     DROP TABLE IF EXISTS public.pg_dist_poolinfo;
     DROP TABLE IF EXISTS public.pg_dist_rebalance_strategy;
+    DROP TABLE IF EXISTS public.pg_dist_object;
 
     --
     -- backup citus catalog tables

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/9.5-2.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/9.5-2.sql
@@ -18,6 +18,7 @@ BEGIN
     DROP TABLE IF EXISTS public.pg_dist_authinfo;
     DROP TABLE IF EXISTS public.pg_dist_poolinfo;
     DROP TABLE IF EXISTS public.pg_dist_rebalance_strategy;
+    DROP TABLE IF EXISTS public.pg_dist_object;
 
     --
     -- backup citus catalog tables

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
@@ -18,6 +18,7 @@ BEGIN
     DROP TABLE IF EXISTS public.pg_dist_authinfo;
     DROP TABLE IF EXISTS public.pg_dist_poolinfo;
     DROP TABLE IF EXISTS public.pg_dist_rebalance_strategy;
+    DROP TABLE IF EXISTS public.pg_dist_object;
 
     --
     -- backup citus catalog tables

--- a/src/test/regress/upgrade/pg_upgrade_test.py
+++ b/src/test/regress/upgrade/pg_upgrade_test.py
@@ -67,6 +67,8 @@ def main(config):
                    NODE_PORTS[COORDINATOR_NAME], AFTER_PG_UPGRADE_SCHEDULE)
 
     citus_prepare_pg_upgrade(config.old_bindir)
+    # prepare should be idempotent, calling it a second time should never fail.
+    citus_prepare_pg_upgrade(config.old_bindir)
     common.stop_databases(config.old_bindir, config.old_datadir)
 
     common.initialize_db_for_cluster(


### PR DESCRIPTION
PR #5076 broke the idempotent behaviour of `citus_prepare_pg_upgrade`.
Apparently we didn't cover the idempotency in our upgrade tests.

The first commit makes sure we cover the idempotent behaviour in our upgrade tests.

Subsequent commits is to retroactively fix the behaviour for our backported releases.

backports
 - release-9.4:  this version didn't include the idempotency for the upgrade function
 - release-9.5 PR #5096
 - release-10.0 PR #5097
 - release-10.1 PR #5098

Related to https://github.com/citusdata/citus/issues/3527

