### PR TITLE
Add changelog entry for 9.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### citus v9.5.6 (July 8, 2021) ###
+
+* Makes `citus_prepare_pg_upgrade` idempotent by dropping a transition table
+
 ### citus v9.5.5 (July 7, 2021) ###
 
 * Adds a configure flag to enforce security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### citus v9.5.6 (July 8, 2021) ###
 
-* Makes `citus_prepare_pg_upgrade` idempotent by dropping a transition table
+* Fixes minor bug in `citus_prepare_pg_upgrade` that caused it to lose its
+  idempotency
 
 ### citus v9.5.5 (July 7, 2021) ###
 


### PR DESCRIPTION
I added a new changelog entry as the change in `v9.5.6` is no longer trivial and needs to be documented. 