### PR TITLE
Drop unsupported indexes when converting table to columnar

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -1866,8 +1866,9 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 			if (!ColumnarSupportsIndexAM(indexStmt->accessMethod))
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("only btree and hash indexes are supported on "
-									   "columnar tables ")));
+								errmsg("unsupported access method for the "
+									   "index on columnar table %s",
+									   RelationGetRelationName(rel))));
 			}
 		}
 

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -1863,9 +1863,7 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 									   GetCreateIndexRelationLockMode(indexStmt));
 		if (rel->rd_tableam == GetColumnarTableAmRoutine())
 		{
-			/* for now, we don't support index access methods other than btree & hash */
-			if (strncmp(indexStmt->accessMethod, "btree", NAMEDATALEN) != 0 &&
-				strncmp(indexStmt->accessMethod, "hash", NAMEDATALEN) != 0)
+			if (!ColumnarSupportsIndexAM(indexStmt->accessMethod))
 			{
 				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								errmsg("only btree and hash indexes are supported on "
@@ -1878,6 +1876,18 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 
 	PrevProcessUtilityHook(pstmt, queryString, context,
 						   params, queryEnv, dest, completionTag);
+}
+
+
+/*
+ * ColumnarSupportsIndexAM returns true if indexAM with given name is
+ * supported by columnar tables.
+ */
+bool
+ColumnarSupportsIndexAM(char *indexAMName)
+{
+	return strncmp(indexAMName, "btree", NAMEDATALEN) == 0 ||
+		   strncmp(indexAMName, "hash", NAMEDATALEN) == 0;
 }
 
 

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -52,6 +52,7 @@ extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot sna
 												 uint32 flags, Bitmapset *attr_needed,
 												 List *scanQual);
 extern int64 ColumnarScanChunkGroupsFiltered(TableScanDesc scanDesc);
+extern bool ColumnarSupportsIndexAM(char *indexAMName);
 extern bool IsColumnarTableAmTable(Oid relationId);
 extern TableDDLCommand * ColumnarGetTableOptionsDDL(Oid relationId);
 extern char * GetShardedTableDDLCommandColumnar(uint64 shardId, void *context);

--- a/src/test/regress/expected/alter_table_set_access_method.out
+++ b/src/test/regress/expected/alter_table_set_access_method.out
@@ -301,7 +301,6 @@ SELECT event FROM time_partitioned ORDER BY 1;
 \set VERBOSITY default
 DROP TABLE time_partitioned;
 -- test altering a table with index to columnar
--- the index will be dropped
 CREATE TABLE index_table (a INT) ;
 CREATE INDEX idx1 ON index_table (a);
 -- also create an index with statistics
@@ -321,8 +320,6 @@ SELECT a.amname FROM pg_class c, pg_am a where c.relname = 'index_table' AND c.r
 (1 row)
 
 SELECT alter_table_set_access_method('index_table', 'columnar');
-NOTICE:  the index idx1 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
-NOTICE:  the index idx2 on table alter_table_set_access_method.index_table will be dropped, because columnar tables cannot have indexes
 NOTICE:  creating a new table for alter_table_set_access_method.index_table
 NOTICE:  moving the data of alter_table_set_access_method.index_table
 NOTICE:  dropping the old alter_table_set_access_method.index_table
@@ -335,13 +332,100 @@ NOTICE:  renaming the new table to alter_table_set_access_method.index_table
 SELECT indexname FROM pg_indexes WHERE schemaname = 'alter_table_set_access_method' AND tablename = 'index_table';
  indexname
 ---------------------------------------------------------------------
-(0 rows)
+ idx1
+ idx2
+(2 rows)
 
 SELECT a.amname FROM pg_class c, pg_am a where c.relname = 'index_table' AND c.relnamespace = 'alter_table_set_access_method'::regnamespace AND c.relam = a.oid;
   amname
 ---------------------------------------------------------------------
  columnar
 (1 row)
+
+CREATE TABLE "heap_\'tbl" (
+  c1 CIRCLE,
+  c2 TEXT,
+  i int4[],
+  p point,
+  a int,
+  EXCLUDE USING gist
+    (c1 WITH &&, (c2::circle) WITH &&)
+    WHERE (circle_center(c1) <> '(0,0)'),
+  EXCLUDE USING btree
+    (a WITH =)
+	INCLUDE(p)
+	WHERE (c2 < 'astring')
+);
+CREATE INDEX heap_tbl_gin ON "heap_\'tbl" USING gin (i);
+CREATE INDEX "heap_tbl_\'gist" ON "heap_\'tbl" USING gist(p);
+CREATE INDEX heap_tbl_brin ON "heap_\'tbl" USING brin (a) WITH (pages_per_range = 1);
+CREATE INDEX heap_tbl_hash ON "heap_\'tbl" USING hash (c2);
+ALTER TABLE "heap_\'tbl" ADD CONSTRAINT heap_tbl_unique UNIQUE (c2);
+CREATE UNIQUE INDEX "heap_tbl_\'btree" ON "heap_\'tbl" USING btree (a);
+ALTER TABLE "heap_\'tbl" ADD CONSTRAINT "heap_tbl_\'pkey" PRIMARY KEY USING INDEX "heap_tbl_\'btree";
+NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "heap_tbl_\'btree" to "heap_tbl_\'pkey"
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'alter_table_set_access_method' AND
+      tablename = 'heap_\''tbl'
+ORDER BY indexname;
+       indexname
+---------------------------------------------------------------------
+ heap_\'tbl_a_p_excl
+ heap_\'tbl_c1_c2_excl
+ heap_tbl_\'gist
+ heap_tbl_\'pkey
+ heap_tbl_brin
+ heap_tbl_gin
+ heap_tbl_hash
+ heap_tbl_unique
+(8 rows)
+
+SELECT conname FROM pg_constraint
+WHERE conrelid = 'heap_\''tbl'::regclass
+ORDER BY conname;
+        conname
+---------------------------------------------------------------------
+ heap_\'tbl_a_p_excl
+ heap_\'tbl_c1_c2_excl
+ heap_tbl_\'pkey
+ heap_tbl_unique
+(4 rows)
+
+SELECT alter_table_set_access_method('heap_\''tbl', 'columnar');
+NOTICE:  unsupported access method for index heap_\'tbl_c1_c2_excl on columnar table alter_table_set_access_method."heap_\'tbl", given index and the constraint depending on the index (if any) will be dropped
+NOTICE:  unsupported access method for index heap_tbl_gin on columnar table alter_table_set_access_method."heap_\'tbl", given index and the constraint depending on the index (if any) will be dropped
+NOTICE:  unsupported access method for index heap_tbl_\'gist on columnar table alter_table_set_access_method."heap_\'tbl", given index and the constraint depending on the index (if any) will be dropped
+NOTICE:  unsupported access method for index heap_tbl_brin on columnar table alter_table_set_access_method."heap_\'tbl", given index and the constraint depending on the index (if any) will be dropped
+NOTICE:  creating a new table for alter_table_set_access_method."heap_\'tbl"
+NOTICE:  moving the data of alter_table_set_access_method."heap_\'tbl"
+NOTICE:  dropping the old alter_table_set_access_method."heap_\'tbl"
+NOTICE:  renaming the new table to alter_table_set_access_method."heap_\'tbl"
+ alter_table_set_access_method
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'alter_table_set_access_method' AND
+      tablename = 'heap_\''tbl'
+ORDER BY indexname;
+      indexname
+---------------------------------------------------------------------
+ heap_\'tbl_a_p_excl
+ heap_tbl_\'pkey
+ heap_tbl_hash
+ heap_tbl_unique
+(4 rows)
+
+SELECT conname FROM pg_constraint
+WHERE conrelid = 'heap_\''tbl'::regclass
+ORDER BY conname;
+       conname
+---------------------------------------------------------------------
+ heap_\'tbl_a_p_excl
+ heap_tbl_\'pkey
+ heap_tbl_unique
+(3 rows)
 
 -- test different table types
 SET client_min_messages to WARNING;

--- a/src/test/regress/expected/columnar_alter.out
+++ b/src/test/regress/expected/columnar_alter.out
@@ -412,7 +412,7 @@ CREATE TABLE circles (
     c circle,
     EXCLUDE USING gist (c WITH &&)
 ) USING columnar;
-ERROR:  only btree and hash indexes are supported on columnar tables
+ERROR:  unsupported access method for the index on columnar table circles
 -- Row level security
 CREATE TABLE public.row_level_security_col (id int, pgUser CHARACTER VARYING) USING columnar;
 CREATE USER user1;

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -396,19 +396,19 @@ SELECT COUNT(*)=2 FROM pg_indexes WHERE tablename = 'p1';
 CREATE TABLE testjsonb (j JSONB) USING columnar;
 INSERT INTO testjsonb SELECT CAST('{"f1" : ' ||'"'|| i*4 ||'", ' || '"f2" : '||'"'|| i*10 ||'"}' AS JSON) FROM generate_series(1,10) i;
 CREATE INDEX jidx ON testjsonb USING GIN (j);
-ERROR:  only btree and hash indexes are supported on columnar tables
+ERROR:  unsupported access method for the index on columnar table testjsonb
 INSERT INTO testjsonb SELECT CAST('{"f1" : ' ||'"'|| i*4 ||'", ' || '"f2" : '||'"'|| i*10 ||'"}' AS JSON) FROM generate_series(15,20) i;
 -- gist --
 CREATE TABLE gist_point_tbl(id INT4, p POINT) USING columnar;
 INSERT INTO gist_point_tbl (id, p) SELECT g, point(g*10, g*10) FROM generate_series(1, 10) g;
 CREATE INDEX gist_pointidx ON gist_point_tbl USING gist(p);
-ERROR:  only btree and hash indexes are supported on columnar tables
+ERROR:  unsupported access method for the index on columnar table gist_point_tbl
 INSERT INTO gist_point_tbl (id, p) SELECT g, point(g*10, g*10) FROM generate_series(10, 20) g;
 -- sp gist --
 CREATE TABLE box_temp (f1 box) USING columnar;
 INSERT INTO box_temp SELECT box(point(i, i), point(i * 2, i * 2)) FROM generate_series(1, 10) AS i;
 CREATE INDEX CONCURRENTLY box_spgist ON box_temp USING spgist (f1);
-ERROR:  only btree and hash indexes are supported on columnar tables
+ERROR:  unsupported access method for the index on columnar table box_temp
 -- CONCURRENTLY should not leave an invalid index behind
 SELECT COUNT(*)=0 FROM pg_index WHERE indrelid = 'box_temp'::regclass AND indisvalid = 'false';
  ?column?
@@ -420,7 +420,7 @@ INSERT INTO box_temp SELECT box(point(i, i), point(i * 2, i * 2)) FROM generate_
 -- brin --
 CREATE TABLE brin_summarize (value int) USING columnar;
 CREATE INDEX brin_summarize_idx ON brin_summarize USING brin (value) WITH (pages_per_range=2);
-ERROR:  only btree and hash indexes are supported on columnar tables
+ERROR:  unsupported access method for the index on columnar table brin_summarize
 -- Show that we safely fallback to serial index build.
 CREATE TABLE parallel_scan_test(a int) USING columnar WITH ( parallel_workers = 2 );
 INSERT INTO parallel_scan_test SELECT i FROM generate_series(1,10) i;


### PR DESCRIPTION
Previously, as indexes were not supported by columnar tables, we were ignoring all the indexes & index-based constraints of table when converting it to a columnar table.

However, now that we support `btree` & `hash` indexAM's for columnar tables, we only ignore the indexAM's other than those two.

However, the way we ignore the unsuported indexes is now a bit different than before.
Previously we were just _not creating_ any index types after converting table to columnar as we didn't support any of the index types.
Now that we support `btree` & `hash` indexAM's for columnar tables, now we really drop the unsupported index types since re-creating the remaining ones is easier than adding some code that creates only the supported indexes.
