### PR TITLE
Backporting #5010 & #5015

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -322,10 +322,6 @@ static Node * WorkerLimitCount(Node *limitCount, Node *limitOffset, OrderByLimit
 static List * WorkerSortClauseList(Node *limitCount,
 								   List *groupClauseList, List *sortClauseList,
 								   OrderByLimitReference orderByLimitReference);
-static List * GenerateNewTargetEntriesForSortClauses(List *originalTargetList,
-													 List *sortClauseList,
-													 AttrNumber *targetProjectionNumber,
-													 Index *nextSortGroupRefIndex);
 static bool CanPushDownLimitApproximate(List *sortClauseList, List *targetList);
 static bool HasOrderByAggregate(List *sortClauseList, List *targetList);
 static bool HasOrderByNonCommutativeAggregate(List *sortClauseList, List *targetList);
@@ -2705,38 +2701,6 @@ ProcessWindowFunctionsForWorkerQuery(List *windowClauseList,
 		return;
 	}
 
-	WindowClause *windowClause = NULL;
-	foreach_ptr(windowClause, windowClauseList)
-	{
-		List *partitionClauseTargetList =
-			GenerateNewTargetEntriesForSortClauses(originalTargetEntryList,
-												   windowClause->partitionClause,
-												   &(queryTargetList->
-													 targetProjectionNumber),
-												   queryWindowClause->
-												   nextSortGroupRefIndex);
-		List *orderClauseTargetList =
-			GenerateNewTargetEntriesForSortClauses(originalTargetEntryList,
-												   windowClause->orderClause,
-												   &(queryTargetList->
-													 targetProjectionNumber),
-												   queryWindowClause->
-												   nextSortGroupRefIndex);
-
-		/*
-		 * Note that even Citus does push down the window clauses as-is, we may still need to
-		 * add the generated entries to the target list. The reason is that the same aggregates
-		 * might be referred from another target entry that is a bare aggregate (e.g., no window
-		 * functions), which would have been mutated. For instance, when an average aggregate
-		 * is mutated on the target list, the window function would refer to a sum aggregate,
-		 * which is obviously wrong.
-		 */
-		queryTargetList->targetEntryList = list_concat(queryTargetList->targetEntryList,
-													   partitionClauseTargetList);
-		queryTargetList->targetEntryList = list_concat(queryTargetList->targetEntryList,
-													   orderClauseTargetList);
-	}
-
 	queryWindowClause->workerWindowClauseList = windowClauseList;
 	queryWindowClause->hasWindowFunctions = true;
 }
@@ -2802,19 +2766,6 @@ ProcessLimitOrderByForWorkerQuery(OrderByLimitReference orderByLimitReference,
 							 groupClauseList,
 							 sortClauseList,
 							 orderByLimitReference);
-
-	/*
-	 * TODO: Do we really need to add the target entries if we're not pushing
-	 * down ORDER BY?
-	 */
-	List *newTargetEntryListForSortClauses =
-		GenerateNewTargetEntriesForSortClauses(originalTargetList,
-											   queryOrderByLimit->workerSortClauseList,
-											   &(queryTargetList->targetProjectionNumber),
-											   queryOrderByLimit->nextSortGroupRefIndex);
-
-	queryTargetList->targetEntryList =
-		list_concat(queryTargetList->targetEntryList, newTargetEntryListForSortClauses);
 }
 
 
@@ -4800,87 +4751,6 @@ WorkerSortClauseList(Node *limitCount, List *groupClauseList, List *sortClauseLi
 	}
 
 	return workerSortClauseList;
-}
-
-
-/*
- * GenerateNewTargetEntriesForSortClauses goes over provided sort clause lists and
- * creates new target entries if needed to make sure sort clauses has correct
- * references. The function returns list of new target entries, caller is
- * responsible to add those target entries to the end of worker target list.
- *
- * The function is required because we change the target entry if it contains an
- * expression having an aggregate operation, or just the AVG aggregate.
- * Afterwards any order by clause referring to original target entry starts
- * to point to a wrong expression.
- *
- * Note the function modifies SortGroupClause items in sortClauseList,
- * targetProjectionNumber, and nextSortGroupRefIndex.
- */
-static List *
-GenerateNewTargetEntriesForSortClauses(List *originalTargetList,
-									   List *sortClauseList,
-									   AttrNumber *targetProjectionNumber,
-									   Index *nextSortGroupRefIndex)
-{
-	List *createdTargetList = NIL;
-
-	SortGroupClause *sgClause = NULL;
-	foreach_ptr(sgClause, sortClauseList)
-	{
-		TargetEntry *targetEntry = get_sortgroupclause_tle(sgClause, originalTargetList);
-		Expr *targetExpr = targetEntry->expr;
-		bool containsAggregate = contain_aggs_of_level((Node *) targetExpr, 0);
-		bool createNewTargetEntry = false;
-
-		/* we are only interested in target entries containing aggregates */
-		if (!containsAggregate)
-		{
-			continue;
-		}
-
-		/*
-		 * If the target expression is not an Aggref, it is either an expression
-		 * on a single aggregate, or expression containing multiple aggregates.
-		 * Worker query mutates these target entries to have a naked target entry
-		 * per aggregate function. We want to use original target entries if this
-		 * the case.
-		 * If the original target expression is an avg aggref, we also want to use
-		 * original target entry.
-		 */
-		if (!IsA(targetExpr, Aggref))
-		{
-			createNewTargetEntry = true;
-		}
-		else
-		{
-			Aggref *aggNode = (Aggref *) targetExpr;
-			AggregateType aggregateType = GetAggregateType(aggNode);
-			if (aggregateType == AGGREGATE_AVERAGE)
-			{
-				createNewTargetEntry = true;
-			}
-		}
-
-		if (createNewTargetEntry)
-		{
-			bool resJunk = true;
-			AttrNumber nextResNo = (*targetProjectionNumber);
-			Expr *newExpr = copyObject(targetExpr);
-			TargetEntry *newTargetEntry = makeTargetEntry(newExpr, nextResNo,
-														  targetEntry->resname, resJunk);
-			newTargetEntry->ressortgroupref = *nextSortGroupRefIndex;
-
-			createdTargetList = lappend(createdTargetList, newTargetEntry);
-
-			sgClause->tleSortGroupRef = *nextSortGroupRefIndex;
-
-			(*nextSortGroupRefIndex)++;
-			(*targetProjectionNumber)++;
-		}
-	}
-
-	return createdTargetList;
 }
 
 

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -793,7 +793,8 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 								 "foreign keys. Any parallel modification to "
 								 "those hash distributed tables in the same "
 								 "transaction can only be executed in sequential query "
-								 "execution mode", relationName)));
+								 "execution mode",
+								 relationName != NULL ? relationName : "<dropped>")));
 
 			/*
 			 * Switching to sequential mode is admittedly confusing and, could be useless

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -2016,27 +2016,7 @@ ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2010;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2013;
 DROP TABLE partitioning_test_2008, partitioning_test_2009, partitioning_test_2010,
-           partitioning_test_2011, partitioning_test_2013, reference_table_2;
--- verify this doesn't crash and gives a debug message for dropped table
-SET client_min_messages TO DEBUG1;
-DROP TABLE partitioning_test, reference_table;
-DEBUG:  switching to sequential query execution mode
-DETAIL:  Table "<dropped>" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
-CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
-PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
-DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660179 on table partitioning_schema.partitioning_test_1660179
-drop cascades to constraint partitioning_reference_fkey_1660181 on table partitioning_schema.partitioning_test_1660181
-DETAIL:  from localhost:xxxxx
-CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
-PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
-DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660180 on table partitioning_schema.partitioning_test_1660180
-drop cascades to constraint partitioning_reference_fkey_1660182 on table partitioning_schema.partitioning_test_1660182
-DETAIL:  from localhost:xxxxx
-CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
-PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
-RESET client_min_messages;
+           partitioning_test_2011, partitioning_test_2013, reference_table_2, partitioning_test, reference_table;
 RESET SEARCH_PATH;
 -- not timestamp partitioned
 CREATE TABLE not_time_partitioned (x int, y int) PARTITION BY RANGE (x);

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -2015,9 +2015,28 @@ ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2009;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2010;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2013;
-DROP TABLE partitioning_test, partitioning_test_2008, partitioning_test_2009,
-           partitioning_test_2010, partitioning_test_2011, partitioning_test_2013,
-           reference_table, reference_table_2;
+DROP TABLE partitioning_test_2008, partitioning_test_2009, partitioning_test_2010,
+           partitioning_test_2011, partitioning_test_2013, reference_table_2;
+-- verify this doesn't crash and gives a debug message for dropped table
+SET client_min_messages TO DEBUG1;
+DROP TABLE partitioning_test, reference_table;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "<dropped>" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
+PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
+DEBUG:  drop cascades to 2 other objects
+DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660179 on table partitioning_schema.partitioning_test_1660179
+drop cascades to constraint partitioning_reference_fkey_1660181 on table partitioning_schema.partitioning_test_1660181
+DETAIL:  from localhost:xxxxx
+CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
+PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
+DEBUG:  drop cascades to 2 other objects
+DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660180 on table partitioning_schema.partitioning_test_1660180
+drop cascades to constraint partitioning_reference_fkey_1660182 on table partitioning_schema.partitioning_test_1660182
+DETAIL:  from localhost:xxxxx
+CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
+PL/pgSQL function citus_drop_trigger() line 16 at PERFORM
+RESET client_min_messages;
 RESET SEARCH_PATH;
 -- not timestamp partitioned
 CREATE TABLE not_time_partitioned (x int, y int) PARTITION BY RANGE (x);

--- a/src/test/regress/expected/window_functions.out
+++ b/src/test/regress/expected/window_functions.out
@@ -95,6 +95,9 @@ ORDER BY
 
 -- window function operates on the results of
 -- a join
+-- we also want to verify that this doesn't crash
+-- when the logging level is DEBUG4
+SET log_min_messages TO DEBUG4;
 SELECT
 	us.user_id,
 	SUM(us.value_1) OVER (PARTITION BY us.user_id)
@@ -1592,4 +1595,58 @@ from public.users_table as ut limit 1;
 ---------------------------------------------------------------------
 
 (1 row)
+
+-- verify that this doesn't crash with DEBUG4
+SET log_min_messages TO DEBUG4;
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, value_1, random() as r1
+	FROM
+		users_table as us, events_table
+	WHERE
+		us.user_id = events_table.user_id AND event_type IN (1,2)
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+ user_id | max
+---------------------------------------------------------------------
+       1 |   5
+       3 |   5
+       3 |   5
+       4 |   5
+       5 |   5
+       5 |   5
+       6 |   5
+       6 |   5
+       1 |   4
+       2 |   4
+       3 |   4
+       3 |   4
+       3 |   4
+       4 |   4
+       4 |   4
+       5 |   4
+       5 |   4
+       1 |   3
+       2 |   3
+       2 |   3
+       2 |   3
+       6 |   3
+       2 |   2
+       4 |   2
+       4 |   2
+       4 |   2
+       6 |   2
+       1 |   1
+       3 |   1
+       5 |   1
+       6 |   1
+       5 |   0
+(32 rows)
 

--- a/src/test/regress/expected/window_functions_0.out
+++ b/src/test/regress/expected/window_functions_0.out
@@ -95,6 +95,9 @@ ORDER BY
 
 -- window function operates on the results of
 -- a join
+-- we also want to verify that this doesn't crash
+-- when the logging level is DEBUG4
+SET log_min_messages TO DEBUG4;
 SELECT
 	us.user_id,
 	SUM(us.value_1) OVER (PARTITION BY us.user_id)
@@ -1588,4 +1591,58 @@ from public.users_table as ut limit 1;
 ---------------------------------------------------------------------
 
 (1 row)
+
+-- verify that this doesn't crash with DEBUG4
+SET log_min_messages TO DEBUG4;
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, value_1, random() as r1
+	FROM
+		users_table as us, events_table
+	WHERE
+		us.user_id = events_table.user_id AND event_type IN (1,2)
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+ user_id | max
+---------------------------------------------------------------------
+       1 |   5
+       3 |   5
+       3 |   5
+       4 |   5
+       5 |   5
+       5 |   5
+       6 |   5
+       6 |   5
+       1 |   4
+       2 |   4
+       3 |   4
+       3 |   4
+       3 |   4
+       4 |   4
+       4 |   4
+       5 |   4
+       5 |   4
+       1 |   3
+       2 |   3
+       2 |   3
+       2 |   3
+       6 |   3
+       2 |   2
+       4 |   2
+       4 |   2
+       4 |   2
+       6 |   2
+       1 |   1
+       3 |   1
+       5 |   1
+       6 |   1
+       5 |   0
+(32 rows)
 

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -1192,11 +1192,7 @@ ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2013;
 
 DROP TABLE partitioning_test_2008, partitioning_test_2009, partitioning_test_2010,
-           partitioning_test_2011, partitioning_test_2013, reference_table_2;
--- verify this doesn't crash and gives a debug message for dropped table
-SET client_min_messages TO DEBUG1;
-DROP TABLE partitioning_test, reference_table;
-RESET client_min_messages;
+           partitioning_test_2011, partitioning_test_2013, reference_table_2, partitioning_test, reference_table;
 
 RESET SEARCH_PATH;
 

--- a/src/test/regress/sql/multi_partitioning.sql
+++ b/src/test/regress/sql/multi_partitioning.sql
@@ -1191,9 +1191,12 @@ ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2010;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2011;
 ALTER TABLE partitioning_test DETACH PARTITION partitioning_test_2013;
 
-DROP TABLE partitioning_test, partitioning_test_2008, partitioning_test_2009,
-           partitioning_test_2010, partitioning_test_2011, partitioning_test_2013,
-           reference_table, reference_table_2;
+DROP TABLE partitioning_test_2008, partitioning_test_2009, partitioning_test_2010,
+           partitioning_test_2011, partitioning_test_2013, reference_table_2;
+-- verify this doesn't crash and gives a debug message for dropped table
+SET client_min_messages TO DEBUG1;
+DROP TABLE partitioning_test, reference_table;
+RESET client_min_messages;
 
 RESET SEARCH_PATH;
 


### PR DESCRIPTION
Cherry-picked commits at #5010 and #5015 for 10.0. 
#5015 causes test output inconsistency for PG11 and 12&13. Added an extra commit to fix that.