### PR TITLE
Columnar: use clause Vars for chunk group filtering. (#4856)

### DIFF
--- a/src/test/regress/input/am_chunk_filtering.source
+++ b/src/test/regress/input/am_chunk_filtering.source
@@ -101,3 +101,13 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
   SELECT count(*) FROM multi_column_chunk_filtering WHERE a > 50000 AND b > 50000;
 
 DROP TABLE multi_column_chunk_filtering;
+
+--
+-- https://github.com/citusdata/citus/issues/4780
+--
+create table part_table (id int) partition by range (id);
+create table part_1_row partition of part_table for values from (150000) to (160000);
+create table part_2_columnar partition of part_table for values from (0) to (150000) using columnar;
+insert into part_table select generate_series(1,159999);
+select filtered_row_count('select count(*) from part_table where id > 75000');
+drop table part_table;

--- a/src/test/regress/output/am_chunk_filtering.source
+++ b/src/test/regress/output/am_chunk_filtering.source
@@ -182,3 +182,17 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
 (5 rows)
 
 DROP TABLE multi_column_chunk_filtering;
+--
+-- https://github.com/citusdata/citus/issues/4780
+--
+create table part_table (id int) partition by range (id);
+create table part_1_row partition of part_table for values from (150000) to (160000);
+create table part_2_columnar partition of part_table for values from (0) to (150000) using columnar;
+insert into part_table select generate_series(1,159999);
+select filtered_row_count('select count(*) from part_table where id > 75000');
+ filtered_row_count
+---------------------------------------------------------------------
+               5000
+(1 row)
+
+drop table part_table;


### PR DESCRIPTION
* Columnar: use clause Vars for chunk group filtering.

This solves #4780 and also provides a cleaner separation between chunk
group filtering and projection pushdown.

* Columnar: sort and deduplicate Vars pulled from clauses.

* Columnar: cleanup variable names.

* Columnar: remove alternate test output.

* Columnar: do not recurse when looking for whereClauseVars.

Co-authored-by: Jeff Davis <jefdavi@microsoft.com>
(cherry picked from commit 063e67303840cf09248502ae6c40a508824e4ac0)

DESCRIPTION: PR description that will go into the change log, up to 78 characters
