### PR TITLE
Add upgrade and dowgrade tests for Citus 10.2

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -629,6 +629,30 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                                                                                                                                                                                | function worker_partitioned_table_size(regclass) bigint
 (15 rows)
 
+-- Test downgrade to 10.1-1 from 10.2-1
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+ALTER EXTENSION citus UPDATE TO '10.1-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
+-- Snapshot of state at 10.2-1
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+SELECT * FROM multi_extension.print_extension_changes();
+                    previous_object                     |                                      current_object
+---------------------------------------------------------------------
+ function stop_metadata_sync_to_node(text,integer) void |
+                                                        | function citus_internal.downgrade_columnar_storage(regclass) void
+                                                        | function citus_internal.upgrade_columnar_storage(regclass) void
+                                                        | function citus_internal_add_partition_metadata(regclass,"char",text,integer,"char") void
+                                                        | function citus_internal_add_placement_metadata(bigint,integer,bigint,integer,bigint) void
+                                                        | function citus_internal_add_shard_metadata(regclass,bigint,"char",text,text) void
+                                                        | function citus_internal_update_placement_metadata(bigint,integer,integer) void
+                                                        | function stop_metadata_sync_to_node(text,integer,boolean) void
+(8 rows)
+
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version
 SHOW citus.version;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -259,6 +259,16 @@ SELECT * FROM multi_extension.print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '10.1-1';
 SELECT * FROM multi_extension.print_extension_changes();
 
+-- Test downgrade to 10.1-1 from 10.2-1
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+ALTER EXTENSION citus UPDATE TO '10.1-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+
+-- Snapshot of state at 10.2-1
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+SELECT * FROM multi_extension.print_extension_changes();
+
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 
 -- show running version


### PR DESCRIPTION
It seems we forgot to add this when starting 10.2 development.