### PR TITLE
Sync pg_dist_object to all nodes with metadata

### DIFF
--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -1063,16 +1063,7 @@ FinalizeCitusLocalTableCreation(Oid relationId, List *dependentSequenceList)
 			PropagateSequenceListDependencies(dependentSequenceList);
 		}
 		CreateTableMetadataOnWorkers(relationId);
-
-		Oid sequenceOid;
-		foreach_oid(sequenceOid, dependentSequenceList)
-		{
-			ObjectAddress address;
-
-			ObjectAddressSet(address, RelationRelationId, sequenceOid);
-			bool shouldSyncMetadata = true;
-			MarkObjectDistributed(&address, shouldSyncMetadata);
-		}
+		MarkSequenceListDistributed(dependentSequenceList);
 	}
 
 	/*

--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -590,8 +590,6 @@ PostprocessDefineCollationStmt(Node *node, const char *queryString)
 
 	EnsureDependenciesExistOnAllNodes(&collationAddress);
 
-	MarkObjectDistributed(&collationAddress);
-
 	return NodeDDLTaskList(NON_COORDINATOR_NODES, CreateCollationDDLsIdempotent(
 							   collationAddress.objectId));
 }

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -557,15 +557,7 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 	{
 		if (ClusterHasKnownMetadataWorkers())
 		{
-			Oid sequenceOid;
-			foreach_oid(sequenceOid, dependentSequenceList)
-			{
-				ObjectAddress address;
-
-				ObjectAddressSet(address, RelationRelationId, sequenceOid);
-				bool shouldSyncMetadata = true;
-				MarkObjectDistributed(&address, shouldSyncMetadata);
-			}
+			MarkSequenceListDistributed(dependentSequenceList);
 		}
 	}
 
@@ -692,6 +684,25 @@ PropagateSequenceDependencies(Oid sequenceOid)
 	ObjectAddress sequenceAddress = { 0 };
 	ObjectAddressSet(sequenceAddress, RelationRelationId, sequenceOid);
 	EnsureDependenciesExistOnAllNodes(&sequenceAddress);
+}
+
+
+/*
+ * MarkSequenceListDistributed marks all sequences in the list as distributed.
+ * NOTE: The sequences should have already been created on the worker nodes.
+ */
+void
+MarkSequenceListDistributed(List *sequenceList)
+{
+	Oid sequenceOid = InvalidOid;
+	foreach_oid(sequenceOid, sequenceList)
+	{
+		ObjectAddress address;
+
+		ObjectAddressSet(address, RelationRelationId, sequenceOid);
+		bool shouldSyncMetadata = true;
+		MarkObjectDistributed(&address, shouldSyncMetadata);
+	}
 }
 
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -557,6 +557,10 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 	{
 		if (ClusterHasKnownMetadataWorkers())
 		{
+			/*
+			 * Now that we have created the sequence on the worker we can mark
+			 * it as distributed.
+			 */
 			MarkSequenceListDistributed(dependentSequenceList);
 		}
 	}

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -700,8 +700,8 @@ MarkSequenceListDistributed(List *sequenceList)
 		ObjectAddress address;
 
 		ObjectAddressSet(address, RelationRelationId, sequenceOid);
-		bool shouldSyncMetadata = true;
-		MarkObjectDistributed(&address, shouldSyncMetadata);
+		bool localOnly = false;
+		MarkObjectDistributed(&address, localOnly);
 	}
 }
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -652,6 +652,11 @@ AlterSequenceType(Oid seqOid, Oid typeOid)
 		SetDefElemArg(alterSequenceStatement, "as", asTypeNode);
 		ParseState *pstate = make_parsestate(NULL);
 		AlterSequence(pstate, alterSequenceStatement);
+
+		/*
+		 * Make sure later reads in this transaction read the correct type.
+		 */
+		CommandCounterIncrement();
 	}
 }
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -121,8 +121,8 @@ EnsureDependenciesExistOnAllNodes(const ObjectAddress *target)
 	ObjectAddress *dependency = NULL;
 	foreach_ptr(dependency, dependenciesWithCommands)
 	{
-		bool shouldSyncMetadata = true;
-		MarkObjectDistributed(dependency, shouldSyncMetadata);
+		bool localOnly = false;
+		MarkObjectDistributed(dependency, localOnly);
 	}
 }
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -138,6 +138,9 @@ EnsureDependenciesExistOnAllNodesInternal(const ObjectAddress *target,
 	 * before any node is in the cluster. If we would wait till we actually had connected
 	 * to the nodes before marking the objects as distributed these objects would never be
 	 * created on the workers when they get added, causing shards to fail to create.
+	 *
+	 * NOTE: We do this after creating the objects on the workers, otherwise
+	 * MarkObjectDistributed would fail when localOnlyMarkdistributed is false.
 	 */
 	foreach_ptr(dependency, dependenciesWithCommands)
 	{

--- a/src/backend/distributed/commands/distribute_object_ops.c
+++ b/src/backend/distributed/commands/distribute_object_ops.c
@@ -127,6 +127,7 @@ static DistributeObjectOps Any_CompositeType = {
 	.preprocess = PreprocessCompositeTypeStmt,
 	.postprocess = PostprocessCompositeTypeStmt,
 	.address = CompositeTypeStmtObjectAddress,
+	.markDistributed = true,
 };
 static DistributeObjectOps Any_CreateEnum = {
 	.deparse = DeparseCreateEnumStmt,
@@ -134,6 +135,7 @@ static DistributeObjectOps Any_CreateEnum = {
 	.preprocess = PreprocessCreateEnumStmt,
 	.postprocess = PostprocessCreateEnumStmt,
 	.address = CreateEnumStmtObjectAddress,
+	.markDistributed = true,
 };
 static DistributeObjectOps Any_CreateExtension = {
 	.deparse = DeparseCreateExtensionStmt,
@@ -141,6 +143,7 @@ static DistributeObjectOps Any_CreateExtension = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateExtensionStmt,
 	.address = CreateExtensionStmtObjectAddress,
+	.markDistributed = true,
 };
 static DistributeObjectOps Any_CreateFunction = {
 	.deparse = NULL,
@@ -225,6 +228,7 @@ static DistributeObjectOps Collation_Define = {
 	.preprocess = NULL,
 	.postprocess = PostprocessDefineCollationStmt,
 	.address = DefineCollationStmtObjectAddress,
+	.markDistributed = true,
 };
 static DistributeObjectOps Collation_Drop = {
 	.deparse = DeparseDropCollationStmt,

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -591,8 +591,8 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	ObjectAddress *objectAddress = NULL;
 	foreach_ptr(objectAddress, uniqueObjectAddresses)
 	{
-		bool shouldSyncMetadata = true;
-		MarkObjectDistributed(objectAddress, shouldSyncMetadata);
+		bool localOnly = false;
+		MarkObjectDistributed(objectAddress, localOnly);
 	}
 }
 

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -188,8 +188,6 @@ PostprocessCreateExtensionStmt(Node *node, const char *queryString)
 
 	EnsureDependenciesExistOnAllNodes(&extensionAddress);
 
-	MarkObjectDistributed(&extensionAddress);
-
 	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
@@ -593,7 +591,8 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	ObjectAddress *objectAddress = NULL;
 	foreach_ptr(objectAddress, uniqueObjectAddresses)
 	{
-		MarkObjectDistributed(objectAddress);
+		bool shouldSyncMetadata = true;
+		MarkObjectDistributed(objectAddress, shouldSyncMetadata);
 	}
 }
 

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -189,8 +189,6 @@ PostprocessCompositeTypeStmt(Node *node, const char *queryString)
 	ObjectAddress typeAddress = GetObjectAddressFromParseTree(node, false);
 	EnsureDependenciesExistOnAllNodes(&typeAddress);
 
-	MarkObjectDistributed(&typeAddress);
-
 	return NIL;
 }
 
@@ -298,13 +296,6 @@ PostprocessCreateEnumStmt(Node *node, const char *queryString)
 	/* lookup type address of just created type */
 	ObjectAddress typeAddress = GetObjectAddressFromParseTree(node, false);
 	EnsureDependenciesExistOnAllNodes(&typeAddress);
-
-	/*
-	 * now that the object has been created and distributed to the workers we mark them as
-	 * distributed so we know to keep them up to date and recreate on a new node in the
-	 * future
-	 */
-	MarkObjectDistributed(&typeAddress);
 
 	return NIL;
 }

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -654,8 +654,8 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		if (ops && ops->markDistributed)
 		{
 			ObjectAddress address = GetObjectAddressFromParseTree(parsetree, false);
-			bool shouldSyncMetadata = true;
-			MarkObjectDistributed(&address, shouldSyncMetadata);
+			bool localOnly = false;
+			MarkObjectDistributed(&address, localOnly);
 		}
 	}
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -53,6 +53,7 @@
 #include "distributed/coordinator_protocol.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
+#include "distributed/metadata/distobject.h"
 #include "distributed/multi_executor.h"
 #include "distributed/multi_explain.h"
 #include "distributed/multi_physical_planner.h"
@@ -649,6 +650,12 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 				/* no failures during CONCURRENTLY, mark the index as valid */
 				MarkIndexValid(indexStmt);
 			}
+		}
+		if (ops && ops->markDistributed)
+		{
+			ObjectAddress address = GetObjectAddressFromParseTree(parsetree, false);
+			bool shouldSyncMetadata = true;
+			MarkObjectDistributed(&address, shouldSyncMetadata);
 		}
 	}
 

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -141,7 +141,7 @@ ObjectExists(const ObjectAddress *address)
  * by adding appropriate entries to citus.pg_dist_object.
  */
 void
-MarkObjectDistributed(const ObjectAddress *distAddress, bool shouldSyncMetadata)
+MarkObjectDistributed(const ObjectAddress *distAddress, bool localOnly)
 {
 	int paramCount = 3;
 	Oid paramTypes[3] = {
@@ -165,7 +165,7 @@ MarkObjectDistributed(const ObjectAddress *distAddress, bool shouldSyncMetadata)
 		ereport(ERROR, (errmsg("failed to insert object into citus.pg_dist_object")));
 	}
 
-	if (shouldSyncMetadata)
+	if (!localOnly)
 	{
 		char *workerMetadataUpdateCommand = DistributedObjectCreateCommand(
 			distAddress, NULL, NULL);

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -137,8 +137,13 @@ ObjectExists(const ObjectAddress *address)
 
 
 /*
- * MarkObjectDistributed marks an object as a distributed object by citus. Marking is done
- * by adding appropriate entries to citus.pg_dist_object.
+ * MarkObjectDistributed marks an object as a distributed object by citus.
+ * Marking is done by adding appropriate entries to citus.pg_dist_object.
+ *
+ * This also marks the object as distributed on all of the workers with
+ * metadata (unless localOnly is true). This means that the object should
+ * actually be created on those workers already, otherwise the oid of the
+ * object cannot be looked up.
  */
 void
 MarkObjectDistributed(const ObjectAddress *distAddress, bool localOnly)

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -47,6 +47,7 @@
 #include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
 #include "distributed/metadata/distobject.h"
+#include "distributed/metadata/pg_dist_object.h"
 #include "distributed/multi_join_order.h"
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/multi_physical_planner.h"
@@ -126,6 +127,7 @@ PG_FUNCTION_INFO_V1(worker_record_sequence_dependency);
 PG_FUNCTION_INFO_V1(citus_internal_add_partition_metadata);
 PG_FUNCTION_INFO_V1(citus_internal_add_shard_metadata);
 PG_FUNCTION_INFO_V1(citus_internal_add_placement_metadata);
+PG_FUNCTION_INFO_V1(citus_internal_add_object_metadata);
 PG_FUNCTION_INFO_V1(citus_internal_update_placement_metadata);
 PG_FUNCTION_INFO_V1(citus_internal_delete_shard_metadata);
 
@@ -216,7 +218,6 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 	}
 
 	SyncMetadataSnapshotToNode(workerNode, raiseInterrupts);
-	MarkNodeMetadataSynced(workerNode->workerName, workerNode->workerPort, true);
 }
 
 
@@ -357,8 +358,10 @@ SyncMetadataSnapshotToNode(WorkerNode *workerNode, bool raiseOnError)
 	/* generate the queries which drop the metadata */
 	List *dropMetadataCommandList = MetadataDropCommands();
 
+	List *newDistributedObjects = NIL;
+
 	/* generate the queries which create the metadata from scratch */
-	List *createMetadataCommandList = MetadataCreateCommands();
+	List *createMetadataCommandList = MetadataCreateCommands(&newDistributedObjects);
 
 	List *recreateMetadataSnapshotCommandList = list_make1(localGroupIdUpdateCommand);
 	recreateMetadataSnapshotCommandList = list_concat(recreateMetadataSnapshotCommandList,
@@ -378,7 +381,6 @@ SyncMetadataSnapshotToNode(WorkerNode *workerNode, bool raiseOnError)
 												   workerNode->workerPort,
 												   currentUser,
 												   recreateMetadataSnapshotCommandList);
-		return true;
 	}
 	else
 	{
@@ -387,8 +389,20 @@ SyncMetadataSnapshotToNode(WorkerNode *workerNode, bool raiseOnError)
 														 workerNode->workerPort,
 														 currentUser,
 														 recreateMetadataSnapshotCommandList);
-		return success;
+		if (!success)
+		{
+			return false;
+		}
 	}
+	MarkNodeMetadataSynced(workerNode->workerName, workerNode->workerPort, true);
+
+	ObjectAddress *address;
+	foreach_ptr(address, newDistributedObjects)
+	{
+		bool shouldSyncMetadata = true;
+		MarkObjectDistributed(address, shouldSyncMetadata);
+	}
+	return true;
 }
 
 
@@ -428,7 +442,7 @@ DropMetadataSnapshotOnNode(WorkerNode *workerNode)
  * (v)   Queries that populate pg_dist_placement table referenced by (iv)
  */
 List *
-MetadataCreateCommands(void)
+MetadataCreateCommands(List **newDistributedObjects)
 {
 	List *metadataSnapshotCommandList = NIL;
 	List *distributedTableList = CitusTableList();
@@ -486,7 +500,19 @@ MetadataCreateCommands(void)
 		List *dependentSequenceList = NIL;
 		GetDependentSequencesWithRelation(relationId, &attnumList,
 										  &dependentSequenceList, 0);
-		MarkSequenceListDistributedAndPropagateDependencies(dependentSequenceList);
+
+		Oid sequenceOid;
+		foreach_oid(sequenceOid, dependentSequenceList)
+		{
+			ObjectAddress *sequenceAddress = palloc(sizeof(ObjectAddress));
+			ObjectAddressSet(*sequenceAddress, RelationRelationId, sequenceOid);
+			List *addedDependencies =
+				EnsureDependenciesExistOnAllNodesWithoutMarkingDistributed(
+					sequenceAddress);
+			*newDistributedObjects = list_concat(*newDistributedObjects,
+												 addedDependencies);
+			*newDistributedObjects = lappend(*newDistributedObjects, sequenceAddress);
+		}
 
 		List *workerSequenceDDLCommands = SequenceDDLCommandsForTable(relationId);
 		metadataSnapshotCommandList = list_concat(metadataSnapshotCommandList,
@@ -572,6 +598,43 @@ MetadataCreateCommands(void)
 		metadataSnapshotCommandList = list_concat(metadataSnapshotCommandList,
 												  shardCreateCommandList);
 	}
+
+	HeapTuple pgDistObjectTup = NULL;
+
+	Relation pgDistObjectRel = table_open(DistObjectRelationId(), AccessShareLock);
+
+	TupleDesc pgDistObjectDesc = RelationGetDescr(pgDistObjectRel);
+
+	SysScanDesc pgDistObjectScan =
+		systable_beginscan(pgDistObjectRel, InvalidOid, false, NULL, 0, NULL);
+	while (HeapTupleIsValid(pgDistObjectTup = systable_getnext(pgDistObjectScan)))
+	{
+		Form_pg_dist_object pg_dist_object =
+			(Form_pg_dist_object) GETSTRUCT(pgDistObjectTup);
+
+		ObjectAddress address;
+		ObjectAddressSubSet(address, pg_dist_object->classid, pg_dist_object->objid,
+							pg_dist_object->objsubid);
+		bool distributionArgumentIndexIsNull = true;
+		int32 distributionArgumentIndex = DatumGetInt32(
+			heap_getattr(pgDistObjectTup, Anum_pg_dist_object_distribution_argument_index,
+						 pgDistObjectDesc, &distributionArgumentIndexIsNull));
+		bool colocationIdIsNull = true;
+		int32 colocationId = DatumGetInt32(
+			heap_getattr(pgDistObjectTup, Anum_pg_dist_object_distribution_argument_index,
+						 pgDistObjectDesc, &colocationIdIsNull));
+
+		char *workerMetadataUpdateCommand = DistributedObjectCreateCommand(
+			&address,
+			distributionArgumentIndexIsNull ? NULL : &distributionArgumentIndex,
+			colocationIdIsNull ? NULL : &colocationId);
+		metadataSnapshotCommandList = lappend(metadataSnapshotCommandList,
+											  workerMetadataUpdateCommand);
+	}
+
+	systable_endscan(pgDistObjectScan);
+	relation_close(pgDistObjectRel, AccessShareLock);
+
 
 	return metadataSnapshotCommandList;
 }
@@ -666,6 +729,7 @@ GetDistributedTableDDLEvents(Oid relationId)
  * (v)   Queries that delete all the rows from pg_dist_shard table referenced by (iv)
  * (vi)  Queries that delete all the rows from pg_dist_placement table
  *        referenced by (v)
+ * (vii) Truncate pg_dist_object
  */
 List *
 MetadataDropCommands(void)
@@ -680,6 +744,8 @@ MetadataDropCommands(void)
 									  REMOVE_ALL_CLUSTERED_TABLES_COMMAND);
 
 	dropSnapshotCommandList = lappend(dropSnapshotCommandList, DELETE_ALL_NODES);
+	dropSnapshotCommandList = lappend(dropSnapshotCommandList,
+									  DELETE_ALL_DISTRIBUTED_OBJECTS);
 
 	return dropSnapshotCommandList;
 }
@@ -749,6 +815,86 @@ NodeListInsertCommand(List *workerNodeList)
 	}
 
 	return nodeListInsertCommand->data;
+}
+
+
+char *
+DistributedObjectCreateCommand(const ObjectAddress *address,
+							   int32 *distributionArgumentIndex,
+							   int32 *colocationId)
+{
+	StringInfo insertDistributedObjectCommand = makeStringInfo();
+
+	/*
+	 * Here we get the three things that pg_identify_object_as_address returns,
+	 * without going through the hassle of going from and to Datums using
+	 * DirectFunctionCall3.
+	 */
+	List *names;
+	List *args;
+	char *objectType = getObjectTypeDescription(address);
+	getObjectIdentityParts(address, &names, &args);
+
+	appendStringInfo(insertDistributedObjectCommand,
+					 "SELECT citus_internal_add_object_metadata "
+					 "(classid, objid, objsubid, ");
+	if (distributionArgumentIndex == NULL)
+	{
+		appendStringInfo(insertDistributedObjectCommand, "NULL, ");
+	}
+	else
+	{
+		appendStringInfo(insertDistributedObjectCommand, "%d, ",
+						 *distributionArgumentIndex);
+	}
+	if (colocationId == NULL)
+	{
+		appendStringInfo(insertDistributedObjectCommand, "NULL");
+	}
+	else
+	{
+		appendStringInfo(insertDistributedObjectCommand, "%d", *colocationId);
+	}
+
+	appendStringInfo(insertDistributedObjectCommand,
+					 ") FROM pg_get_object_address(%s, ARRAY[",
+					 quote_literal_cstr(objectType));
+
+	char *name;
+	bool firstLoop = true;
+	foreach_ptr(name, names)
+	{
+		if (!firstLoop)
+		{
+			appendStringInfo(insertDistributedObjectCommand, ", ");
+		}
+		firstLoop = false;
+		appendStringInfoString(insertDistributedObjectCommand, quote_literal_cstr(name));
+	}
+
+	appendStringInfo(insertDistributedObjectCommand, "]::text[], ARRAY[");
+
+	char *arg;
+	firstLoop = true;
+	foreach_ptr(arg, args)
+	{
+		if (!firstLoop)
+		{
+			appendStringInfo(insertDistributedObjectCommand, ", ");
+		}
+		firstLoop = false;
+		appendStringInfoString(insertDistributedObjectCommand, quote_literal_cstr(arg));
+	}
+
+	appendStringInfo(insertDistributedObjectCommand, "]::text[])");
+	return insertDistributedObjectCommand->data;
+}
+
+
+char *
+DistributedObjectDeleteCommand(const ObjectAddress *address)
+{
+	return NULL;
 }
 
 
@@ -1803,11 +1949,6 @@ SyncMetadataToNodes(void)
 										 workerNode->workerPort)));
 				result = METADATA_SYNC_FAILED_SYNC;
 			}
-			else
-			{
-				MarkNodeMetadataSynced(workerNode->workerName,
-									   workerNode->workerPort, true);
-			}
 		}
 	}
 
@@ -2476,6 +2617,56 @@ EnsureShardPlacementMetadataIsSane(Oid relationId, int64 shardId, int64 placemen
 						errmsg("Node with group id %d for shard placement "
 							   "%ld does not exist", groupId, shardId)));
 	}
+}
+
+
+/*
+ * citus_internal_add_object_metadata is an internal UDF to
+ * add a row to pg_dist_object.
+ */
+Datum
+citus_internal_add_object_metadata(PG_FUNCTION_ARGS)
+{
+	PG_ENSURE_ARGNOTNULL(0, "classid");
+	Oid classid = PG_GETARG_OID(0);
+	PG_ENSURE_ARGNOTNULL(1, "objid");
+	Oid objid = PG_GETARG_OID(1);
+	PG_ENSURE_ARGNOTNULL(2, "objsubid");
+	Oid objsubid = PG_GETARG_OID(2);
+	int distributionArgumentIndexValue;
+	int colocationIdValue;
+	int *distributionArgumentIndex = NULL;
+	int *colocationId = NULL;
+	if (!PG_ARGISNULL(3))
+	{
+		distributionArgumentIndexValue = PG_GETARG_INT32(3);
+		distributionArgumentIndex = &distributionArgumentIndexValue;
+	}
+	if (!PG_ARGISNULL(4))
+	{
+		colocationIdValue = PG_GETARG_INT32(4);
+		colocationId = &colocationIdValue;
+	}
+
+
+	/* TODO: only owner of the object is allowed to modify the metadata */
+
+	/* TODO: maybe we want to serialize all the metadata changes to this table */
+
+	if (!ShouldSkipMetadataChecks())
+	{
+		/* this UDF is not allowed allowed for executing as a separate command */
+		EnsureCoordinatorInitiatedOperation();
+	}
+
+	ObjectAddress address = { 0 };
+	ObjectAddressSubSet(address, classid, objid, objsubid);
+	bool shouldSyncMetadata = false;
+	MarkObjectDistributed(&address, shouldSyncMetadata);
+	UpdateFunctionDistributionInfo(&address, distributionArgumentIndex, colocationId,
+								   shouldSyncMetadata);
+
+	PG_RETURN_VOID();
 }
 
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -399,8 +399,8 @@ SyncMetadataSnapshotToNode(WorkerNode *workerNode, bool raiseOnError)
 	ObjectAddress *address;
 	foreach_ptr(address, newDistributedObjects)
 	{
-		bool shouldSyncMetadata = true;
-		MarkObjectDistributed(address, shouldSyncMetadata);
+		bool localOnly = false;
+		MarkObjectDistributed(address, localOnly);
 	}
 	return true;
 }
@@ -2661,10 +2661,10 @@ citus_internal_add_object_metadata(PG_FUNCTION_ARGS)
 
 	ObjectAddress address = { 0 };
 	ObjectAddressSubSet(address, classid, objid, objsubid);
-	bool shouldSyncMetadata = false;
-	MarkObjectDistributed(&address, shouldSyncMetadata);
+	bool localOnly = true;
+	MarkObjectDistributed(&address, localOnly);
 	UpdateFunctionDistributionInfo(&address, distributionArgumentIndex, colocationId,
-								   shouldSyncMetadata);
+								   localOnly);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -177,7 +177,7 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
 
-	WorkerNode *workerNode = FindWorkerNode(nodeNameString, nodePort);
+	WorkerNode *workerNode = FindWorkerNodeAnyCluster(nodeNameString, nodePort);
 	if (workerNode == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -509,7 +509,7 @@ MetadataCreateCommands(void)
 			 *
 			 * Instead we rely on the initial sync of the pg_dist_object
 			 * contents at the end of this function. By inserting it here
-			 * locally, it will become part of that the list of commands that
+			 * locally, it will become part of the list of commands that
 			 * DistributedObjectSyncCommandList returns automatically.
 			 *
 			 * The only downside of this approach is that it won't be synced to

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -83,7 +83,7 @@ static List * GetDistributedTableDDLEvents(Oid relationId);
 static char * LocalGroupIdUpdateCommand(int32 groupId);
 static void UpdateDistNodeBoolAttr(const char *nodeName, int32 nodePort,
 								   int attrNum, bool value);
-static List * DistributedObjectSyncCommandList();
+static List * DistributedObjectSyncCommandList(void);
 static List * SequenceDependencyCommandList(Oid relationId);
 static char * TruncateTriggerCreateCommand(Oid relationId);
 static char * SchemaOwnerName(Oid objectId);
@@ -436,7 +436,7 @@ DropMetadataSnapshotOnNode(WorkerNode *workerNode)
  * (vi)  Queries that populate pg_dist_object
  */
 List *
-MetadataCreateCommands()
+MetadataCreateCommands(void)
 {
 	List *metadataSnapshotCommandList = NIL;
 	List *distributedTableList = CitusTableList();
@@ -620,7 +620,7 @@ MetadataCreateCommands()
 
 
 static List *
-DistributedObjectSyncCommandList()
+DistributedObjectSyncCommandList(void)
 {
 	List *commandList = NIL;
 

--- a/src/backend/distributed/sql/citus--10.1-1--10.2-1.sql
+++ b/src/backend/distributed/sql/citus--10.1-1--10.2-1.sql
@@ -13,5 +13,6 @@ ALTER TABLE pg_catalog.pg_dist_placement ADD CONSTRAINT placement_shardid_groupi
 #include "udfs/citus_internal_add_partition_metadata/10.2-1.sql";
 #include "udfs/citus_internal_add_shard_metadata/10.2-1.sql";
 #include "udfs/citus_internal_add_placement_metadata/10.2-1.sql";
+#include "udfs/citus_internal_add_object_metadata/10.2-1.sql";
 #include "udfs/citus_internal_update_placement_metadata/10.2-1.sql";
 #include "udfs/citus_internal_delete_shard_metadata/10.2-1.sql";

--- a/src/backend/distributed/sql/downgrades/citus--10.2-1--10.1-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.2-1--10.1-1.sql
@@ -14,6 +14,7 @@ COMMENT ON FUNCTION pg_catalog.stop_metadata_sync_to_node(nodename text, nodepor
 DROP FUNCTION pg_catalog.citus_internal_add_partition_metadata(regclass, "char", text, integer, "char");
 DROP FUNCTION pg_catalog.citus_internal_add_shard_metadata(regclass, bigint, "char", text, text);
 DROP FUNCTION pg_catalog.citus_internal_add_placement_metadata(bigint, integer, bigint, integer, bigint);
+DROP FUNCTION pg_catalog.citus_internal_add_object_metadata(oid, oid, oid, integer, integer);
 DROP FUNCTION pg_catalog.citus_internal_update_placement_metadata(bigint, integer, integer);
 DROP FUNCTION pg_catalog.citus_internal_delete_shard_metadata(bigint);
 

--- a/src/backend/distributed/sql/udfs/citus_internal_add_object_metadata/10.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_add_object_metadata/10.2-1.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_internal_add_object_metadata(
+							classid oid, objid oid, objsubid oid,
+							distribution_argument_index int, colocationid int)
+    RETURNS void
+    LANGUAGE C
+    AS 'MODULE_PATHNAME';
+
+COMMENT ON FUNCTION pg_catalog.citus_internal_add_object_metadata(oid,oid,oid,int,int) IS
+    'Inserts into pg_dist_object with user checks';

--- a/src/backend/distributed/sql/udfs/citus_internal_add_object_metadata/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_add_object_metadata/latest.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_internal_add_object_metadata(
+							classid oid, objid oid, objsubid oid,
+							distribution_argument_index int, colocationid int)
+    RETURNS void
+    LANGUAGE C
+    AS 'MODULE_PATHNAME';
+
+COMMENT ON FUNCTION pg_catalog.citus_internal_add_object_metadata(oid,oid,oid,int,int) IS
+    'Inserts into pg_dist_object with user checks';

--- a/src/backend/distributed/test/metadata_sync.c
+++ b/src/backend/distributed/test/metadata_sync.c
@@ -42,7 +42,8 @@ Datum
 master_metadata_snapshot(PG_FUNCTION_ARGS)
 {
 	List *dropSnapshotCommands = MetadataDropCommands();
-	List *createSnapshotCommands = MetadataCreateCommands();
+	List *newDistributedObjects = NIL;
+	List *createSnapshotCommands = MetadataCreateCommands(&newDistributedObjects);
 	List *snapshotCommandList = NIL;
 	int snapshotCommandIndex = 0;
 	Oid ddlCommandTypeId = TEXTOID;

--- a/src/backend/distributed/test/metadata_sync.c
+++ b/src/backend/distributed/test/metadata_sync.c
@@ -42,8 +42,7 @@ Datum
 master_metadata_snapshot(PG_FUNCTION_ARGS)
 {
 	List *dropSnapshotCommands = MetadataDropCommands();
-	List *newDistributedObjects = NIL;
-	List *createSnapshotCommands = MetadataCreateCommands(&newDistributedObjects);
+	List *createSnapshotCommands = MetadataCreateCommands();
 	List *snapshotCommandList = NIL;
 	int snapshotCommandIndex = 0;
 	Oid ddlCommandTypeId = TEXTOID;

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -56,6 +56,7 @@ typedef struct DistributeObjectOps
 	List * (*preprocess)(Node *, const char *, ProcessUtilityContext);
 	List * (*postprocess)(Node *, const char *);
 	ObjectAddress (*address)(Node *, bool);
+	bool markDistributed;
 } DistributeObjectOps;
 
 #define CITUS_TRUNCATE_TRIGGER_NAME "citus_truncate_trigger"
@@ -470,6 +471,10 @@ extern List * CreateFunctionDDLCommandsIdempotent(const ObjectAddress *functionA
 extern char * GetFunctionDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace);
 extern char * GenerateBackupNameForProcCollision(const ObjectAddress *address);
 extern ObjectWithArgs * ObjectWithArgsFromOid(Oid funcOid);
+extern void UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
+										   int *distribution_argument_index,
+										   int *colocationId,
+										   bool shouldSyncMetadata);
 
 /* vacuum.c - forward declarations */
 extern void PostprocessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -474,7 +474,7 @@ extern ObjectWithArgs * ObjectWithArgsFromOid(Oid funcOid);
 extern void UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 										   int *distribution_argument_index,
 										   int *colocationId,
-										   bool shouldSyncMetadata);
+										   bool localOnly);
 
 /* vacuum.c - forward declarations */
 extern void PostprocessVacuumStmt(VacuumStmt *vacuumStmt, const char *vacuumCommand);

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -21,7 +21,7 @@ extern bool CitusExtensionObject(const ObjectAddress *objectAddress);
 extern bool IsObjectDistributed(const ObjectAddress *address);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
 extern void MarkObjectDistributed(const ObjectAddress *distAddress,
-								  bool shouldSyncMetadata);
+								  bool localOnly);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
 extern bool IsTableOwnedByExtension(Oid relationId);
 extern bool IsObjectAddressOwnedByExtension(const ObjectAddress *target,

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -20,7 +20,8 @@ extern bool ObjectExists(const ObjectAddress *address);
 extern bool CitusExtensionObject(const ObjectAddress *objectAddress);
 extern bool IsObjectDistributed(const ObjectAddress *address);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
-extern void MarkObjectDistributed(const ObjectAddress *distAddress);
+extern void MarkObjectDistributed(const ObjectAddress *distAddress,
+								  bool shouldSyncMetadata);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
 extern bool IsTableOwnedByExtension(Oid relationId);
 extern bool IsObjectAddressOwnedByExtension(const ObjectAddress *target,

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -31,7 +31,7 @@ typedef enum
 extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
-extern List * MetadataCreateCommands(List **newDistributedObjects);
+extern List * MetadataCreateCommands();
 extern List * MetadataDropCommands(void);
 extern char * DistributedObjectCreateCommand(const ObjectAddress *address,
 											 int32 *distributionArgumentIndex,

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -31,7 +31,7 @@ typedef enum
 extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
-extern List * MetadataCreateCommands();
+extern List * MetadataCreateCommands(void);
 extern List * MetadataDropCommands(void);
 extern char * DistributedObjectCreateCommand(const ObjectAddress *address,
 											 int32 *distributionArgumentIndex,

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -36,7 +36,6 @@ extern List * MetadataDropCommands(void);
 extern char * DistributedObjectCreateCommand(const ObjectAddress *address,
 											 int32 *distributionArgumentIndex,
 											 int32 *colocationId);
-extern char * DistributedObjectDeleteCommand(const ObjectAddress *address);
 extern char * DistributionCreateCommand(CitusTableCacheEntry *cacheEntry);
 extern char * DistributionDeleteCommand(const char *schemaName,
 										const char *tableName);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -31,8 +31,12 @@ typedef enum
 extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
-extern List * MetadataCreateCommands(void);
+extern List * MetadataCreateCommands(List **newDistributedObjects);
 extern List * MetadataDropCommands(void);
+extern char * DistributedObjectCreateCommand(const ObjectAddress *address,
+											 int32 *distributionArgumentIndex,
+											 int32 *colocationId);
+extern char * DistributedObjectDeleteCommand(const ObjectAddress *address);
 extern char * DistributionCreateCommand(CitusTableCacheEntry *cacheEntry);
 extern char * DistributionDeleteCommand(const char *schemaName,
 										const char *tableName);
@@ -63,6 +67,7 @@ extern void GetDependentSequencesWithRelation(Oid relationId, List **attnumList,
 extern Oid GetAttributeTypeOid(Oid relationId, AttrNumber attnum);
 
 #define DELETE_ALL_NODES "TRUNCATE pg_dist_node CASCADE"
+#define DELETE_ALL_DISTRIBUTED_OBJECTS "TRUNCATE citus.pg_dist_object"
 #define REMOVE_ALL_CLUSTERED_TABLES_COMMAND \
 	"SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition"
 #define DISABLE_DDL_PROPAGATION "SET citus.enable_ddl_propagation TO 'off'"

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -251,6 +251,9 @@ extern void CreateTruncateTrigger(Oid relationId);
 extern TableConversionReturn * UndistributeTable(TableConversionParameters *params);
 
 extern void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
+extern void EnsureDependenciesExistOnAllNodesLocalOnlyMarkDistributed(const
+																	  ObjectAddress *
+																	  target);
 extern List * GetDistributableDependenciesForObject(const ObjectAddress *target);
 extern bool ShouldPropagate(void);
 extern bool ShouldPropagateObject(const ObjectAddress *address);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -295,6 +295,7 @@ extern void EnsureSequenceTypeSupported(Oid seqOid, Oid seqTypId);
 extern void AlterSequenceType(Oid seqOid, Oid typeOid);
 extern void PropagateSequenceListDependencies(List *sequenceList);
 extern void PropagateSequenceDependencies(Oid sequenceOid);
+extern void MarkSequenceListDistributed(List *sequenceList);
 extern void EnsureDistributedSequencesHaveOneType(Oid relationId,
 												  List *dependentSequenceList,
 												  List *attnumList);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -293,9 +293,12 @@ extern bool GetNodeDiskSpaceStatsForConnection(MultiConnection *connection,
 extern void ExecuteQueryViaSPI(char *query, int SPIOK);
 extern void EnsureSequenceTypeSupported(Oid seqOid, Oid seqTypId);
 extern void AlterSequenceType(Oid seqOid, Oid typeOid);
-extern void MarkSequenceListDistributedAndPropagateDependencies(List *sequenceList);
-extern void MarkSequenceDistributedAndPropagateDependencies(Oid sequenceOid);
+extern void PropagateSequenceListDependencies(List *sequenceList);
+extern void PropagateSequenceDependencies(Oid sequenceOid);
 extern void EnsureDistributedSequencesHaveOneType(Oid relationId,
 												  List *dependentSequenceList,
 												  List *attnumList);
+extern List * EnsureDependenciesExistOnAllNodesWithoutMarkingDistributed(const
+																		 ObjectAddress *
+																		 target);
 #endif   /* METADATA_UTILITY_H */

--- a/src/test/regress/expected/disable_worker_ddl_propagation.out
+++ b/src/test/regress/expected/disable_worker_ddl_propagation.out
@@ -1,0 +1,14 @@
+SELECT success FROM run_command_on_workers('ALTER SYSTEM SET citus.enable_ddl_propagation TO OFF');
+ success
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+SELECT success FROM run_command_on_workers('select pg_reload_conf()');
+ success
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -252,6 +252,21 @@ SELECT * FROM run_command_on_workers($$SELECT function_tests.dup('0123456789ab')
  localhost |    57638 | t       | (01:23:45:67:89:ab,"01:23:45:67:89:ab is text")
 (2 rows)
 
+-- Wait two times for metadata sync, once for each node in the cluster.
+-- Otherwise the next distributed function creation will fail, telling us to
+-- wait for syncing.
+SELECT public.wait_until_metadata_sync(30000);
+ wait_until_metadata_sync
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT public.wait_until_metadata_sync(30000);
+ wait_until_metadata_sync
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT create_distributed_function('eq(macaddr,macaddr)', '$1', colocate_with := 'streaming_table');
  create_distributed_function
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/enable_worker_ddl_propagation.out
+++ b/src/test/regress/expected/enable_worker_ddl_propagation.out
@@ -1,0 +1,14 @@
+SELECT success FROM run_command_on_workers('ALTER SYSTEM SET citus.enable_ddl_propagation TO ON');
+ success
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+SELECT success FROM run_command_on_workers('select pg_reload_conf()');
+ success
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -646,13 +646,14 @@ SELECT * FROM multi_extension.print_extension_changes();
  function stop_metadata_sync_to_node(text,integer) void |
                                                         | function citus_internal.downgrade_columnar_storage(regclass) void
                                                         | function citus_internal.upgrade_columnar_storage(regclass) void
+                                                        | function citus_internal_add_object_metadata(oid,oid,oid,integer,integer) void
                                                         | function citus_internal_add_partition_metadata(regclass,"char",text,integer,"char") void
                                                         | function citus_internal_add_placement_metadata(bigint,integer,bigint,integer,bigint) void
                                                         | function citus_internal_add_shard_metadata(regclass,bigint,"char",text,text) void
                                                         | function citus_internal_delete_shard_metadata(bigint) void
                                                         | function citus_internal_update_placement_metadata(bigint,integer,integer) void
                                                         | function stop_metadata_sync_to_node(text,integer,boolean) void
-(9 rows)
+(10 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -86,6 +86,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
@@ -96,7 +98,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('public.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('public.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('public.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('public.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('public.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('public.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('public.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(20 rows)
+(22 rows)
 
 -- Show that CREATE INDEX commands are included in the metadata snapshot
 CREATE INDEX mx_index ON mx_test_table(col_2);
@@ -114,6 +116,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
@@ -124,7 +128,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('public.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('public.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('public.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('public.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('public.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('public.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('public.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(21 rows)
+(23 rows)
 
 -- Show that schema changes are included in the metadata snapshot
 CREATE SCHEMA mx_testing_schema;
@@ -144,6 +148,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['mx_testing_schema', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
@@ -154,7 +160,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(22 rows)
+(24 rows)
 
 -- Show that append distributed tables are not included in the metadata snapshot
 CREATE TABLE non_mx_test_table (col_1 int, col_2 text);
@@ -180,6 +186,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['mx_testing_schema', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
@@ -190,7 +198,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(22 rows)
+(24 rows)
 
 -- Show that range distributed tables are not included in the metadata snapshot
 UPDATE pg_dist_partition SET partmethod='r' WHERE logicalrelid='non_mx_test_table'::regclass;
@@ -209,6 +217,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['mx_testing_schema', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
@@ -219,7 +229,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(22 rows)
+(24 rows)
 
 -- Test start_metadata_sync_to_node UDF
 -- Ensure that hasmetadata=false for all nodes

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -29,9 +29,13 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
                                                                                                                                                               unnest
 ---------------------------------------------------------------------
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
-(3 rows)
+(7 rows)
 
 -- this function is dropped in Citus10, added here for tests
 CREATE OR REPLACE FUNCTION pg_catalog.master_create_distributed_table(table_name regclass,
@@ -79,16 +83,20 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  ALTER TABLE public.mx_test_table OWNER TO postgres
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL, col_4 bigint DEFAULT nextval('public.user_defined_seq'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('public.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('public.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('public.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('public.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('public.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('public.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('public.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(16 rows)
+(20 rows)
 
 -- Show that CREATE INDEX commands are included in the metadata snapshot
 CREATE INDEX mx_index ON mx_test_table(col_2);
@@ -103,16 +111,20 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  CREATE INDEX mx_index ON public.mx_test_table USING btree (col_2)
  CREATE TABLE public.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('public.mx_test_table_col_3_seq'::regclass) NOT NULL, col_4 bigint DEFAULT nextval('public.user_defined_seq'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('public.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('public.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('public.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('public.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('public.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('public.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('public.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(17 rows)
+(21 rows)
 
 -- Show that schema changes are included in the metadata snapshot
 CREATE SCHEMA mx_testing_schema;
@@ -128,16 +140,21 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2)
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL, col_4 bigint DEFAULT nextval('public.user_defined_seq'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(17 rows)
+(22 rows)
 
 -- Show that append distributed tables are not included in the metadata snapshot
 CREATE TABLE non_mx_test_table (col_1 int, col_2 text);
@@ -159,16 +176,21 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2)
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL, col_4 bigint DEFAULT nextval('public.user_defined_seq'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(17 rows)
+(22 rows)
 
 -- Show that range distributed tables are not included in the metadata snapshot
 UPDATE pg_dist_partition SET partmethod='r' WHERE logicalrelid='non_mx_test_table'::regclass;
@@ -183,16 +205,21 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  CREATE INDEX mx_index ON mx_testing_schema.mx_test_table USING btree (col_2)
  CREATE TABLE mx_testing_schema.mx_test_table (col_1 integer, col_2 text NOT NULL, col_3 bigint DEFAULT nextval('mx_testing_schema.mx_test_table_col_3_seq'::regclass) NOT NULL, col_4 bigint DEFAULT nextval('public.user_defined_seq'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 2, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 2, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 2, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 2, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('mx_testing_schema.mx_test_table'::regclass, 1310000, 't'::"char", '-2147483648', '-1610612737'), ('mx_testing_schema.mx_test_table'::regclass, 1310001, 't'::"char", '-1610612736', '-1073741825'), ('mx_testing_schema.mx_test_table'::regclass, 1310002, 't'::"char", '-1073741824', '-536870913'), ('mx_testing_schema.mx_test_table'::regclass, 1310003, 't'::"char", '-536870912', '-1'), ('mx_testing_schema.mx_test_table'::regclass, 1310004, 't'::"char", '0', '536870911'), ('mx_testing_schema.mx_test_table'::regclass, 1310005, 't'::"char", '536870912', '1073741823'), ('mx_testing_schema.mx_test_table'::regclass, 1310006, 't'::"char", '1073741824', '1610612735'), ('mx_testing_schema.mx_test_table'::regclass, 1310007, 't'::"char", '1610612736', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(17 rows)
+(22 rows)
 
 -- Test start_metadata_sync_to_node UDF
 -- Ensure that hasmetadata=false for all nodes
@@ -1187,8 +1214,10 @@ DROP TABLE mx_table_with_small_sequence, mx_table_with_sequence;
 -- owner
 CREATE TABLE pg_dist_placement_temp AS SELECT * FROM pg_dist_placement;
 CREATE TABLE pg_dist_partition_temp AS SELECT * FROM pg_dist_partition;
+CREATE TABLE pg_dist_object_temp AS SELECT * FROM citus.pg_dist_object;
 DELETE FROM pg_dist_placement;
 DELETE FROM pg_dist_partition;
+DELETE FROM citus.pg_dist_object;
 SELECT groupid AS old_worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
 SELECT master_remove_node('localhost', :worker_2_port);
  master_remove_node
@@ -1271,8 +1300,10 @@ DROP TABLE mx_table;
 \c - postgres - :master_port
 INSERT INTO pg_dist_placement SELECT * FROM pg_dist_placement_temp;
 INSERT INTO pg_dist_partition SELECT * FROM pg_dist_partition_temp;
+INSERT INTO citus.pg_dist_object SELECT * FROM pg_dist_object_temp ON CONFLICT DO NOTHING;
 DROP TABLE pg_dist_placement_temp;
 DROP TABLE pg_dist_partition_temp;
+DROP TABLE pg_dist_object_temp;
 UPDATE pg_dist_placement
   SET groupid = (SELECT groupid FROM pg_dist_node WHERE nodeport = :worker_2_port)
   WHERE groupid = :old_worker_2_group;
@@ -1677,6 +1708,17 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  CREATE TABLE public.mx_ref (col_1 integer, col_2 text)
  CREATE TABLE public.test_table (id integer DEFAULT nextval('public.mx_test_sequence_0'::regclass), id2 integer DEFAULT nextval('public.mx_test_sequence_1'::regclass))
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (4, 1, 'localhost', 8888, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'default'),(5, 1, 'localhost', 8889, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'second-cluster'),(1, 1, 'localhost', 57637, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default'),(7, 5, 'localhost', 57638, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default')
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('database', ARRAY['regression']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('role', ARRAY['postgres']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_test_schema_1']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_test_schema_2']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['mx_testing_schema_2']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('schema', ARRAY['public']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['mx_testing_schema', 'mx_test_table_col_3_seq']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'mx_test_sequence_0']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'mx_test_sequence_1']::text[], ARRAY[]::text[])
+ SELECT citus_internal_add_object_metadata (classid, objid, objsubid, NULL, NULL) FROM pg_get_object_address('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[])
  SELECT citus_internal_add_partition_metadata ('mx_test_schema_1.mx_table_1'::regclass, 'h', 'col1', 3, 's')
  SELECT citus_internal_add_partition_metadata ('mx_test_schema_2.mx_table_2'::regclass, 'h', 'col1', 3, 's')
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
@@ -1695,6 +1737,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT worker_create_truncate_trigger('public.mx_ref')
  SELECT worker_create_truncate_trigger('public.test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
+ TRUNCATE citus.pg_dist_object
  TRUNCATE pg_dist_node CASCADE
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310000, 1, 0, 1, 100000), (1310001, 1, 0, 5, 100001), (1310002, 1, 0, 1, 100002), (1310003, 1, 0, 5, 100003), (1310004, 1, 0, 1, 100004), (1310005, 1, 0, 5, 100005), (1310006, 1, 0, 1, 100006), (1310007, 1, 0, 5, 100007)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
  WITH placement_data(shardid, shardstate, shardlength, groupid, placementid)  AS (VALUES (1310020, 1, 0, 1, 100020), (1310021, 1, 0, 5, 100021), (1310022, 1, 0, 1, 100022), (1310023, 1, 0, 5, 100023), (1310024, 1, 0, 1, 100024)) SELECT citus_internal_add_placement_metadata(shardid, shardstate, shardlength, groupid, placementid) FROM placement_data;
@@ -1708,7 +1751,7 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.dist_table_1'::regclass, 1310074, 't'::"char", '-2147483648', '-1073741825'), ('public.dist_table_1'::regclass, 1310075, 't'::"char", '-1073741824', '-1'), ('public.dist_table_1'::regclass, 1310076, 't'::"char", '0', '1073741823'), ('public.dist_table_1'::regclass, 1310077, 't'::"char", '1073741824', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.mx_ref'::regclass, 1310073, 't'::"char", NULL, NULL)) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
  WITH shard_data(relationname, shardid, storagetype, shardminvalue, shardmaxvalue)  AS (VALUES ('public.test_table'::regclass, 1310083, 't'::"char", '-2147483648', '-1073741825'), ('public.test_table'::regclass, 1310084, 't'::"char", '-1073741824', '-1'), ('public.test_table'::regclass, 1310085, 't'::"char", '0', '1073741823'), ('public.test_table'::regclass, 1310086, 't'::"char", '1073741824', '2147483647')) SELECT citus_internal_add_shard_metadata(relationname, shardid, storagetype, shardminvalue, shardmaxvalue) FROM shard_data;
-(62 rows)
+(74 rows)
 
 -- shouldn't work since test_table is MX
 ALTER TABLE test_table ADD COLUMN id3 bigserial;

--- a/src/test/regress/expected/multi_unsupported_worker_operations.out
+++ b/src/test/regress/expected/multi_unsupported_worker_operations.out
@@ -353,29 +353,10 @@ CREATE TABLE some_table_with_sequence(a int, b BIGSERIAL, c BIGSERIAL);
 DROP TABLE some_table_with_sequence;
 CREATE SEQUENCE some_sequence;
 DROP SEQUENCE some_sequence;
--- Show that dropping the sequence of an MX table with cascade harms the table and shards
-BEGIN;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_table'::regclass;
- Column |  Type   |                        Modifiers
----------------------------------------------------------------------
- col_1  | integer |
- col_2  | text    |
- col_3  | bigint  | not null default nextval('mx_table_col_3_seq'::regclass)
-(3 rows)
-
--- suppress notice message caused by DROP ... CASCADE to prevent pg version difference
-SET client_min_messages TO 'WARNING';
-DROP SEQUENCE mx_table_col_3_seq CASCADE;
-RESET client_min_messages;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_table'::regclass;
- Column |  Type   | Modifiers
----------------------------------------------------------------------
- col_1  | integer |
- col_2  | text    |
- col_3  | bigint  | not null
-(3 rows)
-
-ROLLBACK;
+-- Show that dropping the sequence of an MX table is not allowed on a worker
+DROP SEQUENCE mx_table_col_3_seq;
+ERROR:  operation is not allowed on this node
+HINT:  Connect to the coordinator and run it again.
 -- Cleanup
 \c - - - :master_port
 DROP TABLE mx_table;

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -66,6 +66,7 @@ ORDER BY 1;
  function citus_internal.replace_isolation_tester_func()
  function citus_internal.restore_isolation_tester_func()
  function citus_internal.upgrade_columnar_storage(regclass)
+ function citus_internal_add_object_metadata(oid,oid,oid,integer,integer)
  function citus_internal_add_partition_metadata(regclass,"char",text,integer,"char")
  function citus_internal_add_placement_metadata(bigint,integer,bigint,integer,bigint)
  function citus_internal_add_shard_metadata(regclass,bigint,"char",text,text)
@@ -253,5 +254,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(237 rows)
+(238 rows)
 

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -327,8 +327,14 @@ test: distributed_procedure
 
 # ---------
 # deparsing logic tests
+#
+# we temporarily disable ddl propagation on the workers, because these tests
+# run queries there directly. We do this disabling/enabling in a separate test,
+# so that the deparse tests can run in parallel.
 # ---------
+test: disable_worker_ddl_propagation
 test: multi_deparse_function multi_deparse_procedure
+test: enable_worker_ddl_propagation
 
 # --------
 # cannot be run in parallel with any other tests as it checks

--- a/src/test/regress/sql/disable_worker_ddl_propagation.sql
+++ b/src/test/regress/sql/disable_worker_ddl_propagation.sql
@@ -1,0 +1,3 @@
+SELECT success FROM run_command_on_workers('ALTER SYSTEM SET citus.enable_ddl_propagation TO OFF');
+SELECT success FROM run_command_on_workers('select pg_reload_conf()');
+

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -204,6 +204,12 @@ END;
 SELECT create_distributed_function('dup(macaddr)', '$1', colocate_with := 'streaming_table');
 SELECT * FROM run_command_on_workers($$SELECT function_tests.dup('0123456789ab');$$) ORDER BY 1,2;
 
+-- Wait two times for metadata sync, once for each node in the cluster.
+-- Otherwise the next distributed function creation will fail, telling us to
+-- wait for syncing.
+SELECT public.wait_until_metadata_sync(30000);
+SELECT public.wait_until_metadata_sync(30000);
+
 SELECT create_distributed_function('eq(macaddr,macaddr)', '$1', colocate_with := 'streaming_table');
 SELECT * FROM run_command_on_workers($$SELECT function_tests.eq('012345689ab','0123456789ab');$$) ORDER BY 1,2;
 SELECT public.verify_function_is_same_on_workers('function_tests.eq(macaddr,macaddr)');

--- a/src/test/regress/sql/enable_worker_ddl_propagation.sql
+++ b/src/test/regress/sql/enable_worker_ddl_propagation.sql
@@ -1,0 +1,3 @@
+SELECT success FROM run_command_on_workers('ALTER SYSTEM SET citus.enable_ddl_propagation TO ON');
+SELECT success FROM run_command_on_workers('select pg_reload_conf()');
+

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -533,8 +533,10 @@ DROP TABLE mx_table_with_small_sequence, mx_table_with_sequence;
 -- owner
 CREATE TABLE pg_dist_placement_temp AS SELECT * FROM pg_dist_placement;
 CREATE TABLE pg_dist_partition_temp AS SELECT * FROM pg_dist_partition;
+CREATE TABLE pg_dist_object_temp AS SELECT * FROM citus.pg_dist_object;
 DELETE FROM pg_dist_placement;
 DELETE FROM pg_dist_partition;
+DELETE FROM citus.pg_dist_object;
 SELECT groupid AS old_worker_2_group FROM pg_dist_node WHERE nodeport = :worker_2_port \gset
 SELECT master_remove_node('localhost', :worker_2_port);
 
@@ -574,8 +576,10 @@ DROP TABLE mx_table;
 \c - postgres - :master_port
 INSERT INTO pg_dist_placement SELECT * FROM pg_dist_placement_temp;
 INSERT INTO pg_dist_partition SELECT * FROM pg_dist_partition_temp;
+INSERT INTO citus.pg_dist_object SELECT * FROM pg_dist_object_temp ON CONFLICT DO NOTHING;
 DROP TABLE pg_dist_placement_temp;
 DROP TABLE pg_dist_partition_temp;
+DROP TABLE pg_dist_object_temp;
 UPDATE pg_dist_placement
   SET groupid = (SELECT groupid FROM pg_dist_node WHERE nodeport = :worker_2_port)
   WHERE groupid = :old_worker_2_group;

--- a/src/test/regress/sql/multi_unsupported_worker_operations.sql
+++ b/src/test/regress/sql/multi_unsupported_worker_operations.sql
@@ -216,15 +216,8 @@ DROP TABLE some_table_with_sequence;
 CREATE SEQUENCE some_sequence;
 DROP SEQUENCE some_sequence;
 
--- Show that dropping the sequence of an MX table with cascade harms the table and shards
-BEGIN;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_table'::regclass;
--- suppress notice message caused by DROP ... CASCADE to prevent pg version difference
-SET client_min_messages TO 'WARNING';
-DROP SEQUENCE mx_table_col_3_seq CASCADE;
-RESET client_min_messages;
-SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='public.mx_table'::regclass;
-ROLLBACK;
+-- Show that dropping the sequence of an MX table is not allowed on a worker
+DROP SEQUENCE mx_table_col_3_seq;
 
 -- Cleanup
 \c - - - :master_port


### PR DESCRIPTION
DESCRIPTION: Sync pg_dist_object to all nodes with metadata

We want to sync `pg_dist_object` to metadata nodes too. This has a few direct advantages:
1. Error are returned when distributed objects are modified on worker nodes.
2. function delegation and pushdown works when connecting to workers.

It also one of the steps needed to allow DDL on workers (#1083).

TODO: 
 - [ ] Cleanup (code deduplication, comments etc)
 - [ ] Tests
 - [ ] Permission checking
 - [x] Fix issue with sequences returning out of range values


Fixes #5065 