### PR TITLE
Include data_type and cache in sequence definition on workers

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -207,10 +207,13 @@ pg_get_sequencedef_string(Oid sequenceRelationId)
 
 	/* build our DDL command */
 	char *qualifiedSequenceName = generate_qualified_relation_name(sequenceRelationId);
+	char *typeName = format_type_be(pgSequenceForm->seqtypid);
 
 	char *sequenceDef = psprintf(CREATE_SEQUENCE_COMMAND, qualifiedSequenceName,
+								 typeName,
 								 pgSequenceForm->seqincrement, pgSequenceForm->seqmin,
 								 pgSequenceForm->seqmax, pgSequenceForm->seqstart,
+								 pgSequenceForm->seqcache,
 								 pgSequenceForm->seqcycle ? "" : "NO ");
 
 	return sequenceDef;

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -21,8 +21,9 @@
 
 
 #define CREATE_SEQUENCE_COMMAND \
-	"CREATE SEQUENCE IF NOT EXISTS %s INCREMENT BY " INT64_FORMAT " MINVALUE " \
-	INT64_FORMAT " MAXVALUE " INT64_FORMAT " START WITH " INT64_FORMAT " %sCYCLE"
+	"CREATE SEQUENCE IF NOT EXISTS %s AS %s INCREMENT BY " INT64_FORMAT \
+	" MINVALUE " INT64_FORMAT " MAXVALUE " INT64_FORMAT \
+	" START WITH " INT64_FORMAT " CACHE " INT64_FORMAT " %sCYCLE"
 
 /* Function declarations for version independent Citus ruleutils wrapper functions */
 extern char * pg_get_extensiondef_string(Oid tableRelationId);

--- a/src/test/regress/expected/distributed_procedure.out
+++ b/src/test/regress/expected/distributed_procedure.out
@@ -215,3 +215,15 @@ SELECT run_command_on_workers($$DROP USER procedureuser;$$);
  (localhost,57638,t,"DROP ROLE")
 (2 rows)
 
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -81,8 +81,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
@@ -105,8 +105,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT citus_internal_add_partition_metadata ('public.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('public.mx_test_table_col_3_seq'::regclass,'public.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('public.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
@@ -130,8 +130,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
@@ -161,8 +161,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
@@ -185,8 +185,8 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster) VALUES (1, 1, 'localhost', 57637, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default'),(2, 2, 'localhost', 57638, 'default', FALSE, FALSE, TRUE, 'primary'::noderole, 'default')
  SELECT citus_internal_add_partition_metadata ('mx_testing_schema.mx_test_table'::regclass, 'h', 'col_1', 0, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')
  SELECT worker_drop_distributed_table(logicalrelid::regclass::text) FROM pg_dist_partition
  TRUNCATE pg_dist_node CASCADE
@@ -273,7 +273,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
-          logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel
+          logicalrelid           | partmethod |                                                        partkey                                                         | colocationid | repmodel
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            0 | s
 (1 row)
@@ -410,7 +410,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 (4 rows)
 
 SELECT * FROM pg_dist_partition ORDER BY logicalrelid;
-          logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel
+          logicalrelid           | partmethod |                                                        partkey                                                         | colocationid | repmodel
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1} |            0 | s
 (1 row)
@@ -1684,10 +1684,10 @@ SELECT unnest(master_metadata_snapshot()) order by 1;
  SELECT citus_internal_add_partition_metadata ('public.mx_ref'::regclass, 'n', NULL, 10002, 't')
  SELECT citus_internal_add_partition_metadata ('public.test_table'::regclass, 'h', 'id', 10004, 's')
  SELECT pg_catalog.worker_record_sequence_dependency('mx_testing_schema.mx_test_table_col_3_seq'::regclass,'mx_testing_schema.mx_test_table'::regclass,'col_3')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_sequence_0 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 NO CYCLE','integer')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_sequence_1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 NO CYCLE','integer')
- SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS mx_testing_schema.mx_test_table_col_3_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_sequence_0 AS integer INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1 NO CYCLE','integer')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.mx_test_sequence_1 AS integer INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1 NO CYCLE','integer')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.user_defined_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
  SELECT worker_create_truncate_trigger('mx_test_schema_1.mx_table_1')
  SELECT worker_create_truncate_trigger('mx_test_schema_2.mx_table_2')
  SELECT worker_create_truncate_trigger('mx_testing_schema.mx_test_table')

--- a/src/test/regress/expected/multi_sequence_default.out
+++ b/src/test/regress/expected/multi_sequence_default.out
@@ -541,7 +541,9 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 
 -- Check that various ALTER SEQUENCE commands
 -- are not allowed for a distributed sequence for now
-CREATE SEQUENCE seq_8;
+-- Also check that various sequence options are passed on to the worker
+-- correctly
+CREATE SEQUENCE seq_8 AS integer INCREMENT BY 3 CACHE 10 CYCLE;
 CREATE SCHEMA sequence_default_8;
 -- can change schema in a sequence not yet distributed
 ALTER SEQUENCE seq_8 SET SCHEMA sequence_default_8;
@@ -564,6 +566,8 @@ ALTER SEQUENCE seq_8 START WITH 6;
 ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_8 RESTART WITH 6;
 ERROR:  Altering a distributed sequence is currently not supported.
+ALTER SEQUENCE seq_8 CACHE 5;
+ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_8 NO CYCLE;
 ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_8 OWNED BY seq_test_7;
@@ -578,6 +582,8 @@ ALTER SEQUENCE seq_test_8_z_seq START WITH 6;
 ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_test_8_z_seq RESTART WITH 6;
 ERROR:  Altering a distributed sequence is currently not supported.
+ALTER SEQUENCE seq_test_8_z_seq CACHE 5;
+ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_test_8_z_seq NO CYCLE;
 ERROR:  Altering a distributed sequence is currently not supported.
 ALTER SEQUENCE seq_test_8_z_seq OWNED BY seq_test_7;
@@ -587,10 +593,10 @@ ERROR:  cannot alter OWNED BY option of a sequence already owned by a distribute
 ALTER SEQUENCE seq_8 SET SCHEMA sequence_default_8;
 \c - - - :worker_1_port
 \d sequence_default_8.seq_8
-                   Sequence "sequence_default_8.seq_8"
-  Type  |   Start   |  Minimum  |  Maximum  | Increment | Cycles? | Cache
+                    Sequence "sequence_default_8.seq_8"
+  Type   |   Start   |  Minimum  |  Maximum  | Increment | Cycles? | Cache
 ---------------------------------------------------------------------
- bigint | 268435457 | 268435457 | 536870913 |         1 | no      |     1
+ integer | 268435457 | 268435457 | 536870913 |         3 | yes     |    10
 
 \c - - - :master_port
 SET citus.shard_replication_factor TO 1;
@@ -605,10 +611,10 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 ALTER TABLE sequence_default_8.seq_8 SET SCHEMA sequence_default;
 \c - - - :worker_1_port
 \d sequence_default.seq_8
-                    Sequence "sequence_default.seq_8"
-  Type  |   Start   |  Minimum  |  Maximum  | Increment | Cycles? | Cache
+                     Sequence "sequence_default.seq_8"
+  Type   |   Start   |  Minimum  |  Maximum  | Increment | Cycles? | Cache
 ---------------------------------------------------------------------
- bigint | 268435457 | 268435457 | 536870913 |         1 | no      |     1
+ integer | 268435457 | 268435457 | 536870913 |         3 | yes     |    10
 
 \c - - - :master_port
 SET citus.shard_replication_factor TO 1;
@@ -768,37 +774,8 @@ ERROR:  relation "seq_11" does not exist
 \c - - - :master_port
 -- clean up
 DROP TABLE sequence_default.seq_test_7_par;
+SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA sequence_default CASCADE;
-NOTICE:  drop cascades to 29 other objects
-DETAIL:  drop cascades to sequence sequence_default.seq_0
-drop cascades to sequence sequence_default.seq_0_local_table
-drop cascades to table sequence_default.seq_test_0
-drop cascades to table sequence_default.seq_test_0_local_table_890004
-drop cascades to table sequence_default.seq_test_0_local_table
-drop cascades to table sequence_default.seq_test_4
-drop cascades to sequence sequence_default.seq_4
-drop cascades to sequence sequence_default.seq_1
-drop cascades to table sequence_default.seq_test_1
-drop cascades to sequence sequence_default.seq_1_local_table
-drop cascades to table sequence_default.seq_test_1_local_table_102016
-drop cascades to table sequence_default.seq_test_1_local_table
-drop cascades to sequence sequence_default.seq_2
-drop cascades to table sequence_default.seq_test_2
-drop cascades to table sequence_default.seq_test_3
-drop cascades to table sequence_default.seq_test_5
-drop cascades to sequence sequence_default.seq_6
-drop cascades to table sequence_default.seq_test_6
-drop cascades to sequence sequence_default.seq_7
-drop cascades to table sequence_default.seq_test_7
-drop cascades to sequence sequence_default.seq_7_par
-drop cascades to sequence sequence_default.seq_8
-drop cascades to table sequence_default.seq_test_8
-drop cascades to sequence sequence_default.seq_9
-drop cascades to table sequence_default.seq_test_9
-drop cascades to sequence sequence_default.seq_11
-drop cascades to table sequence_default.seq_test_10
-drop cascades to table sequence_default.seq_test_10_102060
-drop cascades to table sequence_default.seq_test_11
 SELECT run_command_on_workers('DROP SCHEMA IF EXISTS sequence_default CASCADE');
       run_command_on_workers
 ---------------------------------------------------------------------
@@ -807,7 +784,6 @@ SELECT run_command_on_workers('DROP SCHEMA IF EXISTS sequence_default CASCADE');
 (2 rows)
 
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
-NOTICE:  dropping metadata on the node (localhost,57637)
  stop_metadata_sync_to_node
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/mx_regular_user.out
+++ b/src/test/regress/expected/mx_regular_user.out
@@ -1,5 +1,12 @@
 CREATE SCHEMA "Mx Regular User";
 SET search_path TO "Mx Regular User";
+-- add coordinator in idempotent way
+SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
 -- sync the metadata to both nodes
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node
@@ -69,7 +76,7 @@ COMMIT;
 -- make sure that partitioned tables, columnar and conversion to columnar workes fine
 -- on Citus MX with a non-super user
 CREATE SEQUENCE my_mx_seq;
-CREATE TABLE users_table_part(col_to_drop int, user_id int, value_1 int, value_2 int DEFAULT nextval('my_mx_seq'::regclass), value_3 bigserial) PARTITION BY RANGE (value_1);
+CREATE TABLE users_table_part(col_to_drop int, user_id int, value_1 int, value_2 bigint DEFAULT nextval('my_mx_seq'::regclass), value_3 bigserial) PARTITION BY RANGE (value_1);
 CREATE TABLE users_table_part_0 PARTITION OF users_table_part FOR VALUES FROM (0) TO (1);
 CREATE TABLE users_table_part_1 PARTITION OF users_table_part FOR VALUES FROM (1) TO (2);
 SELECT create_distributed_table('users_table_part', 'user_id', colocate_with:='partitioned_table');
@@ -86,7 +93,7 @@ BEGIN;
 	SET LOCAL citus.force_max_query_parallelization TO ON;
 	CREATE TABLE users_table_part_2 PARTITION OF users_table_part FOR VALUES FROM (2) TO (3);
 	INSERT INTO users_table_part SELECT i, i %3, i %50 FROM generate_series(0, 100) i;
-	CREATE TABLE users_table_part_3 (user_id int, value_1 int, value_2 int, value_3 bigserial);
+	CREATE TABLE users_table_part_3 (user_id int, value_1 int, value_2 bigint, value_3 bigserial);
 	ALTER TABLE users_table_part ATTACH PARTITION users_table_part_3 FOR VALUES FROM (3) TO (4);
 	CREATE TABLE users_table_part_4 PARTITION OF users_table_part FOR VALUES FROM (4) TO (5) USING COLUMNAR;;
 COMMIT;

--- a/src/test/regress/expected/undistribute_table_cascade_mx.out
+++ b/src/test/regress/expected/undistribute_table_cascade_mx.out
@@ -121,7 +121,7 @@ SELECT undistribute_table('reference_table_2');
 (1 row)
 
 create table countries(
-  id serial primary key
+  id bigserial primary key
   , name text
   , code varchar(2) collate "C" unique
 );

--- a/src/test/regress/sql/distributed_procedure.sql
+++ b/src/test/regress/sql/distributed_procedure.sql
@@ -93,3 +93,6 @@ DROP SCHEMA procedure_tests2 CASCADE;
 SELECT run_command_on_workers($$DROP SCHEMA procedure_tests2 CASCADE;$$);
 DROP USER procedureuser;
 SELECT run_command_on_workers($$DROP USER procedureuser;$$);
+
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);

--- a/src/test/regress/sql/multi_sequence_default.sql
+++ b/src/test/regress/sql/multi_sequence_default.sql
@@ -269,7 +269,9 @@ SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 
 -- Check that various ALTER SEQUENCE commands
 -- are not allowed for a distributed sequence for now
-CREATE SEQUENCE seq_8;
+-- Also check that various sequence options are passed on to the worker
+-- correctly
+CREATE SEQUENCE seq_8 AS integer INCREMENT BY 3 CACHE 10 CYCLE;
 CREATE SCHEMA sequence_default_8;
 -- can change schema in a sequence not yet distributed
 ALTER SEQUENCE seq_8 SET SCHEMA sequence_default_8;
@@ -282,6 +284,7 @@ ALTER SEQUENCE seq_8 INCREMENT BY 2;
 ALTER SEQUENCE seq_8 MINVALUE 5 MAXVALUE 5000;
 ALTER SEQUENCE seq_8 START WITH 6;
 ALTER SEQUENCE seq_8 RESTART WITH 6;
+ALTER SEQUENCE seq_8 CACHE 5;
 ALTER SEQUENCE seq_8 NO CYCLE;
 ALTER SEQUENCE seq_8 OWNED BY seq_test_7;
 ALTER SEQUENCE seq_test_8_z_seq AS smallint;
@@ -289,6 +292,7 @@ ALTER SEQUENCE seq_test_8_z_seq INCREMENT BY 2;
 ALTER SEQUENCE seq_test_8_z_seq MINVALUE 5 MAXVALUE 5000;
 ALTER SEQUENCE seq_test_8_z_seq START WITH 6;
 ALTER SEQUENCE seq_test_8_z_seq RESTART WITH 6;
+ALTER SEQUENCE seq_test_8_z_seq CACHE 5;
 ALTER SEQUENCE seq_test_8_z_seq NO CYCLE;
 ALTER SEQUENCE seq_test_8_z_seq OWNED BY seq_test_7;
 -- can change schema in a distributed sequence
@@ -372,6 +376,7 @@ INSERT INTO sequence_default.seq_test_10 VALUES (1);
 
 -- clean up
 DROP TABLE sequence_default.seq_test_7_par;
+SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA sequence_default CASCADE;
 SELECT run_command_on_workers('DROP SCHEMA IF EXISTS sequence_default CASCADE');
 SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);

--- a/src/test/regress/sql/undistribute_table_cascade_mx.sql
+++ b/src/test/regress/sql/undistribute_table_cascade_mx.sql
@@ -67,7 +67,7 @@ SELECT create_reference_table('reference_table_2');
 SELECT undistribute_table('reference_table_2');
 
 create table countries(
-  id serial primary key
+  id bigserial primary key
   , name text
   , code varchar(2) collate "C" unique
 );


### PR DESCRIPTION
DESCRIPTION: Include data_type and cache in sequence definition on workers

These two options were not included when creating the sequences on the
workers as part of metadata syncing.

The missing data_type part made finding the cause of #5126 harder,
because of confusing errors.