### PR TITLE
Backporting master_update_table_statistics improvements to 9.4

### DIFF
--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '9.4-2'
+default_version = '9.4-3'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -35,6 +35,7 @@
 #include "distributed/citus_nodes.h"
 #include "distributed/citus_safe_lib.h"
 #include "distributed/listutils.h"
+#include "distributed/lock_graph.h"
 #include "distributed/metadata_utility.h"
 #include "distributed/coordinator_protocol.h"
 #include "distributed/metadata_cache.h"
@@ -50,6 +51,7 @@
 #include "distributed/relay_utility.h"
 #include "distributed/resource_lock.h"
 #include "distributed/remote_commands.h"
+#include "distributed/tuplestore.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/version_compat.h"
@@ -75,9 +77,13 @@ static uint64 DistributedTableSize(Oid relationId, char *sizeQuery);
 static uint64 DistributedTableSizeOnWorker(WorkerNode *workerNode, Oid relationId,
 										   char *sizeQuery);
 static List * ShardIntervalsOnWorkerGroup(WorkerNode *workerNode, Oid relationId);
+static char * GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList);
+static char * GenerateAllShardNameAndSizeQueryForNode(WorkerNode *workerNode);
+static List * GenerateShardSizesQueryList(List *workerNodeList);
 static void ErrorIfNotSuitableToGetSize(Oid relationId);
 static ShardPlacement * ShardPlacementOnGroup(uint64 shardId, int groupId);
 
+static List * OpenConnectionToNodes(List *workerNodeList);
 
 /* exports for SQL callable functions */
 PG_FUNCTION_INFO_V1(citus_table_size);
@@ -151,6 +157,48 @@ citus_relation_size(PG_FUNCTION_ARGS)
 	uint64 relationSize = DistributedTableSize(relationId, tableSizeFunction);
 
 	PG_RETURN_INT64(relationSize);
+}
+
+
+/*
+ * OpenConnectionToNodes opens a single connection per node
+ * for the given workerNodeList.
+ */
+static List *
+OpenConnectionToNodes(List *workerNodeList)
+{
+	List *connectionList = NIL;
+	WorkerNode *workerNode = NULL;
+	foreach_ptr(workerNode, workerNodeList)
+	{
+		const char *nodeName = workerNode->workerName;
+		int nodePort = workerNode->workerPort;
+		int connectionFlags = 0;
+
+		MultiConnection *connection = StartNodeConnection(connectionFlags, nodeName,
+														  nodePort);
+
+		connectionList = lappend(connectionList, connection);
+	}
+	return connectionList;
+}
+
+
+/*
+ * GenerateShardSizesQueryList generates a query per node that
+ * will return all shard_name, shard_size pairs from the node.
+ */
+static List *
+GenerateShardSizesQueryList(List *workerNodeList)
+{
+	List *shardSizesQueryList = NIL;
+	WorkerNode *workerNode = NULL;
+	foreach_ptr(workerNode, workerNodeList)
+	{
+		char *shardSizesQuery = GenerateAllShardNameAndSizeQueryForNode(workerNode);
+		shardSizesQueryList = lappend(shardSizesQueryList, shardSizesQuery);
+	}
+	return shardSizesQueryList;
 }
 
 
@@ -349,6 +397,62 @@ GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList, char *sizeQuery)
 	appendStringInfo(selectQuery, "0;");
 
 	return selectQuery;
+}
+
+
+/*
+ * GenerateAllShardNameAndSizeQueryForNode generates a query that returns all
+ * shard_name, shard_size pairs for the given node.
+ */
+static char *
+GenerateAllShardNameAndSizeQueryForNode(WorkerNode *workerNode)
+{
+	List *allCitusTableIds = AllCitusTableIds();
+
+	StringInfo allShardNameAndSizeQuery = makeStringInfo();
+
+	Oid relationId = InvalidOid;
+	foreach_oid(relationId, allCitusTableIds)
+	{
+		List *shardIntervalsOnNode = ShardIntervalsOnWorkerGroup(workerNode, relationId);
+		char *shardNameAndSizeQuery =
+			GenerateShardNameAndSizeQueryForShardList(shardIntervalsOnNode);
+		appendStringInfoString(allShardNameAndSizeQuery, shardNameAndSizeQuery);
+	}
+
+	/* Add a dummy entry so that UNION ALL doesn't complain */
+	appendStringInfo(allShardNameAndSizeQuery, "SELECT NULL::text, 0::bigint;");
+	return allShardNameAndSizeQuery->data;
+}
+
+
+/*
+ * GenerateShardNameAndSizeQueryForShardList generates a SELECT shard_name - shard_size query to get
+ * size of multiple tables.
+ */
+static char *
+GenerateShardNameAndSizeQueryForShardList(List *shardIntervalList)
+{
+	StringInfo selectQuery = makeStringInfo();
+
+	ShardInterval *shardInterval = NULL;
+	foreach_ptr(shardInterval, shardIntervalList)
+	{
+		uint64 shardId = shardInterval->shardId;
+		Oid schemaId = get_rel_namespace(shardInterval->relationId);
+		char *schemaName = get_namespace_name(schemaId);
+		char *shardName = get_rel_name(shardInterval->relationId);
+		AppendShardIdToName(&shardName, shardId);
+
+		char *shardQualifiedName = quote_qualified_identifier(schemaName, shardName);
+		char *quotedShardName = quote_literal_cstr(shardQualifiedName);
+
+		appendStringInfo(selectQuery, "SELECT %s AS shard_name, ", quotedShardName);
+		appendStringInfo(selectQuery, PG_RELATION_SIZE_FUNCTION, quotedShardName);
+		appendStringInfo(selectQuery, " UNION ALL ");
+	}
+
+	return selectQuery->data;
 }
 
 

--- a/src/backend/distributed/sql/citus--9.4-2--9.4-3.sql
+++ b/src/backend/distributed/sql/citus--9.4-2--9.4-3.sql
@@ -1,0 +1,7 @@
+-- 9.4-2--9.4-3 was added later as a patch to improve master_update_table_statistics
+CREATE OR REPLACE FUNCTION master_update_table_statistics(relation regclass)
+RETURNS VOID
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_update_table_statistics$$;
+COMMENT ON FUNCTION pg_catalog.master_update_table_statistics(regclass)
+	IS 'updates shard statistics of the given table';

--- a/src/backend/distributed/sql/citus--9.4-3--9.4-2.sql
+++ b/src/backend/distributed/sql/citus--9.4-3--9.4-2.sql
@@ -1,0 +1,22 @@
+-- citus--9.4-3--9.4-2
+-- This is a downgrade path that will revert the changes made in citus--9.4-2--9.4-3.sql
+-- 9.4-2--9.4-3 was added later as a patch to improve master_update_table_statistics.
+-- We have this downgrade script so that we can continue from the main upgrade path
+-- when upgrading to later versions.
+CREATE OR REPLACE FUNCTION master_update_table_statistics(relation regclass)
+RETURNS VOID AS $$
+DECLARE
+	colocated_tables regclass[];
+BEGIN
+	SELECT get_colocated_table_array(relation) INTO colocated_tables;
+
+	PERFORM
+		master_update_shard_statistics(shardid)
+	FROM
+		pg_dist_shard
+	WHERE
+		logicalrelid = ANY (colocated_tables);
+END;
+$$ LANGUAGE 'plpgsql';
+COMMENT ON FUNCTION master_update_table_statistics(regclass)
+	IS 'updates shard statistics of the given table and its colocated tables';

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -89,9 +89,6 @@ static ForeignConstraintRelationshipNode * CreateOrFindNode(HTAB *adjacencyLists
 															relid);
 static List * GetConnectedListHelper(ForeignConstraintRelationshipNode *node,
 									 bool isReferencing);
-static HTAB * CreateOidVisitedHashSet(void);
-static bool OidVisited(HTAB *oidVisitedMap, Oid oid);
-static void VisitOid(HTAB *oidVisitedMap, Oid oid);
 static List * GetForeignConstraintRelationshipHelper(Oid relationId, bool isReferencing);
 
 
@@ -311,7 +308,7 @@ GetConnectedListHelper(ForeignConstraintRelationshipNode *node, bool isReferenci
  * As hash_create allocates memory in heap, callers are responsible to call
  * hash_destroy when appropriate.
  */
-static HTAB *
+HTAB *
 CreateOidVisitedHashSet(void)
 {
 	HASHCTL info = { 0 };
@@ -333,7 +330,7 @@ CreateOidVisitedHashSet(void)
 /*
  * OidVisited returns true if given oid is visited according to given oid hash-set.
  */
-static bool
+bool
 OidVisited(HTAB *oidVisitedMap, Oid oid)
 {
 	bool found = false;
@@ -345,7 +342,7 @@ OidVisited(HTAB *oidVisitedMap, Oid oid)
 /*
  * VisitOid sets given oid as visited in given hash-set.
  */
-static void
+void
 VisitOid(HTAB *oidVisitedMap, Oid oid)
 {
 	bool found = false;

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -75,7 +75,14 @@ typedef struct ForeignConstraintRelationshipEdge
 
 static ForeignConstraintRelationshipGraph *fConstraintRelationshipGraph = NULL;
 
+static ForeignConstraintRelationshipNode * GetRelationshipNodeForRelationId(Oid
+																			relationId,
+																			bool *isFound);
 static void CreateForeignConstraintRelationshipGraph(void);
+static List * GetNeighbourList(ForeignConstraintRelationshipNode *relationshipNode,
+							   bool isReferencing);
+static void SetRelationshipNodeListNotVisited(List *relationshipNodeList);
+static List * GetRelationIdsFromRelationshipNodeList(List *fKeyRelationshipNodeList);
 static void PopulateAdjacencyLists(void);
 static int CompareForeignConstraintRelationshipEdges(const void *leftElement,
 													 const void *rightElement);
@@ -105,7 +112,7 @@ ReferencedRelationIdList(Oid relationId)
 
 /*
  * ReferencingRelationIdList is a wrapper function around GetForeignConstraintRelationshipHelper
- * to get list of relation IDs which are referencing by the given relation id.
+ * to get list of relation IDs which are referencing to given relation id.
  *
  * Note that, if relation A is referenced by relation B and relation B is referenced
  * by relation C, then the result list for relation C consists of the relation
@@ -126,16 +133,9 @@ ReferencingRelationIdList(Oid relationId)
 static List *
 GetForeignConstraintRelationshipHelper(Oid relationId, bool isReferencing)
 {
-	List *foreignConstraintList = NIL;
-	List *foreignNodeList = NIL;
 	bool isFound = false;
-
-	CreateForeignConstraintRelationshipGraph();
-
-	ForeignConstraintRelationshipNode *relationNode =
-		(ForeignConstraintRelationshipNode *) hash_search(
-			fConstraintRelationshipGraph->nodeMap, &relationId,
-			HASH_FIND, &isFound);
+	ForeignConstraintRelationshipNode *relationshipNode =
+		GetRelationshipNodeForRelationId(relationId, &isFound);
 
 	if (!isFound)
 	{
@@ -146,24 +146,39 @@ GetForeignConstraintRelationshipHelper(Oid relationId, bool isReferencing)
 		return NIL;
 	}
 
-	GetConnectedListHelper(relationNode, &foreignNodeList, isReferencing);
+	List *foreignNodeList = NIL;
+	GetConnectedListHelper(relationshipNode, &foreignNodeList, isReferencing);
 
-	/*
-	 * We need only their OIDs, we get back node list to make their visited
-	 * variable to false for using them iteratively.
-	 */
-	ForeignConstraintRelationshipNode *currentNode = NULL;
-	foreach_ptr(currentNode, foreignNodeList)
-	{
-		foreignConstraintList = lappend_oid(foreignConstraintList,
-											currentNode->relationId);
-		currentNode->visited = false;
-	}
+	/* reset visited flags in foreign key graph */
+	SetRelationshipNodeListNotVisited(foreignNodeList);
 
 	/* set to false separately, since we don't add itself to foreign node list */
-	relationNode->visited = false;
+	relationshipNode->visited = false;
 
-	return foreignConstraintList;
+	List *relationIdList = GetRelationIdsFromRelationshipNodeList(foreignNodeList);
+	return relationIdList;
+}
+
+
+/*
+ * GetRelationshipNodeForRelationId searches foreign key graph for relation
+ * with relationId and returns ForeignConstraintRelationshipNode object for
+ * relation if it exists in graph. Otherwise, sets isFound to false.
+ *
+ * Also before searching foreign key graph, this function implicitly builds
+ * foreign key graph if it's invalid or not built yet.
+ */
+static ForeignConstraintRelationshipNode *
+GetRelationshipNodeForRelationId(Oid relationId, bool *isFound)
+{
+	CreateForeignConstraintRelationshipGraph();
+
+	ForeignConstraintRelationshipNode *relationshipNode =
+		(ForeignConstraintRelationshipNode *) hash_search(
+			fConstraintRelationshipGraph->nodeMap, &relationId,
+			HASH_FIND, isFound);
+
+	return relationshipNode;
 }
 
 
@@ -256,28 +271,72 @@ static void
 GetConnectedListHelper(ForeignConstraintRelationshipNode *node, List **adjacentNodeList,
 					   bool isReferencing)
 {
-	List *neighbourList = NIL;
-
 	node->visited = true;
 
+	ForeignConstraintRelationshipNode *neighbourNode = NULL;
+	List *neighbourList = GetNeighbourList(node, isReferencing);
+	foreach_ptr(neighbourNode, neighbourList)
+	{
+		if (neighbourNode->visited == false)
+		{
+			*adjacentNodeList = lappend(*adjacentNodeList, neighbourNode);
+			GetConnectedListHelper(neighbourNode, adjacentNodeList, isReferencing);
+		}
+	}
+}
+
+
+/*
+ * GetNeighbourList returns copy of relevant adjacency list of given
+ * ForeignConstraintRelationshipNode object depending on the isReferencing
+ * flag.
+ */
+static List *
+GetNeighbourList(ForeignConstraintRelationshipNode *relationshipNode, bool isReferencing)
+{
 	if (isReferencing)
 	{
-		neighbourList = node->backAdjacencyList;
+		return relationshipNode->backAdjacencyList;
 	}
 	else
 	{
-		neighbourList = node->adjacencyList;
+		return relationshipNode->adjacencyList;
+	}
+}
+
+
+/*
+ * SetRelationshipNodeListNotVisited takes a list of ForeignConstraintRelationshipNode
+ * objects and sets their visited flags to false.
+ */
+static void
+SetRelationshipNodeListNotVisited(List *relationshipNodeList)
+{
+	ForeignConstraintRelationshipNode *relationshipNode = NULL;
+	foreach_ptr(relationshipNode, relationshipNodeList)
+	{
+		relationshipNode->visited = false;
+	}
+}
+
+
+/*
+ * GetRelationIdsFromRelationshipNodeList returns list of relationId's for
+ * given ForeignConstraintRelationshipNode object list.
+ */
+static List *
+GetRelationIdsFromRelationshipNodeList(List *fKeyRelationshipNodeList)
+{
+	List *relationIdList = NIL;
+
+	ForeignConstraintRelationshipNode *fKeyRelationshipNode = NULL;
+	foreach_ptr(fKeyRelationshipNode, fKeyRelationshipNodeList)
+	{
+		Oid relationId = fKeyRelationshipNode->relationId;
+		relationIdList = lappend_oid(relationIdList, relationId);
 	}
 
-	ForeignConstraintRelationshipNode *neighborNode = NULL;
-	foreach_ptr(neighborNode, neighbourList)
-	{
-		if (neighborNode->visited == false)
-		{
-			*adjacentNodeList = lappend(*adjacentNodeList, neighborNode);
-			GetConnectedListHelper(neighborNode, adjacentNodeList, isReferencing);
-		}
-	}
+	return relationIdList;
 }
 
 

--- a/src/include/distributed/foreign_key_relationship.h
+++ b/src/include/distributed/foreign_key_relationship.h
@@ -20,5 +20,8 @@ extern List * ReferencingRelationIdList(Oid relationId);
 extern void SetForeignConstraintRelationshipGraphInvalid(void);
 extern bool IsForeignConstraintRelationshipGraphValid(void);
 extern void ClearForeignConstraintRelationshipGraphContext(void);
+extern HTAB * CreateOidVisitedHashSet(void);
+extern bool OidVisited(HTAB *oidVisitedMap, Oid oid);
+extern void VisitOid(HTAB *oidVisitedMap, Oid oid);
 
 #endif

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -35,6 +35,8 @@
 #define PG_TOTAL_RELATION_SIZE_FUNCTION "pg_total_relation_size(%s)"
 #define CSTORE_TABLE_SIZE_FUNCTION "cstore_table_size(%s)"
 
+#define UPDATE_SHARD_STATISTICS_COLUMN_COUNT 4
+
 /* In-memory representation of a typed tuple in pg_dist_shard. */
 typedef struct ShardInterval
 {
@@ -167,5 +169,8 @@ extern ShardInterval * DeformedDistShardTupleToShardInterval(Datum *datumArray,
 															 int32 intervalTypeMod);
 extern void GetIntervalTypeInfo(char partitionMethod, Var *partitionColumn,
 								Oid *intervalTypeId, int32 *intervalTypeMod);
+extern List * SendShardStatisticsQueriesInParallel(List *citusTableIds, bool
+												   useDistributedTransaction, bool
+												   useShardMinMaxQuery);
 
 #endif   /* METADATA_UTILITY_H */

--- a/src/test/regress/expected/master_update_table_statistics.out
+++ b/src/test/regress/expected/master_update_table_statistics.out
@@ -1,0 +1,190 @@
+--
+-- master_update_table_statistics.sql
+--
+-- Test master_update_table_statistics function on both
+-- hash and append distributed tables
+-- This function updates shardlength, shardminvalue and shardmaxvalue
+--
+SET citus.next_shard_id TO 981000;
+SET citus.next_placement_id TO 982000;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 2;
+-- test with a hash-distributed table
+-- here we update only shardlength, not shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_hash (id int);
+SELECT create_distributed_table('test_table_statistics_hash', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- populate table
+INSERT INTO test_table_statistics_hash SELECT i FROM generate_series(0, 10000)i;
+-- originally shardlength (size of the shard) is zero
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue AS shardminvalue,
+    ds.shardmaxvalue AS shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength = 0
+ORDER BY 2, 3;
+         tablename          | shardid | placementid |             shardname             | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_hash |  981000 |      982000 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |      982001 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |      982002 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |      982003 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |      982004 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |      982005 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |      982006 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981003 |      982007 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981004 |      982008 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981004 |      982009 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981005 |      982010 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |      982011 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |      982012 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |      982013 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |      982014 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |      982015 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+(16 rows)
+
+-- setting this to on in order to verify that we use a distributed transaction id
+-- to run the size queries from different connections
+-- this is going to help detect deadlocks
+SET citus.log_remote_commands TO ON;
+-- setting this to sequential in order to have a deterministic order
+-- in the output of citus.log_remote_commands
+SET citus.multi_shard_modify_mode TO sequential;
+-- update table statistics and then check that shardlength has changed
+-- but shardminvalue and shardmaxvalue stay the same because this is
+-- a hash distributed table
+SELECT master_update_table_statistics('test_table_statistics_hash');
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981000 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981000') AS shard_size  UNION ALL SELECT 981001 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981001') AS shard_size  UNION ALL SELECT 981002 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981002') AS shard_size  UNION ALL SELECT 981003 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981003') AS shard_size  UNION ALL SELECT 981004 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981004') AS shard_size  UNION ALL SELECT 981005 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981005') AS shard_size  UNION ALL SELECT 981006 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981006') AS shard_size  UNION ALL SELECT 981007 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981007') AS shard_size  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981000 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981000') AS shard_size  UNION ALL SELECT 981001 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981001') AS shard_size  UNION ALL SELECT 981002 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981002') AS shard_size  UNION ALL SELECT 981003 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981003') AS shard_size  UNION ALL SELECT 981004 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981004') AS shard_size  UNION ALL SELECT 981005 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981005') AS shard_size  UNION ALL SELECT 981006 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981006') AS shard_size  UNION ALL SELECT 981007 AS shard_id, NULL::text AS shard_minvalue, NULL::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_hash_981007') AS shard_size  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ master_update_table_statistics
+---------------------------------------------------------------------
+
+(1 row)
+
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength > 0
+ORDER BY 2, 3;
+         tablename          | shardid | placementid |             shardname             | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_hash |  981000 |      982000 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981000 |      982001 | test_table_statistics_hash_981000 | -2147483648   | -1610612737
+ test_table_statistics_hash |  981001 |      982002 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981001 |      982003 | test_table_statistics_hash_981001 | -1610612736   | -1073741825
+ test_table_statistics_hash |  981002 |      982004 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981002 |      982005 | test_table_statistics_hash_981002 | -1073741824   | -536870913
+ test_table_statistics_hash |  981003 |      982006 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981003 |      982007 | test_table_statistics_hash_981003 | -536870912    | -1
+ test_table_statistics_hash |  981004 |      982008 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981004 |      982009 | test_table_statistics_hash_981004 | 0             | 536870911
+ test_table_statistics_hash |  981005 |      982010 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981005 |      982011 | test_table_statistics_hash_981005 | 536870912     | 1073741823
+ test_table_statistics_hash |  981006 |      982012 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981006 |      982013 | test_table_statistics_hash_981006 | 1073741824    | 1610612735
+ test_table_statistics_hash |  981007 |      982014 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+ test_table_statistics_hash |  981007 |      982015 | test_table_statistics_hash_981007 | 1610612736    | 2147483647
+(16 rows)
+
+-- check with an append-distributed table
+-- here we update shardlength, shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_append (id int);
+SELECT create_distributed_table('test_table_statistics_append', 'id', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+COPY test_table_statistics_append FROM PROGRAM 'echo 0 && echo 1 && echo 2 && echo 3' WITH CSV;
+COPY test_table_statistics_append FROM PROGRAM 'echo 4 && echo 5 && echo 6 && echo 7' WITH CSV;
+-- originally shardminvalue and shardmaxvalue will be 0,3 and 4, 7
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+          tablename           | shardid | placementid |              shardname              | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_append |  981008 |      982016 | test_table_statistics_append_981008 | 0             | 3
+ test_table_statistics_append |  981008 |      982017 | test_table_statistics_append_981008 | 0             | 3
+ test_table_statistics_append |  981009 |      982018 | test_table_statistics_append_981009 | 4             | 7
+ test_table_statistics_append |  981009 |      982019 | test_table_statistics_append_981009 | 4             | 7
+(4 rows)
+
+-- delete some data to change shardminvalues of a shards
+DELETE FROM test_table_statistics_append WHERE id = 0 OR id = 4;
+SET citus.log_remote_commands TO ON;
+SET citus.multi_shard_modify_mode TO sequential;
+-- update table statistics and then check that shardminvalue has changed
+-- shardlength (shardsize) is still 8192 since there is very few data
+SELECT master_update_table_statistics('test_table_statistics_append');
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981008 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981008') AS shard_size FROM test_table_statistics_append_981008  UNION ALL SELECT 981009 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981009') AS shard_size FROM test_table_statistics_append_981009  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT 981008 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981008') AS shard_size FROM test_table_statistics_append_981008  UNION ALL SELECT 981009 AS shard_id, min(id)::text AS shard_minvalue, max(id)::text AS shard_maxvalue, pg_relation_size('public.test_table_statistics_append_981009') AS shard_size FROM test_table_statistics_append_981009  UNION ALL SELECT 0::bigint, NULL::text, NULL::text, 0::bigint;
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ master_update_table_statistics
+---------------------------------------------------------------------
+
+(1 row)
+
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
+SELECT
+    ds.logicalrelid::regclass::text AS tablename,
+    ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+    shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+          tablename           | shardid | placementid |              shardname              | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ test_table_statistics_append |  981008 |      982016 | test_table_statistics_append_981008 | 1             | 3
+ test_table_statistics_append |  981008 |      982017 | test_table_statistics_append_981008 | 1             | 3
+ test_table_statistics_append |  981009 |      982018 | test_table_statistics_append_981009 | 5             | 7
+ test_table_statistics_append |  981009 |      982019 | test_table_statistics_append_981009 | 5             | 7
+(4 rows)
+
+DROP TABLE test_table_statistics_hash, test_table_statistics_append;
+ALTER SYSTEM RESET citus.shard_count;
+ALTER SYSTEM RESET citus.shard_replication_factor;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -429,6 +429,82 @@ SELECT * FROM print_extension_changes();
 ---------------------------------------------------------------------
 (0 rows)
 
+-- Test upgrade paths for backported improvement of master_update_table_statistics function
+ALTER EXTENSION citus UPDATE TO '9.4-3';
+-- should see the new source code with internal function citus_update_table_statistics
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+            prosrc
+---------------------------------------------------------------------
+ citus_update_table_statistics
+(1 row)
+
+ALTER EXTENSION citus UPDATE TO '9.4-2';
+-- should see the old source code
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+                               prosrc
+---------------------------------------------------------------------
+                                                                   +
+ DECLARE                                                           +
+  colocated_tables regclass[];                                     +
+ BEGIN                                                             +
+  SELECT get_colocated_table_array(relation) INTO colocated_tables;+
+  PERFORM                                                          +
+   master_update_shard_statistics(shardid)                         +
+  FROM                                                             +
+   pg_dist_shard                                                   +
+  WHERE                                                            +
+   logicalrelid = ANY (colocated_tables);                          +
+ END;                                                              +
+
+(1 row)
+
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
+ALTER EXTENSION citus UPDATE TO '9.4-3';
+-- should see the new source code with internal function citus_update_table_statistics
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+            prosrc
+---------------------------------------------------------------------
+ citus_update_table_statistics
+(1 row)
+
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
+-- Snapshot of state at 9.4-1
+ALTER EXTENSION citus UPDATE TO '9.4-1';
+-- should see the old source code
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+                               prosrc
+---------------------------------------------------------------------
+                                                                   +
+ DECLARE                                                           +
+  colocated_tables regclass[];                                     +
+ BEGIN                                                             +
+  SELECT get_colocated_table_array(relation) INTO colocated_tables;+
+  PERFORM                                                          +
+   master_update_shard_statistics(shardid)                         +
+  FROM                                                             +
+   pg_dist_shard                                                   +
+  WHERE                                                            +
+   logicalrelid = ANY (colocated_tables);                          +
+ END;                                                              +
+
+(1 row)
+
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
 DROP TABLE prev_objects, extension_diff;
 -- show running version
 SHOW citus.version;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -83,6 +83,11 @@ test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins non_colocat
 test: subquery_prepared_statements pg12 cte_inline
 
 # ----------
+# Test for updating table statistics
+# ----------
+test: master_update_table_statistics
+
+# ----------
 # Miscellaneous tests to check our query planning behavior
 # ----------
 test: multi_deparse_shard_query multi_distributed_transaction_id intermediate_results limit_intermediate_size rollback_to_savepoint

--- a/src/test/regress/sql/master_update_table_statistics.sql
+++ b/src/test/regress/sql/master_update_table_statistics.sql
@@ -1,0 +1,107 @@
+--
+-- master_update_table_statistics.sql
+--
+-- Test master_update_table_statistics function on both
+-- hash and append distributed tables
+-- This function updates shardlength, shardminvalue and shardmaxvalue
+--
+SET citus.next_shard_id TO 981000;
+SET citus.next_placement_id TO 982000;
+SET citus.shard_count TO 8;
+SET citus.shard_replication_factor TO 2;
+
+-- test with a hash-distributed table
+-- here we update only shardlength, not shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_hash (id int);
+SELECT create_distributed_table('test_table_statistics_hash', 'id');
+
+-- populate table
+INSERT INTO test_table_statistics_hash SELECT i FROM generate_series(0, 10000)i;
+
+-- originally shardlength (size of the shard) is zero
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue AS shardminvalue,
+    ds.shardmaxvalue AS shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength = 0
+ORDER BY 2, 3;
+
+-- setting this to on in order to verify that we use a distributed transaction id
+-- to run the size queries from different connections
+-- this is going to help detect deadlocks
+SET citus.log_remote_commands TO ON;
+
+-- setting this to sequential in order to have a deterministic order
+-- in the output of citus.log_remote_commands
+SET citus.multi_shard_modify_mode TO sequential;
+
+-- update table statistics and then check that shardlength has changed
+-- but shardminvalue and shardmaxvalue stay the same because this is
+-- a hash distributed table
+
+SELECT master_update_table_statistics('test_table_statistics_hash');
+
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
+
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_hash') AND dsp.shardlength > 0
+ORDER BY 2, 3;
+
+-- check with an append-distributed table
+-- here we update shardlength, shardminvalue and shardmaxvalue
+CREATE TABLE test_table_statistics_append (id int);
+SELECT create_distributed_table('test_table_statistics_append', 'id', 'append');
+COPY test_table_statistics_append FROM PROGRAM 'echo 0 && echo 1 && echo 2 && echo 3' WITH CSV;
+COPY test_table_statistics_append FROM PROGRAM 'echo 4 && echo 5 && echo 6 && echo 7' WITH CSV;
+
+-- originally shardminvalue and shardmaxvalue will be 0,3 and 4, 7
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+
+-- delete some data to change shardminvalues of a shards
+DELETE FROM test_table_statistics_append WHERE id = 0 OR id = 4;
+
+SET citus.log_remote_commands TO ON;
+SET citus.multi_shard_modify_mode TO sequential;
+
+-- update table statistics and then check that shardminvalue has changed
+-- shardlength (shardsize) is still 8192 since there is very few data
+SELECT master_update_table_statistics('test_table_statistics_append');
+
+RESET citus.log_remote_commands;
+RESET citus.multi_shard_modify_mode;
+
+SELECT
+	ds.logicalrelid::regclass::text AS tablename,
+	ds.shardid AS shardid,
+    dsp.placementid AS placementid,
+	shard_name(ds.logicalrelid, ds.shardid) AS shardname,
+    ds.shardminvalue as shardminvalue,
+    ds.shardmaxvalue as shardmaxvalue
+FROM pg_dist_shard ds JOIN pg_dist_shard_placement dsp USING (shardid)
+WHERE ds.logicalrelid::regclass::text in ('test_table_statistics_append')
+ORDER BY 2, 3;
+
+DROP TABLE test_table_statistics_hash, test_table_statistics_append;
+ALTER SYSTEM RESET citus.shard_count;
+ALTER SYSTEM RESET citus.shard_replication_factor;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -207,6 +207,30 @@ SELECT * FROM print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '9.4-1';
 SELECT * FROM print_extension_changes();
 
+-- Test upgrade paths for backported improvement of master_update_table_statistics function
+ALTER EXTENSION citus UPDATE TO '9.4-3';
+-- should see the new source code with internal function citus_update_table_statistics
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+ALTER EXTENSION citus UPDATE TO '9.4-2';
+
+-- should see the old source code
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+
+ALTER EXTENSION citus UPDATE TO '9.4-3';
+-- should see the new source code with internal function citus_update_table_statistics
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+
+-- Snapshot of state at 9.4-1
+ALTER EXTENSION citus UPDATE TO '9.4-1';
+-- should see the old source code
+SELECT prosrc FROM pg_proc WHERE proname = 'master_update_table_statistics' ORDER BY 1;
+-- Should be empty result
+SELECT * FROM print_extension_changes();
+
 DROP TABLE prev_objects, extension_diff;
 
 -- show running version


### PR DESCRIPTION
DESCRIPTION: Improves `master_update_table_statistics` and provides distributed deadlock detection

Users who upgrade to the patch release of 9.4 will get the fix via 9.4-2--9.4-3.