### PR TITLE
Infrastructure for UDF support in column defaults

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -534,7 +534,11 @@ ConvertTable(TableConversionState *con)
 	}
 	char *newAccessMethod = con->accessMethod ? con->accessMethod :
 							con->originalAccessMethod;
-	List *preLoadCommands = GetPreLoadTableCreationCommands(con->relationId, true,
+	bool includeSequenceDefaults = true;
+	bool includeUDFDefaults = false;
+	List *preLoadCommands = GetPreLoadTableCreationCommands(con->relationId,
+															includeSequenceDefaults,
+															includeUDFDefaults,
 															newAccessMethod);
 
 	bool includeIndexes = true;

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -461,9 +461,11 @@ GetShellTableDDLEventsForCitusLocalTable(Oid relationId)
 	 * a sequence.
 	 */
 	bool includeSequenceDefaults = true;
+	bool includeUDFDefaults = false;
 
 	List *tableDDLCommands = GetFullTableCreationCommands(relationId,
-														  includeSequenceDefaults);
+														  includeSequenceDefaults,
+														  includeUDFDefaults);
 
 	List *shellTableDDLEvents = NIL;
 	TableDDLCommand *tableDDLCommand = NULL;

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -1063,8 +1063,10 @@ contain_udf_expression_walker(Node *node, void *context)
 
 			if (procform->pronamespace != PG_CATALOG_NAMESPACE)
 			{
+				ReleaseSysCache(proctup);
 				return true;
 			}
+
 			ReleaseSysCache(proctup);
 		}
 	}

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -1065,6 +1065,7 @@ contain_udf_expression_walker(Node *node, void *context)
 			{
 				return true;
 			}
+			ReleaseSysCache(proctup);
 		}
 	}
 	return expression_tree_walker(node, contain_nextval_expression_walker, context);

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -436,6 +436,7 @@ MetadataCreateCommands(void)
 	bool includeNodesFromOtherClusters = true;
 	List *workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
 	bool includeSequenceDefaults = true;
+	bool includeUDFDefaults = false;
 
 	/* make sure we have deterministic output for our tests */
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
@@ -468,7 +469,8 @@ MetadataCreateCommands(void)
 		}
 
 		List *ddlCommandList = GetFullTableCreationCommands(relationId,
-															includeSequenceDefaults);
+															includeSequenceDefaults,
+															includeUDFDefaults);
 		char *tableOwnerResetCommand = TableOwnerResetCommand(relationId);
 
 		/*
@@ -590,6 +592,7 @@ GetDistributedTableDDLEvents(Oid relationId)
 
 	List *commandList = NIL;
 	bool includeSequenceDefaults = true;
+	bool includeUDFDefaults = false;
 
 	/* if the table is owned by an extension we only propagate pg_dist_* records */
 	bool tableOwnedByExtension = IsTableOwnedByExtension(relationId);
@@ -604,7 +607,8 @@ GetDistributedTableDDLEvents(Oid relationId)
 		 * materialize to the non-sharded version
 		 */
 		List *tableDDLCommands = GetFullTableCreationCommands(relationId,
-															  includeSequenceDefaults);
+															  includeSequenceDefaults,
+															  includeUDFDefaults);
 		TableDDLCommand *tableDDLCommand = NULL;
 		foreach_ptr(tableDDLCommand, tableDDLCommands)
 		{

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -1454,6 +1454,7 @@ RecreateTableDDLCommandList(Oid relationId)
 	StringInfo dropCommand = makeStringInfo();
 	char relationKind = get_rel_relkind(relationId);
 	bool includeSequenceDefaults = false;
+	bool includeUDFDefaults = false;
 
 	/* build appropriate DROP command based on relation kind */
 	if (RegularTable(relationId))
@@ -1476,6 +1477,7 @@ RecreateTableDDLCommandList(Oid relationId)
 	List *dropCommandList = list_make1(makeTableDDLCommandString(dropCommand->data));
 	List *createCommandList = GetPreLoadTableCreationCommands(relationId,
 															  includeSequenceDefaults,
+															  includeUDFDefaults,
 															  NULL);
 	List *recreateCommandList = list_concat(dropCommandList, createCommandList);
 

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -431,8 +431,10 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 	List *foreignConstraintCommandList =
 		GetReferencingForeignConstaintCommands(relationId);
 	bool includeSequenceDefaults = false;
+	bool includeUDFDefaults = false;
 	List *ddlCommandList = GetFullTableCreationCommands(relationId,
-														includeSequenceDefaults);
+														includeSequenceDefaults,
+														includeUDFDefaults);
 	uint32 connectionFlag = FOR_DDL;
 	char *relationOwner = TableOwner(relationId);
 
@@ -544,8 +546,10 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 					  bool useExclusiveConnection, bool colocatedShard)
 {
 	bool includeSequenceDefaults = false;
+	bool includeUDFDefaults = false;
 	List *ddlCommandList = GetFullTableCreationCommands(distributedRelationId,
-														includeSequenceDefaults);
+														includeSequenceDefaults,
+														includeUDFDefaults);
 	List *foreignConstraintCommandList =
 		GetReferencingForeignConstaintCommands(distributedRelationId);
 

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -31,7 +31,9 @@ extern Oid get_extension_schema(Oid ext_oid);
 extern char * pg_get_serverdef_string(Oid tableRelationId);
 extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);
-extern char * pg_get_tableschemadef_string(Oid tableRelationId, bool forShardCreation,
+extern char * pg_get_tableschemadef_string(Oid tableRelationId,
+										   bool includeSequenceDefaults,
+										   bool includeUDFDefaults,
 										   char *accessMethod);
 extern void EnsureRelationKindSupported(Oid relationId);
 extern char * pg_get_tablecolumnoptionsdef_string(Oid tableRelationId);
@@ -41,6 +43,7 @@ extern void deparse_shard_reindex_statement(ReindexStmt *origStmt, Oid distrelid
 											int64 shardid, StringInfo buffer);
 extern char * pg_get_indexclusterdef_string(Oid indexRelationId);
 extern bool contain_nextval_expression_walker(Node *node, void *context);
+extern bool contain_udf_expression_walker(Node *node, void *context);
 extern char * pg_get_replica_identity_command(Oid tableRelationId);
 extern const char * RoleSpecString(RoleSpec *spec, bool withQuoteIdentifier);
 

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -193,11 +193,13 @@ extern bool CStoreTable(Oid relationId);
 extern uint64 GetNextShardId(void);
 extern uint64 GetNextPlacementId(void);
 extern Oid ResolveRelationId(text *relationName, bool missingOk);
-extern List * GetFullTableCreationCommands(Oid relationId, bool includeSequenceDefaults);
+extern List * GetFullTableCreationCommands(Oid relationId, bool includeSequenceDefaults,
+										   bool includeUDFDefaults);
 extern List * GetPostLoadTableCreationCommands(Oid relationId, bool includeIndexes,
 											   bool includeReplicaIdentity);
 extern List * GetPreLoadTableCreationCommands(Oid relationId,
 											  bool includeSequenceDefaults,
+											  bool includeUDFDefaults,
 											  char *accessMethod);
 extern List * GetTableIndexAndConstraintCommands(Oid relationId, int indexFlags);
 extern List * GetTableIndexAndConstraintCommandsExcludingReplicaIdentity(Oid relationId,


### PR DESCRIPTION
We do not want to pass the column defaults to a worker node if it contains some UDF that may be absent on worker nodes.

This PR adds the infrastructure that is needed to re-enable setting column defaults on the worker nodes when we extend distributed object creation to support UDFs on metadata-synced nodes.

Related: #3851

TODO:
- [ ] Fix broken tests
	- [ ] Queries sent to worker nodes no longer contain DEFAULT expressions in many files
	- [ ] The behaviour of MX is slightly different due to the MX nodes not having the column defaults
- [ ] Fix cache reference leaks