### PR TITLE
Use correct snapshot when scanning columnar tables

### DIFF
--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -484,8 +484,6 @@ SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe, StripeSkipList *chunk
 
 	FinishModifyRelation(modifyState);
 	table_close(columnarChunk, RowExclusiveLock);
-
-	CommandCounterIncrement();
 }
 
 
@@ -522,8 +520,6 @@ SaveChunkGroups(RelFileNode relfilenode, uint64 stripe,
 
 	FinishModifyRelation(modifyState);
 	table_close(columnarChunkGroup, NoLock);
-
-	CommandCounterIncrement();
 }
 
 
@@ -887,8 +883,6 @@ InsertStripeMetadataRow(uint64 storageId, StripeMetadata *stripe)
 
 	FinishModifyRelation(modifyState);
 
-	CommandCounterIncrement();
-
 	table_close(columnarStripes, RowExclusiveLock);
 }
 
@@ -1206,6 +1200,8 @@ FinishModifyRelation(ModifyState *state)
 	ExecCleanUpTriggerState(state->estate);
 	ExecResetTupleTable(state->estate->es_tupleTable, false);
 	FreeExecutorState(state->estate);
+
+	CommandCounterIncrement();
 }
 
 

--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -90,6 +90,7 @@ struct ColumnarReadState
 	MemoryContext scanContext;
 
 	Snapshot snapshot;
+	bool snapshotRegisteredByUs;
 };
 
 /* static function declarations */
@@ -171,7 +172,8 @@ static Datum ColumnDefaultValue(TupleConstr *tupleConstraints,
 ColumnarReadState *
 ColumnarBeginRead(Relation relation, TupleDesc tupleDescriptor,
 				  List *projectedColumnList, List *whereClauseList,
-				  MemoryContext scanContext, Snapshot snapshot)
+				  MemoryContext scanContext, Snapshot snapshot,
+				  bool snapshotRegisteredByUs)
 {
 	/*
 	 * We allocate all stripe specific data in the stripeReadContext, and reset
@@ -194,6 +196,7 @@ ColumnarBeginRead(Relation relation, TupleDesc tupleDescriptor,
 																 snapshot);
 	readState->scanContext = scanContext;
 	readState->snapshot = snapshot;
+	readState->snapshotRegisteredByUs = snapshotRegisteredByUs;
 
 	return readState;
 }
@@ -467,6 +470,15 @@ ColumnarRescan(ColumnarReadState *readState)
 void
 ColumnarEndRead(ColumnarReadState *readState)
 {
+	if (readState->snapshotRegisteredByUs)
+	{
+		/*
+		 * init_columnar_read_state created a new snapshot and registered it,
+		 * so now forget it.
+		 */
+		UnregisterSnapshot(readState->snapshot);
+	}
+
 	MemoryContextDelete(readState->stripeReadContext);
 	if (readState->currentStripeMetadata)
 	{

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -213,13 +213,14 @@ extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 TupleDesc tupleDescriptor,
 											 List *projectedColumnList,
 											 List *qualConditions,
-											 MemoryContext scanContext);
+											 MemoryContext scanContext,
+											 Snapshot snaphot);
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);
 extern void ColumnarRescan(ColumnarReadState *readState);
 extern bool ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 									   uint64 rowNumber, Datum *columnValues,
-									   bool *columnNulls, Snapshot snapshot);
+									   bool *columnNulls);
 extern void ColumnarEndRead(ColumnarReadState *state);
 extern void ColumnarResetRead(ColumnarReadState *readState);
 extern int64 ColumnarReadChunkGroupsFiltered(ColumnarReadState *state);
@@ -255,7 +256,8 @@ extern void SaveChunkGroups(RelFileNode relfilenode, uint64 stripe,
 							List *chunkGroupRowCounts);
 extern StripeSkipList * ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 										   TupleDesc tupleDescriptor,
-										   uint32 chunkCount);
+										   uint32 chunkCount,
+										   Snapshot snapshot);
 extern StripeMetadata * FindNextStripeByRowNumber(Relation relation, uint64 rowNumber,
 												  Snapshot snapshot);
 extern StripeMetadata * FindStripeByRowNumber(Relation relation, uint64 rowNumber,

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -214,7 +214,8 @@ extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 List *projectedColumnList,
 											 List *qualConditions,
 											 MemoryContext scanContext,
-											 Snapshot snaphot);
+											 Snapshot snaphot,
+											 bool snapshotRegisteredByUs);
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);
 extern void ColumnarRescan(ColumnarReadState *readState);

--- a/src/test/regress/expected/columnar_insert.out
+++ b/src/test/regress/expected/columnar_insert.out
@@ -1,6 +1,8 @@
 --
 -- Testing insert on columnar tables.
 --
+CREATE SCHEMA columnar_insert;
+SET search_path TO columnar_insert;
 CREATE TABLE test_insert_command (a int) USING columnar;
 -- test single row inserts fail
 select count(*) from test_insert_command;
@@ -228,4 +230,67 @@ ORDER BY 1,2,3,4;
  zero_col |          5 |               0 |        64
 (5 rows)
 
-DROP TABLE zero_col;
+CREATE TABLE selfinsert(x int) USING columnar;
+SELECT alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  INSERT INTO selfinsert SELECT generate_series(1,1010);
+  INSERT INTO selfinsert SELECT * FROM selfinsert;
+  SELECT SUM(x)=1021110 FROM selfinsert;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+  INSERT INTO selfinsert SELECT generate_series(1,1010);
+  INSERT INTO selfinsert SELECT * FROM selfinsert;
+  SELECT SUM(x)=1021110 FROM selfinsert;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+INSERT INTO selfinsert SELECT generate_series(1,1010);
+INSERT INTO selfinsert SELECT * FROM selfinsert;
+SELECT SUM(x)=1021110 FROM selfinsert;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE selfconflict (f1 int PRIMARY KEY, f2 int) USING columnar;
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+  INSERT INTO selfconflict VALUES (2,1), (2,2);
+ERROR:  duplicate key value violates unique constraint "selfconflict_pkey"
+DETAIL:  Key (f1)=(2) already exists.
+COMMIT;
+SELECT COUNT(*)=0 FROM selfconflict;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE flush_create_index(a int, b int) USING columnar;
+BEGIN;
+  INSERT INTO flush_create_index VALUES (5, 10);
+  SET enable_seqscan TO OFF;
+  SET columnar.enable_custom_scan TO OFF;
+  SET enable_indexscan TO ON;
+  CREATE INDEX ON flush_create_index(a);
+  SELECT a FROM flush_create_index WHERE a=5;
+ a
+---------------------------------------------------------------------
+ 5
+(1 row)
+
+ROLLBACK;
+RESET search_path;
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_insert CASCADE;

--- a/src/test/regress/expected/columnar_write_concurrency.out
+++ b/src/test/regress/expected/columnar_write_concurrency.out
@@ -202,3 +202,43 @@ stripe_metadata_for_test_insert_concurrency_ok
 t
 (1 row)
 
+
+starting permutation: s1-begin s2-begin-repeatable s1-insert s2-insert s2-select s1-commit s2-select s2-commit
+step s1-begin:
+    BEGIN;
+
+step s2-begin-repeatable:
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+step s1-insert:
+    INSERT INTO test_insert_concurrency SELECT i, 2 * i FROM generate_series(1, 3) i;
+
+step s2-insert:
+    INSERT INTO test_insert_concurrency SELECT i, 2 * i FROM generate_series(4, 6) i;
+
+step s2-select:
+    SELECT * FROM test_insert_concurrency ORDER BY a;
+
+a| b
+---------------------------------------------------------------------
+4| 8
+5|10
+6|12
+(3 rows)
+
+step s1-commit:
+    COMMIT;
+
+step s2-select:
+    SELECT * FROM test_insert_concurrency ORDER BY a;
+
+a| b
+---------------------------------------------------------------------
+4| 8
+5|10
+6|12
+(3 rows)
+
+step s2-commit:
+    COMMIT;
+

--- a/src/test/regress/spec/columnar_write_concurrency.spec
+++ b/src/test/regress/spec/columnar_write_concurrency.spec
@@ -74,6 +74,11 @@ step "s2-begin"
     BEGIN;
 }
 
+step "s2-begin-repeatable"
+{
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+}
+
 step "s2-insert"
 {
     INSERT INTO test_insert_concurrency SELECT i, 2 * i FROM generate_series(4, 6) i;
@@ -103,3 +108,5 @@ permutation "s1-begin" "s2-begin" "s2-insert" "s1-copy" "s1-select" "s2-select" 
 # Then verify that while the stripe written by session 2 has the greater first_row_number, stripe written by session 1 has
 # the greater stripe_num. This is because, we reserve stripe_num and first_row_number at different times.
 permutation "s1-truncate" "s1-begin" "s1-insert-10000-rows" "s2-begin" "s2-insert" "s2-commit" "s1-commit" "s1-verify-metadata"
+
+permutation "s1-begin" "s2-begin-repeatable" "s1-insert" "s2-insert" "s2-select" "s1-commit" "s2-select" "s2-commit"

--- a/src/test/regress/sql/columnar_insert.sql
+++ b/src/test/regress/sql/columnar_insert.sql
@@ -2,6 +2,9 @@
 -- Testing insert on columnar tables.
 --
 
+CREATE SCHEMA columnar_insert;
+SET search_path TO columnar_insert;
+
 CREATE TABLE test_insert_command (a int) USING columnar;
 
 -- test single row inserts fail
@@ -152,4 +155,51 @@ SELECT relname, stripe_num, chunk_group_num, row_count FROM columnar.chunk_group
 WHERE columnar_test_helpers.columnar_relation_storageid(b.oid)=a.storage_id AND relname = 'zero_col'
 ORDER BY 1,2,3,4;
 
-DROP TABLE zero_col;
+CREATE TABLE selfinsert(x int) USING columnar;
+
+SELECT alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
+
+BEGIN;
+  INSERT INTO selfinsert SELECT generate_series(1,1010);
+  INSERT INTO selfinsert SELECT * FROM selfinsert;
+
+  SELECT SUM(x)=1021110 FROM selfinsert;
+ROLLBACK;
+
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+  INSERT INTO selfinsert SELECT generate_series(1,1010);
+  INSERT INTO selfinsert SELECT * FROM selfinsert;
+
+  SELECT SUM(x)=1021110 FROM selfinsert;
+ROLLBACK;
+
+INSERT INTO selfinsert SELECT generate_series(1,1010);
+INSERT INTO selfinsert SELECT * FROM selfinsert;
+
+SELECT SUM(x)=1021110 FROM selfinsert;
+
+CREATE TABLE selfconflict (f1 int PRIMARY KEY, f2 int) USING columnar;
+
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+  INSERT INTO selfconflict VALUES (2,1), (2,2);
+COMMIT;
+
+SELECT COUNT(*)=0 FROM selfconflict;
+
+CREATE TABLE flush_create_index(a int, b int) USING columnar;
+BEGIN;
+  INSERT INTO flush_create_index VALUES (5, 10);
+
+  SET enable_seqscan TO OFF;
+  SET columnar.enable_custom_scan TO OFF;
+  SET enable_indexscan TO ON;
+
+  CREATE INDEX ON flush_create_index(a);
+
+  SELECT a FROM flush_create_index WHERE a=5;
+ROLLBACK;
+
+RESET search_path;
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_insert CASCADE;
+


### PR DESCRIPTION
Fixes #5180.

i) Instead of using xact snapshot, use the snapshot provided to columnarAM
when scanning table. This is the main purpose of this pr, also see https://github.com/citusdata/citus/pull/5154#issuecomment-891906412.

ii) Let me also explain the tricky part of this pr (bf4dfad6f76a591403551de8596fa4392adeca67):

To avoid visibility issues around pending writes that are force-flushed
to disk when scanning the table in the same xact, update curcid of given
snapshot before starting to scan the columnar table.

The reason behind such visibility issues is that we increment command counter
after modifying columnar metadata tables when flushing pending writes.

Now that we _don't always use_ xact snapshot to scan a columnar table,
writes that we just flushed might not be visible to the query that made
pending writes flushed to disk since curcid of provided snapshot would
become smaller than the command id being used when modifying columnar
metadata tables.

To give an example, before bf4dfad6f76a591403551de8596fa4392adeca67, below was a possible scenario
after the changes done in i):

```sql
CREATE TABLE t(a int, b int) USING columnar;
BEGIN;
  INSERT INTO t VALUES (5, 10);

  SELECT * FROM t;
  ┌───┬───┐
  │ a │ b │
  ├───┼───┤
  └───┴───┘
  (0 rows)

  SELECT * FROM t;
  ┌───┬────┐
  │ a │ b  │
  ├───┼────┤
  │ 5 │ 10 │
  └───┴────┘
  (1 row)
```
