### PR TITLE
Acquire AccessShareLock before updating table statistics

### DIFF
--- a/src/test/regress/expected/isolation_citus_update_table_statistics.out
+++ b/src/test/regress/expected/isolation_citus_update_table_statistics.out
@@ -1,0 +1,90 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-drop-table s2-citus-update-table-statistics s1-commit
+create_distributed_table
+
+
+step s1-begin:
+    BEGIN;
+
+step s1-drop-table:
+    DROP TABLE dist_table;
+
+step s2-citus-update-table-statistics:
+    SET client_min_messages TO NOTICE;
+    SELECT citus_update_table_statistics(logicalrelid) FROM pg_dist_partition;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-citus-update-table-statistics: <... completed>
+s2: NOTICE:  relation with OID XXXX does not exist, skipping
+citus_update_table_statistics
+
+
+
+
+starting permutation: s1-begin s1-drop-table s2-citus-shards s1-commit
+create_distributed_table
+
+
+step s1-begin:
+    BEGIN;
+
+step s1-drop-table:
+    DROP TABLE dist_table;
+
+step s2-citus-shards:
+    SELECT 1 AS result FROM citus_shards GROUP BY result;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-citus-shards: <... completed>
+result
+
+1
+
+starting permutation: s2-begin s2-citus-shards s1-drop-table s2-commit
+create_distributed_table
+
+
+step s2-begin:
+    BEGIN;
+
+step s2-citus-shards:
+    SELECT 1 AS result FROM citus_shards GROUP BY result;
+
+result
+
+1
+step s1-drop-table:
+    DROP TABLE dist_table;
+
+step s2-commit:
+    COMMIT;
+
+
+starting permutation: s2-begin s2-citus-update-table-statistics s1-drop-table s2-commit
+create_distributed_table
+
+
+step s2-begin:
+    BEGIN;
+
+step s2-citus-update-table-statistics:
+    SET client_min_messages TO NOTICE;
+    SELECT citus_update_table_statistics(logicalrelid) FROM pg_dist_partition;
+
+citus_update_table_statistics
+
+
+
+step s1-drop-table:
+    DROP TABLE dist_table;
+ <waiting ...>
+step s2-commit: 
+    COMMIT;
+
+step s1-drop-table: <... completed>
+error in steps s2-commit s1-drop-table: ERROR:  tuple concurrently deleted

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -65,6 +65,7 @@ test: isolation_multiuser_locking
 test: shared_connection_waits
 test: isolation_cancellation
 test: isolation_undistribute_table
+test: isolation_citus_update_table_statistics
 
 # Rebalancer
 test: isolation_blocking_move_single_shard_commands

--- a/src/test/regress/spec/isolation_citus_update_table_statistics.spec
+++ b/src/test/regress/spec/isolation_citus_update_table_statistics.spec
@@ -1,0 +1,59 @@
+setup
+{
+    CREATE TABLE dist_table(a INT, b INT);
+    SELECT create_distributed_table('dist_table', 'a');
+}
+
+teardown
+{
+    DROP TABLE IF EXISTS dist_table;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-drop-table"
+{
+    DROP TABLE dist_table;
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+    BEGIN;
+}
+
+step "s2-citus-update-table-statistics"
+{
+    SET client_min_messages TO NOTICE;
+    SELECT citus_update_table_statistics(logicalrelid) FROM pg_dist_partition;
+}
+
+step "s2-citus-shards"
+{
+    SELECT 1 AS result FROM citus_shards GROUP BY result;
+}
+
+step "s2-commit"
+{
+    COMMIT;
+}
+
+permutation "s1-begin" "s1-drop-table" "s2-citus-update-table-statistics" "s1-commit"
+permutation "s1-begin" "s1-drop-table" "s2-citus-shards" "s1-commit"
+permutation "s2-begin" "s2-citus-shards" "s1-drop-table" "s2-commit"
+
+// ERROR:  tuple concurrently deleted -- is expected in the following permutation
+// Check the explanation at PR #5155 in the following comment
+// https://github.com/citusdata/citus/pull/5155#issuecomment-897028194
+permutation "s2-begin" "s2-citus-update-table-statistics" "s1-drop-table" "s2-commit"


### PR DESCRIPTION
DESCRIPTION: Acquire AccessShareLock before updating table statistics to verify the table exists

If the table doesn't exist, meaning it was concurrently dropped elsewhere, we throw a warning and continue.

Fixes #5116 
