### PR TITLE
Columnar: enable chunk group filtering to work for Params.

### DIFF
--- a/src/test/regress/input/columnar_chunk_filtering.source
+++ b/src/test/regress/input/columnar_chunk_filtering.source
@@ -111,3 +111,19 @@ create table part_2_columnar partition of part_table for values from (0) to (150
 insert into part_table select generate_series(1,159999);
 select filtered_row_count('select count(*) from part_table where id > 75000');
 drop table part_table;
+
+--
+-- https://github.com/citusdata/citus/issues/4488
+--
+create table columnar_prepared_stmt (x int, y int) using columnar;
+insert into columnar_prepared_stmt select s, s from generate_series(1,5000000) s;
+prepare foo (int) as select x from columnar_prepared_stmt where x = $1;
+execute foo(3);
+execute foo(3);
+execute foo(3);
+execute foo(3);
+select filtered_row_count('execute foo(3)');
+select filtered_row_count('execute foo(3)');
+select filtered_row_count('execute foo(3)');
+select filtered_row_count('execute foo(3)');
+drop table columnar_prepared_stmt;

--- a/src/test/regress/output/columnar_chunk_filtering.source
+++ b/src/test/regress/output/columnar_chunk_filtering.source
@@ -196,3 +196,58 @@ select filtered_row_count('select count(*) from part_table where id > 75000');
 (1 row)
 
 drop table part_table;
+--
+-- https://github.com/citusdata/citus/issues/4488
+--
+create table columnar_prepared_stmt (x int, y int) using columnar;
+insert into columnar_prepared_stmt select s, s from generate_series(1,5000000) s;
+prepare foo (int) as select x from columnar_prepared_stmt where x = $1;
+execute foo(3);
+ x
+---------------------------------------------------------------------
+ 3
+(1 row)
+
+execute foo(3);
+ x
+---------------------------------------------------------------------
+ 3
+(1 row)
+
+execute foo(3);
+ x
+---------------------------------------------------------------------
+ 3
+(1 row)
+
+execute foo(3);
+ x
+---------------------------------------------------------------------
+ 3
+(1 row)
+
+select filtered_row_count('execute foo(3)');
+ filtered_row_count
+---------------------------------------------------------------------
+               9999
+(1 row)
+
+select filtered_row_count('execute foo(3)');
+ filtered_row_count
+---------------------------------------------------------------------
+               9999
+(1 row)
+
+select filtered_row_count('execute foo(3)');
+ filtered_row_count
+---------------------------------------------------------------------
+               9999
+(1 row)
+
+select filtered_row_count('execute foo(3)');
+ filtered_row_count
+---------------------------------------------------------------------
+               9999
+(1 row)
+
+drop table columnar_prepared_stmt;


### PR DESCRIPTION
Evaluate extern params into Consts in the qual when the scan begins.

Fixes #4488.

DESCRIPTION: Makes columnar chunk group filtering work with generic plans
