### PR TITLE
Add check for alphabetically sorted gucs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,9 @@ jobs:
       - run:
           name: 'Check if all CI scripts are actually run'
           command: ci/check_all_ci_scripts_are_run.sh
+      - run:
+          name: 'Check if all GUCs are sorted alphabetically'
+          command: ci/check_gucs_are_alphabetically_sorted.sh
 
   check-sql-snapshots:
     docker:

--- a/ci/README.md
+++ b/ci/README.md
@@ -358,3 +358,9 @@ This script checks and fixes issues with `.gitignore` rules:
 2. Makes sure we do not commit any generated files that should be ignored. If there is an
    ignored file in the git tree, the user is expected to review the files that are removed
    from the git tree and commit them.
+
+## `check_gucs_are_alphabetically_sorted.sh`
+
+This script checks the order of the GUCs defined in `shared_library_init.c`.
+To solve this failure, please check `shared_library_init.c` and make sure that the GUC
+definitions are in alphabetical order.

--- a/ci/check_gucs_are_alphabetically_sorted.sh
+++ b/ci/check_gucs_are_alphabetically_sorted.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source ci/ci_helpers.sh
+
+# extract citus gucs in the form of "citus.X"
+grep -o -E "(\.*\"citus.\w+\")," src/backend/distributed/shared_library_init.c > gucs.out
+sort -c gucs.out
+rm gucs.out


### PR DESCRIPTION
Sorting our new GUCs alphabetically again. Adding a check to CI for that. This check basically goes through all GUCs defined in `shared_library_init.c` and fails check_style in case of a misordering.
