### PR TITLE
Use right mem cxt for read state when re-writing a columnar table

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -795,10 +795,12 @@ columnar_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	/* we need all columns */
 	int natts = OldHeap->rd_att->natts;
 	Bitmapset *attr_needed = bms_add_range(NULL, 0, natts - 1);
-	List *projectedColumnList = NeededColumnsList(sourceDesc, attr_needed);
-	ColumnarReadState *readState = ColumnarBeginRead(OldHeap, sourceDesc,
-													 projectedColumnList,
-													 NULL);
+
+	/* no quals for table rewrite */
+	List *scanQual = NIL;
+
+	ColumnarReadState *readState = init_columnar_read_state(OldHeap, sourceDesc,
+															attr_needed, scanQual);
 
 	Datum *values = palloc0(sourceDesc->natts * sizeof(Datum));
 	bool *nulls = palloc0(sourceDesc->natts * sizeof(bool));

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -259,7 +259,7 @@ init_columnar_read_state(Relation relation, TupleDesc tupdesc, Bitmapset *attr_n
 
 	List *neededColumnList = NeededColumnsList(tupdesc, attr_needed);
 	ColumnarReadState *readState = ColumnarBeginRead(relation, tupdesc, neededColumnList,
-													 scanQual);
+													 scanQual, scanContext);
 
 	MemoryContextSwitchTo(oldContext);
 

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -212,7 +212,8 @@ extern MemoryContext ColumnarWritePerTupleContext(ColumnarWriteState *state);
 extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 TupleDesc tupleDescriptor,
 											 List *projectedColumnList,
-											 List *qualConditions);
+											 List *qualConditions,
+											 MemoryContext scanContext);
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);
 extern void ColumnarRescan(ColumnarReadState *readState);

--- a/src/test/regress/expected/columnar_alter.out
+++ b/src/test/regress/expected/columnar_alter.out
@@ -218,6 +218,21 @@ SELECT * FROM domain_test;
  1 | 2 | x
 (2 rows)
 
+-- similar to "add column c str_domain DEFAULT 'x'", both were getting
+-- stucked before fixing https://github.com/citusdata/citus/issues/5164
+BEGIN;
+  ALTER TABLE domain_test ADD COLUMN d INT DEFAULT random();
+ROLLBACK;
+BEGIN;
+  ALTER TABLE domain_test ADD COLUMN d SERIAL;
+  SELECT * FROM domain_test ORDER BY 1,2,3,4;
+ a | b | c | d
+---------------------------------------------------------------------
+ 1 | 2 | x | 1
+ 1 | 2 | x | 2
+(2 rows)
+
+ROLLBACK;
 set default_table_access_method TO 'columnar';
 CREATE TABLE has_volatile AS
 SELECT * FROM generate_series(1,10) id;

--- a/src/test/regress/sql/columnar_alter.sql
+++ b/src/test/regress/sql/columnar_alter.sql
@@ -116,6 +116,16 @@ alter table domain_test add column c str_domain;
 alter table domain_test add column c str_domain DEFAULT 'x';
 SELECT * FROM domain_test;
 
+-- similar to "add column c str_domain DEFAULT 'x'", both were getting
+-- stucked before fixing https://github.com/citusdata/citus/issues/5164
+BEGIN;
+  ALTER TABLE domain_test ADD COLUMN d INT DEFAULT random();
+ROLLBACK;
+BEGIN;
+  ALTER TABLE domain_test ADD COLUMN d SERIAL;
+  SELECT * FROM domain_test ORDER BY 1,2,3,4;
+ROLLBACK;
+
 set default_table_access_method TO 'columnar';
 CREATE TABLE has_volatile AS
 SELECT * FROM generate_series(1,10) id;


### PR DESCRIPTION
Fixes #5164.

Since we were using the default mem cxt for (`ColumnarReadState`)
`currentStripeMetadata` in `columnar_relation_copy_for_cluster`, it was
possible to read garbage values from read state when re-writing table.
That was the reason behind test mentioned in #5164 were getting
stuck when executing given `ALTER TABLE ADD COLUMN` command.

To fix that, make sure to use right mem cxt when creating `ColumnarReadState`.

All the callers except `columnar_relation_copy_for_cluster` were already
switching to right memory context when creating `ColumnarReadState`.

With this pr, we embed that logic into `init_columnar_read_state`
to avoid further such bugs.
That way, we start using the right memory context for
`columnar_relation_copy_for_cluster` too.

Also use scan context for intermediate memory allocations done for
`ColumnarReadState` too.