### PR TITLE
Add changelog entries for 9.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### citus v9.4.6 (August 8, 2021) ###
+
+* Allows more graceful failovers when replication factor > 1
+
+* Improves master_update_table_statistics and provides distributed deadlock
+  detection
+
 ### citus v10.1.1 (August 5, 2021) ###
 
 * Improves citus_update_table_statistics and provides distributed deadlock


### PR DESCRIPTION
Even though we have 7 commits on `release-9.4` after `v9.4.5` We have only 2 entries.

6 of them are introduced in https://github.com/citusdata/citus/pull/5147
1 of them is introduced in https://github.com/citusdata/citus/pull/5158 and cherry-picked into the release branch.