### PR TITLE
Fix assert failure in FindReferencedTableColumn

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -4523,7 +4523,7 @@ FindReferencedTableColumn(Expr *columnExpression, List *parentQueryList, Query *
 		 * When outerVars are considered, we modify parentQueryList, so this
 		 * logic might need to change when we support outervars in CTEs.
 		 */
-		Assert(!skipOuterVars);
+		Assert(skipOuterVars);
 
 		int cteParentListIndex = list_length(parentQueryList) -
 								 rangeTableEntry->ctelevelsup - 1;


### PR DESCRIPTION
We had the assert incorrect, so we correct that here.

https://github.com/citusdata/citus/pull/5079#discussion_r686643853

Locally verified that check-multi-mx check-multi and check-multi-1 pass with asserts enabled.