### PR TITLE
Support partitioning for citus local tables

### DIFF
--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -397,7 +397,8 @@ ErrorIfUnsupportedCitusLocalTableKind(Oid relationId)
 
 
 	char relationKind = get_rel_relkind(relationId);
-	if (!(relationKind == RELKIND_RELATION || relationKind == RELKIND_FOREIGN_TABLE || relationKind == RELKIND_PARTITIONED_TABLE))
+	if (!(relationKind == RELKIND_RELATION || relationKind == RELKIND_FOREIGN_TABLE ||
+		  relationKind == RELKIND_PARTITIONED_TABLE))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot add local table \"%s\" to metadata, only regular "

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -327,6 +327,17 @@ CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys)
 										  attnumList);
 
 	FinalizeCitusLocalTableCreation(shellRelationId, dependentSequenceList);
+
+	/* if this table is partitioned table, add its partitions to metadata too */
+	if (PartitionedTable(relationId))
+	{
+		List *partitionList = PartitionList(relationId);
+		Oid partitionRelationId = InvalidOid;
+		foreach_oid(partitionRelationId, partitionList)
+		{
+			CreateCitusLocalTable(partitionRelationId, false);
+		}
+	}
 }
 
 
@@ -384,20 +395,14 @@ ErrorIfUnsupportedCitusLocalTableKind(Oid relationId)
 							   "relationships", relationName)));
 	}
 
-	if (PartitionTable(relationId))
-	{
-		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("cannot add local table \"%s\" to metadata, local tables "
-							   "added to metadata cannot be partition of other tables ",
-							   relationName)));
-	}
 
 	char relationKind = get_rel_relkind(relationId);
-	if (!(relationKind == RELKIND_RELATION || relationKind == RELKIND_FOREIGN_TABLE))
+	if (!(relationKind == RELKIND_RELATION || relationKind == RELKIND_FOREIGN_TABLE || relationKind == RELKIND_PARTITIONED_TABLE))
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot add local table \"%s\" to metadata, only regular "
-							   "tables and foreign tables can be added to citus metadata ",
+							   "tables, foreign tables and partitioned tables can be "
+							   "added to citus metadata ",
 							   relationName)));
 	}
 

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -356,7 +356,7 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 	 */
 	if (IsCitusTable(parentRelationId))
 	{
-		if(IsCitusTableType(parentRelationId, CITUS_LOCAL_TABLE))
+		if (IsCitusTableType(parentRelationId, CITUS_LOCAL_TABLE))
 		{
 			/* if it's a citus local table, we don't need distribution column */
 			CreateCitusLocalTable(relationId, false);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -356,6 +356,13 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 	 */
 	if (IsCitusTable(parentRelationId))
 	{
+		if(IsCitusTableType(parentRelationId, CITUS_LOCAL_TABLE))
+		{
+			/* if it's a citus local table, we don't need distribution column */
+			CreateCitusLocalTable(relationId, false);
+			return;
+		}
+
 		Var *parentDistributionColumn = DistPartitionKeyOrError(parentRelationId);
 		char parentDistributionMethod = DISTRIBUTE_BY_HASH;
 		char *parentRelationName = generate_qualified_relation_name(parentRelationId);

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -227,12 +227,6 @@ PlacementAccessTypeToText(ShardPlacementAccessType accessType)
 static void
 RecordRelationAccessBase(Oid relationId, ShardPlacementAccessType accessType)
 {
-	/*
-	 * We call this only for reference tables, and we don't support partitioned
-	 * reference tables.
-	 */
-	Assert(!PartitionedTable(relationId) && !PartitionTable(relationId));
-
 	/* make sure that this is not a conflicting access */
 	CheckConflictingRelationAccesses(relationId, accessType);
 


### PR DESCRIPTION
DESCRIPTION: Adds support for partitioned Citus local tables

fixes: #4948 

- [ ] Remove error messages for partitioned Citus local tables
- [ ] Remove failing assertions
- [ ] After `create_citus_local_table`, newly added partitions attach the shell parent table.
- [ ] Dropping errors out with different messages, for all of shell, parent and child tables.
- [ ] Old tests failing
- [ ] Add new tests
