### PR TITLE
Split columnar stripe reservation into two phases

### DIFF
--- a/src/backend/columnar/columnar_storage.c
+++ b/src/backend/columnar/columnar_storage.c
@@ -371,15 +371,13 @@ ColumnarStorageReserveRowNumber(Relation rel, uint64 nrows)
 
 
 /*
- * ColumnarStorageReserveStripe returns stripeId and advances it for next
+ * ColumnarStorageReserveStripeId returns stripeId and advances it for next
  * stripeId reservation.
  * Note that this function doesn't handle row number reservation.
- * This is because, unlike stripeId reservation, we immediately reserve
- * row number during writes, not when flushing stripes to disk.
  * See ColumnarStorageReserveRowNumber function.
  */
 uint64
-ColumnarStorageReserveStripe(Relation rel)
+ColumnarStorageReserveStripeId(Relation rel)
 {
 	LockRelationForExtension(rel, ExclusiveLock);
 

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -547,10 +547,44 @@ columnar_index_fetch_tuple(struct IndexFetchTableData *sscan,
 	}
 
 	uint64 rowNumber = tid_to_row_number(*tid);
-	if (!ColumnarReadRowByRowNumber(scan->cs_readState, rowNumber, slot->tts_values,
-									slot->tts_isnull))
+	StripeMetadata *stripeMetadata =
+		FindStripeWithMatchingFirstRowNumber(columnarRelation, rowNumber, snapshot);
+	if (!stripeMetadata)
 	{
+		/* it is certain that tuple with rowNumber doesn't exist */
 		return false;
+	}
+
+	if (StripeIsFlushed(stripeMetadata) &&
+		!ColumnarReadRowByRowNumber(scan->cs_readState, rowNumber,
+									slot->tts_values, slot->tts_isnull))
+	{
+		/*
+		 * FindStripeWithMatchingFirstRowNumber doesn't verify upper row
+		 * number boundary of found stripe. For this reason, we didn't
+		 * certainly know if given row number belongs to one of the stripes.
+		 */
+		return false;
+	}
+
+	if (!StripeIsFlushed(stripeMetadata))
+	{
+		/*
+		 * We only expect to see un-flushed stripes when checking against
+		 * constraint violation. In that case, indexAM provides dirty
+		 * snapshot to index_fetch_tuple callback.
+		 */
+		Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY);
+
+		/*
+		 * Stripe that "might" contain the tuple with rowNumber is not
+		 * flushed yet. Here we set all attributes of given tupleslot to NULL
+		 * before returning true and expect the indexAM callback that called
+		 * us --possibly to check against constraint violation-- blocks until
+		 * writer transaction commits or aborts, without requiring us to fill
+		 * the tupleslot properly.
+		 */
+		memset(slot->tts_isnull, true, slot->tts_nvalid);
 	}
 
 	slot->tts_tableOid = RelationGetRelid(columnarRelation);
@@ -1393,7 +1427,8 @@ ColumnarGetHighestItemPointer(Relation relation, Snapshot snapshot)
 {
 	StripeMetadata *stripeWithHighestRowNumber =
 		FindStripeWithHighestRowNumber(relation, snapshot);
-	if (stripeWithHighestRowNumber == NULL)
+	if (stripeWithHighestRowNumber == NULL ||
+		StripeGetHighestRowNumber(stripeWithHighestRowNumber) == 0)
 	{
 		/* table is empty according to our snapshot */
 		ItemPointerData invalidItemPtr;

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -246,10 +246,12 @@ extern bool IsColumnarTableAmTable(Oid relationId);
 extern void DeleteMetadataRows(RelFileNode relfilenode);
 extern uint64 ColumnarMetadataNewStorageId(void);
 extern uint64 GetHighestUsedAddress(RelFileNode relfilenode);
-extern StripeMetadata ReserveStripe(Relation rel, uint64 size,
-									uint64 rowCount, uint64 columnCount,
-									uint64 chunkCount, uint64 chunkGroupRowCount,
-									uint64 stripeFirstRowNumber);
+extern EmptyStripeReservation * ReserveEmptyStripe(Relation rel, uint64 columnCount,
+												   uint64 chunkGroupRowCount,
+												   uint64 stripeRowCount);
+extern StripeMetadata * CompleteStripeReservation(Relation rel, uint64 stripeId,
+												  uint64 sizeBytes, uint64 rowCount,
+												  uint64 chunkCount);
 extern void SaveStripeSkipList(RelFileNode relfilenode, uint64 stripe,
 							   StripeSkipList *stripeSkipList,
 							   TupleDesc tupleDescriptor);
@@ -263,6 +265,10 @@ extern StripeMetadata * FindNextStripeByRowNumber(Relation relation, uint64 rowN
 												  Snapshot snapshot);
 extern StripeMetadata * FindStripeByRowNumber(Relation relation, uint64 rowNumber,
 											  Snapshot snapshot);
+extern StripeMetadata * FindStripeWithMatchingFirstRowNumber(Relation relation,
+															 uint64 rowNumber,
+															 Snapshot snapshot);
+extern bool StripeIsFlushed(StripeMetadata *stripeMetadata);
 extern uint64 StripeGetHighestRowNumber(StripeMetadata *stripeMetadata);
 extern StripeMetadata * FindStripeWithHighestRowNumber(Relation relation,
 													   Snapshot snapshot);

--- a/src/include/columnar/columnar_metadata.h
+++ b/src/include/columnar/columnar_metadata.h
@@ -28,6 +28,16 @@ typedef struct StripeMetadata
 	uint64 firstRowNumber;
 } StripeMetadata;
 
+/*
+ * EmptyStripeReservation represents information for an empty stripe
+ * reservation.
+ */
+typedef struct EmptyStripeReservation
+{
+	uint64 stripeId;
+	uint64 stripeFirstRowNumber;
+} EmptyStripeReservation;
+
 extern List * StripesForRelfilenode(RelFileNode relfilenode);
 extern void ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade);
 

--- a/src/include/columnar/columnar_storage.h
+++ b/src/include/columnar/columnar_storage.h
@@ -53,7 +53,7 @@ extern uint64 ColumnarStorageGetReservedOffset(Relation rel, bool force);
 
 extern uint64 ColumnarStorageReserveData(Relation rel, uint64 amount);
 extern uint64 ColumnarStorageReserveRowNumber(Relation rel, uint64 nrows);
-extern uint64 ColumnarStorageReserveStripe(Relation rel);
+extern uint64 ColumnarStorageReserveStripeId(Relation rel);
 
 extern void ColumnarStorageRead(Relation rel, uint64 logicalOffset,
 								char *data, uint32 amount);

--- a/src/test/regress/columnar_isolation_schedule
+++ b/src/test/regress/columnar_isolation_schedule
@@ -1,4 +1,4 @@
-test: columnar_write_concurrency
+test: columnar_write_concurrency columnar_write_concurrency_index
 test: columnar_vacuum_vs_insert
 test: columnar_temp_tables
 test: columnar_index_concurrency

--- a/src/test/regress/expected/columnar_rollback.out
+++ b/src/test/regress/expected/columnar_rollback.out
@@ -19,7 +19,7 @@ select
   from columnar_test_helpers.columnar_storage_info('t');
  version_major | version_minor | reserved_stripe_id | reserved_row_number
 ---------------------------------------------------------------------
-             2 |             0 |                  1 |              150001
+             2 |             0 |                  2 |              150001
 (1 row)
 
 -- check stripe metadata also have been rolled-back
@@ -59,7 +59,7 @@ select
   from columnar_test_helpers.columnar_storage_info('t');
  version_major | version_minor | reserved_stripe_id | reserved_row_number
 ---------------------------------------------------------------------
-             2 |             0 |                  3 |              600001
+             2 |             0 |                  5 |              600001
 (1 row)
 
 SELECT count(*) FROM t;
@@ -89,7 +89,7 @@ select
   from columnar_test_helpers.columnar_storage_info('t');
  version_major | version_minor | reserved_stripe_id | reserved_row_number
 ---------------------------------------------------------------------
-             2 |             0 |                  5 |              750001
+             2 |             0 |                  6 |              750001
 (1 row)
 
 SELECT count(*) FROM t;

--- a/src/test/regress/expected/columnar_vacuum.out
+++ b/src/test/regress/expected/columnar_vacuum.out
@@ -244,7 +244,7 @@ select
   from columnar_test_helpers.columnar_storage_info('t');
  version_major | version_minor | reserved_stripe_id | reserved_row_number
 ---------------------------------------------------------------------
-             2 |             0 |                 16 |               21001
+             2 |             0 |                 18 |               21001
 (1 row)
 
 SELECT * FROM columnar_test_helpers.chunk_group_consistency;

--- a/src/test/regress/expected/columnar_write_concurrency.out
+++ b/src/test/regress/expected/columnar_write_concurrency.out
@@ -159,7 +159,7 @@ step s1-select:
 (6 rows)
 
 
-starting permutation: s1-truncate s1-begin s1-insert-10000-rows s2-begin s2-insert s2-commit s1-commit s1-verify-metadata
+starting permutation: s1-truncate s1-begin s1-insert-10000-rows s2-begin s2-insert s2-commit s1-commit
 step s1-truncate:
     TRUNCATE test_insert_concurrency;
 
@@ -180,27 +180,6 @@ step s2-commit:
 
 step s1-commit:
     COMMIT;
-
-step s1-verify-metadata:
-    WITH test_insert_concurrency_stripes AS (
-      SELECT first_row_number, stripe_num, row_count
-      FROM columnar.stripe a, pg_class b
-      WHERE columnar_relation_storageid(b.oid)=a.storage_id AND
-            relname = 'test_insert_concurrency'
-    )
-    SELECT
-      -- verify that table has two stripes ..
-      count(*) = 2 AND
-      -- .. and those stripes look like:
-      sum(case when stripe_num = 1 AND first_row_number = 150001 AND row_count = 3 then 1 end) = 1 AND
-      sum(case when stripe_num = 2 AND first_row_number = 1 AND row_count = 10000 then 1 end) = 1
-      AS stripe_metadata_for_test_insert_concurrency_ok
-    FROM test_insert_concurrency_stripes;
-
-stripe_metadata_for_test_insert_concurrency_ok
----------------------------------------------------------------------
-t
-(1 row)
 
 
 starting permutation: s1-begin s2-begin-repeatable s1-insert s2-insert s2-select s1-commit s2-select s2-commit

--- a/src/test/regress/expected/columnar_write_concurrency_index.out
+++ b/src/test/regress/expected/columnar_write_concurrency_index.out
@@ -1,0 +1,610 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1-begin s1-insert-1 s2-copy-1 s1-commit s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-copy-1:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 4';
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-copy-1: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+3|1
+6|2
+(2 rows)
+
+
+starting permutation: s1-begin s1-copy-1 s2-insert-1 s1-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-copy-1:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 2';
+
+step s2-insert-1:
+    INSERT INTO write_concurrency_index SELECT (2*s)::text, s FROM generate_series(1,4) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-insert-1: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+2|1
+4|2
+6|3
+8|4
+(4 rows)
+
+
+starting permutation: s1-begin s1-copy-1 s2-insert-2 s3-insert-1 s1-commit s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-copy-1:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 2';
+
+step s2-insert-2:
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(1,2) s;
+ <waiting ...>
+step s3-insert-1: 
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(3,4) s;
+
+step s1-commit:
+    COMMIT;
+
+step s2-insert-2: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+ a|b
+---------------------------------------------------------------------
+21|3
+28|4
+  |1
+  |2
+(4 rows)
+
+
+starting permutation: s1-begin s1-insert-1 s2-insert-2 s3-insert-1 s1-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-insert-2:
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(1,2) s;
+ <waiting ...>
+step s3-insert-1: 
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(3,4) s;
+
+step s1-rollback:
+    ROLLBACK;
+
+step s2-insert-2: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+ a|b
+---------------------------------------------------------------------
+10|2
+21|3
+28|4
+ 5|1
+(4 rows)
+
+
+starting permutation: s1-begin s2-begin s1-insert-1 s2-insert-3 s3-insert-2 s1-commit s2-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-insert-3:
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(3,4) s;
+
+step s3-insert-2:
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s3-insert-2: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s2-rollback:
+    ROLLBACK;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+3|1
+6|2
+(2 rows)
+
+
+starting permutation: s1-begin s2-begin s1-copy-1 s2-copy-2 s3-insert-2 s1-rollback s2-commit s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-copy-1:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 2';
+
+step s2-copy-2:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 3 4';
+
+step s3-insert-2:
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-commit:
+    COMMIT;
+
+step s3-insert-2: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+ |3
+ |4
+(2 rows)
+
+
+starting permutation: s1-begin s2-begin s1-insert-1 s2-copy-2 s3-insert-2 s1-rollback s2-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-copy-2:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 3 4';
+
+step s3-insert-2:
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-rollback:
+    ROLLBACK;
+
+step s3-insert-2: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+ a|b
+---------------------------------------------------------------------
+14|2
+21|3
+(2 rows)
+
+
+starting permutation: s1-begin s1-insert-2 s2-insert-4 s1-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s2-insert-4:
+    INSERT INTO write_concurrency_index SELECT s::text, 2*s FROM generate_series(1,4) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-insert-4: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+1|2
+2|4
+3|6
+4|8
+(4 rows)
+
+
+starting permutation: s1-begin s1-insert-2 s2-insert-5 s3-insert-3 s1-commit s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s2-insert-5:
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(1,2) s;
+ <waiting ...>
+step s3-insert-3: 
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(3,4) s;
+
+step s1-commit:
+    COMMIT;
+
+step s2-insert-5: <... completed>
+ERROR:  conflicting key value violates exclusion constraint "write_concurrency_index_a_excl"
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a| b
+---------------------------------------------------------------------
+1| 3
+2| 6
+3|21
+4|28
+(4 rows)
+
+
+starting permutation: s1-begin s2-begin s1-insert-2 s2-insert-6 s3-insert-4 s1-commit s2-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s2-insert-6:
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(3,4) s;
+
+step s3-insert-4:
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s3-insert-4: <... completed>
+ERROR:  conflicting key value violates exclusion constraint "write_concurrency_index_a_excl"
+step s2-rollback:
+    ROLLBACK;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+1|3
+2|6
+(2 rows)
+
+
+starting permutation: s1-begin s2-begin s1-insert-2 s2-insert-6 s3-insert-4 s1-rollback s2-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s2-insert-6:
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(3,4) s;
+
+step s3-insert-4:
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-rollback:
+    ROLLBACK;
+
+step s3-insert-4: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a| b
+---------------------------------------------------------------------
+2|14
+3|21
+(2 rows)
+
+
+starting permutation: s1-begin s1-insert-1 s2-index-select-all-b s1-rollback
+step s1-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-index-select-all-b:
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+
+b
+-
+(0 rows)
+
+step s1-rollback:
+    ROLLBACK;
+
+
+starting permutation: s1-begin s2-begin s1-insert-1 s2-copy-2 s2-index-select-all-b s3-index-select-all-b s1-commit s2-index-select-all-b s2-rollback
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-copy-2:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 3 4';
+
+step s2-index-select-all-b:
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+
+b
+-
+3
+4
+(2 rows)
+
+step s3-index-select-all-b:
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+
+b
+-
+(0 rows)
+
+step s1-commit:
+    COMMIT;
+
+step s2-index-select-all-b:
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+
+b
+-
+1
+2
+3
+4
+(4 rows)
+
+step s2-rollback:
+    ROLLBACK;
+
+
+starting permutation: s1-begin s2-begin s1-insert-1 s1-select-all s2-insert-1 s1-commit s2-rollback
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+3|1
+6|2
+(2 rows)
+
+step s2-insert-1:
+    INSERT INTO write_concurrency_index SELECT (2*s)::text, s FROM generate_series(1,4) s;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-insert-1: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s2-rollback:
+    ROLLBACK;
+
+
+starting permutation: s1-begin s2-begin s1-insert-1 s1-select-all s2-insert-1 s1-rollback s2-rollback
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+3|1
+6|2
+(2 rows)
+
+step s2-insert-1:
+    INSERT INTO write_concurrency_index SELECT (2*s)::text, s FROM generate_series(1,4) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-insert-1: <... completed>
+step s2-rollback:
+    ROLLBACK;
+
+
+starting permutation: s1-begin s1-copy-1 s1-select-all s2-insert-2 s3-insert-1 s1-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-copy-1:
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 2';
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+ |1
+ |2
+(2 rows)
+
+step s2-insert-2:
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(1,2) s;
+ <waiting ...>
+step s3-insert-1: 
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(3,4) s;
+
+step s1-rollback:
+    ROLLBACK;
+
+step s2-insert-2: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+ a|b
+---------------------------------------------------------------------
+10|2
+21|3
+28|4
+ 5|1
+(4 rows)
+
+
+starting permutation: s1-begin s1-insert-2 s1-select-all s2-insert-5 s3-insert-3 s1-commit s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+1|3
+2|6
+(2 rows)
+
+step s2-insert-5:
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(1,2) s;
+ <waiting ...>
+step s3-insert-3: 
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(3,4) s;
+
+step s1-commit:
+    COMMIT;
+
+step s2-insert-5: <... completed>
+ERROR:  conflicting key value violates exclusion constraint "write_concurrency_index_a_excl"
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a| b
+---------------------------------------------------------------------
+1| 3
+2| 6
+3|21
+4|28
+(4 rows)
+
+
+starting permutation: s1-begin s2-begin s1-insert-2 s1-select-all s2-insert-6 s3-insert-4 s1-rollback s2-rollback s1-select-all
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+    BEGIN;
+
+step s1-insert-2:
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a|b
+---------------------------------------------------------------------
+1|3
+2|6
+(2 rows)
+
+step s2-insert-6:
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(3,4) s;
+
+step s3-insert-4:
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(2,3) s;
+ <waiting ...>
+step s1-rollback: 
+    ROLLBACK;
+
+step s2-rollback:
+    ROLLBACK;
+
+step s3-insert-4: <... completed>
+step s1-select-all:
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+
+a| b
+---------------------------------------------------------------------
+2|14
+3|21
+(2 rows)
+
+
+starting permutation: s1-begin s2-begin-repeatable s1-insert-1 s2-insert-1 s1-commit s2-rollback
+step s1-begin:
+    BEGIN;
+
+step s2-begin-repeatable:
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+step s1-insert-1:
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+
+step s2-insert-1:
+    INSERT INTO write_concurrency_index SELECT (2*s)::text, s FROM generate_series(1,4) s;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-insert-1: <... completed>
+ERROR:  duplicate key value violates unique constraint "write_concurrency_index_b_key"
+step s2-rollback:
+    ROLLBACK;
+

--- a/src/test/regress/spec/columnar_write_concurrency.spec
+++ b/src/test/regress/spec/columnar_write_concurrency.spec
@@ -44,24 +44,6 @@ step "s1-truncate"
     TRUNCATE test_insert_concurrency;
 }
 
-step "s1-verify-metadata"
-{
-    WITH test_insert_concurrency_stripes AS (
-      SELECT first_row_number, stripe_num, row_count
-      FROM columnar.stripe a, pg_class b
-      WHERE columnar_relation_storageid(b.oid)=a.storage_id AND
-            relname = 'test_insert_concurrency'
-    )
-    SELECT
-      -- verify that table has two stripes ..
-      count(*) = 2 AND
-      -- .. and those stripes look like:
-      sum(case when stripe_num = 1 AND first_row_number = 150001 AND row_count = 3 then 1 end) = 1 AND
-      sum(case when stripe_num = 2 AND first_row_number = 1 AND row_count = 10000 then 1 end) = 1
-      AS stripe_metadata_for_test_insert_concurrency_ok
-    FROM test_insert_concurrency_stripes;
-}
-
 step "s1-commit"
 {
     COMMIT;
@@ -103,10 +85,6 @@ permutation "s1-begin" "s2-begin" "s1-copy" "s2-insert" "s1-select" "s2-select" 
 // insert vs copy
 permutation "s1-begin" "s2-begin" "s2-insert" "s1-copy" "s1-select" "s2-select" "s1-commit" "s2-commit" "s1-select"
 
-# insert vs insert
-# Start inserting rows in session 1, reserve first_row_number to be 1 for session 1 but commit session 2 before session 1.
-# Then verify that while the stripe written by session 2 has the greater first_row_number, stripe written by session 1 has
-# the greater stripe_num. This is because, we reserve stripe_num and first_row_number at different times.
-permutation "s1-truncate" "s1-begin" "s1-insert-10000-rows" "s2-begin" "s2-insert" "s2-commit" "s1-commit" "s1-verify-metadata"
+permutation "s1-truncate" "s1-begin" "s1-insert-10000-rows" "s2-begin" "s2-insert" "s2-commit" "s1-commit"
 
 permutation "s1-begin" "s2-begin-repeatable" "s1-insert" "s2-insert" "s2-select" "s1-commit" "s2-select" "s2-commit"

--- a/src/test/regress/spec/columnar_write_concurrency_index.spec
+++ b/src/test/regress/spec/columnar_write_concurrency_index.spec
@@ -1,0 +1,174 @@
+setup
+{
+    CREATE TABLE write_concurrency_index (a text, b int unique,
+    EXCLUDE USING hash (a WITH =)) USING columnar;
+}
+
+teardown
+{
+    DROP TABLE IF EXISTS write_concurrency_index CASCADE;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+step "s1-rollback"
+{
+    ROLLBACK;
+}
+
+step "s1-insert-1"
+{
+    INSERT INTO write_concurrency_index SELECT (3*s)::text, s FROM generate_series(1,2) s;
+}
+
+step "s1-insert-2"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 3*s FROM generate_series(1,2) s;
+}
+
+step "s1-copy-1"
+{
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 2';
+}
+
+step "s1-select-all"
+{
+    SELECT * FROM write_concurrency_index ORDER BY a,b;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+    BEGIN;
+}
+
+step "s2-begin-repeatable"
+{
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+}
+
+step "s2-commit"
+{
+    COMMIT;
+}
+
+step "s2-rollback"
+{
+    ROLLBACK;
+}
+
+step "s2-insert-1"
+{
+    INSERT INTO write_concurrency_index SELECT (2*s)::text, s FROM generate_series(1,4) s;
+}
+
+step "s2-insert-2"
+{
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(1,2) s;
+}
+
+step "s2-insert-3"
+{
+    INSERT INTO write_concurrency_index SELECT (5*s)::text, s FROM generate_series(3,4) s;
+}
+
+step "s2-insert-4"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 2*s FROM generate_series(1,4) s;
+}
+
+step "s2-insert-5"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(1,2) s;
+}
+
+step "s2-insert-6"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 5*s FROM generate_series(3,4) s;
+}
+
+step "s2-copy-1"
+{
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 1 4';
+}
+
+step "s2-copy-2"
+{
+    COPY write_concurrency_index(b) FROM PROGRAM 'seq 3 4';
+}
+
+step "s2-index-select-all-b"
+{
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+}
+
+session "s3"
+
+step "s3-insert-1"
+{
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(3,4) s;
+}
+
+step "s3-insert-2"
+{
+    INSERT INTO write_concurrency_index SELECT (7*s)::text, s FROM generate_series(2,3) s;
+}
+
+step "s3-insert-3"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(3,4) s;
+}
+
+step "s3-insert-4"
+{
+    INSERT INTO write_concurrency_index SELECT s::text, 7*s FROM generate_series(2,3) s;
+}
+
+step "s3-index-select-all-b"
+{
+    SET enable_seqscan TO OFF;
+    SET columnar.enable_custom_scan TO OFF;
+    SELECT b FROM write_concurrency_index ORDER BY 1;
+}
+
+# unique (btree) on int column
+permutation "s1-begin" "s1-insert-1" "s2-copy-1" "s1-commit" "s1-select-all"
+permutation "s1-begin" "s1-copy-1" "s2-insert-1" "s1-rollback" "s1-select-all"
+permutation "s1-begin" "s1-copy-1" "s2-insert-2" "s3-insert-1" "s1-commit" "s1-select-all"
+permutation "s1-begin" "s1-insert-1" "s2-insert-2" "s3-insert-1" "s1-rollback" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-insert-3" "s3-insert-2" "s1-commit" "s2-rollback" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-copy-1" "s2-copy-2" "s3-insert-2" "s1-rollback" "s2-commit" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-copy-2" "s3-insert-2" "s1-rollback" "s2-rollback" "s1-select-all"
+
+# exclusion (hash) on text column that checks against duplicate values
+permutation "s1-begin" "s1-insert-2" "s2-insert-4" "s1-rollback" "s1-select-all"
+permutation "s1-begin" "s1-insert-2" "s2-insert-5" "s3-insert-3" "s1-commit" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-insert-2" "s2-insert-6" "s3-insert-4" "s1-commit" "s2-rollback" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-insert-2" "s2-insert-6" "s3-insert-4" "s1-rollback" "s2-rollback" "s1-select-all"
+
+# make sure that pending writes are not visible to other backends
+permutation "s1-begin" "s1-insert-1" "s2-index-select-all-b" "s1-rollback"
+permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-copy-2" "s2-index-select-all-b" "s3-index-select-all-b" "s1-commit" "s2-index-select-all-b" "s2-rollback"
+
+# force flushing write state of s1 before inserting some more data via other sessions
+permutation "s1-begin" "s2-begin" "s1-insert-1" "s1-select-all" "s2-insert-1" "s1-commit" "s2-rollback"
+permutation "s1-begin" "s2-begin" "s1-insert-1" "s1-select-all" "s2-insert-1" "s1-rollback" "s2-rollback"
+permutation "s1-begin" "s1-copy-1" "s1-select-all" "s2-insert-2" "s3-insert-1" "s1-rollback" "s1-select-all"
+permutation "s1-begin" "s1-insert-2" "s1-select-all" "s2-insert-5" "s3-insert-3" "s1-commit" "s1-select-all"
+permutation "s1-begin" "s2-begin" "s1-insert-2" "s1-select-all" "s2-insert-6" "s3-insert-4" "s1-rollback" "s2-rollback" "s1-select-all"
+
+# test with repeatable read isolation mode
+permutation "s1-begin" "s2-begin-repeatable" "s1-insert-1" "s2-insert-1" "s1-commit" "s2-rollback"


### PR DESCRIPTION
Fixes #5160.
(Rebased onto #5154)

Previously, we were doing `first_row_number` reservation for the first
row written to current `WriteState` but were doing `stripe_id`
reservation when flushing the `WriteState` and were inserting the
related record to `columnar.stripe` at that time as well.

However, inserting `columnar.stripe` record at flush-time is
problematic. This is because, as told in #5160, if relation has
any index-based constraints and if there are two concurrent
writes that are inserting conflicting key values for that constraint,
then postgres relies on `tableAM->fetch_index_tuple`
(=`columnar_fetch_index_tuple`) callback to return `true` when
indexAM is checking against possible constraint violations.

However, pending writes of other backends are not visible to concurrent
sessions in columnar since we were not inserting the stripe metadata
record until flushing the stripe.

With this PR, we split stripe reservation into two phases:
i) Reserve `stripe_id` and insert a "dummy" record to `columnar.stripe`
at the very same time we reserve `first_row_number`, i.e. when writing
the first row to the current `WriteState`.
ii) At flush time, do the storage level allocation and complete the
missing fields of the dummy record inserted into `columnar.stripe`
during i).

That way, any concurrent writes would be able to check against possible
constraint violations by using `SnapshotDirty` when scanning
`columnar.stripe`.

Note that `columnar_fetch_index_tuple` still wouldn't be able to fill
the output tupleslot for the requested tid but it would at least return
`true` for such index look-up's and we believe this should be sufficient
for the caller indexAM callback to make the concurrent writer block on
prior one.

That is how we fix #5160.

Only downside of reserving `stripe_id` at the same time we reserve
`first_row_number` is that now any aborted writes would also waste
some amount of `stripe_id` as in the case of `first_row_number` but
we are just wasting them one-by-one.

Considering the fact that we waste `first_row_number` by the amount
stripe row limit (=150k by default) in such cases, this shouldn't be
important at all.