### PR TITLE
Distributes partition-to-be table before ProcessUtility

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -408,10 +408,15 @@ PreprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 	{
 		if (alterTableCommand->subtype == AT_AttachPartition)
 		{
-			Oid relationId = AlterTableLookupRelation(alterTableStatement, NoLock);
+			/*
+			 * We acquire the lock on the parent and child as we are in the pre-process
+			 * and want to ensure we acquire the locks in the same order with Postgres
+			 */
+			LOCKMODE lockmode = AlterTableGetLockLevel(alterTableStatement->cmds);
+			Oid relationId = AlterTableLookupRelation(alterTableStatement, lockmode);
 			PartitionCmd *partitionCommand = (PartitionCmd *) alterTableCommand->def;
 			bool partitionMissingOk = false;
-			Oid partitionRelationId = RangeVarGetRelid(partitionCommand->name, NoLock,
+			Oid partitionRelationId = RangeVarGetRelid(partitionCommand->name, lockmode,
 													   partitionMissingOk);
 
 			/*

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -372,7 +372,7 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 
 
 /*
- * PostprocessAlterTableStmtAttachPartition takes AlterTableStmt object as
+ * PreprocessAlterTableStmtAttachPartition takes AlterTableStmt object as
  * parameter but it only processes into ALTER TABLE ... ATTACH PARTITION
  * commands and distributes the partition if necessary. There are four cases
  * to consider;
@@ -399,8 +399,8 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
  * ATTACH PARTITION OF command.
  */
 List *
-PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
-										 const char *queryString)
+PreprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
+										const char *queryString)
 {
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *alterTableCommand = NULL;
@@ -434,6 +434,13 @@ PostprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 				!IsCitusTable(partitionRelationId))
 			{
 				Var *distributionColumn = DistPartitionKeyOrError(relationId);
+				char *distributionColumnName = ColumnToColumnName(relationId,
+																  nodeToString(
+																	  distributionColumn));
+				distributionColumn = FindColumnWithNameOnTargetRelation(relationId,
+																		distributionColumnName,
+																		partitionRelationId);
+
 				char distributionMethod = DISTRIBUTE_BY_HASH;
 				char *parentRelationName = generate_qualified_relation_name(relationId);
 				bool viaDeprecatedAPI = false;

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -443,6 +443,17 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		PreprocessTruncateStatement((TruncateStmt *) parsetree);
 	}
 
+	/*
+	 * We only process ALTER TABLE ... ATTACH PARTITION commands in the function below
+	 * and distribute the partition if necessary.
+	 */
+	if (IsA(parsetree, AlterTableStmt))
+	{
+		AlterTableStmt *alterTableStatement = (AlterTableStmt *) parsetree;
+
+		PreprocessAlterTableStmtAttachPartition(alterTableStatement, queryString);
+	}
+
 	/* only generate worker DDLJobs if propagation is enabled */
 	const DistributeObjectOps *ops = NULL;
 	if (EnableDDLPropagation)
@@ -609,17 +620,6 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		CreateStmt *createStatement = (CreateStmt *) parsetree;
 
 		PostprocessCreateTableStmt(createStatement, queryString);
-	}
-
-	/*
-	 * We only process ALTER TABLE ... ATTACH PARTITION commands in the function below
-	 * and distribute the partition if necessary.
-	 */
-	if (IsA(parsetree, AlterTableStmt))
-	{
-		AlterTableStmt *alterTableStatement = (AlterTableStmt *) parsetree;
-
-		PostprocessAlterTableStmtAttachPartition(alterTableStatement, queryString);
 	}
 
 	/* after local command has completed, finish by executing worker DDLJobs, if any */

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -25,7 +25,6 @@
 
 #include "distributed/citus_clauses.h"
 #include "distributed/citus_ruleutils.h"
-#include "distributed/commands/utility_hook.h"
 #include "distributed/deparse_shard_query.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
@@ -92,7 +91,6 @@ static AttrNumber FindResnoForVarInTargetList(List *targetList, int varno, int v
 static bool RelationInfoContainsOnlyRecurringTuples(PlannerInfo *plannerInfo,
 													Relids relids);
 static Var * PartitionColumnForPushedDownSubquery(Query *query);
-static bool SimpleAlterTableConstraintCheck(Query *query);
 
 
 /*
@@ -814,18 +812,6 @@ DeferredErrorIfUnsupportedRecurringTuplesJoin(
 			if (RelationInfoContainsOnlyRecurringTuples(plannerInfo, outerrelRelids))
 			{
 				/*
-				 * These constraints will be validated in worker nodes, so no
-				 * need to run them on coordinator. In fact, we disable their
-				 * execution: check CitusExecutorRun. We don't care whether
-				 * we can pushdown the subquery or not. Hence we simply
-				 * consider this as a supported Recurring Tuples Join.
-				 */
-				if (SimpleAlterTableConstraintCheck(plannerInfo->parse))
-				{
-					continue;
-				}
-
-				/*
 				 * Find the first (or only) recurring RTE to give a meaningful
 				 * error to the user.
 				 */
@@ -898,37 +884,6 @@ DeferredErrorIfUnsupportedRecurringTuplesJoin(
 	}
 
 	return NULL;
-}
-
-
-/*
- * SimpleAlterTableConstraintCheck returns if the given query is an ALTER TABLE
- * constraint check query.
- *
- * Postgres uses SPI to execute these queries. To see examples of how these
- * constraint check queries look like, see RI_Initial_Check() and RI_Fkey_check().
- *
- * For cases where the input query might be a SELECT on some catalog tables while
- * an ALTER TABLE is in progress, use AlterTableConstraintCheck with QueryDesc
- */
-static bool
-SimpleAlterTableConstraintCheck(Query *query)
-{
-	if (!AlterTableInProgress())
-	{
-		return false;
-	}
-
-	/*
-	 * These queries are one or more SELECT queries, where postgres checks
-	 * their results either for NULL values or existence of a row at all.
-	 */
-	if (query->commandType != CMD_SELECT)
-	{
-		return false;
-	}
-
-	return true;
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -399,9 +399,8 @@ extern List * PreprocessDropTableStmt(Node *stmt, const char *queryString,
 extern void PostprocessCreateTableStmt(CreateStmt *createStatement,
 									   const char *queryString);
 extern bool ShouldEnableLocalReferenceForeignKeys(void);
-extern List * PostprocessAlterTableStmtAttachPartition(
-	AlterTableStmt *alterTableStatement,
-	const char *queryString);
+extern List * PreprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
+													  const char *queryString);
 extern List * PostprocessAlterTableSchemaStmt(Node *node, const char *queryString);
 extern List * PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 									   ProcessUtilityContext processUtilityContext);

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -2210,8 +2210,42 @@ SELECT worker_partitioned_relation_total_size(oid) FROM pg_class WHERE relname L
 
  \c - - - :master_port
 DROP TABLE "events.Energy Added";
+-- test we skip the foreign key validation query on coordinator
+-- that happens when attaching a non-distributed partition to a distributed-partitioned table
+-- with a foreign key to another distributed table
+SET search_path = partitioning_schema;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE another_distributed_table (x int primary key, y int);
+SELECT create_distributed_table('another_distributed_table','x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE distributed_parent_table (
+  event_id serial NOT NULL REFERENCES another_distributed_table (x),
+  event_time timestamptz NOT NULL DEFAULT now())
+  PARTITION BY RANGE (event_time);
+SELECT create_distributed_table('distributed_parent_table', 'event_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE non_distributed_child_1 (event_id int NOT NULL, event_time timestamptz NOT NULL DEFAULT now());
+ALTER TABLE distributed_parent_table ATTACH PARTITION non_distributed_child_1 FOR VALUES FROM ('2021-06-30') TO ('2021-07-01');
+-- check DEFAULT partition behaves as expected
+CREATE TABLE non_distributed_child_2 (event_id int NOT NULL, event_time timestamptz NOT NULL DEFAULT now());
+ALTER TABLE distributed_parent_table ATTACH PARTITION non_distributed_child_2 DEFAULT;
+-- check adding another partition when default partition exists
+CREATE TABLE non_distributed_child_3 (event_id int NOT NULL, event_time timestamptz NOT NULL DEFAULT now());
+ALTER TABLE distributed_parent_table ATTACH PARTITION non_distributed_child_3 FOR VALUES FROM ('2021-07-30') TO ('2021-08-01');
 DROP SCHEMA partitioning_schema CASCADE;
-NOTICE:  drop cascades to table partitioning_schema."schema-test"
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table "schema-test"
+drop cascades to table another_distributed_table
+drop cascades to table distributed_parent_table
+RESET search_path;
 DROP TABLE IF EXISTS
 	partitioning_hash_test,
 	partitioning_hash_join_test,


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that prevents attaching partitions when colocated foreign key exists

The error in the issue #4483 occurs during fk validation of the partition because the partition-to-be table is not distributed.

### Current approach:
If in an `ALTER TABLE .. ATTACH PARTITION` command, the partition-to-be is not distributed, distribute the partition-to-be table before going into `standard_ProcessUtility`, therefore before the fk validation. Details:

- We were distributing the partition in `PostprocessAlterTableStmtAttachPartition` logic: we move that logic to a preprocess function that runs even before `PreprocessAlterTableStmt` -> `PreprocessAlterTableStmtAttachPartition`
- From what I have checked, the only affected part by this change are the changes from the merged PR #5131 . ~~For this reason I added the Oid of the parent-to-be table as an argument to CreateDistributedTable, to treat the partition-to-be table that we distribute as if it were a partition already in order to make the necessary checks.~~ For this reason, we make sure that we pass in the correct distribution column definition for the partition-to-be table.

### Previous approach:
Skips ALTER TABLE constraint checks while planning since we ignore them in the executor anyway. Details:

- A "hacky solution" that has a specific exception on top of the planner. The idea came from the current "a bit dirty" status of the executor as well where ALTER TABLE constraint checks are ignored. See merged PR #2629 
- You can check this solution from the first commit
- We can check for SELECT validation queries in ALTER TABLE _earlier_ in the planner. Currently, I have put the check right before it would normally error out.

### So ... 
I would appreciate if the reviewer picks their "favorite" approach - maybe the current solution to current approach can be improved to be cleaner.

Fixes #4483 