### PR TITLE
Use relcache utils instead of scanning catalog tables for indexes and ext stats

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -888,16 +888,11 @@ GetIndexAccessMethodName(Oid indexId)
 	Oid indexAMId = indexForm->relam;
 	ReleaseSysCache(indexTuple);
 
-	/* fetch pg_am tuple of index' access method */
-	HeapTuple indexAMTuple = SearchSysCache1(AMOID, ObjectIdGetDatum(indexAMId));
-	if (!HeapTupleIsValid(indexAMTuple))
+	char *indexAmName = get_am_name(indexAMId);
+	if (!indexAmName)
 	{
 		ereport(ERROR, (errmsg("access method with oid %u does not exist", indexAMId)));
 	}
-
-	Form_pg_am indexAMForm = (Form_pg_am) GETSTRUCT(indexAMTuple);
-	char *indexAmName = pstrdup(indexAMForm->amname.data);
-	ReleaseSysCache(indexAMTuple);
 
 	return indexAmName;
 }

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -687,7 +687,10 @@ GetRenameShardIndexCommand(Oid indexOid, uint64 shardId)
 static void
 RenameShardRelationStatistics(Oid shardRelationId, uint64 shardId)
 {
-	List *statsOidList = GetExplicitStatisticsIdList(shardRelationId);
+	Relation shardRelation = RelationIdGetRelation(shardRelationId);
+	List *statsOidList = RelationGetStatExtList(shardRelation);
+	RelationClose(shardRelation);
+
 	List *statsCommandList = GetRenameStatsCommandList(statsOidList, shardId);
 
 	char *command = NULL;

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -69,6 +69,9 @@ static char * GetRenameShardTriggerCommand(Oid shardRelationId, char *triggerNam
 static void DropRelationTruncateTriggers(Oid relationId);
 static char * GetDropTriggerCommand(Oid relationId, char *triggerName);
 static List * GetRenameStatsCommandList(List *statsOidList, uint64 shardId);
+static void AppendExplicitIndexIdsToList(Form_pg_index indexForm,
+										 List **explicitIndexIdList,
+										 int flags);
 static void DropDefaultExpressionsAndMoveOwnedSequenceOwnerships(Oid sourceRelationId,
 																 Oid targetRelationId);
 static void DropDefaultColumnDefinition(Oid relationId, char *columnName);
@@ -834,51 +837,25 @@ GetDropTriggerCommand(Oid relationId, char *triggerName)
 List *
 GetExplicitIndexOidList(Oid relationId)
 {
-	int scanKeyCount = 1;
-	ScanKeyData scanKey[1];
+	/* flags are not applicable for AppendExplicitIndexIdsToList */
+	int flags = 0;
+	return ExecuteFunctionOnEachTableIndex(relationId, AppendExplicitIndexIdsToList,
+										   flags);
+}
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
 
-	Relation pgIndex = table_open(IndexRelationId, AccessShareLock);
-
-	ScanKeyInit(&scanKey[0], Anum_pg_index_indrelid,
-				BTEqualStrategyNumber, F_OIDEQ, relationId);
-
-	bool useIndex = true;
-	SysScanDesc scanDescriptor = systable_beginscan(pgIndex, IndexIndrelidIndexId,
-													useIndex, NULL, scanKeyCount,
-													scanKey);
-
-	List *indexOidList = NIL;
-
-	HeapTuple heapTuple = systable_getnext(scanDescriptor);
-	while (HeapTupleIsValid(heapTuple))
+/*
+ * AppendExplicitIndexIdsToList adds the given index oid if it is
+ * explicitly created on its relation.
+ */
+static void
+AppendExplicitIndexIdsToList(Form_pg_index indexForm, List **explicitIndexIdList,
+							 int flags)
+{
+	if (!IndexImpliedByAConstraint(indexForm))
 	{
-		Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(heapTuple);
-
-		Oid indexId = indexForm->indexrelid;
-
-		bool indexImpliedByConstraint = IndexImpliedByAConstraint(indexForm);
-
-		/*
-		 * Skip the indexes that are not implied by explicitly executing
-		 * a CREATE INDEX command.
-		 */
-		if (!indexImpliedByConstraint)
-		{
-			indexOidList = lappend_oid(indexOidList, indexId);
-		}
-
-		heapTuple = systable_getnext(scanDescriptor);
+		*explicitIndexIdList = lappend_oid(*explicitIndexIdList, indexForm->indexrelid);
 	}
-
-	systable_endscan(scanDescriptor);
-	table_close(pgIndex, NoLock);
-
-	/* revert back to original search_path */
-	PopOverrideSearchPath();
-
-	return indexOidList;
 }
 
 

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -798,6 +798,9 @@ void
 GatherIndexAndConstraintDefinitionList(Form_pg_index indexForm, List **indexDDLEventList,
 									   int indexFlags)
 {
+	/* generate fully-qualified names */
+	PushOverrideEmptySearchPath(CurrentMemoryContext);
+
 	Oid indexId = indexForm->indexrelid;
 	bool indexImpliedByConstraint = IndexImpliedByAConstraint(indexForm);
 
@@ -845,6 +848,9 @@ GatherIndexAndConstraintDefinitionList(Form_pg_index indexForm, List **indexDDLE
 		*indexDDLEventList = list_concat(*indexDDLEventList,
 										 alterIndexStatisticsCommands);
 	}
+
+	/* revert back to original search_path */
+	PopOverrideSearchPath();
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -388,7 +388,6 @@ extern List * PreprocessAlterStatisticsOwnerStmt(Node *node, const char *querySt
 extern List * GetExplicitStatisticsCommandList(Oid relationId);
 extern List * GetExplicitStatisticsSchemaIdList(Oid relationId);
 extern List * GetAlterIndexStatisticsCommands(Oid indexOid);
-extern List * GetExplicitStatisticsIdList(Oid relationId);
 
 /* subscription.c - forward declarations */
 extern Node * ProcessCreateSubscriptionStmt(CreateSubscriptionStmt *createSubStmt);


### PR DESCRIPTION
While reading `relcache.c` code for some reason, I realized that we could avoid writing our own functions to scan `pg_index` & `pg_stats_ext` but could directly use `RelationGetIndexList` & `RelationGetStatExtList` functions instead.
Then searched the codebase and got rid of some of the functions that we implemented for such purposes.