### PR TITLE
Fetch tuples in small batches in adaptive executor where possible

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -335,7 +335,26 @@ typedef struct DistributedExecution
 	bool useSortedMerge;
 
 	/*
-	* Memory context for the execution.
+	 * Flag to track whether sessions have already been cleaned up.
+	 * Used to avoid double-cleanup in FinishDistributedExecution when
+	 * SequentialRunDistributedExecution already cleaned up per-task.
+	 */
+	bool sessionsCleanedUp;
+
+	/*
+	 * Flag to track whether local tasks have been executed. Local tasks
+	 * are executed after all remote batches complete.
+	 */
+	bool localTasksExecuted;
+
+	/*
+	 * Maximum number of rows to fetch per batch in RunDistributedExecution.
+	 * Computed from work_mem and TupleDesc, or set via GUC override.
+	 */
+	int maxBatchSize;
+
+	/*
+	 * Memory context for the execution.
 	 */
 	MemoryContext memoryContext;
 } DistributedExecution;
@@ -526,6 +545,12 @@ int ExecutorSlowStartInterval = 10;
 bool EnableCostBasedConnectionEstablishment = true;
 bool PreventIncompleteConnectionEstablishment = true;
 
+/* GUC, number of rows per batch (0 = auto from work_mem) */
+int ExecutorBatchSize = 0;
+
+/* GUC, libpq chunk size in bytes for chunked row mode (PG17+) */
+int ExecutorChunkSize = 8192;
+
 
 /*
  * TaskExecutionState indicates whether or not a command on a shard
@@ -677,6 +702,7 @@ static void RunDistributedExecution(DistributedExecution *execution, bool toComp
 static void SequentialRunDistributedExecution(DistributedExecution *execution);
 static void FinishDistributedExecution(DistributedExecution *execution);
 static void CleanUpSessions(DistributedExecution *execution);
+static int CalculateMaxBatchSize(TupleDesc tupleDescriptor);
 
 static bool DistributedExecutionModifiesDatabase(DistributedExecution *execution);
 static void AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution);
@@ -791,9 +817,9 @@ AdaptiveExecutorPreExecutorRun(CitusScanState *scanState)
 
 
 /*
- * AdaptiveExecutor is called via CitusExecScan on the
- * first call of CitusExecScan. The function fills the tupleStore
- * of the input scanScate.
+ * AdaptiveExecutorStart is called via CitusExecScan on the first call.
+ * It initializes the distributed execution state, including the tuplestore,
+ * connections, and batch size. Actual execution happens in AdaptiveExecutorRun.
  */
 void
 AdaptiveExecutorStart(CitusScanState *scanState)
@@ -916,6 +942,9 @@ AdaptiveExecutorStart(CitusScanState *scanState)
 		localExecutionSupported,
 		distributedPlan->useSortedMerge);
 
+	/* compute batch size from GUC or work_mem */
+	execution->maxBatchSize = CalculateMaxBatchSize(tupleDescriptor);
+
 	/*
 	 * Make sure that we acquire the appropriate locks even if the local tasks
 	 * are going to be executed with local execution.
@@ -957,7 +986,7 @@ AdaptiveExecutorRun(CitusScanState *scanState)
 	}
 	else
 	{
-		/* if we need to sort the whole tuple store, run to completino */
+		/* if we need to sort the whole tuple store, run to completion */
 		bool runToCompletion = sortTupleStore;
 
 		RunDistributedExecution(execution, runToCompletion);
@@ -971,11 +1000,11 @@ AdaptiveExecutorRun(CitusScanState *scanState)
 		/* done with remote tasks, finish the execution */
 	}
 
-	/* execute tasks local to the node (if any) */
-	if (list_length(execution->localTaskList) > 0)
+	/* execute local tasks after remote execution completes */
+	if (list_length(execution->localTaskList) > 0 && !execution->localTasksExecuted)
 	{
-		/* now execute the local tasks */
 		RunLocalExecution(scanState, execution);
+		execution->localTasksExecuted = true;
 	}
 
 	if (commandType != CMD_SELECT)
@@ -1006,6 +1035,117 @@ AdaptiveExecutorRun(CitusScanState *scanState)
 	MemoryContextSwitchTo(oldContext);
 
 	return true;
+}
+
+
+/*
+ * AdaptiveExecutorEnd performs cleanup of a distributed execution that
+ * may still be in progress. This is called from CitusEndScan to handle
+ * the case where execution is aborted between batches (e.g., cursor
+ * closed early, LIMIT satisfied, or error between batches).
+ *
+ * Worker connections may still have in-progress queries from single-row
+ * or chunked mode. We must cancel those queries and drain pending results
+ * before unclaiming the connections, otherwise the subsequent COMMIT will
+ * fail with "another command is already in progress".
+ *
+ * In the normal case (finishedRemoteScan == true), this is a no-op because
+ * FinishDistributedExecution already cleaned up in AdaptiveExecutorRun.
+ */
+void
+AdaptiveExecutorEnd(CitusScanState *scanState)
+{
+	DistributedExecution *execution = scanState->execution;
+	if (execution == NULL)
+	{
+		return;
+	}
+
+	if (scanState->finishedRemoteScan)
+	{
+		return;
+	}
+
+	/*
+	 * Cancel in-progress queries and drain results on all session connections.
+	 * Without this, connections in single-row/chunked mode still have pending
+	 * results, and any subsequent command (like COMMIT) would fail.
+	 */
+	WorkerSession *session = NULL;
+	foreach_declared_ptr(session, execution->sessionList)
+	{
+		MultiConnection *connection = session->connection;
+
+		if (connection->pgConn == NULL)
+		{
+			continue;
+		}
+
+		if (PQstatus(connection->pgConn) == CONNECTION_OK &&
+			PQtransactionStatus(connection->pgConn) == PQTRANS_ACTIVE)
+		{
+			SendCancelationRequest(connection);
+		}
+
+		ClearResultsDiscardWarnings(connection, false);
+		UnclaimConnection(connection);
+	}
+
+	FreeExecutionWaitEvents(execution);
+}
+
+
+/*
+ * CalculateMaxBatchSize computes the number of rows per batch based on
+ * the GUC citus.executor_batch_size and work_mem.
+ *
+ * If ExecutorBatchSize > 0, use it directly. Otherwise, estimate the
+ * tuple size from the TupleDesc and derive a batch size from work_mem.
+ */
+static int
+CalculateMaxBatchSize(TupleDesc tupleDescriptor)
+{
+	if (ExecutorBatchSize > 0)
+	{
+		return ExecutorBatchSize;
+	}
+
+	int natts = tupleDescriptor->natts;
+	Size estimatedTupleSize = 0;
+
+	for (int i = 0; i < natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, i);
+		if (attr->attlen > 0)
+		{
+			estimatedTupleSize += attr->attlen;
+		}
+		else if (attr->atttypmod > 0)
+		{
+			/* for varchar(N), typmod encodes max length */
+			estimatedTupleSize += attr->atttypmod;
+		}
+		else
+		{
+			/* default estimate for unbounded varlena */
+			estimatedTupleSize += 128;
+		}
+	}
+
+	/* add per-tuple overhead: header + null bitmap + alignment */
+	estimatedTupleSize += MAXALIGN(SizeofHeapTupleHeader +
+								   (natts > 0 ? BITMAPLEN(natts) : 0));
+
+	estimatedTupleSize = Max(estimatedTupleSize, 64);
+
+	/* work_mem is in KB */
+	Size workMemBytes = (Size) work_mem * 1024L;
+	int batchSize = (int) (workMemBytes / estimatedTupleSize);
+
+	batchSize = Max(batchSize, 100);
+	batchSize = Min(batchSize, 1000000);
+
+	return batchSize;
 }
 
 
@@ -1502,7 +1642,7 @@ StartDistributedExecution(DistributedExecution *execution)
 	if (!ShouldRunTasksSequentially(execution->remoteTaskList))
 	{
 		/*
-		 * If a (co-located) shard placement was accessed over a session earier in the
+		 * If a (co-located) shard placement was accessed over a session earlier in the
 		 * transaction, assign the task to the same session. Otherwise, assign it to
 		 * the general worker pool(s).
 		 */
@@ -1530,10 +1670,7 @@ DistributedExecutionModifiesDatabase(DistributedExecution *execution)
 static void
 FinishDistributedExecution(DistributedExecution *execution)
 {
-	/*
-	 * Sequential executions unclaim connections separately.
-	 */
-	if (!ShouldRunTasksSequentially(execution->remoteTaskList))
+	if (!execution->sessionsCleanedUp)
 	{
 		CleanUpSessions(execution);
 	}
@@ -2036,7 +2173,7 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
  * any of the connections and runs the connection state machine when a connection
  * has an event.
  */
-void
+static void
 RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 {
 	WaitEvent *events = NULL;
@@ -2056,8 +2193,8 @@ RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 		execution->rebuildWaitEventSet = true;
 		execution->rowsReceivedInCurrentRun = 0;
 
-		/* TODO: GUC? be smart? */
-		int maxBatchSize = 10000;
+		int maxBatchSize = execution->maxBatchSize > 0 ?
+						   execution->maxBatchSize : 10000;
 
 		/*
 		 * Iterate until all the tasks are finished. Once all the tasks
@@ -4099,8 +4236,12 @@ SendNextQuery(TaskPlacementExecution *placementExecution,
 		return false;
 	}
 
-	int singleRowMode = PQsetSingleRowMode(connection->pgConn);
-	if (singleRowMode == 0)
+#ifdef LIBPQ_HAS_CHUNK_MODE
+	int rowMode = PQsetChunkedRowsMode(connection->pgConn, ExecutorChunkSize);
+#else
+	int rowMode = PQsetSingleRowMode(connection->pgConn);
+#endif
+	if (rowMode == 0)
 	{
 		connection->connectionState = MULTI_CONNECTION_LOST;
 		return false;
@@ -4187,7 +4328,11 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 			placementExecution->queryIndex++;
 			continue;
 		}
-		else if (resultStatus != PGRES_SINGLE_TUPLE)
+		else if (resultStatus != PGRES_SINGLE_TUPLE
+#ifdef LIBPQ_HAS_CHUNK_MODE
+				 && resultStatus != PGRES_TUPLES_CHUNK
+#endif
+				 )
 		{
 			/* query failures are always hard errors */
 			ReportResultError(connection, result, ERROR);
@@ -5109,6 +5254,8 @@ CleanUpSessions(DistributedExecution *execution)
 									 "execution: %d", connection->connectionState)));
 		}
 	}
+
+	execution->sessionsCleanedUp = true;
 }
 
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -686,7 +686,7 @@ static DistributedExecution * CreateDistributedExecution(RowModifyLevel modLevel
 														 int targetPoolSize,
 														 TupleDestination *
 														 defaultTupleDest,
-														 TransactionProperties
+														 TransactionProperties *
 														 xactProperties,
 														 List *jobIdList,
 														 bool localExecutionSupported,
@@ -937,7 +937,7 @@ AdaptiveExecutorStart(CitusScanState *scanState)
 		paramListInfo,
 		targetPoolSize,
 		defaultTupleDest,
-		xactProperties,
+		&xactProperties,
 		jobIdList,
 		localExecutionSupported,
 		distributedPlan->useSortedMerge);
@@ -988,6 +988,48 @@ AdaptiveExecutorRun(CitusScanState *scanState)
 	{
 		/* if we need to sort the whole tuple store, run to completion */
 		bool runToCompletion = sortTupleStore;
+
+		/*
+		 * Disable batching inside a coordinated transaction.
+		 *
+		 * The batched/streaming path may cancel an in-flight worker query
+		 * (e.g. plain LIMIT satisfied with no Sort barrier above the Citus
+		 * scan, EXPLAIN ANALYZE finishing instrumentation, error between
+		 * batches). The cancel leaves the worker's PostgreSQL transaction
+		 * in PQTRANS_INERROR, which is sticky inside a transaction block;
+		 * the only recovery is ROLLBACK or ROLLBACK TO SAVEPOINT to a
+		 * savepoint established before the cancelled statement, and Citus
+		 * does not emit a per-statement savepoint on workers today. The
+		 * connection therefore becomes unusable for the remainder of the
+		 * coordinated transaction and surfaces as one of:
+		 *
+		 *  - "failure on connection marked as essential" at COMMIT (rolls
+		 *    back the entire outer transaction, including prior writes);
+		 *  - "unable to recover from inconsistent state in the connection
+		 *    state machine on coordinator" on the next leg of a multi-leg
+		 *    distributed operation (recursively-planned subquery feed of
+		 *    INSERT..SELECT, CTE feeding a downstream write);
+		 *  - "cannot perform query, because modifications were made over a
+		 *    connection that cannot be used at this time" on the next
+		 *    statement reusing the same connection (EXPLAIN ANALYZE DML
+		 *    inside a transaction block).
+		 *
+		 * runToCompletion drains every task to its tuple store before the
+		 * executor returns, so no cancel is ever sent and the connection
+		 * stays in PQTRANS_INTRANS. The cost is buffering the full result
+		 * (potentially spilling to a temporary file if it exceeds work_mem).
+		 * Top-level statements in autocommit mode -- the primary target of
+		 * the batched executor -- still stream.
+		 *
+		 * Future work: preserve streaming inside coordinated transactions
+		 * by emitting a Citus-owned per-statement savepoint and using
+		 * ROLLBACK TO SAVEPOINT in AdaptiveExecutorEnd to recover the
+		 * connection after cancel.
+		 */
+		if (InCoordinatedTransaction())
+		{
+			runToCompletion = true;
+		}
 
 		RunDistributedExecution(execution, runToCompletion);
 
@@ -1096,11 +1138,31 @@ AdaptiveExecutorEnd(CitusScanState *scanState)
 
 
 /*
+ * EagerAdaptiveExecutor runs the full distributed execution eagerly
+ * (all tuples fetched in a single batch). This is used by sorted-merge
+ * plans which need all per-task tuple stores filled before the merge
+ * adapter can produce globally-sorted output.
+ */
+void
+EagerAdaptiveExecutor(CitusScanState *scanState)
+{
+	AdaptiveExecutorStart(scanState);
+	scanState->execution->maxBatchSize = INT_MAX;
+	scanState->finishedRemoteScan = AdaptiveExecutorRun(scanState);
+}
+
+
+/*
  * CalculateMaxBatchSize computes the number of rows per batch based on
  * the GUC citus.executor_batch_size and work_mem.
  *
  * If ExecutorBatchSize > 0, use it directly. Otherwise, estimate the
  * tuple size from the TupleDesc and derive a batch size from work_mem.
+ *
+ * Note: the batch size is a soft limit. ReceiveResults() processes an
+ * entire PQgetResult() chunk (up to ExecutorChunkSize rows on PG17+)
+ * before the batch limit is re-checked, so the actual number of rows
+ * in the tuplestore may exceed maxBatchSize by up to one chunk.
  */
 static int
 CalculateMaxBatchSize(TupleDesc tupleDescriptor)
@@ -1118,17 +1180,19 @@ CalculateMaxBatchSize(TupleDesc tupleDescriptor)
 		Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, i);
 		if (attr->attlen > 0)
 		{
+			/* fixed-width type: use exact length */
 			estimatedTupleSize += attr->attlen;
-		}
-		else if (attr->atttypmod > 0)
-		{
-			/* for varchar(N), typmod encodes max length */
-			estimatedTupleSize += attr->atttypmod;
 		}
 		else
 		{
-			/* default estimate for unbounded varlena */
-			estimatedTupleSize += 128;
+			/*
+			 * Variable-length type: use get_typavgwidth() which handles
+			 * type-specific typmod interpretation correctly (e.g. numeric
+			 * precision/scale, varchar character limits, bit counts).
+			 * Falls back to a reasonable default when no statistics exist.
+			 */
+			estimatedTupleSize += get_typavgwidth(attr->atttypid,
+												  attr->atttypmod);
 		}
 	}
 
@@ -1345,7 +1409,7 @@ ExecuteTaskListExtended(ExecutionParams *executionParams)
 		CreateDistributedExecution(
 			executionParams->modLevel, executionParams->taskList,
 			executionParams->paramListInfo, executionParams->targetPoolSize,
-			defaultTupleDest, executionParams->xactProperties,
+			defaultTupleDest, &executionParams->xactProperties,
 			executionParams->jobIdList, executionParams->localExecutionSupported,
 			false);
 
@@ -1423,7 +1487,7 @@ CreateDistributedExecution(RowModifyLevel modLevel, List *taskList,
 
 	execution->modLevel = modLevel;
 	execution->remoteAndLocalTaskList = taskList;
-	execution->transactionProperties = xactProperties;
+	execution->transactionProperties = *xactProperties;
 
 	/* we are going to calculate this values below */
 	execution->localTaskList = NIL;
@@ -2179,8 +2243,6 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
 static void
 RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 {
-	WaitEvent *events = NULL;
-
 	PG_TRY();
 	{
 		/* Preemptively step state machines in case of immediate errors */
@@ -2199,8 +2261,9 @@ RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 		}
 		execution->rowsReceivedInCurrentRun = 0;
 
-		int maxBatchSize = execution->maxBatchSize > 0 ?
-						   execution->maxBatchSize : 10000;
+		/* maxBatchSize is always > 0: either the GUC value or >= 100 from auto-calculation */
+		Assert(execution->maxBatchSize > 0 || toCompletion);
+		int maxBatchSize = execution->maxBatchSize;
 
 		/*
 		 * Iterate until all the tasks are finished. Once all the tasks
@@ -2275,11 +2338,6 @@ RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 
 			ProcessWaitEvents(execution, execution->events, eventCount,
 							  &cancellationReceived);
-		}
-
-		if (events != NULL)
-		{
-			pfree(events);
 		}
 
 		/*

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -548,7 +548,7 @@ bool PreventIncompleteConnectionEstablishment = true;
 /* GUC, number of rows per batch (0 = auto from work_mem) */
 int ExecutorBatchSize = 0;
 
-/* GUC, libpq chunk size in bytes for chunked row mode (PG17+) */
+/* GUC, max rows per PQgetResult() chunk in chunked row mode (PG17+) */
 int ExecutorChunkSize = 8192;
 
 
@@ -1670,6 +1670,9 @@ DistributedExecutionModifiesDatabase(DistributedExecution *execution)
 static void
 FinishDistributedExecution(DistributedExecution *execution)
 {
+	/* Free WaitEventSet that may have been preserved across batches */
+	FreeExecutionWaitEvents(execution);
+
 	if (!execution->sessionsCleanedUp)
 	{
 		CleanUpSessions(execution);
@@ -2189,8 +2192,11 @@ RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 
 		bool cancellationReceived = false;
 
-		/* always (re)build the wait event set the first time */
-		execution->rebuildWaitEventSet = true;
+		/* build the wait event set on first entry; reuse across batches */
+		if (execution->waitEventSet == NULL)
+		{
+			execution->rebuildWaitEventSet = true;
+		}
 		execution->rowsReceivedInCurrentRun = 0;
 
 		int maxBatchSize = execution->maxBatchSize > 0 ?
@@ -2276,10 +2282,14 @@ RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 			pfree(events);
 		}
 
-		if (execution->waitEventSet != NULL)
+		/*
+		 * Only free the WaitEventSet when running to completion.
+		 * For batched execution, preserve it across re-entries to
+		 * avoid expensive epoll_create/close syscalls per batch.
+		 */
+		if (toCompletion)
 		{
-			FreeWaitEventSet(execution->waitEventSet);
-			execution->waitEventSet = NULL;
+			FreeExecutionWaitEvents(execution);
 		}
 	}
 	PG_CATCH();

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -275,7 +275,7 @@ typedef struct DistributedExecution
 	bool raiseInterrupts;
 
 	/* transactional properties of the current execution */
-	TransactionProperties *transactionProperties;
+	TransactionProperties transactionProperties;
 
 	/* indicates whether distributed execution has failed */
 	bool failed;
@@ -290,6 +290,13 @@ typedef struct DistributedExecution
 	 * a single replica's rows that are processed.
 	 */
 	uint64 rowsProcessed;
+
+	/*
+	 * RunDistributedExecution can be called multiple time to perform partial
+	 * execution. In that case, rowsReceivedInCurrentRun contains the number
+	 * of rows received.
+	 */
+	uint64 rowsReceivedInCurrentRun;
 
 	/*
 	 * The following fields are used while receiving results from remote nodes.
@@ -326,6 +333,11 @@ typedef struct DistributedExecution
 	 * run, and the executor reads from the adapter on first fetch.
 	 */
 	bool useSortedMerge;
+
+	/*
+	* Memory context for the execution.
+	 */
+	MemoryContext memoryContext;
 } DistributedExecution;
 
 
@@ -649,7 +661,7 @@ static DistributedExecution * CreateDistributedExecution(RowModifyLevel modLevel
 														 int targetPoolSize,
 														 TupleDestination *
 														 defaultTupleDest,
-														 TransactionProperties *
+														 TransactionProperties
 														 xactProperties,
 														 List *jobIdList,
 														 bool localExecutionSupported,
@@ -661,7 +673,7 @@ static TransactionProperties DecideTaskListTransactionProperties(RowModifyLevel
 																 excludeFromTransaction);
 static void StartDistributedExecution(DistributedExecution *execution);
 static void RunLocalExecution(CitusScanState *scanState, DistributedExecution *execution);
-static void RunDistributedExecution(DistributedExecution *execution);
+static void RunDistributedExecution(DistributedExecution *execution, bool toCompletion);
 static void SequentialRunDistributedExecution(DistributedExecution *execution);
 static void FinishDistributedExecution(DistributedExecution *execution);
 static void CleanUpSessions(DistributedExecution *execution);
@@ -783,11 +795,9 @@ AdaptiveExecutorPreExecutorRun(CitusScanState *scanState)
  * first call of CitusExecScan. The function fills the tupleStore
  * of the input scanScate.
  */
-TupleTableSlot *
-AdaptiveExecutor(CitusScanState *scanState)
+void
+AdaptiveExecutorStart(CitusScanState *scanState)
 {
-	TupleTableSlot *resultSlot = NULL;
-
 	DistributedPlan *distributedPlan = scanState->distributedPlan;
 	EState *executorState = ScanStateGetExecutorState(scanState);
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
@@ -802,14 +812,10 @@ AdaptiveExecutor(CitusScanState *scanState)
 	/* we should only call this once before the scan finished */
 	Assert(!scanState->finishedRemoteScan);
 
-	MemoryContext localContext = AllocSetContextCreate(CurrentMemoryContext,
-													   "AdaptiveExecutor",
-													   ALLOCSET_DEFAULT_SIZES);
-	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
-
-
-	/* Reset Task fields that are only valid for a single execution */
-	ResetExplainAnalyzeData(taskList);
+	MemoryContext memoryContext = AllocSetContextCreate(executorState->es_query_cxt,
+														"AdaptiveExecutor",
+														ALLOCSET_DEFAULT_SIZES);
+	MemoryContext oldContext = MemoryContextSwitchTo(memoryContext);
 
 	TupleDesc tupleDescriptor = ScanStateGetTupleDescriptor(scanState);
 	TupleDestination *defaultTupleDest = NULL;
@@ -846,6 +852,9 @@ AdaptiveExecutor(CitusScanState *scanState)
 	}
 
 	bool localExecutionSupported = true;
+
+	/* Reset Task fields that are only valid for a single execution */
+	ResetExplainAnalyzeData(taskList);
 
 	if (RequestedForExplainAnalyze(scanState))
 	{
@@ -902,7 +911,7 @@ AdaptiveExecutor(CitusScanState *scanState)
 		paramListInfo,
 		targetPoolSize,
 		defaultTupleDest,
-		&xactProperties,
+		xactProperties,
 		jobIdList,
 		localExecutionSupported,
 		distributedPlan->useSortedMerge);
@@ -913,13 +922,53 @@ AdaptiveExecutor(CitusScanState *scanState)
 	 */
 	StartDistributedExecution(execution);
 
+	/* store the execution in the custom scan state */
+	scanState->execution = execution;
+
+	execution->memoryContext = MemoryContextSwitchTo(oldContext);
+}
+
+
+bool
+AdaptiveExecutorRun(CitusScanState *scanState)
+{
+	DistributedExecution *execution = scanState->execution;
+	DistributedPlan *distributedPlan = scanState->distributedPlan;
+	Job *job = distributedPlan->workerJob;
+	CmdType commandType = job->jobQuery->commandType;
+
+	Assert(execution != NULL);
+
+	MemoryContext oldContext = MemoryContextSwitchTo(execution->memoryContext);
+
+	EState *executorState = ScanStateGetExecutorState(scanState);
+	bool sortTupleStore = false;
+
+	if (SortReturning && distributedPlan->expectResults && commandType != CMD_SELECT)
+	{
+		/* sort the tuple store to get consistent DML output in tests */
+		sortTupleStore = true;
+	}
+
 	if (ShouldRunTasksSequentially(execution->remoteTaskList))
 	{
+		/* sequential execution always runs to completion */
 		SequentialRunDistributedExecution(execution);
 	}
 	else
 	{
-		RunDistributedExecution(execution);
+		/* if we need to sort the whole tuple store, run to completino */
+		bool runToCompletion = sortTupleStore;
+
+		RunDistributedExecution(execution, runToCompletion);
+
+		if (execution->unfinishedTaskCount > 0)
+		{
+			MemoryContextSwitchTo(oldContext);
+			return false;
+		}
+
+		/* done with remote tasks, finish the execution */
 	}
 
 	/* execute tasks local to the node (if any) */
@@ -929,7 +978,6 @@ AdaptiveExecutor(CitusScanState *scanState)
 		RunLocalExecution(scanState, execution);
 	}
 
-	CmdType commandType = job->jobQuery->commandType;
 	if (commandType != CMD_SELECT)
 	{
 		executorState->es_processed = execution->rowsProcessed;
@@ -950,14 +998,14 @@ AdaptiveExecutor(CitusScanState *scanState)
 		ClearPerTaskDispatchDests(scanState);
 	}
 
-	if (SortReturning && distributedPlan->expectResults && commandType != CMD_SELECT)
+	if (sortTupleStore)
 	{
 		SortTupleStore(scanState);
 	}
 
 	MemoryContextSwitchTo(oldContext);
 
-	return resultSlot;
+	return true;
 }
 
 
@@ -1157,7 +1205,7 @@ ExecuteTaskListExtended(ExecutionParams *executionParams)
 		CreateDistributedExecution(
 			executionParams->modLevel, executionParams->taskList,
 			executionParams->paramListInfo, executionParams->targetPoolSize,
-			defaultTupleDest, &executionParams->xactProperties,
+			defaultTupleDest, executionParams->xactProperties,
 			executionParams->jobIdList, executionParams->localExecutionSupported,
 			false);
 
@@ -1171,7 +1219,10 @@ ExecuteTaskListExtended(ExecutionParams *executionParams)
 
 	/* run the remote execution */
 	StartDistributedExecution(execution);
-	RunDistributedExecution(execution);
+
+	bool runToCompletion = true;
+	RunDistributedExecution(execution, runToCompletion);
+
 	FinishDistributedExecution(execution);
 
 	/* now, switch back to the local execution */
@@ -1391,7 +1442,7 @@ DecideTaskListTransactionProperties(RowModifyLevel modLevel, List *taskList, boo
 void
 StartDistributedExecution(DistributedExecution *execution)
 {
-	TransactionProperties *xactProperties = execution->transactionProperties;
+	TransactionProperties *xactProperties = &(execution->transactionProperties);
 
 	if (xactProperties->useRemoteTransactionBlocks == TRANSACTION_BLOCKS_REQUIRED)
 	{
@@ -1443,6 +1494,20 @@ StartDistributedExecution(DistributedExecution *execution)
 		bool isRemote = true;
 		EnsureTaskExecutionAllowed(isRemote);
 	}
+
+	/*
+	 * We skip AssignTasksToConnectionsOrWorkerPool for sequential executions,
+	 * because we do it separately for each task in SequentialRunDistributedExecution.
+	 */
+	if (!ShouldRunTasksSequentially(execution->remoteTaskList))
+	{
+		/*
+		 * If a (co-located) shard placement was accessed over a session earier in the
+		 * transaction, assign the task to the same session. Otherwise, assign it to
+		 * the general worker pool(s).
+		 */
+		AssignTasksToConnectionsOrWorkerPool(execution);
+	}
 }
 
 
@@ -1465,6 +1530,14 @@ DistributedExecutionModifiesDatabase(DistributedExecution *execution)
 static void
 FinishDistributedExecution(DistributedExecution *execution)
 {
+	/*
+	 * Sequential executions unclaim connections separately.
+	 */
+	if (!ShouldRunTasksSequentially(execution->remoteTaskList))
+	{
+		CleanUpSessions(execution);
+	}
+
 	if (DistributedExecutionModifiesDatabase(execution))
 	{
 		/* prevent copying shards in same transaction */
@@ -1550,7 +1623,7 @@ AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution)
 			List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
 			MultiConnection *connection = NULL;
-			if (execution->transactionProperties->useRemoteTransactionBlocks !=
+			if (execution->transactionProperties.useRemoteTransactionBlocks !=
 				TRANSACTION_BLOCKS_DISALLOWED)
 			{
 				/*
@@ -1934,8 +2007,20 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
 			break;
 		}
 
+		/*
+		 * We skipped AssignTasksToConnectionsOrWorkerPool in StartDistributedExecution
+		 * when all the tasks were in the execution. Do it now instead.
+		 */
+		AssignTasksToConnectionsOrWorkerPool(execution);
+
 		/* simply call the regular execution function */
-		RunDistributedExecution(execution);
+		bool runToCompletion = true;
+		RunDistributedExecution(execution, runToCompletion);
+
+		/*
+		 * Unclaim connections since the current execution is technically finished.
+		 */
+		CleanUpSessions(execution);
 	}
 
 	/* set back the original execution mode */
@@ -1952,9 +2037,9 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
  * has an event.
  */
 void
-RunDistributedExecution(DistributedExecution *execution)
+RunDistributedExecution(DistributedExecution *execution, bool toCompletion)
 {
-	AssignTasksToConnectionsOrWorkerPool(execution);
+	WaitEvent *events = NULL;
 
 	PG_TRY();
 	{
@@ -1969,6 +2054,10 @@ RunDistributedExecution(DistributedExecution *execution)
 
 		/* always (re)build the wait event set the first time */
 		execution->rebuildWaitEventSet = true;
+		execution->rowsReceivedInCurrentRun = 0;
+
+		/* TODO: GUC? be smart? */
+		int maxBatchSize = 10000;
 
 		/*
 		 * Iterate until all the tasks are finished. Once all the tasks
@@ -1988,8 +2077,10 @@ RunDistributedExecution(DistributedExecution *execution)
 		 * irrespective of the current status of the tasks or the connections.
 		 */
 		while (!cancellationReceived &&
-			   (execution->unfinishedTaskCount > 0 ||
-				HasIncompleteConnectionEstablishment(execution)))
+			   ((execution->unfinishedTaskCount > 0 ||
+				 HasIncompleteConnectionEstablishment(execution)) &&
+				(toCompletion ||
+				 execution->rowsReceivedInCurrentRun < maxBatchSize)))
 		{
 			WorkerPool *workerPool = NULL;
 			foreach_declared_ptr(workerPool, execution->workerList)
@@ -2043,9 +2134,16 @@ RunDistributedExecution(DistributedExecution *execution)
 							  &cancellationReceived);
 		}
 
-		FreeExecutionWaitEvents(execution);
+		if (events != NULL)
+		{
+			pfree(events);
+		}
 
-		CleanUpSessions(execution);
+		if (execution->waitEventSet != NULL)
+		{
+			FreeWaitEventSet(execution->waitEventSet);
+			execution->waitEventSet = NULL;
+		}
 	}
 	PG_CATCH();
 	{
@@ -2300,7 +2398,7 @@ ManageWorkerPool(WorkerPool *workerPool)
 	/* increase the open rate every cycle (like TCP slow start) */
 	workerPool->maxNewConnectionsPerCycle += 1;
 
-	OpenNewConnections(workerPool, newConnectionCount, execution->transactionProperties);
+	OpenNewConnections(workerPool, newConnectionCount, &execution->transactionProperties);
 
 	/*
 	 * Cannot establish new connections to the local host, most probably because the
@@ -2830,7 +2928,7 @@ CheckConnectionTimeout(WorkerPool *workerPool)
 				 */
 				logLevel = DEBUG1;
 			}
-			else if (execution->transactionProperties->errorOnAnyFailure ||
+			else if (execution->transactionProperties.errorOnAnyFailure ||
 					 execution->failed)
 			{
 				/*
@@ -3246,7 +3344,7 @@ ConnectionStateMachine(WorkerSession *session)
 
 				if (transaction->transactionCritical ||
 					execution->failed ||
-					(execution->transactionProperties->errorOnAnyFailure &&
+					(execution->transactionProperties.errorOnAnyFailure &&
 					 workerPool->failureState != WORKER_POOL_FAILED_OVER_TO_LOCAL))
 				{
 					/* a task has failed due to this connection failure */
@@ -3438,7 +3536,7 @@ TransactionModifiedDistributedTable(DistributedExecution *execution)
 	 * should not be pretending that we're in a coordinated transaction even
 	 * if XACT_MODIFICATION_DATA is set. That's why we implemented this workaround.
 	 */
-	return execution->transactionProperties->useRemoteTransactionBlocks ==
+	return execution->transactionProperties.useRemoteTransactionBlocks ==
 		   TRANSACTION_BLOCKS_REQUIRED &&
 		   XactModificationLevel == XACT_MODIFICATION_DATA;
 }
@@ -3453,7 +3551,7 @@ TransactionStateMachine(WorkerSession *session)
 	WorkerPool *workerPool = session->workerPool;
 	DistributedExecution *execution = workerPool->distributedExecution;
 	TransactionBlocksUsage useRemoteTransactionBlocks =
-		execution->transactionProperties->useRemoteTransactionBlocks;
+		execution->transactionProperties.useRemoteTransactionBlocks;
 
 	MultiConnection *connection = session->connection;
 	RemoteTransaction *transaction = &(connection->remoteTransaction);
@@ -3880,7 +3978,7 @@ StartPlacementExecutionOnSession(TaskPlacementExecution *placementExecution,
 	ShardPlacement *taskPlacement = placementExecution->shardPlacement;
 	List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
-	if (execution->transactionProperties->useRemoteTransactionBlocks !=
+	if (execution->transactionProperties.useRemoteTransactionBlocks !=
 		TRANSACTION_BLOCKS_DISALLOWED)
 	{
 		/*
@@ -4234,6 +4332,7 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 			MemoryContextReset(rowContext);
 
 			execution->rowsProcessed++;
+			execution->rowsReceivedInCurrentRun++;
 		}
 
 		PQclear(result);

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -304,14 +304,7 @@ CitusExecScan(CustomScanState *node)
 	{
 		bool isMultiTaskPlan = IsMultiTaskPlan(scanState->distributedPlan);
 
-		if (LegacyFallback)
-		{
-			EagerAdaptiveExecutor(scanState);
-		}
-		else
-		{
-			AdaptiveExecutorStart(scanState);
-		}
+		AdaptiveExecutorStart(scanState);
 
 		if (!scanState->distributedPlan->disableTrackingQueryCounters)
 		{
@@ -938,8 +931,6 @@ CitusEndScan(CustomScanState *node)
 
 	CitusEndScanCommon(scanState);
 
-	AdaptiveExecutorEnd(scanState);
-
 	if (scanState->tuplestorestate)
 	{
 		tuplestore_end(scanState->tuplestorestate);
@@ -957,10 +948,10 @@ CitusEndScan(CustomScanState *node)
 
 /*
  * SortedMergeExecScan is the per-row callback for sorted-merge plans.
- * On the first call CitusExecScanCommon runs the distributed query
- * (filling the per-task tuple stores attached to the streaming merge
- * adapter); subsequent calls just pull globally-sorted tuples directly
- * from the adapter via ReturnTupleFromSortedMerge.
+ * On the first call EagerAdaptiveExecutor runs the distributed query
+ * to completion (filling the per-task tuple stores attached to the
+ * streaming merge adapter); subsequent calls just pull globally-sorted
+ * tuples directly from the adapter via ReturnTupleFromSortedMerge.
  */
 static TupleTableSlot *
 SortedMergeExecScan(CustomScanState *node)
@@ -971,7 +962,7 @@ SortedMergeExecScan(CustomScanState *node)
 	{
 		bool isMultiTaskPlan = IsMultiTaskPlan(scanState->distributedPlan);
 
-		AdaptiveExecutor(scanState);
+		EagerAdaptiveExecutor(scanState);
 
 		if (!scanState->distributedPlan->disableTrackingQueryCounters)
 		{
@@ -984,8 +975,6 @@ SortedMergeExecScan(CustomScanState *node)
 				IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_SINGLE_SHARD);
 			}
 		}
-
-		scanState->finishedRemoteScan = true;
 	}
 
 	return ReturnTupleFromSortedMerge(scanState);

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -331,7 +331,6 @@ CitusExecScan(CustomScanState *node)
 	TupleTableSlot *resultSlot = ReturnTupleFromTuplestore(scanState);
 	if (TupIsNull(resultSlot) && !scanState->finishedRemoteScan)
 	{
-		/* clear the tuple store for the next batch */
 		tuplestore_clear(scanState->tuplestorestate);
 
 		scanState->finishedRemoteScan = AdaptiveExecutorRun(scanState);

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -25,6 +25,7 @@
 
 #include "pg_version_constants.h"
 
+#include "distributed/adaptive_executor.h"
 #include "distributed/backend_data.h"
 #include "distributed/citus_clauses.h"
 #include "distributed/citus_custom_scan.h"
@@ -78,7 +79,6 @@ static void CitusReScan(CustomScanState *node);
 static TupleTableSlot * SortedMergeExecScan(CustomScanState *node);
 static void SortedMergeEndScan(CustomScanState *node);
 static void SortedMergeReScan(CustomScanState *node);
-static void CitusExecScanCommon(CitusScanState *scanState);
 static void CitusEndScanCommon(CitusScanState *scanState);
 static void CitusReScanCommon(CustomScanState *node);
 static void EnsureForceDelegationDistributionKey(Job *job);
@@ -287,44 +287,6 @@ CitusPreExecScan(CitusScanState *scanState)
 
 
 /*
- * CitusExecScanCommon performs the first-call work shared by all Citus
- * custom-scan ExecCustomScan callbacks: it runs the distributed query
- * (filling the tuplestore or per-task stores attached to the streaming
- * merge adapter), increments the multi/single-shard query counter, and
- * marks the remote scan as finished. Subsequent calls are no-ops.
- *
- * Variant-specific tuple delivery (ReturnTupleFromTuplestore vs
- * ReturnTupleFromSortedMerge) is left to each caller.
- */
-static void
-CitusExecScanCommon(CitusScanState *scanState)
-{
-	if (scanState->finishedRemoteScan)
-	{
-		return;
-	}
-
-	bool isMultiTaskPlan = IsMultiTaskPlan(scanState->distributedPlan);
-
-	AdaptiveExecutor(scanState);
-
-	if (!scanState->distributedPlan->disableTrackingQueryCounters)
-	{
-		if (isMultiTaskPlan)
-		{
-			IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_MULTI_SHARD);
-		}
-		else
-		{
-			IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_SINGLE_SHARD);
-		}
-	}
-
-	scanState->finishedRemoteScan = true;
-}
-
-
-/*
  * CitusExecScan is called when a tuple is pulled from a non-sorted-merge
  * Citus custom scan. On the first call, it executes the distributed
  * query and fills the scan's tuplestore. The postgres executor calls
@@ -338,9 +300,46 @@ CitusExecScan(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
 
-	CitusExecScanCommon(scanState);
+	if (!scanState->executionStarted)
+	{
+		bool isMultiTaskPlan = IsMultiTaskPlan(scanState->distributedPlan);
 
-	return ReturnTupleFromTuplestore(scanState);
+		if (LegacyFallback)
+		{
+			EagerAdaptiveExecutor(scanState);
+		}
+		else
+		{
+			AdaptiveExecutorStart(scanState);
+		}
+
+		if (!scanState->distributedPlan->disableTrackingQueryCounters)
+		{
+			if (isMultiTaskPlan)
+			{
+				IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_MULTI_SHARD);
+			}
+			else
+			{
+				IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_SINGLE_SHARD);
+			}
+		}
+
+		scanState->executionStarted = true;
+	}
+
+	TupleTableSlot *resultSlot = ReturnTupleFromTuplestore(scanState);
+	if (TupIsNull(resultSlot) && !scanState->finishedRemoteScan)
+	{
+		/* clear the tuple store for the next batch */
+		tuplestore_clear(scanState->tuplestorestate);
+
+		scanState->finishedRemoteScan = AdaptiveExecutorRun(scanState);
+
+		resultSlot = ReturnTupleFromTuplestore(scanState);
+	}
+
+	return resultSlot;
 }
 
 
@@ -778,6 +777,7 @@ AdaptiveExecutorCreateScan(CustomScan *scan)
 
 	scanState->finishedPreScan = false;
 	scanState->finishedRemoteScan = false;
+	scanState->executionStarted = false;
 
 	return (Node *) scanState;
 }
@@ -939,6 +939,8 @@ CitusEndScan(CustomScanState *node)
 
 	CitusEndScanCommon(scanState);
 
+	AdaptiveExecutorEnd(scanState);
+
 	if (scanState->tuplestorestate)
 	{
 		tuplestore_end(scanState->tuplestorestate);
@@ -959,7 +961,26 @@ SortedMergeExecScan(CustomScanState *node)
 {
 	CitusScanState *scanState = (CitusScanState *) node;
 
-	CitusExecScanCommon(scanState);
+	if (!scanState->finishedRemoteScan)
+	{
+		bool isMultiTaskPlan = IsMultiTaskPlan(scanState->distributedPlan);
+
+		AdaptiveExecutor(scanState);
+
+		if (!scanState->distributedPlan->disableTrackingQueryCounters)
+		{
+			if (isMultiTaskPlan)
+			{
+				IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_MULTI_SHARD);
+			}
+			else
+			{
+				IncrementStatCounterForMyDb(STAT_QUERY_EXECUTION_SINGLE_SHARD);
+			}
+		}
+
+		scanState->finishedRemoteScan = true;
+	}
 
 	return ReturnTupleFromSortedMerge(scanState);
 }

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -946,6 +946,13 @@ CitusEndScan(CustomScanState *node)
 		tuplestore_end(scanState->tuplestorestate);
 		scanState->tuplestorestate = NULL;
 	}
+
+	/*
+	 * Clean up any in-flight distributed execution. This handles the case
+	 * where an error occurs between batches in the adaptive executor,
+	 * ensuring sessions and connections are properly released.
+	 */
+	AdaptiveExecutorEnd(scanState);
 }
 
 

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -94,7 +94,8 @@ static PlannedStmt * TryCreateDistributedPlannedStmt(PlannedStmt *localPlan,
 													 Query *query, ParamListInfo
 													 boundParams,
 													 PlannerRestrictionContext *
-													 plannerRestrictionContext);
+													 plannerRestrictionContext,
+													 int cursorOptions);
 static DeferredErrorMessage * DeferErrorIfPartitionTableNotSingleReplicated(Oid
 																			relationId);
 
@@ -866,7 +867,8 @@ CreateDistributedPlannedStmt(DistributedPlanningContext *planContext)
 	distributedPlan->planId = planId;
 
 	/* create final plan by combining local plan with distributed plan */
-	resultPlan = FinalizePlan(planContext->plan, distributedPlan);
+	resultPlan = FinalizePlan(planContext->plan, distributedPlan,
+							  planContext->cursorOptions);
 
 	/*
 	 * The streaming sorted merge adapter does not support backward scan.
@@ -931,7 +933,9 @@ InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
 														  planContext->query,
 														  planContext->boundParams,
 														  planContext->
-														  plannerRestrictionContext);
+														  plannerRestrictionContext,
+														  planContext->
+														  cursorOptions);
 
 	return result;
 }
@@ -947,7 +951,8 @@ static PlannedStmt *
 TryCreateDistributedPlannedStmt(PlannedStmt *localPlan,
 								Query *originalQuery,
 								Query *query, ParamListInfo boundParams,
-								PlannerRestrictionContext *plannerRestrictionContext)
+								PlannerRestrictionContext *plannerRestrictionContext,
+								int cursorOptions)
 {
 	MemoryContext savedContext = CurrentMemoryContext;
 	PlannedStmt *result = NULL;
@@ -959,6 +964,7 @@ TryCreateDistributedPlannedStmt(PlannedStmt *localPlan,
 	planContext->originalQuery = originalQuery;
 	planContext->query = query;
 	planContext->plannerRestrictionContext = plannerRestrictionContext;
+	planContext->cursorOptions = cursorOptions;
 
 
 	PG_TRY();
@@ -1466,7 +1472,8 @@ GetDistributedPlan(CustomScan *customScan)
  * which can be run by the PostgreSQL executor.
  */
 PlannedStmt *
-FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
+FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
+			 int cursorOptions)
 {
 	PlannedStmt *finalPlan = NULL;
 	CustomScan *customScan = makeNode(CustomScan);
@@ -1569,6 +1576,20 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan)
 	else
 	{
 		finalPlan = FinalizeRouterPlan(localPlan, customScan);
+	}
+
+	/*
+	 * For SCROLL cursors, wrap the plan in a Material node so that backward
+	 * scan works correctly with batched execution. PG's standard_planner()
+	 * already added a Material node, but Citus discarded the entire plan tree
+	 * above and replaced it with a CustomScan. Re-apply it here.
+	 *
+	 * Material is lazy (non-blocking): it fetches one tuple at a time from the
+	 * child and appends it to its own tuplestore, so batching is preserved.
+	 */
+	if (cursorOptions & CURSOR_OPT_SCROLL)
+	{
+		finalPlan->planTree = materialize_finished_plan(finalPlan->planTree);
 	}
 
 	return finalPlan;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -871,22 +871,6 @@ CreateDistributedPlannedStmt(DistributedPlanningContext *planContext)
 							  planContext->cursorOptions);
 
 	/*
-	 * The streaming sorted merge adapter does not support backward scan.
-	 * If the query is a SCROLL cursor, insert a Material node above the
-	 * plan tree so backward fetches work.
-	 *
-	 * Normally standard_planner() handles this (planner.c:447-451), but
-	 * Citus replaces the plan tree after standard_planner returns via
-	 * FinalizePlan(), losing any Material node it inserted.
-	 */
-	if ((planContext->cursorOptions & CURSOR_OPT_SCROLL) &&
-		distributedPlan->useSortedMerge &&
-		!ExecSupportsBackwardScan(resultPlan->planTree))
-	{
-		resultPlan->planTree = materialize_finished_plan(resultPlan->planTree);
-	}
-
-	/*
 	 * As explained above, force planning costs to be unrealistically high if
 	 * query planning failed (possibly) due to prepared statement parameters or
 	 * if it is planned as a multi shard modify query.
@@ -1540,18 +1524,8 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 
 	customScan->custom_private = list_make1(distributedPlanData);
 
-	/* necessary to avoid extra Result node in PG15 */
-	int customFlags = CUSTOMPATH_SUPPORT_PROJECTION;
-	if (!distributedPlan->useSortedMerge)
-	{
-		/*
-		 * Sorted-merge plans use the forward-only streaming adapter, so we
-		 * cannot advertise backward-scan support. PostgreSQL's planner will
-		 * insert a Material node above us for scrollable cursors.
-		 */
-		customFlags |= CUSTOMPATH_SUPPORT_BACKWARD_SCAN;
-	}
-	customScan->flags = customFlags;
+	/* CUSTOMPATH_SUPPORT_PROJECTION avoids an extra Result node in PG15+ */
+	customScan->flags = CUSTOMPATH_SUPPORT_PROJECTION;
 
 	/*
 	 * Fast path queries cannot have any subplans by definition, so skip
@@ -1587,7 +1561,8 @@ FinalizePlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 	 * Material is lazy (non-blocking): it fetches one tuple at a time from the
 	 * child and appends it to its own tuplestore, so batching is preserved.
 	 */
-	if (cursorOptions & CURSOR_OPT_SCROLL)
+	if ((cursorOptions & CURSOR_OPT_SCROLL) &&
+		!ExecSupportsBackwardScan(finalPlan->planTree))
 	{
 		finalPlan->planTree = materialize_finished_plan(finalPlan->planTree);
 	}

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -499,7 +499,8 @@ TryToDelegateFunctionCall(DistributedPlanningContext *planContext)
 	/* worker will take care of any necessary locking, treat query as read-only */
 	distributedPlan->modLevel = ROW_MODIFY_READONLY;
 
-	return FinalizePlan(planContext->plan, distributedPlan);
+	return FinalizePlan(planContext->plan, distributedPlan,
+						planContext->cursorOptions);
 }
 
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1713,6 +1713,31 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
+		"citus.executor_batch_size",
+		gettext_noop("Maximum number of rows per batch in the adaptive executor."),
+		gettext_noop("When set to 0 (the default), the batch size is automatically "
+					 "calculated from work_mem and the estimated tuple size. A positive "
+					 "value overrides the automatic calculation with a fixed row count."),
+		&ExecutorBatchSize,
+		0, 0, INT_MAX,
+		PGC_USERSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"citus.executor_chunk_size",
+		gettext_noop("Chunk size in bytes for libpq chunked row mode."),
+		gettext_noop("Controls the chunk size passed to PQsetChunkedRowsMode when "
+					 "fetching rows from workers. Larger values reduce per-result "
+					 "overhead but increase memory usage per fetch. Only effective "
+					 "on PostgreSQL 17 and later."),
+		&ExecutorChunkSize,
+		8192, 1, INT_MAX,
+		PGC_USERSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
 		"citus.executor_slow_start_interval",
 		gettext_noop("Time to wait between opening connections to the same worker node"),
 		gettext_noop("When the individual tasks of a multi-shard query take very "

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1716,8 +1716,13 @@ RegisterCitusConfigVariables(void)
 		"citus.executor_batch_size",
 		gettext_noop("Maximum number of rows per batch in the adaptive executor."),
 		gettext_noop("When set to 0 (the default), the batch size is automatically "
-					 "calculated from work_mem and the estimated tuple size. A positive "
-					 "value overrides the automatic calculation with a fixed row count."),
+					 "calculated from work_mem and the estimated tuple size. This is a "
+					 "soft limit because a full result chunk from a worker is always "
+					 "processed atomically, so the actual number of rows per batch can "
+					 "exceed the estimate by the value of citus.executor_chunk_size. "
+					 "A non-zero value overrides the automatic calculation with a fixed "
+					 "row count. Small values (e.g. 1) can cause extreme overhead and"
+					 " should only be used for testing."),
 		&ExecutorBatchSize,
 		0, 0, INT_MAX,
 		PGC_USERSET,
@@ -1726,11 +1731,13 @@ RegisterCitusConfigVariables(void)
 
 	DefineCustomIntVariable(
 		"citus.executor_chunk_size",
-		gettext_noop("Chunk size in bytes for libpq chunked row mode."),
-		gettext_noop("Controls the chunk size passed to PQsetChunkedRowsMode when "
-					 "fetching rows from workers. Larger values reduce per-result "
-					 "overhead but increase memory usage per fetch. Only effective "
-					 "on PostgreSQL 17 and later."),
+		gettext_noop("Chunk size in rows for libpq chunked row mode."),
+		gettext_noop(
+			"Controls the number of rows per chunk passed to PQsetChunkedRowsMode "
+			"when fetching rows from workers. Larger values reduce per-result "
+			"overhead but increase memory usage per fetch. Only effective "
+			"on PostgreSQL 17 and later. A value of 1 is equivalent to "
+			"single-row mode."),
 		&ExecutorChunkSize,
 		8192, 1, INT_MAX,
 		PGC_USERSET,

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -10,6 +10,11 @@ extern bool ForceMaxQueryParallelization;
 extern int MaxAdaptiveExecutorPoolSize;
 extern bool EnableBinaryProtocol;
 
+/* GUC, number of rows per batch (0 = auto from work_mem) */
+extern int ExecutorBatchSize;
+
+/* GUC, libpq chunk size in bytes for chunked row mode (PG17+) */
+extern int ExecutorChunkSize;
 
 /* GUC, number of ms to wait between opening connections to the same worker */
 extern int ExecutorSlowStartInterval;
@@ -19,6 +24,7 @@ extern bool PreventIncompleteConnectionEstablishment;
 extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
 extern void AdaptiveExecutorStart(CitusScanState *scanState);
 extern bool AdaptiveExecutorRun(CitusScanState *scanState);
+extern void AdaptiveExecutorEnd(CitusScanState *scanState);
 extern bool ShouldRunTasksSequentially(List *taskList);
 extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList);
 extern uint64 ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported);

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -1,7 +1,9 @@
 #ifndef ADAPTIVE_EXECUTOR_H
 #define ADAPTIVE_EXECUTOR_H
 
+#include "distributed/citus_custom_scan.h"
 #include "distributed/multi_physical_planner.h"
+
 
 /* GUC, determining whether Citus opens 1 connection per task */
 extern bool ForceMaxQueryParallelization;
@@ -14,6 +16,10 @@ extern int ExecutorSlowStartInterval;
 extern bool EnableCostBasedConnectionEstablishment;
 extern bool PreventIncompleteConnectionEstablishment;
 
+extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
+extern void AdaptiveExecutorStart(CitusScanState *scanState);
+extern bool AdaptiveExecutorRun(CitusScanState *scanState);
+extern bool ShouldRunTasksSequentially(List *taskList);
 extern uint64 ExecuteTaskList(RowModifyLevel modLevel, List *taskList);
 extern uint64 ExecuteUtilityTaskList(List *utilityTaskList, bool localExecutionSupported);
 extern uint64 ExecuteUtilityTaskListExtended(List *utilityTaskList, int poolSize,

--- a/src/include/distributed/adaptive_executor.h
+++ b/src/include/distributed/adaptive_executor.h
@@ -13,7 +13,7 @@ extern bool EnableBinaryProtocol;
 /* GUC, number of rows per batch (0 = auto from work_mem) */
 extern int ExecutorBatchSize;
 
-/* GUC, libpq chunk size in bytes for chunked row mode (PG17+) */
+/* GUC, libpq chunk size in rows for chunked row mode (PG17+) */
 extern int ExecutorChunkSize;
 
 /* GUC, number of ms to wait between opening connections to the same worker */
@@ -33,5 +33,6 @@ extern uint64 ExecuteUtilityTaskListExtended(List *utilityTaskList, int poolSize
 extern uint64 ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
 												int targetPoolSize, List *jobIdList);
 
+extern void EagerAdaptiveExecutor(CitusScanState *scanState);
 
 #endif /* ADAPTIVE_EXECUTOR_H */

--- a/src/include/distributed/citus_custom_scan.h
+++ b/src/include/distributed/citus_custom_scan.h
@@ -16,6 +16,8 @@
 #include "distributed/distributed_planner.h"
 #include "distributed/multi_server_executor.h"
 
+struct DistributedExecution;
+
 typedef struct CitusScanState
 {
 	CustomScanState customScanState;  /* underlying custom scan node */
@@ -27,10 +29,14 @@ typedef struct CitusScanState
 	DistributedPlan *distributedPlan; /* distributed execution plan */
 	MultiExecutorType executorType;   /* distributed executor type */
 	bool finishedRemoteScan;          /* flag to check if remote scan is finished */
+	bool executionStarted;            /* flag to check whether execution started */
 	Tuplestorestate *tuplestorestate; /* tuple store to store distributed results */
 
 	/* streaming sorted merge adapter (NULL when not using sorted merge) */
 	struct SortedMergeAdapter *mergeAdapter;
+
+	/* execution state when using adaptive executor */
+	struct DistributedExecution *execution;
 } CitusScanState;
 
 

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -279,7 +279,8 @@ extern LOCKMODE GetQueryLockMode(Query *query);
 extern int32 BlessRecordExpression(Expr *expr);
 extern void DissuadePlannerFromUsingPlan(PlannedStmt *plan);
 extern PlannedStmt * FinalizePlan(PlannedStmt *localPlan,
-								  struct DistributedPlan *distributedPlan);
+								  struct DistributedPlan *distributedPlan,
+								  int cursorOptions);
 extern void DisableTrackingQueryCountersForPlannedStmt(PlannedStmt *plannedStmt);
 extern bool ContainsSingleShardTable(Query *query);
 extern RTEListProperties * GetRTEListPropertiesForQuery(Query *query);

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -77,8 +77,6 @@ extern int ExecutorLevel;
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 							 bool execute_once);
-extern void AdaptiveExecutorPreExecutorRun(CitusScanState *scanState);
-extern TupleTableSlot * AdaptiveExecutor(CitusScanState *scanState);
 
 
 /*

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -273,6 +273,9 @@ DEPS = {
     "multi_subquery_in_where_reference_clause": TestDeps(
         "minimal_schedule", ["multi_behavioral_analytics_create_table"]
     ),
+    "adaptive_executor_batching": TestDeps(
+        "minimal_schedule", ["multi_behavioral_analytics_create_table"]
+    ),
     "subquery_in_where": TestDeps(
         "minimal_schedule", ["multi_behavioral_analytics_create_table"]
     ),

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -228,6 +228,7 @@ DEPS = {
         repeatable=False,
     ),
     "multi_prepare_plsql": TestDeps("base_schedule"),
+    "multi_utility_statements": TestDeps("base_schedule"),
     "pg15": TestDeps("base_schedule"),
     "foreign_key_to_reference_shard_rebalance": TestDeps(
         "minimal_schedule", ["remove_coordinator_from_metadata"]

--- a/src/test/regress/expected/adaptive_executor_batching.out
+++ b/src/test/regress/expected/adaptive_executor_batching.out
@@ -1,0 +1,300 @@
+--
+-- Tests for the batched adaptive executor (reentrant execution)
+--
+CREATE SCHEMA adaptive_executor_batching;
+SET search_path TO adaptive_executor_batching;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 802009000;
+CREATE TABLE batch_test (x int, y text);
+SELECT create_distributed_table('batch_test', 'x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Insert enough rows to exercise multiple batches
+INSERT INTO batch_test SELECT i, 'row_' || i FROM generate_series(1, 200) i;
+-- Verify baseline: all rows present
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+--
+-- Test 1: Force small batch size and verify all rows are returned
+--
+SET citus.executor_batch_size TO 10;
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+-- Ordered output to verify correctness across batches
+SELECT x FROM batch_test WHERE x <= 20 ORDER BY x;
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+--
+-- Test 2: Batch size of 1 (extreme case)
+--
+SET citus.executor_batch_size TO 1;
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+SELECT x FROM batch_test WHERE x <= 5 ORDER BY x;
+ x
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+--
+-- Test 3: Batch size larger than result set (single batch)
+--
+SET citus.executor_batch_size TO 100000;
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+--
+-- Test 4: Auto batch size (from work_mem)
+--
+SET citus.executor_batch_size TO 0;
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+--
+-- Test 5: Empty result set with batching
+--
+SET citus.executor_batch_size TO 10;
+SELECT count(*) FROM batch_test WHERE x > 9999;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+--
+-- Test 6: LIMIT with batching
+--
+SELECT x FROM batch_test ORDER BY x LIMIT 5;
+ x
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+--
+-- Test 7: Aggregation across batches
+--
+SELECT sum(x), min(x), max(x) FROM batch_test;
+  sum  | min | max
+---------------------------------------------------------------------
+ 20100 |   1 | 200
+(1 row)
+
+--
+-- Test 8: DML with RETURNING across batches
+--
+SET citus.executor_batch_size TO 10;
+-- Use a separate table for DML test
+CREATE TABLE batch_dml_test (x int, y text);
+SELECT create_distributed_table('batch_dml_test', 'x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO batch_dml_test SELECT i, 'val_' || i FROM generate_series(1, 50) i;
+WITH deleted AS (
+    DELETE FROM batch_dml_test WHERE x <= 20 RETURNING x
+)
+SELECT count(*) FROM deleted;
+ count
+---------------------------------------------------------------------
+    20
+(1 row)
+
+SELECT count(*) FROM batch_dml_test WHERE x <= 20;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+--
+-- Test 9: Verify GUC is session-level
+--
+SHOW citus.executor_batch_size;
+ citus.executor_batch_size
+---------------------------------------------------------------------
+ 10
+(1 row)
+
+SET citus.executor_batch_size TO 500;
+SHOW citus.executor_batch_size;
+ citus.executor_batch_size
+---------------------------------------------------------------------
+ 500
+(1 row)
+
+RESET citus.executor_batch_size;
+SHOW citus.executor_batch_size;
+ citus.executor_batch_size
+---------------------------------------------------------------------
+ 0
+(1 row)
+
+--
+-- Test 10: M1 — Between-batch error cleanup (CitusEndScan must release sessions)
+--
+-- This validates that when an error occurs on the coordinator between
+-- AdaptiveExecutorRun calls (mid-scan, mid-batch), CitusEndScan properly
+-- cleans up distributed execution sessions via AdaptiveExecutorEnd.
+-- Without the M1 fix, sessions/connections would leak on each error.
+--
+SET citus.executor_batch_size TO 10;
+-- Helper: iterates a distributed query and raises error after N rows.
+-- With batch_size=10 and error at row 15, the error fires during
+-- the second batch — between the first AdaptiveExecutorRun (which
+-- returned control to the executor) and the scan completing.
+CREATE OR REPLACE FUNCTION trigger_between_batch_error(fail_after int)
+RETURNS void AS $$
+DECLARE
+    r RECORD;
+    cnt int := 0;
+BEGIN
+    FOR r IN SELECT x FROM batch_test ORDER BY x LOOP
+        cnt := cnt + 1;
+        IF cnt >= fail_after THEN
+            RAISE EXCEPTION 'intentional error at row %', cnt;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+-- Single invocation: error should be caught cleanly
+DO $$
+BEGIN
+    PERFORM trigger_between_batch_error(15);
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'caught: %', SQLERRM;
+END;
+$$;
+NOTICE:  caught: intentional error at row 15
+CONTEXT:  PL/pgSQL function inline_code_block line XX at RAISE
+-- Repeat 20 times to verify connections don't accumulate across errors.
+-- If CitusEndScan didn't clean up, we'd exhaust the connection pool.
+DO $$
+BEGIN
+    FOR i IN 1..20 LOOP
+        BEGIN
+            PERFORM trigger_between_batch_error(15);
+        EXCEPTION WHEN OTHERS THEN
+            -- expected, swallow
+        END;
+    END LOOP;
+END;
+$$;
+-- After 20 error cycles, distributed queries must still work
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+-- Also verify with a cursor closed mid-batch (non-error path through
+-- CitusEndScan with finishedRemoteScan = false)
+BEGIN;
+DECLARE c CURSOR FOR SELECT x FROM batch_test ORDER BY x;
+FETCH 5 FROM c;
+ x
+---------------------------------------------------------------------
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+CLOSE c;
+COMMIT;
+-- Still healthy after cursor close mid-batch
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+--
+-- Test 11: Cross-batch-size result consistency
+--
+-- Runs the same analytical queries at batch sizes 1, 10, 100, 10000, and 0
+-- (auto) and asserts identical results. Any batch-boundary bug would cause
+-- a mismatch.
+--
+CREATE TABLE batch_consistency AS
+SELECT
+    bs,
+    (SELECT count(*) FROM batch_test)::bigint AS cnt,
+    (SELECT sum(x) FROM batch_test)::bigint AS s,
+    (SELECT min(x) FROM batch_test)::int AS mn,
+    (SELECT max(x) FROM batch_test)::int AS mx,
+    (SELECT count(*) FROM batch_test WHERE x BETWEEN 50 AND 150)::bigint AS range_cnt
+FROM (SELECT unnest(ARRAY[1, 10, 100, 10000]) bs) sizes,
+LATERAL (SELECT set_config('citus.executor_batch_size', bs::text, false)) AS apply;
+-- All batch sizes must produce the same result — collapse to 1 distinct row
+SELECT count(DISTINCT (cnt, s, mn, mx, range_cnt)) AS distinct_results FROM batch_consistency;
+ distinct_results
+---------------------------------------------------------------------
+                1
+(1 row)
+
+-- Show the actual values (should be a single row)
+SELECT DISTINCT cnt, s, mn, mx, range_cnt FROM batch_consistency;
+ cnt |   s   | mn | mx  | range_cnt
+---------------------------------------------------------------------
+ 200 | 20100 |  1 | 200 |       101
+(1 row)
+
+DROP TABLE batch_consistency;
+--
+-- Cleanup
+--
+SET client_min_messages TO WARNING;
+DROP SCHEMA adaptive_executor_batching CASCADE;

--- a/src/test/regress/expected/adaptive_executor_batching.out
+++ b/src/test/regress/expected/adaptive_executor_batching.out
@@ -131,6 +131,926 @@ SELECT sum(x), min(x), max(x) FROM batch_test;
 (1 row)
 
 --
+-- Additional tables for join / subquery / CTE tests
+--
+CREATE TABLE batch_orders (
+    order_id int,
+    customer_id int,
+    amount numeric(10,2),
+    region text,
+    order_date date
+);
+SELECT create_distributed_table('batch_orders', 'order_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE batch_items (
+    item_id int,
+    order_id int,
+    product text,
+    qty int,
+    price numeric(10,2)
+);
+SELECT create_distributed_table('batch_items', 'order_id', colocate_with => 'batch_orders');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE batch_regions (
+    region text,
+    country text
+);
+SELECT create_reference_table('batch_regions');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Populate orders (300 rows across 4 shards) with deterministic amounts
+INSERT INTO batch_orders
+SELECT i,
+       (i % 50) + 1,
+       round(((i * 127 + 53) % 500 + 10)::numeric, 2),
+       (ARRAY['NA', 'EMEA', 'APAC', 'LATAM'])[1 + (i % 4)],
+       '2025-01-01'::date + (i % 365)
+FROM generate_series(1, 300) i;
+-- Populate items (600 rows, ~2 items per order) with deterministic prices
+INSERT INTO batch_items
+SELECT i,
+       ((i - 1) / 2) + 1,
+       'product_' || (i % 20),
+       1 + (i % 5),
+       round(((i * 31 + 7) % 100 + 1)::numeric, 2)
+FROM generate_series(1, 600) i;
+-- Populate reference table
+INSERT INTO batch_regions VALUES
+    ('NA', 'United States'),
+    ('EMEA', 'Germany'),
+    ('APAC', 'Japan'),
+    ('LATAM', 'Brazil');
+-- Create vanilla PostgreSQL copies with identical data for result verification
+CREATE TABLE local_orders AS SELECT * FROM batch_orders;
+CREATE TABLE local_items AS SELECT * FROM batch_items;
+CREATE TABLE local_regions AS SELECT * FROM batch_regions;
+-- ================================================================
+-- Test 7a: Distributed join with batching
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- Co-located join on distribution column (both distributed on order_id)
+SELECT count(*)
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id;
+ count
+---------------------------------------------------------------------
+   600
+(1 row)
+
+-- Join with filter that spans multiple batches
+SELECT o.order_id, o.region, i.product
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id
+WHERE o.order_id <= 10
+ORDER BY o.order_id, i.item_id;
+ order_id | region |  product
+---------------------------------------------------------------------
+        1 | EMEA   | product_1
+        1 | EMEA   | product_2
+        2 | APAC   | product_3
+        2 | APAC   | product_4
+        3 | LATAM  | product_5
+        3 | LATAM  | product_6
+        4 | NA     | product_7
+        4 | NA     | product_8
+        5 | EMEA   | product_9
+        5 | EMEA   | product_10
+        6 | APAC   | product_11
+        6 | APAC   | product_12
+        7 | LATAM  | product_13
+        7 | LATAM  | product_14
+        8 | NA     | product_15
+        8 | NA     | product_16
+        9 | EMEA   | product_17
+        9 | EMEA   | product_18
+       10 | APAC   | product_19
+       10 | APAC   | product_0
+(20 rows)
+
+-- ================================================================
+-- Test 7b: Reference table joins with batching
+-- ================================================================
+SET citus.executor_batch_size TO 15;
+SELECT o.order_id, o.region, r.country
+FROM batch_orders o
+JOIN batch_regions r ON o.region = r.region
+WHERE o.order_id <= 20
+ORDER BY o.order_id;
+ order_id | region |    country
+---------------------------------------------------------------------
+        1 | EMEA   | Germany
+        2 | APAC   | Japan
+        3 | LATAM  | Brazil
+        4 | NA     | United States
+        5 | EMEA   | Germany
+        6 | APAC   | Japan
+        7 | LATAM  | Brazil
+        8 | NA     | United States
+        9 | EMEA   | Germany
+       10 | APAC   | Japan
+       11 | LATAM  | Brazil
+       12 | NA     | United States
+       13 | EMEA   | Germany
+       14 | APAC   | Japan
+       15 | LATAM  | Brazil
+       16 | NA     | United States
+       17 | EMEA   | Germany
+       18 | APAC   | Japan
+       19 | LATAM  | Brazil
+       20 | NA     | United States
+(20 rows)
+
+-- Aggregate over reference table join
+SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+FROM batch_orders o
+JOIN batch_regions r ON o.region = r.region
+GROUP BY r.country
+ORDER BY r.country;
+    country    | count |   sum
+---------------------------------------------------------------------
+ Brazil        |    75 | 20500.00
+ Germany       |    75 | 18950.00
+ Japan         |    75 | 20975.00
+ United States |    75 | 17525.00
+(4 rows)
+
+-- ================================================================
+-- Test 7c: GROUP BY with HAVING across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- Simple GROUP BY
+SELECT region, count(*) AS cnt, min(amount) AS min_amt, max(amount) AS max_amt
+FROM batch_orders
+GROUP BY region
+ORDER BY region;
+ region | cnt | min_amt | max_amt
+---------------------------------------------------------------------
+ APAC   |  75 |   17.00 |  509.00
+ EMEA   |  75 |   10.00 |  502.00
+ LATAM  |  75 |   12.00 |  508.00
+ NA     |  75 |   11.00 |  503.00
+(4 rows)
+
+-- GROUP BY with HAVING (filters groups after aggregation)
+SELECT region, count(*) AS cnt
+FROM batch_orders
+GROUP BY region
+HAVING count(*) > 50
+ORDER BY region;
+ region | cnt
+---------------------------------------------------------------------
+ APAC   |  75
+ EMEA   |  75
+ LATAM  |  75
+ NA     |  75
+(4 rows)
+
+-- Multi-column GROUP BY across batch boundaries
+SELECT region, (order_id % 10) AS bucket, count(*)
+FROM batch_orders
+WHERE order_id <= 100
+GROUP BY region, (order_id % 10)
+ORDER BY region, bucket;
+ region | bucket | count
+---------------------------------------------------------------------
+ APAC   |      0 |     5
+ APAC   |      2 |     5
+ APAC   |      4 |     5
+ APAC   |      6 |     5
+ APAC   |      8 |     5
+ EMEA   |      1 |     5
+ EMEA   |      3 |     5
+ EMEA   |      5 |     5
+ EMEA   |      7 |     5
+ EMEA   |      9 |     5
+ LATAM  |      1 |     5
+ LATAM  |      3 |     5
+ LATAM  |      5 |     5
+ LATAM  |      7 |     5
+ LATAM  |      9 |     5
+ NA     |      0 |     5
+ NA     |      2 |     5
+ NA     |      4 |     5
+ NA     |      6 |     5
+ NA     |      8 |     5
+(20 rows)
+
+-- ================================================================
+-- Test 7d: Distinct and distinct aggregates
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+SELECT DISTINCT region FROM batch_orders ORDER BY region;
+ region
+---------------------------------------------------------------------
+ APAC
+ EMEA
+ LATAM
+ NA
+(4 rows)
+
+SELECT count(DISTINCT region), count(DISTINCT customer_id)
+FROM batch_orders;
+ count | count
+---------------------------------------------------------------------
+     4 |    50
+(1 row)
+
+-- ================================================================
+-- Test 7e: CTE (Common Table Expressions) with batching
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- Inlinable CTE with join
+WITH regional_totals AS (
+    SELECT o.region, sum(o.amount) AS total
+    FROM batch_orders o
+    GROUP BY o.region
+)
+SELECT rt.region, rt.total::numeric(12,2), r.country
+FROM regional_totals rt
+JOIN batch_regions r ON rt.region = r.region
+ORDER BY rt.region;
+ region |  total   |    country
+---------------------------------------------------------------------
+ APAC   | 20975.00 | Japan
+ EMEA   | 18950.00 | Germany
+ LATAM  | 20500.00 | Brazil
+ NA     | 17525.00 | United States
+(4 rows)
+
+-- CTE that feeds into a filtered query
+WITH top_customers AS (
+    SELECT customer_id, count(*) AS order_count
+    FROM batch_orders
+    GROUP BY customer_id
+    HAVING count(*) >= 5
+)
+SELECT tc.customer_id, tc.order_count
+FROM top_customers tc
+ORDER BY tc.customer_id;
+ customer_id | order_count
+---------------------------------------------------------------------
+           1 |           6
+           2 |           6
+           3 |           6
+           4 |           6
+           5 |           6
+           6 |           6
+           7 |           6
+           8 |           6
+           9 |           6
+          10 |           6
+          11 |           6
+          12 |           6
+          13 |           6
+          14 |           6
+          15 |           6
+          16 |           6
+          17 |           6
+          18 |           6
+          19 |           6
+          20 |           6
+          21 |           6
+          22 |           6
+          23 |           6
+          24 |           6
+          25 |           6
+          26 |           6
+          27 |           6
+          28 |           6
+          29 |           6
+          30 |           6
+          31 |           6
+          32 |           6
+          33 |           6
+          34 |           6
+          35 |           6
+          36 |           6
+          37 |           6
+          38 |           6
+          39 |           6
+          40 |           6
+          41 |           6
+          42 |           6
+          43 |           6
+          44 |           6
+          45 |           6
+          46 |           6
+          47 |           6
+          48 |           6
+          49 |           6
+          50 |           6
+(50 rows)
+
+-- Nested CTEs
+WITH order_stats AS (
+    SELECT region, count(*) AS cnt, avg(amount) AS avg_amt
+    FROM batch_orders
+    GROUP BY region
+),
+enriched AS (
+    SELECT os.*, r.country
+    FROM order_stats os
+    JOIN batch_regions r ON os.region = r.region
+)
+SELECT country, cnt, avg_amt::numeric(10,2)
+FROM enriched
+ORDER BY country;
+    country    | cnt | avg_amt
+---------------------------------------------------------------------
+ Brazil        |  75 |  273.33
+ Germany       |  75 |  252.67
+ Japan         |  75 |  279.67
+ United States |  75 |  233.67
+(4 rows)
+
+-- ================================================================
+-- Test 7f: Subqueries (correlated and uncorrelated)
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- Uncorrelated subquery in WHERE
+SELECT order_id, amount
+FROM batch_orders
+WHERE amount > (SELECT avg(amount) FROM batch_orders)
+ORDER BY order_id
+LIMIT 15;
+ order_id | amount
+---------------------------------------------------------------------
+        2 | 317.00
+        3 | 444.00
+        6 | 325.00
+        7 | 452.00
+       10 | 333.00
+       11 | 460.00
+       14 | 341.00
+       15 | 468.00
+       18 | 349.00
+       19 | 476.00
+       22 | 357.00
+       23 | 484.00
+       26 | 365.00
+       27 | 492.00
+       30 | 373.00
+(15 rows)
+
+-- Subquery in FROM (derived table)
+SELECT sub.region, sub.total_orders, sub.total_amount::numeric(12,2)
+FROM (
+    SELECT region, count(*) AS total_orders, sum(amount) AS total_amount
+    FROM batch_orders
+    GROUP BY region
+) sub
+ORDER BY sub.region;
+ region | total_orders | total_amount
+---------------------------------------------------------------------
+ APAC   |           75 |     20975.00
+ EMEA   |           75 |     18950.00
+ LATAM  |           75 |     20500.00
+ NA     |           75 |     17525.00
+(4 rows)
+
+-- IN subquery spanning batches
+SELECT order_id, region
+FROM batch_orders
+WHERE region IN (
+    SELECT region FROM batch_regions WHERE country IN ('Japan', 'Brazil')
+)
+ORDER BY order_id
+LIMIT 20;
+ order_id | region
+---------------------------------------------------------------------
+        2 | APAC
+        3 | LATAM
+        6 | APAC
+        7 | LATAM
+       10 | APAC
+       11 | LATAM
+       14 | APAC
+       15 | LATAM
+       18 | APAC
+       19 | LATAM
+       22 | APAC
+       23 | LATAM
+       26 | APAC
+       27 | LATAM
+       30 | APAC
+       31 | LATAM
+       34 | APAC
+       35 | LATAM
+       38 | APAC
+       39 | LATAM
+(20 rows)
+
+-- EXISTS subquery (co-located via distribution column)
+SELECT o.order_id, o.region
+FROM batch_orders o
+WHERE EXISTS (
+    SELECT 1 FROM batch_items i
+    WHERE i.order_id = o.order_id
+      AND i.qty >= 4
+)
+ORDER BY o.order_id
+LIMIT 15;
+ order_id | region
+---------------------------------------------------------------------
+        2 | APAC
+        4 | NA
+        5 | EMEA
+        7 | LATAM
+        9 | EMEA
+       10 | APAC
+       12 | NA
+       14 | APAC
+       15 | LATAM
+       17 | EMEA
+       19 | LATAM
+       20 | NA
+       22 | APAC
+       24 | NA
+       25 | EMEA
+(15 rows)
+
+-- ================================================================
+-- Test 7g: Window functions across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+SELECT order_id, region, amount,
+       row_number() OVER (ORDER BY order_id) AS rn,
+       sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+FROM batch_orders
+WHERE order_id <= 20
+ORDER BY order_id;
+ order_id | region | amount | rn | running_total
+---------------------------------------------------------------------
+        1 | EMEA   | 190.00 |  1 |        190.00
+        2 | APAC   | 317.00 |  2 |        317.00
+        3 | LATAM  | 444.00 |  3 |        444.00
+        4 | NA     |  71.00 |  4 |         71.00
+        5 | EMEA   | 198.00 |  5 |        388.00
+        6 | APAC   | 325.00 |  6 |        642.00
+        7 | LATAM  | 452.00 |  7 |        896.00
+        8 | NA     |  79.00 |  8 |        150.00
+        9 | EMEA   | 206.00 |  9 |        594.00
+       10 | APAC   | 333.00 | 10 |        975.00
+       11 | LATAM  | 460.00 | 11 |       1356.00
+       12 | NA     |  87.00 | 12 |        237.00
+       13 | EMEA   | 214.00 | 13 |        808.00
+       14 | APAC   | 341.00 | 14 |       1316.00
+       15 | LATAM  | 468.00 | 15 |       1824.00
+       16 | NA     |  95.00 | 16 |        332.00
+       17 | EMEA   | 222.00 | 17 |       1030.00
+       18 | APAC   | 349.00 | 18 |       1665.00
+       19 | LATAM  | 476.00 | 19 |       2300.00
+       20 | NA     | 103.00 | 20 |        435.00
+(20 rows)
+
+-- RANK / DENSE_RANK
+SELECT order_id, region,
+       rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+FROM batch_orders
+WHERE order_id <= 40
+ORDER BY region, rnk, order_id
+LIMIT 20;
+ order_id | region | rnk
+---------------------------------------------------------------------
+       38 | APAC   |   1
+       34 | APAC   |   2
+       30 | APAC   |   3
+       26 | APAC   |   4
+       22 | APAC   |   5
+       18 | APAC   |   6
+       14 | APAC   |   7
+       10 | APAC   |   8
+        6 | APAC   |   9
+        2 | APAC   |  10
+       37 | EMEA   |   1
+       33 | EMEA   |   2
+       29 | EMEA   |   3
+       25 | EMEA   |   4
+       21 | EMEA   |   5
+       17 | EMEA   |   6
+       13 | EMEA   |   7
+        9 | EMEA   |   8
+        5 | EMEA   |   9
+        1 | EMEA   |  10
+(20 rows)
+
+-- ================================================================
+-- Test 7h: UNION / UNION ALL across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+SELECT order_id, 'orders' AS source FROM batch_orders WHERE order_id <= 10
+UNION ALL
+SELECT item_id, 'items' FROM batch_items WHERE item_id <= 10
+ORDER BY source, order_id;
+ order_id | source
+---------------------------------------------------------------------
+        1 | items
+        2 | items
+        3 | items
+        4 | items
+        5 | items
+        6 | items
+        7 | items
+        8 | items
+        9 | items
+       10 | items
+        1 | orders
+        2 | orders
+        3 | orders
+        4 | orders
+        5 | orders
+        6 | orders
+        7 | orders
+        8 | orders
+        9 | orders
+       10 | orders
+(20 rows)
+
+-- UNION (deduplicated)
+SELECT region FROM batch_orders WHERE order_id <= 50
+UNION
+SELECT region FROM batch_orders WHERE order_id > 250
+ORDER BY region;
+ region
+---------------------------------------------------------------------
+ APAC
+ EMEA
+ LATAM
+ NA
+(4 rows)
+
+-- ================================================================
+-- Test 7i: Multi-table join with GROUP BY and HAVING
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id
+JOIN batch_regions r ON o.region = r.region
+WHERE o.order_id <= 50
+GROUP BY r.country
+HAVING sum(i.qty) > 10
+ORDER BY r.country;
+    country    | orders | total_qty
+---------------------------------------------------------------------
+ Brazil        |     12 |        72
+ Germany       |     13 |        78
+ Japan         |     13 |        80
+ United States |     12 |        70
+(4 rows)
+
+-- ================================================================
+-- Test 7j: ORDER BY with LIMIT/OFFSET across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- OFFSET spans batch boundaries
+SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 10 OFFSET 15;
+ order_id | region
+---------------------------------------------------------------------
+       16 | NA
+       17 | EMEA
+       18 | APAC
+       19 | LATAM
+       20 | NA
+       21 | EMEA
+       22 | APAC
+       23 | LATAM
+       24 | NA
+       25 | EMEA
+(10 rows)
+
+-- Large OFFSET
+SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 5 OFFSET 290;
+ order_id | region
+---------------------------------------------------------------------
+      291 | LATAM
+      292 | NA
+      293 | EMEA
+      294 | APAC
+      295 | LATAM
+(5 rows)
+
+-- ================================================================
+-- Test 7k: Cross-batch-size consistency for complex queries
+-- Runs the same complex query at different batch sizes and verifies
+-- identical results.
+-- ================================================================
+CREATE TABLE batch_complex_consistency AS
+SELECT
+    bs,
+    (SELECT count(*)
+     FROM batch_orders o
+     JOIN batch_regions r ON o.region = r.region)::bigint AS join_cnt,
+    (SELECT count(DISTINCT region) FROM batch_orders)::int AS dist_regions,
+    (SELECT sum(amount)::numeric(14,2) FROM batch_orders) AS total_amount,
+    (SELECT count(*)
+     FROM batch_orders
+     WHERE amount > (SELECT avg(amount) FROM batch_orders))::bigint AS above_avg
+FROM (SELECT unnest(ARRAY[1, 7, 25, 100, 10000]) bs) sizes,
+LATERAL (SELECT set_config('citus.executor_batch_size', bs::text, false)) AS apply;
+-- All batch sizes must produce the same results
+SELECT count(DISTINCT (join_cnt, dist_regions, total_amount, above_avg)) AS distinct_results
+FROM batch_complex_consistency;
+ distinct_results
+---------------------------------------------------------------------
+                1
+(1 row)
+
+SELECT DISTINCT join_cnt, dist_regions, total_amount, above_avg
+FROM batch_complex_consistency;
+ join_cnt | dist_regions | total_amount | above_avg
+---------------------------------------------------------------------
+      300 |            4 |     77950.00 |       149
+(1 row)
+
+DROP TABLE batch_complex_consistency;
+-- ================================================================
+-- Test 7l: Distributed vs vanilla PostgreSQL result verification
+-- Every query is run against both distributed and local tables;
+-- EXCEPT should return zero rows if results are identical.
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+-- Join count
+SELECT count(*) AS diff FROM (
+    (SELECT count(*) AS c FROM batch_orders o JOIN batch_items i ON o.order_id = i.order_id)
+    EXCEPT
+    (SELECT count(*) AS c FROM local_orders o JOIN local_items i ON o.order_id = i.order_id)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Join with filter
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region, i.product
+     FROM batch_orders o JOIN batch_items i ON o.order_id = i.order_id
+     WHERE o.order_id <= 10)
+    EXCEPT
+    (SELECT o.order_id, o.region, i.product
+     FROM local_orders o JOIN local_items i ON o.order_id = i.order_id
+     WHERE o.order_id <= 10)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Reference table join
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region, r.country
+     FROM batch_orders o JOIN batch_regions r ON o.region = r.region
+     WHERE o.order_id <= 20)
+    EXCEPT
+    (SELECT o.order_id, o.region, r.country
+     FROM local_orders o JOIN local_regions r ON o.region = r.region
+     WHERE o.order_id <= 20)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Aggregate over reference table join
+SELECT count(*) AS diff FROM (
+    (SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+     FROM batch_orders o JOIN batch_regions r ON o.region = r.region
+     GROUP BY r.country)
+    EXCEPT
+    (SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+     FROM local_orders o JOIN local_regions r ON o.region = r.region
+     GROUP BY r.country)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- GROUP BY with HAVING
+SELECT count(*) AS diff FROM (
+    (SELECT region, count(*) AS cnt, min(amount), max(amount)
+     FROM batch_orders GROUP BY region)
+    EXCEPT
+    (SELECT region, count(*) AS cnt, min(amount), max(amount)
+     FROM local_orders GROUP BY region)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Multi-column GROUP BY
+SELECT count(*) AS diff FROM (
+    (SELECT region, (order_id % 10) AS bucket, count(*)
+     FROM batch_orders WHERE order_id <= 100
+     GROUP BY region, (order_id % 10))
+    EXCEPT
+    (SELECT region, (order_id % 10) AS bucket, count(*)
+     FROM local_orders WHERE order_id <= 100
+     GROUP BY region, (order_id % 10))
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- DISTINCT
+SELECT count(*) AS diff FROM (
+    (SELECT DISTINCT region FROM batch_orders)
+    EXCEPT
+    (SELECT DISTINCT region FROM local_orders)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Distinct aggregates
+SELECT count(*) AS diff FROM (
+    (SELECT count(DISTINCT region), count(DISTINCT customer_id) FROM batch_orders)
+    EXCEPT
+    (SELECT count(DISTINCT region), count(DISTINCT customer_id) FROM local_orders)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- CTE with join
+SELECT count(*) AS diff FROM (
+    (WITH rt AS (SELECT region, sum(amount) AS total FROM batch_orders GROUP BY region)
+     SELECT rt.region, rt.total::numeric(12,2), r.country
+     FROM rt JOIN batch_regions r ON rt.region = r.region)
+    EXCEPT
+    (WITH rt AS (SELECT region, sum(amount) AS total FROM local_orders GROUP BY region)
+     SELECT rt.region, rt.total::numeric(12,2), r.country
+     FROM rt JOIN local_regions r ON rt.region = r.region)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Nested CTEs
+SELECT count(*) AS diff FROM (
+    (WITH os AS (SELECT region, count(*) AS cnt, avg(amount) AS avg_amt FROM batch_orders GROUP BY region),
+          en AS (SELECT os.*, r.country FROM os JOIN batch_regions r ON os.region = r.region)
+     SELECT country, cnt, avg_amt::numeric(10,2) FROM en)
+    EXCEPT
+    (WITH os AS (SELECT region, count(*) AS cnt, avg(amount) AS avg_amt FROM local_orders GROUP BY region),
+          en AS (SELECT os.*, r.country FROM os JOIN local_regions r ON os.region = r.region)
+     SELECT country, cnt, avg_amt::numeric(10,2) FROM en)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Uncorrelated subquery in WHERE
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, amount FROM batch_orders
+     WHERE amount > (SELECT avg(amount) FROM batch_orders))
+    EXCEPT
+    (SELECT order_id, amount FROM local_orders
+     WHERE amount > (SELECT avg(amount) FROM local_orders))
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Subquery in FROM
+SELECT count(*) AS diff FROM (
+    (SELECT region, count(*) AS total_orders, sum(amount)::numeric(12,2) AS total_amount
+     FROM batch_orders GROUP BY region)
+    EXCEPT
+    (SELECT region, count(*) AS total_orders, sum(amount)::numeric(12,2) AS total_amount
+     FROM local_orders GROUP BY region)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- IN subquery
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region FROM batch_orders
+     WHERE region IN (SELECT region FROM batch_regions WHERE country IN ('Japan', 'Brazil')))
+    EXCEPT
+    (SELECT order_id, region FROM local_orders
+     WHERE region IN (SELECT region FROM local_regions WHERE country IN ('Japan', 'Brazil')))
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- EXISTS subquery
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region FROM batch_orders o
+     WHERE EXISTS (SELECT 1 FROM batch_items i WHERE i.order_id = o.order_id AND i.qty >= 4))
+    EXCEPT
+    (SELECT o.order_id, o.region FROM local_orders o
+     WHERE EXISTS (SELECT 1 FROM local_items i WHERE i.order_id = o.order_id AND i.qty >= 4))
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Window functions
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region, amount,
+            row_number() OVER (ORDER BY order_id) AS rn,
+            sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+     FROM batch_orders WHERE order_id <= 20)
+    EXCEPT
+    (SELECT order_id, region, amount,
+            row_number() OVER (ORDER BY order_id) AS rn,
+            sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+     FROM local_orders WHERE order_id <= 20)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- RANK window function
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region,
+            rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+     FROM batch_orders WHERE order_id <= 40)
+    EXCEPT
+    (SELECT order_id, region,
+            rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+     FROM local_orders WHERE order_id <= 40)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- UNION ALL
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, 'orders' AS source FROM batch_orders WHERE order_id <= 10
+     UNION ALL
+     SELECT item_id, 'items' FROM batch_items WHERE item_id <= 10)
+    EXCEPT
+    (SELECT order_id, 'orders' AS source FROM local_orders WHERE order_id <= 10
+     UNION ALL
+     SELECT item_id, 'items' FROM local_items WHERE item_id <= 10)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- 3-table join with GROUP BY and HAVING
+SELECT count(*) AS diff FROM (
+    (SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+     FROM batch_orders o
+     JOIN batch_items i ON o.order_id = i.order_id
+     JOIN batch_regions r ON o.region = r.region
+     WHERE o.order_id <= 50
+     GROUP BY r.country HAVING sum(i.qty) > 10)
+    EXCEPT
+    (SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+     FROM local_orders o
+     JOIN local_items i ON o.order_id = i.order_id
+     JOIN local_regions r ON o.region = r.region
+     WHERE o.order_id <= 50
+     GROUP BY r.country HAVING sum(i.qty) > 10)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- ORDER BY with LIMIT/OFFSET
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 10 OFFSET 15)
+    EXCEPT
+    (SELECT order_id, region FROM local_orders ORDER BY order_id LIMIT 10 OFFSET 15)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- Reset for subsequent tests
+SET citus.executor_batch_size TO 10;
+--
 -- Test 8: DML with RETURNING across batches
 --
 SET citus.executor_batch_size TO 10;
@@ -182,12 +1102,12 @@ SHOW citus.executor_batch_size;
 (1 row)
 
 --
--- Test 10: M1 — Between-batch error cleanup (CitusEndScan must release sessions)
+-- Test 10: Between-batch error cleanup (CitusEndScan must release sessions)
 --
 -- This validates that when an error occurs on the coordinator between
 -- AdaptiveExecutorRun calls (mid-scan, mid-batch), CitusEndScan properly
 -- cleans up distributed execution sessions via AdaptiveExecutorEnd.
--- Without the M1 fix, sessions/connections would leak on each error.
+-- Without this fix, sessions/connections would leak on each error.
 --
 SET citus.executor_batch_size TO 10;
 -- Helper: iterates a distributed query and raises error after N rows.
@@ -293,6 +1213,731 @@ SELECT DISTINCT cnt, s, mn, mx, range_cnt FROM batch_consistency;
 (1 row)
 
 DROP TABLE batch_consistency;
+--
+-- Test 12: EXPLAIN ANALYZE with batching
+-- Verify that EXPLAIN ANALYZE works correctly when batching is active.
+-- We check: (a) it runs without error, (b) row counts in the output are
+-- correct, and (c) it works with result sets that are exact multiples of
+-- the batch size as well as non-multiples.
+--
+-- 12a: exact multiple of batch size (200 rows, batch_size=50 → 4 batches)
+SET citus.executor_batch_size TO 50;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM adaptive_executor_batching.batch_test');
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive) (actual rows=N loops=N)
+   Task Count: N
+   Tuple data received from nodes: N bytes
+   Tasks Shown: One of N
+   ->  Task
+         Tuple data received from node: N bytes
+         Node: host=localhost port=N dbname=regression
+         ->  Seq Scan on batch_test_802009000 batch_test (actual rows=N loops=N)
+(8 rows)
+
+-- Verify the actual query still returns the right count
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+-- 12b: non-multiple of batch size (200 rows, batch_size=30 → 6 full + 1 partial)
+SET citus.executor_batch_size TO 30;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM adaptive_executor_batching.batch_test');
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive) (actual rows=N loops=N)
+   Task Count: N
+   Tuple data received from nodes: N bytes
+   Tasks Shown: One of N
+   ->  Task
+         Tuple data received from node: N bytes
+         Node: host=localhost port=N dbname=regression
+         ->  Seq Scan on batch_test_802009000 batch_test (actual rows=N loops=N)
+(8 rows)
+
+SELECT count(*) FROM batch_test;
+ count
+---------------------------------------------------------------------
+   200
+(1 row)
+
+-- 12c: small batch_size (200 rows, batch_size=7 → many small batches)
+SET citus.executor_batch_size TO 7;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT x, y FROM adaptive_executor_batching.batch_test WHERE x <= 10');
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive) (actual rows=N loops=N)
+   Task Count: N
+   Tuple data received from nodes: N bytes
+   Tasks Shown: One of N
+   ->  Task
+         Tuple data received from node: N bytes
+         Node: host=localhost port=N dbname=regression
+         ->  Seq Scan on batch_test_802009000 batch_test (actual rows=N loops=N)
+               Filter: (x <= N)
+               Rows Removed by Filter: N
+(10 rows)
+
+SELECT count(*) FROM batch_test WHERE x <= 10;
+ count
+---------------------------------------------------------------------
+    10
+(1 row)
+
+-- 12d: EXPLAIN ANALYZE with aggregation across batches
+SET citus.executor_batch_size TO 25;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT count(*), sum(x), min(x), max(x) FROM adaptive_executor_batching.batch_test');
+                                        explain_filter
+---------------------------------------------------------------------
+ Aggregate (actual rows=N loops=N)
+   ->  Custom Scan (Citus Adaptive) (actual rows=N loops=N)
+         Task Count: N
+         Tuple data received from nodes: N bytes
+         Tasks Shown: One of N
+         ->  Task
+               Tuple data received from node: N bytes
+               Node: host=localhost port=N dbname=regression
+               ->  Aggregate (actual rows=N loops=N)
+                     ->  Seq Scan on batch_test_802009000 batch_test (actual rows=N loops=N)
+(10 rows)
+
+SELECT count(*), sum(x), min(x), max(x) FROM batch_test;
+ count |  sum  | min | max
+---------------------------------------------------------------------
+   200 | 20100 |   1 | 200
+(1 row)
+
+--
+-- Test 13: Scrollable cursor with batching
+-- Verifies that DECLARE SCROLL CURSOR works correctly with the batched
+-- executor. For scrollable cursors, the executor preserves the tuplestore
+-- across batches (skips tuplestore_clear) so backward fetches can access
+-- rows from earlier batches.
+--
+-- With batch_size=10, a 50-row result spans 5 batches:
+--   batch 1: rows 1-10, batch 2: rows 11-20, batch 3: rows 21-30,
+--   batch 4: rows 31-40, batch 5: rows 41-50
+--
+SET citus.executor_batch_size TO 10;
+-- 13a: Forward/backward zigzag across batch boundaries
+BEGIN;
+DECLARE scroll_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+-- Read into batch 2 (rows 1-15)
+FETCH FORWARD 15 FROM scroll_cur;
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+(15 rows)
+
+-- Backward 10: crosses batch 2→1 boundary, returns rows 14..5
+FETCH BACKWARD 10 FROM scroll_cur;
+ x
+---------------------------------------------------------------------
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+(10 rows)
+
+-- Forward 5 from position 5: returns rows 6..10
+FETCH FORWARD 5 FROM scroll_cur;
+ x
+---------------------------------------------------------------------
+  6
+  7
+  8
+  9
+ 10
+(5 rows)
+
+-- Forward 15 more: crosses batch 1→2→3, returns rows 11..25
+FETCH FORWARD 15 FROM scroll_cur;
+ x
+---------------------------------------------------------------------
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+(15 rows)
+
+-- Backward 20: crosses batch 3→2→1, returns rows 24..5
+FETCH BACKWARD 20 FROM scroll_cur;
+ x
+---------------------------------------------------------------------
+ 24
+ 23
+ 22
+ 21
+ 20
+ 19
+ 18
+ 17
+ 16
+ 15
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+(20 rows)
+
+CLOSE scroll_cur;
+COMMIT;
+-- 13b: FETCH FIRST / LAST / ABSOLUTE across all batches
+BEGIN;
+DECLARE abs_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+-- Jump to various positions across different batches
+FETCH ABSOLUTE 5 FROM abs_cur;   -- batch 1
+ x
+---------------------------------------------------------------------
+ 5
+(1 row)
+
+FETCH ABSOLUTE 45 FROM abs_cur;  -- batch 5
+ x
+---------------------------------------------------------------------
+ 45
+(1 row)
+
+FETCH ABSOLUTE 1 FROM abs_cur;   -- batch 1 (backward jump)
+ x
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+FETCH ABSOLUTE 50 FROM abs_cur;  -- batch 5 (last row)
+ x
+---------------------------------------------------------------------
+ 50
+(1 row)
+
+FETCH ABSOLUTE 15 FROM abs_cur;  -- batch 2 (backward jump)
+ x
+---------------------------------------------------------------------
+ 15
+(1 row)
+
+FETCH ABSOLUTE 35 FROM abs_cur;  -- batch 4 (forward jump)
+ x
+---------------------------------------------------------------------
+ 35
+(1 row)
+
+FETCH ABSOLUTE 10 FROM abs_cur;  -- batch 1 (backward jump across 3 batches)
+ x
+---------------------------------------------------------------------
+ 10
+(1 row)
+
+-- FIRST and LAST
+FETCH LAST FROM abs_cur;
+ x
+---------------------------------------------------------------------
+ 50
+(1 row)
+
+FETCH FIRST FROM abs_cur;
+ x
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+FETCH LAST FROM abs_cur;
+ x
+---------------------------------------------------------------------
+ 50
+(1 row)
+
+CLOSE abs_cur;
+COMMIT;
+-- 13c: Read all rows forward, then backward through all batches
+BEGIN;
+DECLARE full_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 30 ORDER BY x;
+-- Drain all 3 batches forward
+FETCH FORWARD ALL FROM full_cur;
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+ 26
+ 27
+ 28
+ 29
+ 30
+(30 rows)
+
+-- Now backward through all 3 batches
+FETCH BACKWARD 30 FROM full_cur;
+ x
+---------------------------------------------------------------------
+ 30
+ 29
+ 28
+ 27
+ 26
+ 25
+ 24
+ 23
+ 22
+ 21
+ 20
+ 19
+ 18
+ 17
+ 16
+ 15
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+  4
+  3
+  2
+  1
+(30 rows)
+
+-- And forward to the end again
+FETCH FORWARD ALL FROM full_cur;
+ x
+---------------------------------------------------------------------
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+ 26
+ 27
+ 28
+ 29
+ 30
+(29 rows)
+
+CLOSE full_cur;
+COMMIT;
+-- 13d: FETCH RELATIVE across batch boundaries
+BEGIN;
+DECLARE rel_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+FETCH ABSOLUTE 25 FROM rel_cur;  -- middle of batch 3
+ x
+---------------------------------------------------------------------
+ 25
+(1 row)
+
+FETCH RELATIVE -15 FROM rel_cur; -- jump back to batch 1 (row 10)
+ x
+---------------------------------------------------------------------
+ 10
+(1 row)
+
+FETCH RELATIVE 30 FROM rel_cur;  -- jump forward to batch 4 (row 40)
+ x
+---------------------------------------------------------------------
+ 40
+(1 row)
+
+FETCH RELATIVE -35 FROM rel_cur; -- jump back to batch 1 (row 5)
+ x
+---------------------------------------------------------------------
+ 5
+(1 row)
+
+FETCH RELATIVE 10 FROM rel_cur;  -- forward within batch 2 (row 15)
+ x
+---------------------------------------------------------------------
+ 15
+(1 row)
+
+CLOSE rel_cur;
+COMMIT;
+-- 13e: SCROLL cursor with inlinable CTE
+-- Exercises the CTE-inlining planner path (InlineCtesAndCreateDistributedPlannedStmt
+-- → TryCreateDistributedPlannedStmt → CreateDistributedPlannedStmt → FinalizePlan)
+-- to verify that cursorOptions (CURSOR_OPT_SCROLL) is forwarded through
+-- TryCreateDistributedPlannedStmt so FinalizePlan wraps the plan in a Material node.
+BEGIN;
+DECLARE cte_scroll SCROLL CURSOR FOR
+  WITH batch_cte AS (
+    SELECT x FROM batch_test WHERE x <= 30
+  )
+  SELECT x FROM batch_cte ORDER BY x;
+-- Forward into batch 2
+FETCH FORWARD 15 FROM cte_scroll;
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+(15 rows)
+
+-- Backward across batch boundary (rows 14..5)
+FETCH BACKWARD 10 FROM cte_scroll;
+ x
+---------------------------------------------------------------------
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+(10 rows)
+
+-- Forward to end (rows 6..30)
+FETCH FORWARD ALL FROM cte_scroll;
+ x
+---------------------------------------------------------------------
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+ 26
+ 27
+ 28
+ 29
+ 30
+(25 rows)
+
+-- Backward all the way (rows 29..1)
+FETCH BACKWARD ALL FROM cte_scroll;
+ x
+---------------------------------------------------------------------
+ 30
+ 29
+ 28
+ 27
+ 26
+ 25
+ 24
+ 23
+ 22
+ 21
+ 20
+ 19
+ 18
+ 17
+ 16
+ 15
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+  4
+  3
+  2
+  1
+(30 rows)
+
+CLOSE cte_scroll;
+COMMIT;
+--
+-- Test 14: WITH HOLD cursor with batching
+--
+-- Validates that DECLARE ... SCROLL CURSOR WITH HOLD works correctly
+-- with the batched executor. At COMMIT, PostgreSQL calls
+-- PersistHoldablePortal(), which:
+--
+--   1. ExecutorRewind() → ExecReScan on the Material node (inserted by
+--      FinalizePlan for SCROLL cursors), which does tuplestore_rescan()
+--      to rewind the already-materialized rows — no distributed re-execution.
+--   2. ExecutorRun(Forward, 0) → drains ALL tuples through the Material
+--      node into the portal's holdStore tuplestore.
+--   3. ExecutorEnd() shuts down the executor and releases connections.
+--
+-- After COMMIT the cursor survives and all FETCHes read from the local
+-- holdStore — no distributed execution occurs. The Material node is
+-- critical: without it, ExecutorRewind would call CitusReScan directly,
+-- which could attempt to re-execute the distributed query at an unsafe time.
+--
+-- Also tests a non-SCROLL WITH HOLD cursor, where no Material node is
+-- inserted. PersistHoldablePortal skips ExecutorRewind and only does a
+-- forward drain of the remaining (unfetched) rows.
+--
+SET citus.executor_batch_size TO 5;
+-- 14a: SCROLL + WITH HOLD — full backward/forward after COMMIT
+CREATE TABLE withhold_test (id int, val int, label text);
+SELECT create_distributed_table('withhold_test', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO withhold_test VALUES
+    (1, 100, 'alpha'),   (2, 200, 'bravo'),
+    (3, 300, 'charlie'),  (4, 100, 'delta'),
+    (5, 200, 'echo'),     (6, 300, 'foxtrot'),
+    (7, 100, 'golf'),     (8, 200, 'hotel'),
+    (9, 300, 'india'),    (10, 100, 'juliet'),
+    (11, 200, NULL),      (12, NULL, 'lima');
+-- Also create a vanilla copy for result verification
+CREATE TABLE withhold_local AS SELECT * FROM withhold_test;
+BEGIN;
+DECLARE hold_scroll SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY val NULLS LAST, id;
+-- Fetch only 3 of 12 rows inside the transaction
+FETCH FORWARD 3 FROM hold_scroll;
+ id | val
+---------------------------------------------------------------------
+  1 | 100
+  4 | 100
+  7 | 100
+(3 rows)
+
+COMMIT;
+-- After COMMIT the cursor survives; remaining rows must be accessible
+FETCH FORWARD 5 FROM hold_scroll;
+ id | val
+---------------------------------------------------------------------
+ 10 | 100
+  2 | 200
+  5 | 200
+  8 | 200
+ 11 | 200
+(5 rows)
+
+-- Backward scan into already-fetched territory
+FETCH BACKWARD 4 FROM hold_scroll;
+ id | val
+---------------------------------------------------------------------
+  8 | 200
+  5 | 200
+  2 | 200
+ 10 | 100
+(4 rows)
+
+-- Fetch to end
+FETCH FORWARD ALL FROM hold_scroll;
+ id | val
+---------------------------------------------------------------------
+  2 | 200
+  5 | 200
+  8 | 200
+ 11 | 200
+  3 | 300
+  6 | 300
+  9 | 300
+ 12 |
+(8 rows)
+
+-- Verify the very end
+FETCH BACKWARD 1 FROM hold_scroll;
+ id | val
+---------------------------------------------------------------------
+ 12 |
+(1 row)
+
+CLOSE hold_scroll;
+-- 14b: Non-SCROLL WITH HOLD — forward-only after COMMIT
+BEGIN;
+DECLARE hold_fwd NO SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY id;
+-- Fetch 4 rows inside the transaction
+FETCH FORWARD 4 FROM hold_fwd;
+ id | val
+---------------------------------------------------------------------
+  1 | 100
+  2 | 200
+  3 | 300
+  4 | 100
+(4 rows)
+
+COMMIT;
+-- After COMMIT, remaining 8 rows must be available
+FETCH FORWARD ALL FROM hold_fwd;
+ id | val
+---------------------------------------------------------------------
+  5 | 200
+  6 | 300
+  7 | 100
+  8 | 200
+  9 | 300
+ 10 | 100
+ 11 | 200
+ 12 |
+(8 rows)
+
+CLOSE hold_fwd;
+-- 14c: NO SCROLL cursor rejects backward fetches
+-- Without explicit SCROLL, a cursor on a multi-shard query with ORDER BY
+-- would normally auto-promote to SCROLL (because the Sort node supports
+-- backward scan). Explicit NO SCROLL prevents this and must reject
+-- backward fetches with an error.
+BEGIN;
+DECLARE hold_noscroll NO SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY id;
+FETCH 3 FROM hold_noscroll;
+ id | val
+---------------------------------------------------------------------
+  1 | 100
+  2 | 200
+  3 | 300
+(3 rows)
+
+FETCH FORWARD 3 FROM hold_noscroll;
+ id | val
+---------------------------------------------------------------------
+  4 | 100
+  5 | 200
+  6 | 300
+(3 rows)
+
+COMMIT;
+-- Forward still works after COMMIT
+FETCH 3 FROM hold_noscroll;
+ id | val
+---------------------------------------------------------------------
+  7 | 100
+  8 | 200
+  9 | 300
+(3 rows)
+
+-- Backward must fail
+FETCH BACKWARD 3 FROM hold_noscroll;
+ERROR:  cursor can only scan forward
+HINT:  Declare it with SCROLL option to enable backward scan.
+CLOSE hold_noscroll;
+-- 14d: Verify WITH HOLD results match vanilla PostgreSQL
+-- Run the same ordered query against the local table and EXCEPT
+SELECT count(*) AS diff FROM (
+    (SELECT id, val FROM withhold_test ORDER BY val NULLS LAST, id)
+    EXCEPT
+    (SELECT id, val FROM withhold_local ORDER BY val NULLS LAST, id)
+) t;
+ diff
+---------------------------------------------------------------------
+    0
+(1 row)
+
+DROP TABLE withhold_test;
+DROP TABLE withhold_local;
+-- Reset batch size
+RESET citus.executor_batch_size;
 --
 -- Cleanup
 --

--- a/src/test/regress/expected/adaptive_executor_batching.out
+++ b/src/test/regress/expected/adaptive_executor_batching.out
@@ -191,10 +191,32 @@ INSERT INTO batch_regions VALUES
     ('EMEA', 'Germany'),
     ('APAC', 'Japan'),
     ('LATAM', 'Brazil');
--- Create vanilla PostgreSQL copies with identical data for result verification
-CREATE TABLE local_orders AS SELECT * FROM batch_orders;
-CREATE TABLE local_items AS SELECT * FROM batch_items;
-CREATE TABLE local_regions AS SELECT * FROM batch_regions;
+-- Create vanilla PostgreSQL copies with identical data for result verification.
+-- Populate them from the same deterministic sources used for the distributed
+-- tables (NOT via SELECT * FROM batch_*), so the local tables remain an
+-- independent reference even if the distributed executor has bugs.
+CREATE TABLE local_orders (LIKE batch_orders INCLUDING ALL);
+CREATE TABLE local_items  (LIKE batch_items  INCLUDING ALL);
+CREATE TABLE local_regions (LIKE batch_regions INCLUDING ALL);
+INSERT INTO local_orders
+SELECT i,
+       (i % 50) + 1,
+       round(((i * 127 + 53) % 500 + 10)::numeric, 2),
+       (ARRAY['NA', 'EMEA', 'APAC', 'LATAM'])[1 + (i % 4)],
+       '2025-01-01'::date + (i % 365)
+FROM generate_series(1, 300) i;
+INSERT INTO local_items
+SELECT i,
+       ((i - 1) / 2) + 1,
+       'product_' || (i % 20),
+       1 + (i % 5),
+       round(((i * 31 + 7) % 100 + 1)::numeric, 2)
+FROM generate_series(1, 600) i;
+INSERT INTO local_regions VALUES
+    ('NA', 'United States'),
+    ('EMEA', 'Germany'),
+    ('APAC', 'Japan'),
+    ('LATAM', 'Brazil');
 -- ================================================================
 -- Test 7a: Distributed join with batching
 -- ================================================================
@@ -1312,9 +1334,9 @@ SELECT count(*), sum(x), min(x), max(x) FROM batch_test;
 --
 -- Test 13: Scrollable cursor with batching
 -- Verifies that DECLARE SCROLL CURSOR works correctly with the batched
--- executor. For scrollable cursors, the executor preserves the tuplestore
--- across batches (skips tuplestore_clear) so backward fetches can access
--- rows from earlier batches.
+-- executor. The tuplestore is still cleared between batches, but backward
+-- fetches work because FinalizePlan wraps the Citus CustomScan in a lazy
+-- Material node when CURSOR_OPT_SCROLL is set.
 --
 -- With batch_size=10, a 50-row result spans 5 batches:
 --   batch 1: rows 1-10, batch 2: rows 11-20, batch 3: rows 21-30,
@@ -1938,6 +1960,445 @@ DROP TABLE withhold_test;
 DROP TABLE withhold_local;
 -- Reset batch size
 RESET citus.executor_batch_size;
+--
+-- Test 15: Early-close cursor on batched DML RETURNING is all-or-nothing
+--
+-- A plpgsql function wraps DELETE ... RETURNING so we can open a cursor
+-- on the result set.  With a small batch size the executor fetches only
+-- a few rows before the cursor is closed, which triggers
+-- AdaptiveExecutorEnd → SendCancelationRequest on worker connections
+-- that are inside a coordinated transaction block.  The cancel aborts
+-- the worker transactions, and when the coordinator rolls back, no rows
+-- are deleted.
+--
+-- This verifies that partial batched DML never gets committed.
+--
+CREATE OR REPLACE FUNCTION delete_returning_x(max_x int)
+RETURNS SETOF int LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY DELETE FROM batch_test WHERE x <= max_x RETURNING x;
+END;
+$$;
+SET citus.executor_batch_size TO 10;
+-- Baseline row count
+SELECT count(*) AS before_count FROM batch_test;
+ before_count
+---------------------------------------------------------------------
+          200
+(1 row)
+
+BEGIN;
+-- The function executes DELETE ... RETURNING through the batched
+-- adaptive executor.  With batch_size=10 only a partial batch is
+-- consumed before we close the cursor.
+DECLARE dml_cur CURSOR FOR SELECT * FROM delete_returning_x(50);
+-- Fetch a few rows from the first batch
+FETCH 5 FROM dml_cur;
+ delete_returning_x
+---------------------------------------------------------------------
+                  1
+                  2
+                  3
+                  4
+                  5
+(5 rows)
+
+-- Close the cursor before all batches complete.
+CLOSE dml_cur;
+ROLLBACK;
+-- All rows must still be present — the DELETE was rolled back.
+SELECT count(*) AS after_count FROM batch_test;
+ after_count
+---------------------------------------------------------------------
+         200
+(1 row)
+
+DROP FUNCTION delete_returning_x(int);
+RESET citus.executor_batch_size;
+-- ================================================================
+-- Test 16: SELECT with LIMIT (no Sort) inside a write transaction
+--          must not cancel worker queries
+-- ================================================================
+--
+-- Inside a coordinated transaction that has already performed writes,
+-- a plain LIMIT (with no Sort/Material barrier above the Citus scan)
+-- terminates the executor early.  Without a fallback, AdaptiveExecutorEnd
+-- would SendCancelationRequest() on the still-active worker connections,
+-- abort the worker transactions (PQTRANS_INERROR), and cause the user's
+-- COMMIT to fail with "failure on connection marked as essential" --
+-- silently rolling back the preceding writes.
+--
+-- AdaptiveExecutorRun detects this case (CMD_SELECT inside a coordinated
+-- transaction with XactModificationLevel >= XACT_MODIFICATION_DATA) and
+-- forces runToCompletion=true, matching pre-batching behavior.
+--
+CREATE TABLE limit_in_write_txn (id int PRIMARY KEY, v int);
+SELECT create_distributed_table('limit_in_write_txn', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO limit_in_write_txn
+    SELECT g, g FROM generate_series(1, 1000) g;
+-- Small batch + chunk sizes guarantee the first batch satisfies LIMIT
+-- long before the workers finish their queries -- the precise condition
+-- that previously triggered the cancel.
+SET citus.executor_batch_size TO 10;
+SET citus.executor_chunk_size TO 5;
+BEGIN;
+UPDATE limit_in_write_txn SET v = v + 1000 WHERE id <= 5;
+-- LIMIT with no ORDER BY: no Sort barrier, scan terminates after 3 rows.
+-- Discard the unstable row contents -- shard order is not deterministic --
+-- and just confirm we got 3 rows.
+SELECT count(*) AS fetched FROM (
+    SELECT id FROM limit_in_write_txn LIMIT 3
+) s;
+ fetched
+---------------------------------------------------------------------
+       3
+(1 row)
+
+COMMIT;
+-- The UPDATE must have persisted: COMMIT did not error and the worker
+-- transactions were not aborted by a stray cancel.
+SELECT id, v FROM limit_in_write_txn WHERE id <= 5 ORDER BY id;
+ id |  v
+---------------------------------------------------------------------
+  1 | 1001
+  2 | 1002
+  3 | 1003
+  4 | 1004
+  5 | 1005
+(5 rows)
+
+RESET citus.executor_batch_size;
+RESET citus.executor_chunk_size;
+DROP TABLE limit_in_write_txn;
+-- ================================================================
+-- Test 17: Prepared statements crossing the generic-plan threshold
+-- ================================================================
+--
+-- PostgreSQL's plan_cache_mode = auto switches from per-execution
+-- custom plans to a single cached generic plan after the 5th
+-- EXECUTE.  Citus's CustomScan rewrites distribution at planning
+-- time, so the generic-plan path drives a different code path
+-- through AdaptiveExecutorStart / executionScanContext reuse /
+-- wait-event-set preservation / tuplestore reset across
+-- re-invocations.  Run the same prepared statement 7 times with a
+-- small batch size to exercise both custom-plan and generic-plan
+-- executions through the batched executor.
+--
+SET citus.executor_batch_size TO 5;
+SET plan_cache_mode TO auto;
+PREPARE p_batch_select(int) AS
+    SELECT count(*) FROM batch_test WHERE x <= $1;
+-- Executions 1-5: per-execution custom plan.
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+-- Executions 6-7: generic plan (PG's threshold is 5).
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+EXECUTE p_batch_select(50);
+ count
+---------------------------------------------------------------------
+    50
+(1 row)
+
+-- Same prepared statement returning a multi-batch result set: the
+-- batched executor must reset its per-invocation state cleanly.
+PREPARE p_batch_rows(int) AS
+    SELECT x FROM batch_test WHERE x <= $1 ORDER BY x;
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+-- Generic plan from here on.
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+EXECUTE p_batch_rows(20);
+ x
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+DEALLOCATE p_batch_select;
+DEALLOCATE p_batch_rows;
+RESET plan_cache_mode;
+RESET citus.executor_batch_size;
+-- ================================================================
+-- Test 18: Batched SELECT interleaved with SAVEPOINT / ROLLBACK TO
+-- ================================================================
+--
+-- ROLLBACK TO SAVEPOINT triggers CoordinatedRemoteTransactionsSavepointRollback
+-- which sends cancel + drain + ROLLBACK TO SAVEPOINT on every connection
+-- participating in the current transaction.  Verify that:
+--   (a) a batched SELECT inside a subtransaction composes with
+--       ROLLBACK TO SAVEPOINT,
+--   (b) post-rollback the connection is reusable for further
+--       batched SELECTs and DML,
+--   (c) the outer COMMIT preserves only the work outside the
+--       rolled-back savepoint.
+--
+CREATE TABLE savepoint_batch (id int PRIMARY KEY, v int);
+SELECT create_distributed_table('savepoint_batch', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO savepoint_batch
+    SELECT g, g FROM generate_series(1, 100) g;
+SET citus.executor_batch_size TO 5;
+BEGIN;
+    -- Pre-savepoint write: must survive the outer COMMIT.
+    UPDATE savepoint_batch SET v = v + 10000 WHERE id <= 3;
+    SAVEPOINT sp1;
+        -- Inside-savepoint write: must be undone by ROLLBACK TO sp1.
+        UPDATE savepoint_batch SET v = -1 WHERE id BETWEEN 10 AND 20;
+        -- Batched SELECT inside the savepoint scope.
+        SELECT count(*) FROM savepoint_batch WHERE v < 0;
+ count
+---------------------------------------------------------------------
+    11
+(1 row)
+
+    ROLLBACK TO SAVEPOINT sp1;
+    -- After ROLLBACK TO sp1 the inner UPDATE must be gone; a fresh
+    -- batched SELECT must use the same connections cleanly.
+    SELECT count(*) FROM savepoint_batch WHERE v < 0;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+    -- Another batched SELECT to confirm the connection state is
+    -- usable for a multi-batch scan after the savepoint rollback.
+    SELECT count(*) FROM (
+        SELECT id FROM savepoint_batch ORDER BY id
+    ) s;
+ count
+---------------------------------------------------------------------
+   100
+(1 row)
+
+    -- Post-rollback DML must succeed and persist through COMMIT.
+    UPDATE savepoint_batch SET v = v + 20000 WHERE id = 50;
+COMMIT;
+-- Verify final state:
+--   - ids 1-3 carry the pre-savepoint +10000 update
+--   - ids 10-20 are unchanged (inner UPDATE rolled back)
+--   - id 50 carries the post-rollback +20000 update
+SELECT id, v FROM savepoint_batch WHERE id IN (1, 2, 3, 10, 15, 20, 50)
+ORDER BY id;
+ id |   v
+---------------------------------------------------------------------
+  1 | 10001
+  2 | 10002
+  3 | 10003
+ 10 |    10
+ 15 |    15
+ 20 |    20
+ 50 | 20050
+(7 rows)
+
+RESET citus.executor_batch_size;
+DROP TABLE savepoint_batch;
 --
 -- Cleanup
 --

--- a/src/test/regress/expected/arbitrary_configs_router.out
+++ b/src/test/regress/expected/arbitrary_configs_router.out
@@ -969,7 +969,7 @@ END;
 WARNING:  there is no transaction in progress
 -- cursor queries are fast-path router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/expected/multi_mx_alter_distributed_table.out
+++ b/src/test/regress/expected/multi_mx_alter_distributed_table.out
@@ -188,13 +188,13 @@ SELECT create_distributed_function('proc_0(float8)', 'dist_key', 'test_proc_colo
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410002
+ test_proc_colocation_0 |      1410003
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0');
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410002
+ proc_0  |      1410003
 (1 row)
 
 SET client_min_messages TO DEBUG1;
@@ -223,13 +223,13 @@ RESET client_min_messages;
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410003
+ test_proc_colocation_0 |      1410004
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0');
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410003
+ proc_0  |      1410004
 (1 row)
 
 -- colocatewith is not null && list_length(colocatedTableList) = 1
@@ -269,13 +269,13 @@ RESET client_min_messages;
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410005
+ test_proc_colocation_0 |      1410006
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0');
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410005
+ proc_0  |      1410006
 (1 row)
 
 -- shardCount is not null && cascade_to_colocated is true
@@ -302,13 +302,13 @@ RESET client_min_messages;
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410006
+ test_proc_colocation_0 |      1410007
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0');
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410006
+ proc_0  |      1410007
 (1 row)
 
 -- colocatewith is not null && cascade_to_colocated is true
@@ -356,13 +356,13 @@ RESET client_min_messages;
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410008
+ test_proc_colocation_0 |      1410009
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0');
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410008
+ proc_0  |      1410009
 (1 row)
 
 -- try a case with more than one procedure
@@ -386,14 +386,14 @@ SELECT create_distributed_function('proc_1(float8)', 'dist_key', 'test_proc_colo
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410008
+ test_proc_colocation_0 |      1410009
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0', 'proc_1') ORDER BY proname;
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410008
- proc_1  |      1410008
+ proc_0  |      1410009
+ proc_1  |      1410009
 (2 rows)
 
 SET client_min_messages TO DEBUG1;
@@ -437,14 +437,14 @@ RESET client_min_messages;
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410009
+ test_proc_colocation_0 |      1410010
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0', 'proc_1') ORDER BY proname;
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410009
- proc_1  |      1410009
+ proc_0  |      1410010
+ proc_1  |      1410010
 (2 rows)
 
 -- case which shouldn't preserve colocation for now
@@ -462,14 +462,14 @@ NOTICE:  renaming the new table to mx_alter_distributed_table.test_proc_colocati
 SELECT logicalrelid, colocationid FROM pg_dist_partition WHERE logicalrelid::regclass::text IN ('test_proc_colocation_0');
       logicalrelid      | colocationid
 ---------------------------------------------------------------------
- test_proc_colocation_0 |      1410010
+ test_proc_colocation_0 |      1410011
 (1 row)
 
 SELECT proname, colocationid FROM pg_proc JOIN pg_catalog.pg_dist_object ON pg_proc.oid = pg_catalog.pg_dist_object.objid WHERE proname IN ('proc_0', 'proc_1') ORDER BY proname;
  proname | colocationid
 ---------------------------------------------------------------------
- proc_0  |      1410009
- proc_1  |      1410009
+ proc_0  |      1410010
+ proc_1  |      1410010
 (2 rows)
 
 SET client_min_messages TO WARNING;

--- a/src/test/regress/expected/multi_mx_reference_table.out
+++ b/src/test/regress/expected/multi_mx_reference_table.out
@@ -539,7 +539,7 @@ SELECT * FROM reference_table_test WHERE value_1 = 1;
 END;
 -- cursor queries also works fine
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM reference_table_test
 		WHERE value_1 = 1 OR value_1 = 2
@@ -927,4 +927,4 @@ SELECT count(*) FROM numbers;
 
 RESET log_min_messages;
 -- clean up tables
-DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, numbers;
+DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, colocated_table_test, colocated_table_test_2, numbers;

--- a/src/test/regress/expected/multi_mx_router_planner.out
+++ b/src/test/regress/expected/multi_mx_router_planner.out
@@ -1303,7 +1303,7 @@ DEBUG:  query has a single distribution column value: 1
 END;
 -- cursor queries are router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash_mx
 		WHERE author_id = 1

--- a/src/test/regress/expected/multi_mx_schema_support.out
+++ b/src/test/regress/expected/multi_mx_schema_support.out
@@ -25,7 +25,7 @@ SELECT * FROM citus_mx_test_schema.nation_hash ORDER BY n_nationkey LIMIT 4;
 -- test cursors
 SET search_path TO public;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_hash
         WHERE n_nationkey = 1;
@@ -50,7 +50,7 @@ END;
 -- test with search_path is set
 SET search_path TO citus_mx_test_schema;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_hash
         WHERE n_nationkey = 1;

--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -560,7 +560,7 @@ SELECT * FROM reference_table_test WHERE value_1 = 1;
 END;
 -- cursor queries also works fine
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM reference_table_test
 		WHERE value_1 = 1 OR value_1 = 2

--- a/src/test/regress/expected/multi_router_planner.out
+++ b/src/test/regress/expected/multi_router_planner.out
@@ -2443,7 +2443,7 @@ DEBUG:  query has a single distribution column value: 1
 END;
 -- cursor queries are router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/expected/multi_router_planner_fast_path.out
+++ b/src/test/regress/expected/multi_router_planner_fast_path.out
@@ -1324,7 +1324,7 @@ END;
 WARNING:  there is no transaction in progress
 -- cursor queries are fast-path router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -110,7 +110,7 @@ RESET citus.shard_replication_factor;
 -- test cursors
 SET search_path TO public;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM test_schema_support.nation_append
         WHERE n_nationkey = 1;
@@ -136,7 +136,7 @@ END;
 -- test with search_path is set
 SET search_path TO test_schema_support;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_append
         WHERE n_nationkey = 1;

--- a/src/test/regress/expected/multi_utility_statements.out
+++ b/src/test/regress/expected/multi_utility_statements.out
@@ -216,7 +216,7 @@ SELECT create_distributed_table('cursor_me', 'x');
 (1 row)
 
 INSERT INTO cursor_me SELECT s/10, s FROM generate_series(1, 100) s;
-DECLARE holdCursor CURSOR WITH HOLD FOR
+DECLARE holdCursor SCROLL CURSOR WITH HOLD FOR
 		SELECT * FROM cursor_me WHERE x = 1 ORDER BY y;
 FETCH NEXT FROM holdCursor;
  x | y
@@ -257,7 +257,7 @@ FETCH FORWARD 3 FROM holdCursor;
 CLOSE holdCursor;
 -- Test DECLARE CURSOR .. WITH HOLD inside transaction block
 BEGIN;
-DECLARE holdCursor CURSOR WITH HOLD FOR
+DECLARE holdCursor SCROLL CURSOR WITH HOLD FOR
 		SELECT * FROM cursor_me WHERE x = 1 ORDER BY y;
 FETCH 3 FROM holdCursor;
  x | y
@@ -328,7 +328,7 @@ CLOSE holdCursor;
 -- Test DECLARE CURSOR .. WITH HOLD with parameter
 CREATE OR REPLACE FUNCTION declares_cursor(p int)
 RETURNS void AS $$
-	DECLARE c CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE x = $1;
+	DECLARE c SCROLL CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE x = $1;
 $$ LANGUAGE SQL;
 SELECT declares_cursor(5);
  declares_cursor
@@ -387,7 +387,7 @@ SELECT declares_cursor_2();
 -- Test DECLARE CURSOR .. WITH HOLD with parameter on non-dist key
 CREATE OR REPLACE FUNCTION declares_cursor_3(p int)
 RETURNS void AS $$
-	DECLARE c3 CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE y = $1;
+	DECLARE c3 SCROLL CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE y = $1;
 $$ LANGUAGE SQL;
 SELECT declares_cursor_3(5);
  declares_cursor_3
@@ -427,7 +427,7 @@ CLOSE c3;
 -- Test DECLARE CURSOR .. WITH HOLD with parameter on dist key, but not fast-path planner
 CREATE OR REPLACE FUNCTION declares_cursor_4(p int)
 RETURNS void AS $$
-	DECLARE c4 CURSOR WITH HOLD FOR SELECT *, (SELECT 1) FROM cursor_me WHERE x = $1;
+	DECLARE c4 SCROLL CURSOR WITH HOLD FOR SELECT *, (SELECT 1) FROM cursor_me WHERE x = $1;
 $$ LANGUAGE SQL;
 SELECT declares_cursor_4(5);
  declares_cursor_4

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -82,7 +82,7 @@ test: issue_8468
 test: multi_subquery_complex_reference_clause multi_subquery_window_functions multi_view multi_sql_function multi_prepare_sql
 test: sql_procedure multi_function_in_join row_types materialized_view
 test: sql_procedure_no_transaction_block
-test: multi_subquery_in_where_reference_clause adaptive_executor propagate_set_commands geqo
+test: multi_subquery_in_where_reference_clause adaptive_executor adaptive_executor_batching propagate_set_commands geqo
 test: forcedelegation_functions system_queries
 # this should be run alone as it gets too many clients
 test: join_pushdown

--- a/src/test/regress/sql/adaptive_executor_batching.sql
+++ b/src/test/regress/sql/adaptive_executor_batching.sql
@@ -67,6 +67,506 @@ SELECT x FROM batch_test ORDER BY x LIMIT 5;
 SELECT sum(x), min(x), max(x) FROM batch_test;
 
 --
+-- Additional tables for join / subquery / CTE tests
+--
+CREATE TABLE batch_orders (
+    order_id int,
+    customer_id int,
+    amount numeric(10,2),
+    region text,
+    order_date date
+);
+SELECT create_distributed_table('batch_orders', 'order_id');
+
+CREATE TABLE batch_items (
+    item_id int,
+    order_id int,
+    product text,
+    qty int,
+    price numeric(10,2)
+);
+SELECT create_distributed_table('batch_items', 'order_id', colocate_with => 'batch_orders');
+
+CREATE TABLE batch_regions (
+    region text,
+    country text
+);
+SELECT create_reference_table('batch_regions');
+
+-- Populate orders (300 rows across 4 shards) with deterministic amounts
+INSERT INTO batch_orders
+SELECT i,
+       (i % 50) + 1,
+       round(((i * 127 + 53) % 500 + 10)::numeric, 2),
+       (ARRAY['NA', 'EMEA', 'APAC', 'LATAM'])[1 + (i % 4)],
+       '2025-01-01'::date + (i % 365)
+FROM generate_series(1, 300) i;
+
+-- Populate items (600 rows, ~2 items per order) with deterministic prices
+INSERT INTO batch_items
+SELECT i,
+       ((i - 1) / 2) + 1,
+       'product_' || (i % 20),
+       1 + (i % 5),
+       round(((i * 31 + 7) % 100 + 1)::numeric, 2)
+FROM generate_series(1, 600) i;
+
+-- Populate reference table
+INSERT INTO batch_regions VALUES
+    ('NA', 'United States'),
+    ('EMEA', 'Germany'),
+    ('APAC', 'Japan'),
+    ('LATAM', 'Brazil');
+
+-- Create vanilla PostgreSQL copies with identical data for result verification
+CREATE TABLE local_orders AS SELECT * FROM batch_orders;
+CREATE TABLE local_items AS SELECT * FROM batch_items;
+CREATE TABLE local_regions AS SELECT * FROM batch_regions;
+
+-- ================================================================
+-- Test 7a: Distributed join with batching
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- Co-located join on distribution column (both distributed on order_id)
+SELECT count(*)
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id;
+
+-- Join with filter that spans multiple batches
+SELECT o.order_id, o.region, i.product
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id
+WHERE o.order_id <= 10
+ORDER BY o.order_id, i.item_id;
+
+-- ================================================================
+-- Test 7b: Reference table joins with batching
+-- ================================================================
+SET citus.executor_batch_size TO 15;
+
+SELECT o.order_id, o.region, r.country
+FROM batch_orders o
+JOIN batch_regions r ON o.region = r.region
+WHERE o.order_id <= 20
+ORDER BY o.order_id;
+
+-- Aggregate over reference table join
+SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+FROM batch_orders o
+JOIN batch_regions r ON o.region = r.region
+GROUP BY r.country
+ORDER BY r.country;
+
+-- ================================================================
+-- Test 7c: GROUP BY with HAVING across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- Simple GROUP BY
+SELECT region, count(*) AS cnt, min(amount) AS min_amt, max(amount) AS max_amt
+FROM batch_orders
+GROUP BY region
+ORDER BY region;
+
+-- GROUP BY with HAVING (filters groups after aggregation)
+SELECT region, count(*) AS cnt
+FROM batch_orders
+GROUP BY region
+HAVING count(*) > 50
+ORDER BY region;
+
+-- Multi-column GROUP BY across batch boundaries
+SELECT region, (order_id % 10) AS bucket, count(*)
+FROM batch_orders
+WHERE order_id <= 100
+GROUP BY region, (order_id % 10)
+ORDER BY region, bucket;
+
+-- ================================================================
+-- Test 7d: Distinct and distinct aggregates
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+SELECT DISTINCT region FROM batch_orders ORDER BY region;
+
+SELECT count(DISTINCT region), count(DISTINCT customer_id)
+FROM batch_orders;
+
+-- ================================================================
+-- Test 7e: CTE (Common Table Expressions) with batching
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- Inlinable CTE with join
+WITH regional_totals AS (
+    SELECT o.region, sum(o.amount) AS total
+    FROM batch_orders o
+    GROUP BY o.region
+)
+SELECT rt.region, rt.total::numeric(12,2), r.country
+FROM regional_totals rt
+JOIN batch_regions r ON rt.region = r.region
+ORDER BY rt.region;
+
+-- CTE that feeds into a filtered query
+WITH top_customers AS (
+    SELECT customer_id, count(*) AS order_count
+    FROM batch_orders
+    GROUP BY customer_id
+    HAVING count(*) >= 5
+)
+SELECT tc.customer_id, tc.order_count
+FROM top_customers tc
+ORDER BY tc.customer_id;
+
+-- Nested CTEs
+WITH order_stats AS (
+    SELECT region, count(*) AS cnt, avg(amount) AS avg_amt
+    FROM batch_orders
+    GROUP BY region
+),
+enriched AS (
+    SELECT os.*, r.country
+    FROM order_stats os
+    JOIN batch_regions r ON os.region = r.region
+)
+SELECT country, cnt, avg_amt::numeric(10,2)
+FROM enriched
+ORDER BY country;
+
+-- ================================================================
+-- Test 7f: Subqueries (correlated and uncorrelated)
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- Uncorrelated subquery in WHERE
+SELECT order_id, amount
+FROM batch_orders
+WHERE amount > (SELECT avg(amount) FROM batch_orders)
+ORDER BY order_id
+LIMIT 15;
+
+-- Subquery in FROM (derived table)
+SELECT sub.region, sub.total_orders, sub.total_amount::numeric(12,2)
+FROM (
+    SELECT region, count(*) AS total_orders, sum(amount) AS total_amount
+    FROM batch_orders
+    GROUP BY region
+) sub
+ORDER BY sub.region;
+
+-- IN subquery spanning batches
+SELECT order_id, region
+FROM batch_orders
+WHERE region IN (
+    SELECT region FROM batch_regions WHERE country IN ('Japan', 'Brazil')
+)
+ORDER BY order_id
+LIMIT 20;
+
+-- EXISTS subquery (co-located via distribution column)
+SELECT o.order_id, o.region
+FROM batch_orders o
+WHERE EXISTS (
+    SELECT 1 FROM batch_items i
+    WHERE i.order_id = o.order_id
+      AND i.qty >= 4
+)
+ORDER BY o.order_id
+LIMIT 15;
+
+-- ================================================================
+-- Test 7g: Window functions across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+SELECT order_id, region, amount,
+       row_number() OVER (ORDER BY order_id) AS rn,
+       sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+FROM batch_orders
+WHERE order_id <= 20
+ORDER BY order_id;
+
+-- RANK / DENSE_RANK
+SELECT order_id, region,
+       rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+FROM batch_orders
+WHERE order_id <= 40
+ORDER BY region, rnk, order_id
+LIMIT 20;
+
+-- ================================================================
+-- Test 7h: UNION / UNION ALL across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+SELECT order_id, 'orders' AS source FROM batch_orders WHERE order_id <= 10
+UNION ALL
+SELECT item_id, 'items' FROM batch_items WHERE item_id <= 10
+ORDER BY source, order_id;
+
+-- UNION (deduplicated)
+SELECT region FROM batch_orders WHERE order_id <= 50
+UNION
+SELECT region FROM batch_orders WHERE order_id > 250
+ORDER BY region;
+
+-- ================================================================
+-- Test 7i: Multi-table join with GROUP BY and HAVING
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+FROM batch_orders o
+JOIN batch_items i ON o.order_id = i.order_id
+JOIN batch_regions r ON o.region = r.region
+WHERE o.order_id <= 50
+GROUP BY r.country
+HAVING sum(i.qty) > 10
+ORDER BY r.country;
+
+-- ================================================================
+-- Test 7j: ORDER BY with LIMIT/OFFSET across batches
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- OFFSET spans batch boundaries
+SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 10 OFFSET 15;
+
+-- Large OFFSET
+SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 5 OFFSET 290;
+
+-- ================================================================
+-- Test 7k: Cross-batch-size consistency for complex queries
+-- Runs the same complex query at different batch sizes and verifies
+-- identical results.
+-- ================================================================
+CREATE TABLE batch_complex_consistency AS
+SELECT
+    bs,
+    (SELECT count(*)
+     FROM batch_orders o
+     JOIN batch_regions r ON o.region = r.region)::bigint AS join_cnt,
+    (SELECT count(DISTINCT region) FROM batch_orders)::int AS dist_regions,
+    (SELECT sum(amount)::numeric(14,2) FROM batch_orders) AS total_amount,
+    (SELECT count(*)
+     FROM batch_orders
+     WHERE amount > (SELECT avg(amount) FROM batch_orders))::bigint AS above_avg
+FROM (SELECT unnest(ARRAY[1, 7, 25, 100, 10000]) bs) sizes,
+LATERAL (SELECT set_config('citus.executor_batch_size', bs::text, false)) AS apply;
+
+-- All batch sizes must produce the same results
+SELECT count(DISTINCT (join_cnt, dist_regions, total_amount, above_avg)) AS distinct_results
+FROM batch_complex_consistency;
+
+SELECT DISTINCT join_cnt, dist_regions, total_amount, above_avg
+FROM batch_complex_consistency;
+
+DROP TABLE batch_complex_consistency;
+
+-- ================================================================
+-- Test 7l: Distributed vs vanilla PostgreSQL result verification
+-- Every query is run against both distributed and local tables;
+-- EXCEPT should return zero rows if results are identical.
+-- ================================================================
+SET citus.executor_batch_size TO 10;
+
+-- Join count
+SELECT count(*) AS diff FROM (
+    (SELECT count(*) AS c FROM batch_orders o JOIN batch_items i ON o.order_id = i.order_id)
+    EXCEPT
+    (SELECT count(*) AS c FROM local_orders o JOIN local_items i ON o.order_id = i.order_id)
+) t;
+
+-- Join with filter
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region, i.product
+     FROM batch_orders o JOIN batch_items i ON o.order_id = i.order_id
+     WHERE o.order_id <= 10)
+    EXCEPT
+    (SELECT o.order_id, o.region, i.product
+     FROM local_orders o JOIN local_items i ON o.order_id = i.order_id
+     WHERE o.order_id <= 10)
+) t;
+
+-- Reference table join
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region, r.country
+     FROM batch_orders o JOIN batch_regions r ON o.region = r.region
+     WHERE o.order_id <= 20)
+    EXCEPT
+    (SELECT o.order_id, o.region, r.country
+     FROM local_orders o JOIN local_regions r ON o.region = r.region
+     WHERE o.order_id <= 20)
+) t;
+
+-- Aggregate over reference table join
+SELECT count(*) AS diff FROM (
+    (SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+     FROM batch_orders o JOIN batch_regions r ON o.region = r.region
+     GROUP BY r.country)
+    EXCEPT
+    (SELECT r.country, count(*), sum(o.amount)::numeric(12,2)
+     FROM local_orders o JOIN local_regions r ON o.region = r.region
+     GROUP BY r.country)
+) t;
+
+-- GROUP BY with HAVING
+SELECT count(*) AS diff FROM (
+    (SELECT region, count(*) AS cnt, min(amount), max(amount)
+     FROM batch_orders GROUP BY region)
+    EXCEPT
+    (SELECT region, count(*) AS cnt, min(amount), max(amount)
+     FROM local_orders GROUP BY region)
+) t;
+
+-- Multi-column GROUP BY
+SELECT count(*) AS diff FROM (
+    (SELECT region, (order_id % 10) AS bucket, count(*)
+     FROM batch_orders WHERE order_id <= 100
+     GROUP BY region, (order_id % 10))
+    EXCEPT
+    (SELECT region, (order_id % 10) AS bucket, count(*)
+     FROM local_orders WHERE order_id <= 100
+     GROUP BY region, (order_id % 10))
+) t;
+
+-- DISTINCT
+SELECT count(*) AS diff FROM (
+    (SELECT DISTINCT region FROM batch_orders)
+    EXCEPT
+    (SELECT DISTINCT region FROM local_orders)
+) t;
+
+-- Distinct aggregates
+SELECT count(*) AS diff FROM (
+    (SELECT count(DISTINCT region), count(DISTINCT customer_id) FROM batch_orders)
+    EXCEPT
+    (SELECT count(DISTINCT region), count(DISTINCT customer_id) FROM local_orders)
+) t;
+
+-- CTE with join
+SELECT count(*) AS diff FROM (
+    (WITH rt AS (SELECT region, sum(amount) AS total FROM batch_orders GROUP BY region)
+     SELECT rt.region, rt.total::numeric(12,2), r.country
+     FROM rt JOIN batch_regions r ON rt.region = r.region)
+    EXCEPT
+    (WITH rt AS (SELECT region, sum(amount) AS total FROM local_orders GROUP BY region)
+     SELECT rt.region, rt.total::numeric(12,2), r.country
+     FROM rt JOIN local_regions r ON rt.region = r.region)
+) t;
+
+-- Nested CTEs
+SELECT count(*) AS diff FROM (
+    (WITH os AS (SELECT region, count(*) AS cnt, avg(amount) AS avg_amt FROM batch_orders GROUP BY region),
+          en AS (SELECT os.*, r.country FROM os JOIN batch_regions r ON os.region = r.region)
+     SELECT country, cnt, avg_amt::numeric(10,2) FROM en)
+    EXCEPT
+    (WITH os AS (SELECT region, count(*) AS cnt, avg(amount) AS avg_amt FROM local_orders GROUP BY region),
+          en AS (SELECT os.*, r.country FROM os JOIN local_regions r ON os.region = r.region)
+     SELECT country, cnt, avg_amt::numeric(10,2) FROM en)
+) t;
+
+-- Uncorrelated subquery in WHERE
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, amount FROM batch_orders
+     WHERE amount > (SELECT avg(amount) FROM batch_orders))
+    EXCEPT
+    (SELECT order_id, amount FROM local_orders
+     WHERE amount > (SELECT avg(amount) FROM local_orders))
+) t;
+
+-- Subquery in FROM
+SELECT count(*) AS diff FROM (
+    (SELECT region, count(*) AS total_orders, sum(amount)::numeric(12,2) AS total_amount
+     FROM batch_orders GROUP BY region)
+    EXCEPT
+    (SELECT region, count(*) AS total_orders, sum(amount)::numeric(12,2) AS total_amount
+     FROM local_orders GROUP BY region)
+) t;
+
+-- IN subquery
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region FROM batch_orders
+     WHERE region IN (SELECT region FROM batch_regions WHERE country IN ('Japan', 'Brazil')))
+    EXCEPT
+    (SELECT order_id, region FROM local_orders
+     WHERE region IN (SELECT region FROM local_regions WHERE country IN ('Japan', 'Brazil')))
+) t;
+
+-- EXISTS subquery
+SELECT count(*) AS diff FROM (
+    (SELECT o.order_id, o.region FROM batch_orders o
+     WHERE EXISTS (SELECT 1 FROM batch_items i WHERE i.order_id = o.order_id AND i.qty >= 4))
+    EXCEPT
+    (SELECT o.order_id, o.region FROM local_orders o
+     WHERE EXISTS (SELECT 1 FROM local_items i WHERE i.order_id = o.order_id AND i.qty >= 4))
+) t;
+
+-- Window functions
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region, amount,
+            row_number() OVER (ORDER BY order_id) AS rn,
+            sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+     FROM batch_orders WHERE order_id <= 20)
+    EXCEPT
+    (SELECT order_id, region, amount,
+            row_number() OVER (ORDER BY order_id) AS rn,
+            sum(amount) OVER (PARTITION BY region ORDER BY order_id) AS running_total
+     FROM local_orders WHERE order_id <= 20)
+) t;
+
+-- RANK window function
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region,
+            rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+     FROM batch_orders WHERE order_id <= 40)
+    EXCEPT
+    (SELECT order_id, region,
+            rank() OVER (PARTITION BY region ORDER BY amount DESC) AS rnk
+     FROM local_orders WHERE order_id <= 40)
+) t;
+
+-- UNION ALL
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, 'orders' AS source FROM batch_orders WHERE order_id <= 10
+     UNION ALL
+     SELECT item_id, 'items' FROM batch_items WHERE item_id <= 10)
+    EXCEPT
+    (SELECT order_id, 'orders' AS source FROM local_orders WHERE order_id <= 10
+     UNION ALL
+     SELECT item_id, 'items' FROM local_items WHERE item_id <= 10)
+) t;
+
+-- 3-table join with GROUP BY and HAVING
+SELECT count(*) AS diff FROM (
+    (SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+     FROM batch_orders o
+     JOIN batch_items i ON o.order_id = i.order_id
+     JOIN batch_regions r ON o.region = r.region
+     WHERE o.order_id <= 50
+     GROUP BY r.country HAVING sum(i.qty) > 10)
+    EXCEPT
+    (SELECT r.country, count(DISTINCT o.order_id) AS orders, sum(i.qty) AS total_qty
+     FROM local_orders o
+     JOIN local_items i ON o.order_id = i.order_id
+     JOIN local_regions r ON o.region = r.region
+     WHERE o.order_id <= 50
+     GROUP BY r.country HAVING sum(i.qty) > 10)
+) t;
+
+-- ORDER BY with LIMIT/OFFSET
+SELECT count(*) AS diff FROM (
+    (SELECT order_id, region FROM batch_orders ORDER BY order_id LIMIT 10 OFFSET 15)
+    EXCEPT
+    (SELECT order_id, region FROM local_orders ORDER BY order_id LIMIT 10 OFFSET 15)
+) t;
+
+-- Reset for subsequent tests
+SET citus.executor_batch_size TO 10;
+
+--
 -- Test 8: DML with RETURNING across batches
 --
 SET citus.executor_batch_size TO 10;
@@ -95,12 +595,12 @@ RESET citus.executor_batch_size;
 SHOW citus.executor_batch_size;
 
 --
--- Test 10: M1 — Between-batch error cleanup (CitusEndScan must release sessions)
+-- Test 10: Between-batch error cleanup (CitusEndScan must release sessions)
 --
 -- This validates that when an error occurs on the coordinator between
 -- AdaptiveExecutorRun calls (mid-scan, mid-batch), CitusEndScan properly
 -- cleans up distributed execution sessions via AdaptiveExecutorEnd.
--- Without the M1 fix, sessions/connections would leak on each error.
+-- Without this fix, sessions/connections would leak on each error.
 --
 SET citus.executor_batch_size TO 10;
 
@@ -185,6 +685,256 @@ SELECT count(DISTINCT (cnt, s, mn, mx, range_cnt)) AS distinct_results FROM batc
 SELECT DISTINCT cnt, s, mn, mx, range_cnt FROM batch_consistency;
 
 DROP TABLE batch_consistency;
+
+--
+-- Test 12: EXPLAIN ANALYZE with batching
+-- Verify that EXPLAIN ANALYZE works correctly when batching is active.
+-- We check: (a) it runs without error, (b) row counts in the output are
+-- correct, and (c) it works with result sets that are exact multiples of
+-- the batch size as well as non-multiples.
+--
+
+-- 12a: exact multiple of batch size (200 rows, batch_size=50 → 4 batches)
+SET citus.executor_batch_size TO 50;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM adaptive_executor_batching.batch_test');
+
+-- Verify the actual query still returns the right count
+SELECT count(*) FROM batch_test;
+
+-- 12b: non-multiple of batch size (200 rows, batch_size=30 → 6 full + 1 partial)
+SET citus.executor_batch_size TO 30;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM adaptive_executor_batching.batch_test');
+
+SELECT count(*) FROM batch_test;
+
+-- 12c: small batch_size (200 rows, batch_size=7 → many small batches)
+SET citus.executor_batch_size TO 7;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT x, y FROM adaptive_executor_batching.batch_test WHERE x <= 10');
+
+SELECT count(*) FROM batch_test WHERE x <= 10;
+
+-- 12d: EXPLAIN ANALYZE with aggregation across batches
+SET citus.executor_batch_size TO 25;
+SELECT public.explain_filter('EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT count(*), sum(x), min(x), max(x) FROM adaptive_executor_batching.batch_test');
+
+SELECT count(*), sum(x), min(x), max(x) FROM batch_test;
+
+--
+-- Test 13: Scrollable cursor with batching
+-- Verifies that DECLARE SCROLL CURSOR works correctly with the batched
+-- executor. For scrollable cursors, the executor preserves the tuplestore
+-- across batches (skips tuplestore_clear) so backward fetches can access
+-- rows from earlier batches.
+--
+-- With batch_size=10, a 50-row result spans 5 batches:
+--   batch 1: rows 1-10, batch 2: rows 11-20, batch 3: rows 21-30,
+--   batch 4: rows 31-40, batch 5: rows 41-50
+--
+SET citus.executor_batch_size TO 10;
+
+-- 13a: Forward/backward zigzag across batch boundaries
+BEGIN;
+DECLARE scroll_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+
+-- Read into batch 2 (rows 1-15)
+FETCH FORWARD 15 FROM scroll_cur;
+
+-- Backward 10: crosses batch 2→1 boundary, returns rows 14..5
+FETCH BACKWARD 10 FROM scroll_cur;
+
+-- Forward 5 from position 5: returns rows 6..10
+FETCH FORWARD 5 FROM scroll_cur;
+
+-- Forward 15 more: crosses batch 1→2→3, returns rows 11..25
+FETCH FORWARD 15 FROM scroll_cur;
+
+-- Backward 20: crosses batch 3→2→1, returns rows 24..5
+FETCH BACKWARD 20 FROM scroll_cur;
+
+CLOSE scroll_cur;
+COMMIT;
+
+-- 13b: FETCH FIRST / LAST / ABSOLUTE across all batches
+BEGIN;
+DECLARE abs_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+
+-- Jump to various positions across different batches
+FETCH ABSOLUTE 5 FROM abs_cur;   -- batch 1
+FETCH ABSOLUTE 45 FROM abs_cur;  -- batch 5
+FETCH ABSOLUTE 1 FROM abs_cur;   -- batch 1 (backward jump)
+FETCH ABSOLUTE 50 FROM abs_cur;  -- batch 5 (last row)
+FETCH ABSOLUTE 15 FROM abs_cur;  -- batch 2 (backward jump)
+FETCH ABSOLUTE 35 FROM abs_cur;  -- batch 4 (forward jump)
+FETCH ABSOLUTE 10 FROM abs_cur;  -- batch 1 (backward jump across 3 batches)
+
+-- FIRST and LAST
+FETCH LAST FROM abs_cur;
+FETCH FIRST FROM abs_cur;
+FETCH LAST FROM abs_cur;
+
+CLOSE abs_cur;
+COMMIT;
+
+-- 13c: Read all rows forward, then backward through all batches
+BEGIN;
+DECLARE full_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 30 ORDER BY x;
+
+-- Drain all 3 batches forward
+FETCH FORWARD ALL FROM full_cur;
+
+-- Now backward through all 3 batches
+FETCH BACKWARD 30 FROM full_cur;
+
+-- And forward to the end again
+FETCH FORWARD ALL FROM full_cur;
+
+CLOSE full_cur;
+COMMIT;
+
+-- 13d: FETCH RELATIVE across batch boundaries
+BEGIN;
+DECLARE rel_cur SCROLL CURSOR FOR
+  SELECT x FROM batch_test WHERE x <= 50 ORDER BY x;
+
+FETCH ABSOLUTE 25 FROM rel_cur;  -- middle of batch 3
+FETCH RELATIVE -15 FROM rel_cur; -- jump back to batch 1 (row 10)
+FETCH RELATIVE 30 FROM rel_cur;  -- jump forward to batch 4 (row 40)
+FETCH RELATIVE -35 FROM rel_cur; -- jump back to batch 1 (row 5)
+FETCH RELATIVE 10 FROM rel_cur;  -- forward within batch 2 (row 15)
+
+CLOSE rel_cur;
+COMMIT;
+
+-- 13e: SCROLL cursor with inlinable CTE
+-- Exercises the CTE-inlining planner path (InlineCtesAndCreateDistributedPlannedStmt
+-- → TryCreateDistributedPlannedStmt → CreateDistributedPlannedStmt → FinalizePlan)
+-- to verify that cursorOptions (CURSOR_OPT_SCROLL) is forwarded through
+-- TryCreateDistributedPlannedStmt so FinalizePlan wraps the plan in a Material node.
+BEGIN;
+DECLARE cte_scroll SCROLL CURSOR FOR
+  WITH batch_cte AS (
+    SELECT x FROM batch_test WHERE x <= 30
+  )
+  SELECT x FROM batch_cte ORDER BY x;
+
+-- Forward into batch 2
+FETCH FORWARD 15 FROM cte_scroll;
+
+-- Backward across batch boundary (rows 14..5)
+FETCH BACKWARD 10 FROM cte_scroll;
+
+-- Forward to end (rows 6..30)
+FETCH FORWARD ALL FROM cte_scroll;
+
+-- Backward all the way (rows 29..1)
+FETCH BACKWARD ALL FROM cte_scroll;
+
+CLOSE cte_scroll;
+COMMIT;
+
+--
+-- Test 14: WITH HOLD cursor with batching
+--
+-- Validates that DECLARE ... SCROLL CURSOR WITH HOLD works correctly
+-- with the batched executor. At COMMIT, PostgreSQL calls
+-- PersistHoldablePortal(), which:
+--
+--   1. ExecutorRewind() → ExecReScan on the Material node (inserted by
+--      FinalizePlan for SCROLL cursors), which does tuplestore_rescan()
+--      to rewind the already-materialized rows — no distributed re-execution.
+--   2. ExecutorRun(Forward, 0) → drains ALL tuples through the Material
+--      node into the portal's holdStore tuplestore.
+--   3. ExecutorEnd() shuts down the executor and releases connections.
+--
+-- After COMMIT the cursor survives and all FETCHes read from the local
+-- holdStore — no distributed execution occurs. The Material node is
+-- critical: without it, ExecutorRewind would call CitusReScan directly,
+-- which could attempt to re-execute the distributed query at an unsafe time.
+--
+-- Also tests a non-SCROLL WITH HOLD cursor, where no Material node is
+-- inserted. PersistHoldablePortal skips ExecutorRewind and only does a
+-- forward drain of the remaining (unfetched) rows.
+--
+SET citus.executor_batch_size TO 5;
+
+-- 14a: SCROLL + WITH HOLD — full backward/forward after COMMIT
+CREATE TABLE withhold_test (id int, val int, label text);
+SELECT create_distributed_table('withhold_test', 'id');
+
+INSERT INTO withhold_test VALUES
+    (1, 100, 'alpha'),   (2, 200, 'bravo'),
+    (3, 300, 'charlie'),  (4, 100, 'delta'),
+    (5, 200, 'echo'),     (6, 300, 'foxtrot'),
+    (7, 100, 'golf'),     (8, 200, 'hotel'),
+    (9, 300, 'india'),    (10, 100, 'juliet'),
+    (11, 200, NULL),      (12, NULL, 'lima');
+
+-- Also create a vanilla copy for result verification
+CREATE TABLE withhold_local AS SELECT * FROM withhold_test;
+
+BEGIN;
+DECLARE hold_scroll SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY val NULLS LAST, id;
+-- Fetch only 3 of 12 rows inside the transaction
+FETCH FORWARD 3 FROM hold_scroll;
+COMMIT;
+
+-- After COMMIT the cursor survives; remaining rows must be accessible
+FETCH FORWARD 5 FROM hold_scroll;
+-- Backward scan into already-fetched territory
+FETCH BACKWARD 4 FROM hold_scroll;
+-- Fetch to end
+FETCH FORWARD ALL FROM hold_scroll;
+-- Verify the very end
+FETCH BACKWARD 1 FROM hold_scroll;
+CLOSE hold_scroll;
+
+-- 14b: Non-SCROLL WITH HOLD — forward-only after COMMIT
+BEGIN;
+DECLARE hold_fwd NO SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY id;
+-- Fetch 4 rows inside the transaction
+FETCH FORWARD 4 FROM hold_fwd;
+COMMIT;
+
+-- After COMMIT, remaining 8 rows must be available
+FETCH FORWARD ALL FROM hold_fwd;
+CLOSE hold_fwd;
+
+-- 14c: NO SCROLL cursor rejects backward fetches
+-- Without explicit SCROLL, a cursor on a multi-shard query with ORDER BY
+-- would normally auto-promote to SCROLL (because the Sort node supports
+-- backward scan). Explicit NO SCROLL prevents this and must reject
+-- backward fetches with an error.
+BEGIN;
+DECLARE hold_noscroll NO SCROLL CURSOR WITH HOLD FOR
+    SELECT id, val FROM withhold_test ORDER BY id;
+FETCH 3 FROM hold_noscroll;
+FETCH FORWARD 3 FROM hold_noscroll;
+COMMIT;
+
+-- Forward still works after COMMIT
+FETCH 3 FROM hold_noscroll;
+-- Backward must fail
+FETCH BACKWARD 3 FROM hold_noscroll;
+CLOSE hold_noscroll;
+
+-- 14d: Verify WITH HOLD results match vanilla PostgreSQL
+-- Run the same ordered query against the local table and EXCEPT
+SELECT count(*) AS diff FROM (
+    (SELECT id, val FROM withhold_test ORDER BY val NULLS LAST, id)
+    EXCEPT
+    (SELECT id, val FROM withhold_local ORDER BY val NULLS LAST, id)
+) t;
+
+DROP TABLE withhold_test;
+DROP TABLE withhold_local;
+
+-- Reset batch size
+RESET citus.executor_batch_size;
 
 --
 -- Cleanup

--- a/src/test/regress/sql/adaptive_executor_batching.sql
+++ b/src/test/regress/sql/adaptive_executor_batching.sql
@@ -1,0 +1,193 @@
+--
+-- Tests for the batched adaptive executor (reentrant execution)
+--
+CREATE SCHEMA adaptive_executor_batching;
+SET search_path TO adaptive_executor_batching;
+
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 802009000;
+
+CREATE TABLE batch_test (x int, y text);
+SELECT create_distributed_table('batch_test', 'x');
+
+-- Insert enough rows to exercise multiple batches
+INSERT INTO batch_test SELECT i, 'row_' || i FROM generate_series(1, 200) i;
+
+-- Verify baseline: all rows present
+SELECT count(*) FROM batch_test;
+
+--
+-- Test 1: Force small batch size and verify all rows are returned
+--
+SET citus.executor_batch_size TO 10;
+
+SELECT count(*) FROM batch_test;
+
+-- Ordered output to verify correctness across batches
+SELECT x FROM batch_test WHERE x <= 20 ORDER BY x;
+
+--
+-- Test 2: Batch size of 1 (extreme case)
+--
+SET citus.executor_batch_size TO 1;
+
+SELECT count(*) FROM batch_test;
+SELECT x FROM batch_test WHERE x <= 5 ORDER BY x;
+
+--
+-- Test 3: Batch size larger than result set (single batch)
+--
+SET citus.executor_batch_size TO 100000;
+
+SELECT count(*) FROM batch_test;
+
+--
+-- Test 4: Auto batch size (from work_mem)
+--
+SET citus.executor_batch_size TO 0;
+
+SELECT count(*) FROM batch_test;
+
+--
+-- Test 5: Empty result set with batching
+--
+SET citus.executor_batch_size TO 10;
+
+SELECT count(*) FROM batch_test WHERE x > 9999;
+
+--
+-- Test 6: LIMIT with batching
+--
+SELECT x FROM batch_test ORDER BY x LIMIT 5;
+
+--
+-- Test 7: Aggregation across batches
+--
+SELECT sum(x), min(x), max(x) FROM batch_test;
+
+--
+-- Test 8: DML with RETURNING across batches
+--
+SET citus.executor_batch_size TO 10;
+
+-- Use a separate table for DML test
+CREATE TABLE batch_dml_test (x int, y text);
+SELECT create_distributed_table('batch_dml_test', 'x');
+INSERT INTO batch_dml_test SELECT i, 'val_' || i FROM generate_series(1, 50) i;
+
+WITH deleted AS (
+    DELETE FROM batch_dml_test WHERE x <= 20 RETURNING x
+)
+SELECT count(*) FROM deleted;
+
+SELECT count(*) FROM batch_dml_test WHERE x <= 20;
+
+--
+-- Test 9: Verify GUC is session-level
+--
+SHOW citus.executor_batch_size;
+
+SET citus.executor_batch_size TO 500;
+SHOW citus.executor_batch_size;
+
+RESET citus.executor_batch_size;
+SHOW citus.executor_batch_size;
+
+--
+-- Test 10: M1 — Between-batch error cleanup (CitusEndScan must release sessions)
+--
+-- This validates that when an error occurs on the coordinator between
+-- AdaptiveExecutorRun calls (mid-scan, mid-batch), CitusEndScan properly
+-- cleans up distributed execution sessions via AdaptiveExecutorEnd.
+-- Without the M1 fix, sessions/connections would leak on each error.
+--
+SET citus.executor_batch_size TO 10;
+
+-- Helper: iterates a distributed query and raises error after N rows.
+-- With batch_size=10 and error at row 15, the error fires during
+-- the second batch — between the first AdaptiveExecutorRun (which
+-- returned control to the executor) and the scan completing.
+CREATE OR REPLACE FUNCTION trigger_between_batch_error(fail_after int)
+RETURNS void AS $$
+DECLARE
+    r RECORD;
+    cnt int := 0;
+BEGIN
+    FOR r IN SELECT x FROM batch_test ORDER BY x LOOP
+        cnt := cnt + 1;
+        IF cnt >= fail_after THEN
+            RAISE EXCEPTION 'intentional error at row %', cnt;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Single invocation: error should be caught cleanly
+DO $$
+BEGIN
+    PERFORM trigger_between_batch_error(15);
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'caught: %', SQLERRM;
+END;
+$$;
+
+-- Repeat 20 times to verify connections don't accumulate across errors.
+-- If CitusEndScan didn't clean up, we'd exhaust the connection pool.
+DO $$
+BEGIN
+    FOR i IN 1..20 LOOP
+        BEGIN
+            PERFORM trigger_between_batch_error(15);
+        EXCEPTION WHEN OTHERS THEN
+            -- expected, swallow
+        END;
+    END LOOP;
+END;
+$$;
+
+-- After 20 error cycles, distributed queries must still work
+SELECT count(*) FROM batch_test;
+
+-- Also verify with a cursor closed mid-batch (non-error path through
+-- CitusEndScan with finishedRemoteScan = false)
+BEGIN;
+DECLARE c CURSOR FOR SELECT x FROM batch_test ORDER BY x;
+FETCH 5 FROM c;
+CLOSE c;
+COMMIT;
+
+-- Still healthy after cursor close mid-batch
+SELECT count(*) FROM batch_test;
+
+--
+-- Test 11: Cross-batch-size result consistency
+--
+-- Runs the same analytical queries at batch sizes 1, 10, 100, 10000, and 0
+-- (auto) and asserts identical results. Any batch-boundary bug would cause
+-- a mismatch.
+--
+CREATE TABLE batch_consistency AS
+SELECT
+    bs,
+    (SELECT count(*) FROM batch_test)::bigint AS cnt,
+    (SELECT sum(x) FROM batch_test)::bigint AS s,
+    (SELECT min(x) FROM batch_test)::int AS mn,
+    (SELECT max(x) FROM batch_test)::int AS mx,
+    (SELECT count(*) FROM batch_test WHERE x BETWEEN 50 AND 150)::bigint AS range_cnt
+FROM (SELECT unnest(ARRAY[1, 10, 100, 10000]) bs) sizes,
+LATERAL (SELECT set_config('citus.executor_batch_size', bs::text, false)) AS apply;
+
+-- All batch sizes must produce the same result — collapse to 1 distinct row
+SELECT count(DISTINCT (cnt, s, mn, mx, range_cnt)) AS distinct_results FROM batch_consistency;
+
+-- Show the actual values (should be a single row)
+SELECT DISTINCT cnt, s, mn, mx, range_cnt FROM batch_consistency;
+
+DROP TABLE batch_consistency;
+
+--
+-- Cleanup
+--
+SET client_min_messages TO WARNING;
+DROP SCHEMA adaptive_executor_batching CASCADE;

--- a/src/test/regress/sql/adaptive_executor_batching.sql
+++ b/src/test/regress/sql/adaptive_executor_batching.sql
@@ -118,10 +118,35 @@ INSERT INTO batch_regions VALUES
     ('APAC', 'Japan'),
     ('LATAM', 'Brazil');
 
--- Create vanilla PostgreSQL copies with identical data for result verification
-CREATE TABLE local_orders AS SELECT * FROM batch_orders;
-CREATE TABLE local_items AS SELECT * FROM batch_items;
-CREATE TABLE local_regions AS SELECT * FROM batch_regions;
+-- Create vanilla PostgreSQL copies with identical data for result verification.
+-- Populate them from the same deterministic sources used for the distributed
+-- tables (NOT via SELECT * FROM batch_*), so the local tables remain an
+-- independent reference even if the distributed executor has bugs.
+CREATE TABLE local_orders (LIKE batch_orders INCLUDING ALL);
+CREATE TABLE local_items  (LIKE batch_items  INCLUDING ALL);
+CREATE TABLE local_regions (LIKE batch_regions INCLUDING ALL);
+
+INSERT INTO local_orders
+SELECT i,
+       (i % 50) + 1,
+       round(((i * 127 + 53) % 500 + 10)::numeric, 2),
+       (ARRAY['NA', 'EMEA', 'APAC', 'LATAM'])[1 + (i % 4)],
+       '2025-01-01'::date + (i % 365)
+FROM generate_series(1, 300) i;
+
+INSERT INTO local_items
+SELECT i,
+       ((i - 1) / 2) + 1,
+       'product_' || (i % 20),
+       1 + (i % 5),
+       round(((i * 31 + 7) % 100 + 1)::numeric, 2)
+FROM generate_series(1, 600) i;
+
+INSERT INTO local_regions VALUES
+    ('NA', 'United States'),
+    ('EMEA', 'Germany'),
+    ('APAC', 'Japan'),
+    ('LATAM', 'Brazil');
 
 -- ================================================================
 -- Test 7a: Distributed join with batching
@@ -722,9 +747,9 @@ SELECT count(*), sum(x), min(x), max(x) FROM batch_test;
 --
 -- Test 13: Scrollable cursor with batching
 -- Verifies that DECLARE SCROLL CURSOR works correctly with the batched
--- executor. For scrollable cursors, the executor preserves the tuplestore
--- across batches (skips tuplestore_clear) so backward fetches can access
--- rows from earlier batches.
+-- executor. The tuplestore is still cleared between batches, but backward
+-- fetches work because FinalizePlan wraps the Citus CustomScan in a lazy
+-- Material node when CURSOR_OPT_SCROLL is set.
 --
 -- With batch_size=10, a 50-row result spans 5 batches:
 --   batch 1: rows 1-10, batch 2: rows 11-20, batch 3: rows 21-30,
@@ -935,6 +960,205 @@ DROP TABLE withhold_local;
 
 -- Reset batch size
 RESET citus.executor_batch_size;
+
+--
+-- Test 15: Early-close cursor on batched DML RETURNING is all-or-nothing
+--
+-- A plpgsql function wraps DELETE ... RETURNING so we can open a cursor
+-- on the result set.  With a small batch size the executor fetches only
+-- a few rows before the cursor is closed, which triggers
+-- AdaptiveExecutorEnd → SendCancelationRequest on worker connections
+-- that are inside a coordinated transaction block.  The cancel aborts
+-- the worker transactions, and when the coordinator rolls back, no rows
+-- are deleted.
+--
+-- This verifies that partial batched DML never gets committed.
+--
+CREATE OR REPLACE FUNCTION delete_returning_x(max_x int)
+RETURNS SETOF int LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY DELETE FROM batch_test WHERE x <= max_x RETURNING x;
+END;
+$$;
+
+SET citus.executor_batch_size TO 10;
+
+-- Baseline row count
+SELECT count(*) AS before_count FROM batch_test;
+
+BEGIN;
+
+-- The function executes DELETE ... RETURNING through the batched
+-- adaptive executor.  With batch_size=10 only a partial batch is
+-- consumed before we close the cursor.
+DECLARE dml_cur CURSOR FOR SELECT * FROM delete_returning_x(50);
+
+-- Fetch a few rows from the first batch
+FETCH 5 FROM dml_cur;
+
+-- Close the cursor before all batches complete.
+CLOSE dml_cur;
+
+ROLLBACK;
+
+-- All rows must still be present — the DELETE was rolled back.
+SELECT count(*) AS after_count FROM batch_test;
+
+DROP FUNCTION delete_returning_x(int);
+
+RESET citus.executor_batch_size;
+
+-- ================================================================
+-- Test 16: SELECT with LIMIT (no Sort) inside a write transaction
+--          must not cancel worker queries
+-- ================================================================
+--
+-- Inside a coordinated transaction that has already performed writes,
+-- a plain LIMIT (with no Sort/Material barrier above the Citus scan)
+-- terminates the executor early.  Without a fallback, AdaptiveExecutorEnd
+-- would SendCancelationRequest() on the still-active worker connections,
+-- abort the worker transactions (PQTRANS_INERROR), and cause the user's
+-- COMMIT to fail with "failure on connection marked as essential" --
+-- silently rolling back the preceding writes.
+--
+-- AdaptiveExecutorRun detects this case (CMD_SELECT inside a coordinated
+-- transaction with XactModificationLevel >= XACT_MODIFICATION_DATA) and
+-- forces runToCompletion=true, matching pre-batching behavior.
+--
+CREATE TABLE limit_in_write_txn (id int PRIMARY KEY, v int);
+SELECT create_distributed_table('limit_in_write_txn', 'id');
+INSERT INTO limit_in_write_txn
+    SELECT g, g FROM generate_series(1, 1000) g;
+
+-- Small batch + chunk sizes guarantee the first batch satisfies LIMIT
+-- long before the workers finish their queries -- the precise condition
+-- that previously triggered the cancel.
+SET citus.executor_batch_size TO 10;
+SET citus.executor_chunk_size TO 5;
+
+BEGIN;
+UPDATE limit_in_write_txn SET v = v + 1000 WHERE id <= 5;
+-- LIMIT with no ORDER BY: no Sort barrier, scan terminates after 3 rows.
+-- Discard the unstable row contents -- shard order is not deterministic --
+-- and just confirm we got 3 rows.
+SELECT count(*) AS fetched FROM (
+    SELECT id FROM limit_in_write_txn LIMIT 3
+) s;
+COMMIT;
+
+-- The UPDATE must have persisted: COMMIT did not error and the worker
+-- transactions were not aborted by a stray cancel.
+SELECT id, v FROM limit_in_write_txn WHERE id <= 5 ORDER BY id;
+
+RESET citus.executor_batch_size;
+RESET citus.executor_chunk_size;
+DROP TABLE limit_in_write_txn;
+
+-- ================================================================
+-- Test 17: Prepared statements crossing the generic-plan threshold
+-- ================================================================
+--
+-- PostgreSQL's plan_cache_mode = auto switches from per-execution
+-- custom plans to a single cached generic plan after the 5th
+-- EXECUTE.  Citus's CustomScan rewrites distribution at planning
+-- time, so the generic-plan path drives a different code path
+-- through AdaptiveExecutorStart / executionScanContext reuse /
+-- wait-event-set preservation / tuplestore reset across
+-- re-invocations.  Run the same prepared statement 7 times with a
+-- small batch size to exercise both custom-plan and generic-plan
+-- executions through the batched executor.
+--
+SET citus.executor_batch_size TO 5;
+SET plan_cache_mode TO auto;
+
+PREPARE p_batch_select(int) AS
+    SELECT count(*) FROM batch_test WHERE x <= $1;
+
+-- Executions 1-5: per-execution custom plan.
+EXECUTE p_batch_select(50);
+EXECUTE p_batch_select(50);
+EXECUTE p_batch_select(50);
+EXECUTE p_batch_select(50);
+EXECUTE p_batch_select(50);
+-- Executions 6-7: generic plan (PG's threshold is 5).
+EXECUTE p_batch_select(50);
+EXECUTE p_batch_select(50);
+
+-- Same prepared statement returning a multi-batch result set: the
+-- batched executor must reset its per-invocation state cleanly.
+PREPARE p_batch_rows(int) AS
+    SELECT x FROM batch_test WHERE x <= $1 ORDER BY x;
+
+EXECUTE p_batch_rows(20);
+EXECUTE p_batch_rows(20);
+EXECUTE p_batch_rows(20);
+EXECUTE p_batch_rows(20);
+EXECUTE p_batch_rows(20);
+-- Generic plan from here on.
+EXECUTE p_batch_rows(20);
+EXECUTE p_batch_rows(20);
+
+DEALLOCATE p_batch_select;
+DEALLOCATE p_batch_rows;
+RESET plan_cache_mode;
+RESET citus.executor_batch_size;
+
+-- ================================================================
+-- Test 18: Batched SELECT interleaved with SAVEPOINT / ROLLBACK TO
+-- ================================================================
+--
+-- ROLLBACK TO SAVEPOINT triggers CoordinatedRemoteTransactionsSavepointRollback
+-- which sends cancel + drain + ROLLBACK TO SAVEPOINT on every connection
+-- participating in the current transaction.  Verify that:
+--   (a) a batched SELECT inside a subtransaction composes with
+--       ROLLBACK TO SAVEPOINT,
+--   (b) post-rollback the connection is reusable for further
+--       batched SELECTs and DML,
+--   (c) the outer COMMIT preserves only the work outside the
+--       rolled-back savepoint.
+--
+CREATE TABLE savepoint_batch (id int PRIMARY KEY, v int);
+SELECT create_distributed_table('savepoint_batch', 'id');
+INSERT INTO savepoint_batch
+    SELECT g, g FROM generate_series(1, 100) g;
+
+SET citus.executor_batch_size TO 5;
+
+BEGIN;
+    -- Pre-savepoint write: must survive the outer COMMIT.
+    UPDATE savepoint_batch SET v = v + 10000 WHERE id <= 3;
+
+    SAVEPOINT sp1;
+        -- Inside-savepoint write: must be undone by ROLLBACK TO sp1.
+        UPDATE savepoint_batch SET v = -1 WHERE id BETWEEN 10 AND 20;
+
+        -- Batched SELECT inside the savepoint scope.
+        SELECT count(*) FROM savepoint_batch WHERE v < 0;
+    ROLLBACK TO SAVEPOINT sp1;
+
+    -- After ROLLBACK TO sp1 the inner UPDATE must be gone; a fresh
+    -- batched SELECT must use the same connections cleanly.
+    SELECT count(*) FROM savepoint_batch WHERE v < 0;
+
+    -- Another batched SELECT to confirm the connection state is
+    -- usable for a multi-batch scan after the savepoint rollback.
+    SELECT count(*) FROM (
+        SELECT id FROM savepoint_batch ORDER BY id
+    ) s;
+
+    -- Post-rollback DML must succeed and persist through COMMIT.
+    UPDATE savepoint_batch SET v = v + 20000 WHERE id = 50;
+COMMIT;
+
+-- Verify final state:
+--   - ids 1-3 carry the pre-savepoint +10000 update
+--   - ids 10-20 are unchanged (inner UPDATE rolled back)
+--   - id 50 carries the post-rollback +20000 update
+SELECT id, v FROM savepoint_batch WHERE id IN (1, 2, 3, 10, 15, 20, 50)
+ORDER BY id;
+
+RESET citus.executor_batch_size;
+DROP TABLE savepoint_batch;
 
 --
 -- Cleanup

--- a/src/test/regress/sql/arbitrary_configs_router.sql
+++ b/src/test/regress/sql/arbitrary_configs_router.sql
@@ -462,7 +462,7 @@ END;
 
 -- cursor queries are fast-path router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/sql/multi_mx_reference_table.sql
+++ b/src/test/regress/sql/multi_mx_reference_table.sql
@@ -319,7 +319,7 @@ END;
 
 -- cursor queries also works fine
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM reference_table_test
 		WHERE value_1 = 1 OR value_1 = 2
@@ -567,4 +567,4 @@ SELECT count(*) FROM numbers;
 RESET log_min_messages;
 
 -- clean up tables
-DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, numbers;
+DROP TABLE reference_table_test, reference_table_test_second, reference_table_test_third, colocated_table_test, colocated_table_test_2, numbers;

--- a/src/test/regress/sql/multi_mx_router_planner.sql
+++ b/src/test/regress/sql/multi_mx_router_planner.sql
@@ -572,7 +572,7 @@ END;
 
 -- cursor queries are router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash_mx
 		WHERE author_id = 1

--- a/src/test/regress/sql/multi_mx_schema_support.sql
+++ b/src/test/regress/sql/multi_mx_schema_support.sql
@@ -13,7 +13,7 @@ SELECT * FROM citus_mx_test_schema.nation_hash ORDER BY n_nationkey LIMIT 4;
 -- test cursors
 SET search_path TO public;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_hash
         WHERE n_nationkey = 1;
@@ -25,7 +25,7 @@ END;
 -- test with search_path is set
 SET search_path TO citus_mx_test_schema;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_hash
         WHERE n_nationkey = 1;

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -339,7 +339,7 @@ END;
 
 -- cursor queries also works fine
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM reference_table_test
 		WHERE value_1 = 1 OR value_1 = 2

--- a/src/test/regress/sql/multi_router_planner.sql
+++ b/src/test/regress/sql/multi_router_planner.sql
@@ -1115,7 +1115,7 @@ END;
 
 -- cursor queries are router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/sql/multi_router_planner_fast_path.sql
+++ b/src/test/regress/sql/multi_router_planner_fast_path.sql
@@ -608,7 +608,7 @@ END;
 
 -- cursor queries are fast-path router plannable
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
 	SELECT *
 		FROM articles_hash
 		WHERE author_id = 1

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -139,7 +139,7 @@ RESET citus.shard_replication_factor;
 -- test cursors
 SET search_path TO public;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM test_schema_support.nation_append
         WHERE n_nationkey = 1;
@@ -151,7 +151,7 @@ END;
 -- test with search_path is set
 SET search_path TO test_schema_support;
 BEGIN;
-DECLARE test_cursor CURSOR FOR
+DECLARE test_cursor SCROLL CURSOR FOR
     SELECT *
         FROM nation_append
         WHERE n_nationkey = 1;

--- a/src/test/regress/sql/multi_utility_statements.sql
+++ b/src/test/regress/sql/multi_utility_statements.sql
@@ -126,7 +126,7 @@ CREATE TABLE cursor_me (x int, y int);
 SELECT create_distributed_table('cursor_me', 'x');
 INSERT INTO cursor_me SELECT s/10, s FROM generate_series(1, 100) s;
 
-DECLARE holdCursor CURSOR WITH HOLD FOR
+DECLARE holdCursor SCROLL CURSOR WITH HOLD FOR
 		SELECT * FROM cursor_me WHERE x = 1 ORDER BY y;
 
 FETCH NEXT FROM holdCursor;
@@ -139,7 +139,7 @@ CLOSE holdCursor;
 
 -- Test DECLARE CURSOR .. WITH HOLD inside transaction block
 BEGIN;
-DECLARE holdCursor CURSOR WITH HOLD FOR
+DECLARE holdCursor SCROLL CURSOR WITH HOLD FOR
 		SELECT * FROM cursor_me WHERE x = 1 ORDER BY y;
 FETCH 3 FROM holdCursor;
 FETCH BACKWARD 3 FROM holdCursor;
@@ -164,7 +164,7 @@ CLOSE holdCursor;
 -- Test DECLARE CURSOR .. WITH HOLD with parameter
 CREATE OR REPLACE FUNCTION declares_cursor(p int)
 RETURNS void AS $$
-	DECLARE c CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE x = $1;
+	DECLARE c SCROLL CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE x = $1;
 $$ LANGUAGE SQL;
 
 SELECT declares_cursor(5);
@@ -187,7 +187,7 @@ SELECT declares_cursor_2();
 -- Test DECLARE CURSOR .. WITH HOLD with parameter on non-dist key
 CREATE OR REPLACE FUNCTION declares_cursor_3(p int)
 RETURNS void AS $$
-	DECLARE c3 CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE y = $1;
+	DECLARE c3 SCROLL CURSOR WITH HOLD FOR SELECT * FROM cursor_me WHERE y = $1;
 $$ LANGUAGE SQL;
 
 SELECT declares_cursor_3(5);
@@ -202,7 +202,7 @@ CLOSE c3;
 -- Test DECLARE CURSOR .. WITH HOLD with parameter on dist key, but not fast-path planner
 CREATE OR REPLACE FUNCTION declares_cursor_4(p int)
 RETURNS void AS $$
-	DECLARE c4 CURSOR WITH HOLD FOR SELECT *, (SELECT 1) FROM cursor_me WHERE x = $1;
+	DECLARE c4 SCROLL CURSOR WITH HOLD FOR SELECT *, (SELECT 1) FROM cursor_me WHERE x = $1;
 $$ LANGUAGE SQL;
 
 SELECT declares_cursor_4(5);


### PR DESCRIPTION
DESCRIPTION: Fetch tuples in small batches in adaptive executor where possible

### Motivation

Currently adaptive executor runs the entire distributed query to completion
on the first `ExecScan` call, buffering all rows before returning any to the
client. For large result sets this can mean:

- **Excessive memory / disk I/O**: Spill to disk when result size exceeds
  `work_mem`, even when the client only needs a few rows (e.g. cursors, `LIMIT`).
- **Per-row libpq overhead**: `PQsetSingleRowMode()` returns exactly
  one row per `PQgetResult()` call. A 200K-row result makes ~200K
  `PQgetResult()` calls, each allocating and freeing a `PGresult`.
- **Long time-to-first-row**: The first row is not available until the
  entire result set has been fetched from all workers.

### Batched Adaptive Executor

This PR makes `RunDistributedExecution` **re-entrant**: instead of
running to completion, it stops after collecting `maxBatchSize` rows into
the tuplestore, returns control to PostgreSQL, and resumes where it left
off when PostgreSQL asks for more rows.

#### Adaptive Executor entry points

The executor is split from a single `AdaptiveExecutor()` call into:

- **`AdaptiveExecutorStart()`** — called once on the first `ExecScan`.
  Sets up connections, computes `maxBatchSize`, creates the `WaitEventSet`.
- **`AdaptiveExecutorRun()`** — called repeatedly. Each call runs
  `RunDistributedExecution` to fill one batch and returns `false` (more
  rows available) or `true` (query complete).
- **`AdaptiveExecutorEnd()`** — called on `EndScan` or early termination
  (cursor close, `LIMIT`). If the latter, cancels in-flight worker queries, 
  drains pending results, and releases connections.

`CitusExecScan` reads from the tuplestore until it's empty, then calls
`AdaptiveExecutorRun` again for the next batch. Between batches the
tuplestore is cleared via `tuplestore_clear()`.

#### Adaptive batch sizing

`CalculateMaxBatchSize()` sizes each batch to fit within `work_mem`. It
estimates the per-row memory footprint from the `TupleDesc` (fixed-width
attribute lengths, 128 bytes for unbounded varlena, typmod-based estimate
for bounded varlena) and divides `work_mem` by that estimate, clamped to
a floor of 100 and ceiling of 1M rows. The tuplestore should never spill
to disk during normal operation.

The GUC `citus.executor_batch_size` overrides the auto-calculation with
a fixed row count (default 0 = auto).

#### Chunked libpq mode (PG17+)

On PostgreSQL 17 and later, `PQsetChunkedRowsMode(conn, chunkSize)` is
used instead of `PQsetSingleRowMode()`. Each `PQgetResult()` returns up
to `chunkSize` rows (default 8192, configurable via
`citus.executor_chunk_size`). For a 200K-row result this is ~24
`PQgetResult()` calls instead of ~200K — roughly an 8,000x reduction in
libpq overhead.

On PG16, `PQsetSingleRowMode()` is still used, but the batching and
re-entrancy benefits still apply.

#### WaitEventSet preservation

The `WaitEventSet` is created once in `AdaptiveExecutorStart` and reused
across all batches of the same query. Previously, even in the single-shot
code path, the event set was created once per execution; now it simply
persists until `AdaptiveExecutorEnd` frees it.

#### Scrollable cursor support (Material node insertion)

The Citus `CustomScan` now does not advertise backward-scan capability
(`EXEC_FLAG_BACKWARD`), because the tuplestore is cleared between batches
and cannot support backward fetches across batch boundaries.

For `SCROLL CURSOR` queries, `FinalizePlan()` now calls PostgreSQL's
`materialize_finished_plan()` to wrap the Citus `CustomScan` in a
`Material` node. The `Material` node has its own tuplestore that
accumulates all rows across batches, supporting full backward scan. Since
`Material` is lazy (it doesn't force the child to run to completion
upfront), batching benefits are preserved: rows are pulled on demand.

Cursors declared without `SCROLL` work naturally — forward-only iteration
drains one batch at a time without materialization.

#### Early termination

If the consumer stops reading before the query completes (cursor close,
`LIMIT` satisfied), `AdaptiveExecutorEnd()` handles cleanup:

1. Sends cancel requests to workers with in-progress queries
2. Drains any pending `PQgetResult()` data so connections are clean
3. Unclaims connections back to the connection pool

This prevents "another command is already in progress" errors on
subsequent statements in the same transaction.

#### Local execution

Local execution (queries routed to the coordinator's own shards) is not
batched — it runs to completion eagerly, same as before. Batching only
applies to remote worker connections.

### What This PR Does Not Cover

- **Per-task tuplestores**: All workers currently write into a single
  shared tuplestore. A future extension would give each task its own
  tuplestore, enabling k-way merge of sorted streams and streaming
  distributed aggregation.
- **Multi-row INSERT batching**: Multi-row `INSERT` statements are not
  batched (they complete in one shot).
