### PR TITLE
Update failure tests README

### DIFF
--- a/src/test/regress/mitmscripts/README.md
+++ b/src/test/regress/mitmscripts/README.md
@@ -25,7 +25,7 @@ Once you've installed it:
 
 ```bash
 $ cd src/test/regress
-$ pipenv --python 3.6
+$ pipenv --python 3.6 --python=`which python3`
 $ pipenv install  # there's already a Pipfile.lock in src/test/regress with packages
 $ pipenv shell  # this enters the virtual environment, putting mitmproxy onto $PATH
 ```


### PR DESCRIPTION
I keep finding this page when trying to run failure tests, so updating the README that way:
https://github.com/pypa/pipenv/issues/3363#issuecomment-452171564

