### PR TITLE
Fixes ConnectionModifiedPlacement output for a failed transaction

### DIFF
--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -808,9 +808,11 @@ CoordinatedRemoteTransactionsPrepare(void)
 		if (transaction->transactionState != REMOTE_TRANS_PREPARING)
 		{
 			/*
-			 * Verify that the connection didn't modify any placement
+			 * Verify that either the transaction failed, hence we couldn't prepare
+			 * or the connection didn't modify any placement
 			 */
-			Assert(!ConnectionModifiedPlacement(connection));
+			Assert(transaction->transactionFailed ||
+				   !ConnectionModifiedPlacement(connection));
 			continue;
 		}
 


### PR DESCRIPTION
We skip `FinishRemoteTransactionPrepare` for connections for which `ConnectionModifiedPlacement` returned false.

However, for transactions that failed, `ConnectionModifiedPlacement` returns true from this if condition
```
if (dlist_is_empty(&connection->referencedPlacements))
```
causing the test `failure_mx_metadata_sync` to fail in onquery.kill() commands in the assert: 
```
Assert(!ConnectionModifiedPlacement(connection));
```

~~Since we don't prepare a transaction that failed, I added `transaction->transactionFailed` to the assert.~~

Alternatively, we could add a check in `ConnectionModifiedPlacement` which returns false if the transaction failed.

Fixes #5199 