### PR TITLE
Fixes order of citus_drop_all_shards arguments in citus_truncate_trigger

### DIFF
--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -93,8 +93,8 @@ citus_truncate_trigger(PG_FUNCTION_ARGS)
 
 		DirectFunctionCall4(citus_drop_all_shards,
 							ObjectIdGetDatum(relationId),
-							CStringGetTextDatum(relationName),
 							CStringGetTextDatum(schemaName),
+							CStringGetTextDatum(relationName),
 							BoolGetDatum(dropShardsMetadataOnly));
 	}
 	else


### PR DESCRIPTION
Even though the order is mixed when calling `citus_drop_all_shards`, `CheckTableSchemaNameForDrop` rewrites the schema name and the relation name if the relation exists, regardless of the input. Hence we haven't suffered from this order mixup. Hence, I don't think this is worth backporting to other releases.

Addresses https://github.com/citusdata/citus/pull/5176#discussion_r691116442
