### PR TITLE
fix: parallel vacuum workers spec for pg13

### DIFF
--- a/src/test/regress/expected/pg13.out
+++ b/src/test/regress/expected/pg13.out
@@ -33,7 +33,7 @@ NOTICE:  issuing VACUUM (PARALLEL 0) test_pg13.dist_table_65001
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- This should error out since -5 is not valid.
 VACUUM (PARALLEL -5) dist_table;
-ERROR:  parallel vacuum degree must be between 0 and 1024
+ERROR:  parallel workers for vacuum must be between 0 and 1024
 -- This should error out since no number is given
 VACUUM (PARALLEL) dist_table;
 ERROR:  parallel option requires a value between 0 and 1024


### PR DESCRIPTION
The regress tests are failing for pg 13 due the new error messages:

```
diff -dU10 -w /build/citus/src/test/regress/expected/pg13.out /build/citus/src/test/regress/results/pg13.out
--- /build/citus/src/test/regress/expected/pg13.out.modified	2021-08-20 20:42:46.844090101 +0000
+++ /build/citus/src/test/regress/results/pg13.out.modified	2021-08-20 20:42:46.852090144 +0000
@@ -26,21 +26,21 @@
 DETAIL:  on server postgres@localhost:57637 connectionId: 3
 NOTICE:  issuing VACUUM (PARALLEL 2) test_pg13.dist_table_65001
 DETAIL:  on server postgres@localhost:57638 connectionId: 4
 VACUUM (PARALLEL 0) dist_table;
 NOTICE:  issuing VACUUM (PARALLEL 0) test_pg13.dist_table_65000
 DETAIL:  on server postgres@localhost:57637 connectionId: 3
 NOTICE:  issuing VACUUM (PARALLEL 0) test_pg13.dist_table_65001
 DETAIL:  on server postgres@localhost:57638 connectionId: 4
 -- This should error out since -5 is not valid.
 VACUUM (PARALLEL -5) dist_table;
-ERROR:  parallel vacuum degree must be between 0 and 1024
+ERROR:  parallel workers for vacuum must be between 0 and 1024
```

This PR fixes the error message expected in the vacuum parallel execution,
changed in the commit [9012e5594c6ff803abb6d51e164797e3810845c1](https://github.com/postgres/postgres/commit/9012e5594c6ff803abb6d51e164797e3810845c1), added in the
version 13.4.
