### PR TITLE
Allow configuring tcp_user_timeout using citus.node_conn_info

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1896,6 +1896,7 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 		"sslcrl",
 		"sslmode",
 		"sslrootcert"
+		"tcp_user_timeout",
 	};
 	char *errorMsg = NULL;
 	bool conninfoValid = CheckConninfo(*newval, allowedConninfoKeywords,


### PR DESCRIPTION
`tcp_user_timeout` is the awesome relatively unknown big brother of the
TCP keepalive related options. Instead of depending on keepalives being
sent, this determines that a socket is dead by waiting at most N seconds
for an ack of data that it has sent. It's exposed in libpq starting from
PG12.