### PR TITLE
Fix crash with no distributed tables for rebalance plan

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1753,6 +1753,11 @@ RebalancePlacementUpdates(List *workerNodeList, List *shardPlacementListList,
 	List *shardPlacementList = NIL;
 	List *placementUpdateList = NIL;
 
+	if (list_length(shardPlacementListList) == 0)
+	{
+		return NIL;
+	}
+
 	foreach_ptr(shardPlacementList, shardPlacementListList)
 	{
 		state = InitRebalanceState(workerNodeList, shardPlacementList,

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -35,6 +35,12 @@ SELECT * FROM master_add_node('localhost', :worker_1_port);
                1
 (1 row)
 
+-- make sure that when there are no distributed tables, we don't crash.
+SELECT 1 FROM get_rebalance_table_shards_plan();
+ ?column?
+---------------------------------------------------------------------
+(0 rows)
+
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -15,6 +15,9 @@ SELECT master_get_active_worker_nodes();
 -- try to add a node that is already in the cluster
 SELECT * FROM master_add_node('localhost', :worker_1_port);
 
+-- make sure that when there are no distributed tables, we don't crash.
+SELECT 1 FROM get_rebalance_table_shards_plan();
+
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
 


### PR DESCRIPTION
DESCRIPTION: Fixes a crash when there is no distributed table for get_rebalance_table_shards_plan


