### PR TITLE
Fix missing comma in connection options

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1895,7 +1895,7 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 		"sslcompression",
 		"sslcrl",
 		"sslmode",
-		"sslrootcert"
+		"sslrootcert",
 		"tcp_user_timeout",
 	};
 	char *errorMsg = NULL;


### PR DESCRIPTION
https://github.com/citusdata/citus/commit/a31429aae5aa6c8271ec3dee663d70a67f64e60d#r55402663