### PR TITLE
Store test results as artifact on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,10 @@ jobs:
           path: src/test/regress/regression.diffs
           when: on_fail
       - store_artifacts:
+          name: 'Save results'
+          path: src/test/regress/results/
+          when: on_fail
+      - store_artifacts:
           name: 'Save core dumps'
           path: /tmp/core_dumps
           when: on_fail


### PR DESCRIPTION
There are some libpq changes on postgres side that gives some extra
outputs on the pg13.4 and pg12.8. It is possible that we won't get these
outputs in our local and in those cases it is useful to download those
outputs from the CI.

In order to do that, we store the test results as an artifact in CI.
You can go to artifacts tab in CI to download them.