### PR TITLE
Introduce citus.metadata_sync_to_new_nodes

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -65,6 +65,8 @@ int GroupSize = 1;
 
 /* config variable managed via guc.c */
 char *CurrentCluster = "default";
+bool MetadataSyncToNewNodes = false;
+
 
 /*
  * Config variable to control whether we should replicate reference tables on
@@ -269,6 +271,12 @@ citus_add_node(PG_FUNCTION_ARGS)
 	if (!nodeAlreadyExists)
 	{
 		ActivateNode(nodeNameString, nodePort);
+	}
+
+	if (MetadataSyncToNewNodes)
+	{
+		ereport(WARNING, (errmsg("You can not use this yet")));
+		StartMetadataSyncToNode(nodeNameString, nodePort);
 	}
 
 	PG_RETURN_INT32(nodeId);

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1323,6 +1323,18 @@ RegisterCitusConfigVariables(void)
 		GUC_UNIT_MS | GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.metadata_sync_to_new_nodes",
+		gettext_noop("Enables metadata syncing on newly added nodes."),
+		gettext_noop("Set to false by default. If set to true, enables "
+					 "metadata syncing to nodes that are added or updated "
+					 "by citus_add_node UDF."),
+		&MetadataSyncToNewNodes,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomEnumVariable(
 		"citus.multi_shard_commit_protocol",
 		gettext_noop("Sets the commit protocol for commands modifying multiple shards."),

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -17,6 +17,7 @@
 #include "nodes/pg_list.h"
 
 /* config variables */
+extern bool MetadataSyncToNewNodes;
 extern int MetadataSyncInterval;
 extern int MetadataSyncRetryInterval;
 

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -866,6 +866,39 @@ SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
      17 |      14 | localhost |    57637 | default  | f           | t        | primary  | default     | f              | t
 (1 row)
 
+-- check that we can make metadata syncing default on new nodes
+SET citus.metadata_sync_to_new_nodes TO on;
+SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport=:worker_2_port \gset
+SELECT master_remove_node('localhost', :worker_2_port);
+ master_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT master_add_node('localhost', :worker_2_port, groupId := :worker_2_group);
+WARNING:  citus.enable_object_propagation is off, not creating distributed objects on worker
+DETAIL:  distributed objects are only kept in sync when citus.enable_object_propagation is set to on. Newly activated nodes will not get these objects created
+WARNING:  You can not use this yet
+ master_add_node
+---------------------------------------------------------------------
+              31
+(1 row)
+
+SELECT metadatasynced FROM pg_dist_node WHERE nodeport = :worker_2_port;
+ metadatasynced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- cleanup
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+NOTICE:  dropping metadata on the node (localhost,57638)
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+RESET citus.metadata_sync_to_new_nodes;
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE test_dist (x int, y int);
 SELECT create_distributed_table('test_dist', 'x');

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -341,6 +341,17 @@ SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
 SELECT master_update_node(:worker_1_node, 'localhost', :worker_1_port);
 SELECT * FROM pg_dist_node WHERE nodeid = :worker_1_node;
 
+-- check that we can make metadata syncing default on new nodes
+SET citus.metadata_sync_to_new_nodes TO on;
+SELECT groupid AS worker_2_group FROM pg_dist_node WHERE nodeport=:worker_2_port \gset
+SELECT master_remove_node('localhost', :worker_2_port);
+
+SELECT master_add_node('localhost', :worker_2_port, groupId := :worker_2_group);
+SELECT metadatasynced FROM pg_dist_node WHERE nodeport = :worker_2_port;
+
+-- cleanup
+SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
+RESET citus.metadata_sync_to_new_nodes;
 
 SET citus.shard_replication_factor TO 1;
 


### PR DESCRIPTION
This GUC is off by default. If set to true, enables
metadata syncing to nodes that are added or updated
by citus_add_node UDF.

DESCRIPTION: Intoduces citus.metadata_sync_to_new_nodes GUC to enable metadata syncing by
default on new nodes.

