### PR TITLE
Use get_attnum to find the attribute number of target entry

### DIFF
--- a/src/test/regress/expected/modification_correctness.out
+++ b/src/test/regress/expected/modification_correctness.out
@@ -1,5 +1,7 @@
 CREATE SCHEMA modification_correctness;
-CREATE TABLE test(a int, b int, c int unique, d int, e int);
+SET search_path to 'modification_correctness';
+CREATE TABLE test(k int, a int, b int, c int unique, d int, e int);
+ALTER TABLE test DROP column k;
 SELECT create_distributed_table('test', 'c');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -34,7 +36,21 @@ INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
 INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c;
 INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
 INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
+-- make sure that without fast path planner, we don't get any unexpected errors.
+SET citus.enable_fast_path_router_planner to false;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
+UPDATE test SET e = c, d = 3;
+UPDATE test SET c = c;
+UPDATE test SET c = c, c = 3;
+ERROR:  multiple assignments to same column "c"
+UPDATE test SET c = c, d = c;
+UPDATE test SET c = c, d = 5, e = 3;
+RESET citus.enable_fast_path_router_planner;
 PREPARE foo(int,int) AS INSERT INTO test (c,a) VALUES($1,$2) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = $1;
+EXECUTE foo(1,2);
 EXECUTE foo(1,2);
 EXECUTE foo(1,2);
 EXECUTE foo(1,2);
@@ -48,4 +64,11 @@ EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+-- we don't get an error because this is something like c = c
+UPDATE test SET a = 5,d  = 2, c = 5 FROM (SELECT * FROM test LIMIT 10) t2 WHERE t2.d = test.c  and test.c = 5;
+-- we should get an error because c gets 6 -> 5
+UPDATE test SET a = 5,d  = 2, c = 5 FROM (SELECT * FROM test LIMIT 10) t2 WHERE t2.d = test.c  and test.c = 6;
+ERROR:  modifying the partition value of rows is not allowed
 DROP SCHEMA modification_correctness CASCADE;
+NOTICE:  drop cascades to table test

--- a/src/test/regress/expected/modification_correctness.out
+++ b/src/test/regress/expected/modification_correctness.out
@@ -1,0 +1,51 @@
+CREATE SCHEMA modification_correctness;
+CREATE TABLE test(a int, b int, c int unique, d int, e int);
+SELECT create_distributed_table('test', 'c');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE test DROP column b;
+UPDATE test SET a = 5, c = 5;
+ERROR:  modifying the partition value of rows is not allowed
+UPDATE test SET a = 5, c = d, d =3;
+ERROR:  modifying the partition value of rows is not allowed
+UPDATE test SET c = d, d =3;
+ERROR:  modifying the partition value of rows is not allowed
+UPDATE test SET d=c, c = d;
+ERROR:  modifying the partition value of rows is not allowed
+UPDATE test SET e = c, d = 3;
+UPDATE test SET c = c;
+UPDATE test SET c = c, c = 3;
+ERROR:  multiple assignments to same column "c"
+UPDATE test SET c = c, d = c;
+UPDATE test SET c = c, d = 5, e = 3;
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=7;
+ERROR:  modifying the partition value of rows is not allowed
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET a=7;
+INSERT INTO test (d,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=7;
+ERROR:  modifying the partition value of rows is not allowed
+INSERT INTO test (d,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (a,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c) VALUES(3) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
+PREPARE foo(int,int) AS INSERT INTO test (c,a) VALUES($1,$2) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = $1;
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+PREPARE foo1(int, int) AS UPDATE test SET c = c, d = $1, e = $2;
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+DROP SCHEMA modification_correctness CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -76,7 +76,7 @@ test: ch_bench_subquery_repartition
 test: multi_agg_type_conversion multi_count_type_conversion recursive_relation_planning_restriction_pushdown
 test: multi_partition_pruning single_hash_repartition_join
 test: multi_join_pruning multi_hash_pruning intermediate_result_pruning
-test: multi_null_minmax_value_pruning cursors
+test: multi_null_minmax_value_pruning cursors modification_correctness
 test: multi_query_directory_cleanup
 test: multi_task_assignment_policy multi_cross_shard
 test: multi_utility_statements

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -76,7 +76,8 @@ test: ch_bench_subquery_repartition
 test: multi_agg_type_conversion multi_count_type_conversion recursive_relation_planning_restriction_pushdown
 test: multi_partition_pruning single_hash_repartition_join
 test: multi_join_pruning multi_hash_pruning intermediate_result_pruning
-test: multi_null_minmax_value_pruning cursors modification_correctness
+test: multi_null_minmax_value_pruning cursors
+test: modification_correctness
 test: multi_query_directory_cleanup
 test: multi_task_assignment_policy multi_cross_shard
 test: multi_utility_statements

--- a/src/test/regress/sql/modification_correctness.sql
+++ b/src/test/regress/sql/modification_correctness.sql
@@ -1,0 +1,51 @@
+CREATE SCHEMA modification_correctness;
+
+CREATE TABLE test(a int, b int, c int unique, d int, e int);
+SELECT create_distributed_table('test', 'c');
+ALTER TABLE test DROP column b;
+
+UPDATE test SET a = 5, c = 5;
+UPDATE test SET a = 5, c = d, d =3;
+UPDATE test SET c = d, d =3;
+UPDATE test SET d=c, c = d;
+UPDATE test SET e = c, d = 3;
+UPDATE test SET c = c;
+UPDATE test SET c = c, c = 3;
+UPDATE test SET c = c, d = c;
+UPDATE test SET c = c, d = 5, e = 3;
+
+
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=7;
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET a=7;
+INSERT INTO test (d,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=7;
+INSERT INTO test (d,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (a,c) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c) VALUES(3) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
+
+
+PREPARE foo(int,int) AS INSERT INTO test (c,a) VALUES($1,$2) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = $1;
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+EXECUTE foo(1,2);
+
+PREPARE foo1(int, int) AS UPDATE test SET c = c, d = $1, e = $2;
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
+
+
+
+
+
+DROP SCHEMA modification_correctness CASCADE;

--- a/src/test/regress/sql/modification_correctness.sql
+++ b/src/test/regress/sql/modification_correctness.sql
@@ -1,6 +1,8 @@
 CREATE SCHEMA modification_correctness;
+SET search_path to 'modification_correctness';
 
-CREATE TABLE test(a int, b int, c int unique, d int, e int);
+CREATE TABLE test(k int, a int, b int, c int unique, d int, e int);
+ALTER TABLE test DROP column k;
 SELECT create_distributed_table('test', 'c');
 ALTER TABLE test DROP column b;
 
@@ -15,6 +17,7 @@ UPDATE test SET c = c, d = c;
 UPDATE test SET c = c, d = 5, e = 3;
 
 
+
 INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=7;
 INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
 INSERT INTO test (c,d) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET a=7;
@@ -27,8 +30,22 @@ INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d 
 INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
 INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
 
+-- make sure that without fast path planner, we don't get any unexpected errors.
+SET citus.enable_fast_path_router_planner to false;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET d=7;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = EXCLUDED.c;
+INSERT INTO test (c,a) VALUES(3,4) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = 7;
+UPDATE test SET e = c, d = 3;
+UPDATE test SET c = c;
+UPDATE test SET c = c, c = 3;
+UPDATE test SET c = c, d = c;
+UPDATE test SET c = c, d = 5, e = 3;
+RESET citus.enable_fast_path_router_planner;
+
 
 PREPARE foo(int,int) AS INSERT INTO test (c,a) VALUES($1,$2) ON CONFLICT(c) DO UPDATE SET c=EXCLUDED.c, d = EXCLUDED.c, e = $1;
+EXECUTE foo(1,2);
 EXECUTE foo(1,2);
 EXECUTE foo(1,2);
 EXECUTE foo(1,2);
@@ -43,9 +60,12 @@ EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
 EXECUTE foo1(1,2);
+EXECUTE foo1(1,2);
 
-
-
+-- we don't get an error because this is something like c = c
+UPDATE test SET a = 5,d  = 2, c = 5 FROM (SELECT * FROM test LIMIT 10) t2 WHERE t2.d = test.c  and test.c = 5;
+-- we should get an error because c gets 6 -> 5
+UPDATE test SET a = 5,d  = 2, c = 5 FROM (SELECT * FROM test LIMIT 10) t2 WHERE t2.d = test.c  and test.c = 6;
 
 
 DROP SCHEMA modification_correctness CASCADE;


### PR DESCRIPTION
This is mostly done for PG14 support.

With Postgres 14, with UPDATE queries the targetEntry->resno no longer points to the attribute number hence some of our logic became broken.

We can use `get_attnum` to get attribute number correctly, so we switch to this approach.

