### PR TITLE
Give NOTICE msg when enabling built-in pg compression for a columnar table

### DIFF
--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -644,5 +644,51 @@ REINDEX TABLE dist_part_table;
 ERROR:  REINDEX TABLE queries on distributed partitioned tables are not supported
 -- but we support REINDEXing partitions
 REINDEX TABLE dist_part_table_1;
+--
+-- Show that we print a nice notice message if we are using
+-- built-in column compression for a columnar table.
+--
+CREATE TABLE heap_table (comp_text_1 TEXT COMPRESSION pglz);
+CREATE TABLE parent_heap_table (a INT, b TEXT COMPRESSION pglz) PARTITION BY RANGE(a);
+-- doensn't inherit column compression from other table
+CREATE TABLE columnar_table_1 (LIKE heap_table) USING columnar;
+CREATE TABLE columnar_table_5 USING columnar AS TABLE heap_table;
+CREATE TABLE columnar_partition PARTITION OF parent_heap_table FOR VALUES FROM (5) TO (8) USING columnar;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+CREATE TABLE columnar_table_6 (plain_int_col INT) INHERITS (heap_table) USING columnar;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+CREATE TABLE columnar_table_2 (LIKE heap_table INCLUDING ALL) USING columnar;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+VACUUM FULL columnar_table_2;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+ALTER TABLE columnar_table_6 ALTER COLUMN plain_int_col TYPE bigint;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+-- wouldn't print the notice message when dropping filenode
+TRUNCATE columnar_table_2;
+-- doensn't print such a notice message for an uncompressed column
+ALTER TABLE columnar_table_2 ADD COLUMN plain_text_1 TEXT;
+ALTER TABLE columnar_table_2 ADD COLUMN comp_text_2 TEXT COMPRESSION pglz;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+ALTER TABLE columnar_table_2 ALTER COLUMN plain_text_1 SET COMPRESSION pglz;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+-- prints notice message even if we already had enabled compression for that column
+ALTER TABLE columnar_table_2 ALTER COLUMN plain_text_1 SET COMPRESSION pglz;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+-- wouldn't print the notice message since it will fail
+ALTER TABLE columnar_table_2 ADD COLUMN comp_text_2 TEXT COMPRESSION pglz;
+ERROR:  column "comp_text_2" of relation "columnar_table_2" already exists
+-- doensn't inherit column compression from other table
+-- but defines such a column itself
+CREATE TABLE columnar_table_3 (LIKE heap_table, comp_text_2 TEXT COMPRESSION pglz) USING columnar;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+-- wouldn't print the notice message since it will fail
+CREATE TABLE columnar_table_4 (LIKE heap_table, comp_text_1 TEXT COMPRESSION pglz) USING columnar;
+ERROR:  column "comp_text_1" specified more than once
+CREATE TABLE columnar_table_7 (a INT, b TEXT COMPRESSION pglz) USING columnar;
+NOTICE:  since columnar tableAM already compresses columns in large chunks, using built-in postgres compression might not bring additional compression benefits, see "alter_columnar_table_set" function and "compression" & "compression_level" arguments to use the compression functionality provided by columnarAM
+-- wouldn't print the notice message since we are dropping or already
+-- dropped the compressed column
+ALTER TABLE columnar_table_7 DROP COLUMN b;
+ALTER TABLE columnar_table_7 ALTER COLUMN a TYPE bigint;
 set client_min_messages to error;
 drop schema pg14 cascade;


### PR DESCRIPTION
Relevant PG commit:
bbe0a81db69bd10bd166907c3701492a29aca294

Since columnar already compresses columns in large chunks, using (pg)
built-in postgres compression might not help much in the current design.
For this reason, we kindly inform the user in case they define a column
which uses (pg) built-in column compression for a columnar table.

For simplicity, we catch such columns created by any kind of `CREATE TABLE .*`
commands via object access hook.

However for an `ALTER TABLE` command, understanding if a compressed
column was already there or is just defined via object access hook is harder.
This is because, object access hook gets called multiple times for such a
command:
- once for the table creation itself (subid=0)
- once for each column being created (subid=attrNum)

However, to detect `CREATE TABLE .*` commands, we investigate all
columns if `subid=0`. For this reason, if we were to use object access hook
for `ALTER TABLE` commands, then we would print that NOTICE message
for multiple times.
