### PR TITLE
Handle aborted writes properly when scanning a columnar table

### DIFF
--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -288,7 +288,7 @@ ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 			return false;
 		}
 
-		if (!StripeIsFlushed(stripeMetadata))
+		if (StripeWriteState(stripeMetadata) != STRIPE_WRITE_FLUSHED)
 		{
 			/*
 			 * Callers are expected to skip stripes that are not flushed to
@@ -582,7 +582,7 @@ AdvanceStripeRead(ColumnarReadState *readState)
 																 readState->snapshot);
 
 	if (readState->currentStripeMetadata &&
-		!StripeIsFlushed(readState->currentStripeMetadata) &&
+		StripeWriteState(readState->currentStripeMetadata) != STRIPE_WRITE_FLUSHED &&
 		!SnapshotMightSeeUnflushedStripes(readState->snapshot))
 	{
 		/*
@@ -596,7 +596,7 @@ AdvanceStripeRead(ColumnarReadState *readState)
 	}
 
 	while (readState->currentStripeMetadata &&
-		   !StripeIsFlushed(readState->currentStripeMetadata))
+		   StripeWriteState(readState->currentStripeMetadata) != STRIPE_WRITE_FLUSHED)
 	{
 		readState->currentStripeMetadata =
 			FindNextStripeByRowNumber(readState->relation,

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -179,6 +179,27 @@ typedef struct StripeBuffers
 } StripeBuffers;
 
 
+/* return value of StripeWriteState to decide stripe write state */
+typedef enum StripeWriteStateEnum
+{
+	/* stripe write is flushed to disk, so it's readable */
+	STRIPE_WRITE_FLUSHED,
+
+	/*
+	 * Writer transaction did abort either before inserting into
+	 * columnar.stripe or after.
+	 */
+	STRIPE_WRITE_ABORTED,
+
+	/*
+	 * Writer transaction is still in-progress. Note that it is not certain
+	 * if it is being written by current backend's current transaction or
+	 * another backend.
+	 */
+	STRIPE_WRITE_IN_PROGRESS
+} StripeWriteStateEnum;
+
+
 /* ColumnarReadState represents state of a columnar scan. */
 struct ColumnarReadState;
 typedef struct ColumnarReadState ColumnarReadState;
@@ -268,7 +289,7 @@ extern StripeMetadata * FindStripeByRowNumber(Relation relation, uint64 rowNumbe
 extern StripeMetadata * FindStripeWithMatchingFirstRowNumber(Relation relation,
 															 uint64 rowNumber,
 															 Snapshot snapshot);
-extern bool StripeIsFlushed(StripeMetadata *stripeMetadata);
+extern StripeWriteStateEnum StripeWriteState(StripeMetadata *stripeMetadata);
 extern uint64 StripeGetHighestRowNumber(StripeMetadata *stripeMetadata);
 extern StripeMetadata * FindStripeWithHighestRowNumber(Relation relation,
 													   Snapshot snapshot);

--- a/src/include/columnar/columnar_metadata.h
+++ b/src/include/columnar/columnar_metadata.h
@@ -26,6 +26,9 @@ typedef struct StripeMetadata
 	uint64 rowCount;
 	uint64 id;
 	uint64 firstRowNumber;
+
+	/* see StripeWriteState */
+	bool aborted;
 } StripeMetadata;
 
 /*

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -542,5 +542,13 @@ SELECT sum(a)>-1 FROM revisit_same_cgroup WHERE b = '1';
  t
 (1 row)
 
+CREATE TABLE aborted_write_test (a INT PRIMARY KEY) USING columnar;
+ALTER TABLE aborted_write_test SET (parallel_workers = 0);
+INSERT INTO aborted_write_test VALUES (16999);
+INSERT INTO aborted_write_test VALUES (16999);
+ERROR:  duplicate key value violates unique constraint "aborted_write_test_pkey"
+DETAIL:  Key (a)=(16999) already exists.
+-- since second INSERT already failed, should not throw a "duplicate key" error
+REINDEX TABLE aborted_write_test;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/src/test/regress/sql/columnar_indexes.sql
+++ b/src/test/regress/sql/columnar_indexes.sql
@@ -397,5 +397,14 @@ INSERT INTO revisit_same_cgroup SELECT random()*500, (random()*500)::INT::TEXT F
 
 SELECT sum(a)>-1 FROM revisit_same_cgroup WHERE b = '1';
 
+CREATE TABLE aborted_write_test (a INT PRIMARY KEY) USING columnar;
+ALTER TABLE aborted_write_test SET (parallel_workers = 0);
+
+INSERT INTO aborted_write_test VALUES (16999);
+INSERT INTO aborted_write_test VALUES (16999);
+
+-- since second INSERT already failed, should not throw a "duplicate key" error
+REINDEX TABLE aborted_write_test;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;


### PR DESCRIPTION
To fix #5241, soon we will set number of parallel workers that a columnar table
can use to 0 via `get_relation_info_hook`.

However, this revealed another bug in reader code-path that happens when it
is certain that we will not use any `parallel_worker`s for a columnar table.
See the first commit for the test added for that.

In that case, stripe entries inserted by aborted transactions become visible to
`SnapshotAny` and that causes `REINDEX` to fail by throwing a duplicate key
error.

To fix that:
* consider three states for a stripe write operation ("flushed", "aborted", or
   "in-progress")
* make sure to have a clear separation between them
* act according to those three states when reading from a columnar table
