### PR TITLE
Not flush writes until need to read them when doing index-scan on columnar

### DIFF
--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -1261,6 +1261,13 @@ BuildStripeMetadata(Relation columnarStripes, HeapTuple heapTuple)
 	stripeMetadata->firstRowNumber = DatumGetUInt64(
 		datumArray[Anum_columnar_stripe_first_row_number - 1]);
 
+	/*
+     * If there is unflushed data in a parent transaction, then we would
+	 * have already thrown an error before starting to scan the table.. If
+	 * the data is from an earlier subxact that committed, then it would
+	 * have been flushed already. For this reason, we don't care about
+	 * subtransaction id here.
+	 */
 	TransactionId entryXmin = HeapTupleHeaderGetXmin(heapTuple->t_data);
 	stripeMetadata->aborted = TransactionIdDidAbort(entryXmin);
 	stripeMetadata->insertedByCurrentXact =

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -1262,7 +1262,7 @@ BuildStripeMetadata(Relation columnarStripes, HeapTuple heapTuple)
 		datumArray[Anum_columnar_stripe_first_row_number - 1]);
 
 	/*
-     * If there is unflushed data in a parent transaction, then we would
+	 * If there is unflushed data in a parent transaction, then we would
 	 * have already thrown an error before starting to scan the table.. If
 	 * the data is from an earlier subxact that committed, then it would
 	 * have been flushed already. For this reason, we don't care about

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -1263,6 +1263,8 @@ BuildStripeMetadata(Relation columnarStripes, HeapTuple heapTuple)
 
 	TransactionId entryXmin = HeapTupleHeaderGetXmin(heapTuple->t_data);
 	stripeMetadata->aborted = TransactionIdDidAbort(entryXmin);
+	stripeMetadata->insertedByCurrentXact =
+		TransactionIdIsCurrentTransactionId(entryXmin);
 
 	CheckStripeMetadataConsistency(stripeMetadata);
 

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -254,56 +254,15 @@ CreateColumnarScanMemoryContext(void)
  */
 static ColumnarReadState *
 init_columnar_read_state(Relation relation, TupleDesc tupdesc, Bitmapset *attr_needed,
-						 List *scanQual, MemoryContext scanContext, Snapshot snapshot)
+						 List *scanQual, MemoryContext scanContext, Snapshot snapshot,
+						 bool flushWrites)
 {
 	MemoryContext oldContext = MemoryContextSwitchTo(scanContext);
-
-	Oid relfilenode = relation->rd_node.relNode;
-	FlushWriteStateForRelfilenode(relfilenode, GetCurrentSubTransactionId());
-
-	bool snapshotRegisteredByUs = false;
-	if (snapshot != InvalidSnapshot && IsMVCCSnapshot(snapshot))
-	{
-		/*
-		 * If we flushed any pending writes, then we should guarantee that
-		 * those writes are visible to us too. For this reason, if given
-		 * snapshot is an MVCC snapshot, then we set its curcid to current
-		 * command id.
-		 *
-		 * For simplicity, we do that even if we didn't flush any writes
-		 * since we don't see any problem with that.
-		 *
-		 * XXX: We should either not update cid if we are executing a FETCH
-		 * (from cursor) command, or we should have a better way to deal with
-		 * pending writes, see the discussion in
-		 * https://github.com/citusdata/citus/issues/5231.
-		 */
-		PushCopiedSnapshot(snapshot);
-
-		/* now our snapshot is the active one */
-		UpdateActiveSnapshotCommandId();
-		snapshot = GetActiveSnapshot();
-		RegisterSnapshot(snapshot);
-
-		/*
-		 * To be able to use UpdateActiveSnapshotCommandId, we pushed the
-		 * copied snapshot to the stack. However, we don't need to keep it
-		 * there since we will anyway rely on ColumnarReadState->snapshot
-		 * during read operation.
-		 *
-		 * Note that since we registered the snapshot already, we guarantee
-		 * that PopActiveSnapshot won't free it.
-		 */
-		PopActiveSnapshot();
-
-		/* not forget to unregister it when finishing read operation */
-		snapshotRegisteredByUs = true;
-	}
 
 	List *neededColumnList = NeededColumnsList(tupdesc, attr_needed);
 	ColumnarReadState *readState = ColumnarBeginRead(relation, tupdesc, neededColumnList,
 													 scanQual, scanContext, snapshot,
-													 snapshotRegisteredByUs);
+													 flushWrites);
 
 	MemoryContextSwitchTo(oldContext);
 
@@ -354,10 +313,12 @@ columnar_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlo
 	 */
 	if (scan->cs_readState == NULL)
 	{
+		bool flushWrites = true;
 		scan->cs_readState =
 			init_columnar_read_state(scan->cs_base.rs_rd, slot->tts_tupleDescriptor,
 									 scan->attr_needed, scan->scanQual,
-									 scan->scanContext, scan->cs_base.rs_snapshot);
+									 scan->scanContext, scan->cs_base.rs_snapshot,
+									 flushWrites);
 	}
 
 	ExecClearTuple(slot);
@@ -534,11 +495,12 @@ columnar_index_fetch_tuple(struct IndexFetchTableData *sscan,
 		/* no quals for index scan */
 		List *scanQual = NIL;
 
+		bool flushWrites = false;
 		scan->cs_readState = init_columnar_read_state(columnarRelation,
 													  slot->tts_tupleDescriptor,
 													  attr_needed, scanQual,
 													  scan->scanContext,
-													  snapshot);
+													  snapshot, flushWrites);
 	}
 
 	uint64 rowNumber = tid_to_row_number(*tid);
@@ -574,18 +536,50 @@ columnar_index_fetch_tuple(struct IndexFetchTableData *sscan,
 	}
 	else if (stripeWriteState == STRIPE_WRITE_IN_PROGRESS)
 	{
-		/* similar to aborted writes .. */
-		Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY);
+		if (stripeMetadata->insertedByCurrentXact)
+		{
+			/*
+			 * Stripe write is in progress and its entry is inserted by current
+			 * transaction, so obviously it must be written by me. Since caller
+			 * might want to use tupleslot datums for some reason, do another
+			 * look-up, but this time by first flushing our writes.
+			 *
+			 * XXX: For index scan, this is the only case that we flush pending
+			 * writes of the current backend. If we have taught reader how to
+			 * read from WriteStateMap. then we could guarantee that
+			 * index_fetch_tuple would never flush pending writes, but this seem
+			 * to be too much work for now, but should be doable.
+			 */
+			ColumnarReadFlushPendingWrites(scan->cs_readState);
 
-		/*
-		 * Stripe that "might" contain the tuple with rowNumber is not
-		 * flushed yet. Here we set all attributes of given tupleslot to NULL
-		 * before returning true and expect the indexAM callback that called
-		 * us --possibly to check against constraint violation-- blocks until
-		 * writer transaction commits or aborts, without requiring us to fill
-		 * the tupleslot properly.
-		 */
-		memset(slot->tts_isnull, true, slot->tts_nvalid * sizeof(bool));
+			/*
+			 * Fill the tupleslot and fall through to return true, it
+			 * certainly exists.
+			 */
+			ColumnarReadRowByRowNumberOrError(scan->cs_readState, rowNumber,
+											  slot->tts_values, slot->tts_isnull);
+		}
+		else
+		{
+			/* similar to aborted writes .. */
+			Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY);
+
+			/*
+			 * Stripe that "might" contain the tuple with rowNumber is not
+			 * flushed yet. Here we set all attributes of given tupleslot to NULL
+			 * before returning true and expect the indexAM callback that called
+			 * us --possibly to check against constraint violation-- blocks until
+			 * writer transaction commits or aborts, without requiring us to fill
+			 * the tupleslot properly.
+			 *
+			 * XXX: Note that the assumption we made above for the tupleslot
+			 * seems to hold for "unique" and "exclusion" constraint checks when
+			 * indexAM is not lossy. Since we only support "btree" and "hash"
+			 * indexAM's and they are not lossy, we believe this should be enough
+			 * for now, in a hacky way.
+			 */
+			memset(slot->tts_isnull, true, slot->tts_nvalid * sizeof(bool));
+		}
 	}
 	else
 	{
@@ -902,9 +896,11 @@ columnar_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	Snapshot snapshot = SnapshotAny;
 
 	MemoryContext scanContext = CreateColumnarScanMemoryContext();
+	bool flushWrites = true;
 	ColumnarReadState *readState = init_columnar_read_state(OldHeap, sourceDesc,
 															attr_needed, scanQual,
-															scanContext, snapshot);
+															scanContext, snapshot,
+															flushWrites);
 
 	Datum *values = palloc0(sourceDesc->natts * sizeof(Datum));
 	bool *nulls = palloc0(sourceDesc->natts * sizeof(bool));

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -236,7 +236,7 @@ extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 List *qualConditions,
 											 MemoryContext scanContext,
 											 Snapshot snaphot,
-											 bool flushWrites);
+											 bool randomAccess);
 extern void ColumnarReadFlushPendingWrites(ColumnarReadState *readState);
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -230,6 +230,8 @@ extern bool ContainsPendingWrites(ColumnarWriteState *state);
 extern MemoryContext ColumnarWritePerTupleContext(ColumnarWriteState *state);
 
 /* Function declarations for reading from columnar table */
+
+/* functions applicable for both sequential and random access */
 extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 TupleDesc tupleDescriptor,
 											 List *projectedColumnList,
@@ -238,18 +240,22 @@ extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 Snapshot snaphot,
 											 bool randomAccess);
 extern void ColumnarReadFlushPendingWrites(ColumnarReadState *readState);
+extern void ColumnarEndRead(ColumnarReadState *state);
+extern void ColumnarResetRead(ColumnarReadState *readState);
+
+/* functions only applicable for sequential access */
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);
+extern int64 ColumnarReadChunkGroupsFiltered(ColumnarReadState *state);
 extern void ColumnarRescan(ColumnarReadState *readState, List *scanQual);
+
+/* functions only applicable for random access */
 extern void ColumnarReadRowByRowNumberOrError(ColumnarReadState *readState,
 											  uint64 rowNumber, Datum *columnValues,
 											  bool *columnNulls);
 extern bool ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 									   uint64 rowNumber, Datum *columnValues,
 									   bool *columnNulls);
-extern void ColumnarEndRead(ColumnarReadState *state);
-extern void ColumnarResetRead(ColumnarReadState *readState);
-extern int64 ColumnarReadChunkGroupsFiltered(ColumnarReadState *state);
 
 /* Function declarations for common functions */
 extern FmgrInfo * GetFunctionInfoOrNull(Oid typeId, Oid accessMethodId,

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -236,10 +236,14 @@ extern ColumnarReadState * ColumnarBeginRead(Relation relation,
 											 List *qualConditions,
 											 MemoryContext scanContext,
 											 Snapshot snaphot,
-											 bool snapshotRegisteredByUs);
+											 bool flushWrites);
+extern void ColumnarReadFlushPendingWrites(ColumnarReadState *readState);
 extern bool ColumnarReadNextRow(ColumnarReadState *state, Datum *columnValues,
 								bool *columnNulls, uint64 *rowNumber);
 extern void ColumnarRescan(ColumnarReadState *readState, List *scanQual);
+extern void ColumnarReadRowByRowNumberOrError(ColumnarReadState *readState,
+											  uint64 rowNumber, Datum *columnValues,
+											  bool *columnNulls);
 extern bool ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 									   uint64 rowNumber, Datum *columnValues,
 									   bool *columnNulls);

--- a/src/include/columnar/columnar_metadata.h
+++ b/src/include/columnar/columnar_metadata.h
@@ -29,6 +29,14 @@ typedef struct StripeMetadata
 
 	/* see StripeWriteState */
 	bool aborted;
+
+	/*
+	 * If write operation is in-progress (i.e. StripeWriteState returned
+	 * STRIPE_WRITE_IN_PROGRESS), then insertedByCurrentXact is used to
+	 * distinguish whether it's being written by current transaction or
+	 * not.
+	 */
+	bool insertedByCurrentXact;
 } StripeMetadata;
 
 /*

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -669,5 +669,40 @@ WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columna
  t
 (1 row)
 
+TRUNCATE uniq;
+begin;
+  SAVEPOINT svpt;
+    insert into uniq select generate_series(1,100);
+  ROLLBACK TO SAVEPOINT svpt;
+  -- Since we rollbacked the writes in the upper transaction, we don't need
+  -- to flush pending writes for uniquenes check when inserting the same
+  -- values. So the following insert should just work.
+  insert into uniq select generate_series(1,100);
+  -- didn't flush anything yet, but should see the in progress stripe-write
+  SELECT stripe_num, first_row_number, row_count FROM columnar.stripe cs
+  WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ stripe_num | first_row_number | row_count
+---------------------------------------------------------------------
+          2 |           150001 |         0
+(1 row)
+
+commit;
+-- should have completed the stripe reservation
+SELECT stripe_num, first_row_number, row_count FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ stripe_num | first_row_number | row_count
+---------------------------------------------------------------------
+          2 |           150001 |       100
+(1 row)
+
+TRUNCATE uniq;
+begin;
+    insert into uniq select generate_series(1,100);
+    SAVEPOINT svpt;
+  -- cannot verify unique constraint when there are pending writes in
+  -- the upper transaction
+  insert into uniq select generate_series(1,100);
+ERROR:  cannot read from index when there is unflushed data in upper transactions
+rollback;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -589,5 +589,85 @@ BEGIN;
   SET LOCAL max_parallel_workers_per_gather = 4;
   create index on events (event_id);
 COMMIT;
+CREATE TABLE pending_index_scan(i INT UNIQUE) USING columnar;
+BEGIN;
+  INSERT INTO pending_index_scan SELECT generate_series(1,100);
+  -- test index scan when there are pending writes
+  SET LOCAL enable_seqscan TO OFF;
+  SET LOCAL columnar.enable_custom_scan TO OFF;
+  SELECT COUNT(*)=100 FROM pending_index_scan ;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+COMMIT;
+-- show that we don't flush single-tuple stripes due to aborted writes ...
+create table uniq(i int unique) using columnar;
+-- a) when table has a unique:
+begin;
+  insert into uniq select generate_series(1,100);
+  -- i) abort before flushing
+rollback;
+insert into uniq select generate_series(1,100);
+SELECT COUNT(*)=1 FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+TRUNCATE uniq;
+begin;
+  insert into uniq select generate_series(1,100);
+  -- ii) abort after flushing
+  SELECT count(*) FROM uniq;
+ count
+---------------------------------------------------------------------
+   100
+(1 row)
+
+rollback;
+insert into uniq select generate_series(1,100);
+SELECT COUNT(*)=1 FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+TRUNCATE uniq;
+-- b) when table has a primary key:
+begin;
+  insert into uniq select generate_series(1,100);
+  -- i) abort before flushing
+rollback;
+insert into uniq select generate_series(1,100);
+SELECT COUNT(*)=1 FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+TRUNCATE uniq;
+begin;
+  insert into uniq select generate_series(1,100);
+  -- ii) abort after flushing
+  SELECT count(*) FROM uniq;
+ count
+---------------------------------------------------------------------
+   100
+(1 row)
+
+rollback;
+insert into uniq select generate_series(1,100);
+SELECT COUNT(*)=1 FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/src/test/regress/sql/columnar_indexes.sql
+++ b/src/test/regress/sql/columnar_indexes.sql
@@ -515,5 +515,36 @@ insert into uniq select generate_series(1,100);
 SELECT COUNT(*)=1 FROM columnar.stripe cs
 WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
 
+TRUNCATE uniq;
+
+begin;
+  SAVEPOINT svpt;
+    insert into uniq select generate_series(1,100);
+  ROLLBACK TO SAVEPOINT svpt;
+
+  -- Since we rollbacked the writes in the upper transaction, we don't need
+  -- to flush pending writes for uniquenes check when inserting the same
+  -- values. So the following insert should just work.
+  insert into uniq select generate_series(1,100);
+
+  -- didn't flush anything yet, but should see the in progress stripe-write
+  SELECT stripe_num, first_row_number, row_count FROM columnar.stripe cs
+  WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+commit;
+
+-- should have completed the stripe reservation
+SELECT stripe_num, first_row_number, row_count FROM columnar.stripe cs
+WHERE cs.storage_id = columnar_test_helpers.columnar_relation_storageid('columnar_indexes.uniq'::regclass);
+
+TRUNCATE uniq;
+
+begin;
+    insert into uniq select generate_series(1,100);
+    SAVEPOINT svpt;
+  -- cannot verify unique constraint when there are pending writes in
+  -- the upper transaction
+  insert into uniq select generate_series(1,100);
+rollback;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;


### PR DESCRIPTION
Fixes #5216.

Not flush pending writes if given tid belongs to a "flushed" or
"aborted" stripe write, or to an "in-progress" stripe write of
another backend.

That way, we would reduce the cases where we flush single-tuple
stripes during index scan.

To do that, we follow below steps for index look-up's:

- Do not flush any pending writes and do stripe metadata look-up for
  given tid.
  If tuple with tid is found, then no need to do another look-up
  since we already found the tuple without needing to flush pending
  writes.

- If tuple is not found without flushing pending writes, then we have two
  scenarios:

  -  If given tid belongs to a pending write of my backend, then do stripe
     metadata look-up for given tid. But this time first **flush any pending
     writes**.
     
     (**If we had enough time**, then we could teach read-path to read from
     `WriteStateMap`. If we had done that, then we could guarantee that
     `index_fetch_tuple` would never flush pending writes, but this seem
     to be too much work for now. I have a somewhat working
     implementation for that in another branch: 8ba8055f02a5e58def3eda7a4fcb1c8b915ae3b5.)

  -  Otherwise, just return false from `index_fetch_tuple` since flushing
      pending writes wouldn't help.