### PR TITLE
Improve memset calls made to reset bool arrays

### DIFF
--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -349,7 +349,7 @@ ColumnarGetRelationInfoHook(PlannerInfo *root, Oid relationObjectId,
 		IndexOptInfo *indexOptInfo = NULL;
 		foreach_ptr(indexOptInfo, rel->indexlist)
 		{
-			memset(indexOptInfo->canreturn, false, indexOptInfo->ncolumns);
+			memset(indexOptInfo->canreturn, false, indexOptInfo->ncolumns * sizeof(bool));
 		}
 	}
 }

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -585,7 +585,7 @@ columnar_index_fetch_tuple(struct IndexFetchTableData *sscan,
 		 * writer transaction commits or aborts, without requiring us to fill
 		 * the tupleslot properly.
 		 */
-		memset(slot->tts_isnull, true, slot->tts_nvalid);
+		memset(slot->tts_isnull, true, slot->tts_nvalid * sizeof(bool));
 	}
 	else
 	{

--- a/src/backend/columnar/columnar_writer.c
+++ b/src/backend/columnar/columnar_writer.c
@@ -118,7 +118,7 @@ ColumnarBeginWrite(RelFileNode relfilenode,
 															 ALLOCSET_DEFAULT_SIZES);
 
 	bool *columnMaskArray = palloc(columnCount * sizeof(bool));
-	memset(columnMaskArray, true, columnCount);
+	memset(columnMaskArray, true, columnCount * sizeof(bool));
 
 	ChunkData *chunkData = CreateEmptyChunkData(columnCount, columnMaskArray,
 												options.chunkRowCount);

--- a/src/backend/columnar/columnar_writer.c
+++ b/src/backend/columnar/columnar_writer.c
@@ -507,7 +507,7 @@ static StringInfo
 SerializeBoolArray(bool *boolArray, uint32 boolArrayLength)
 {
 	uint32 boolArrayIndex = 0;
-	uint32 byteCount = (boolArrayLength + 7) / 8;
+	uint32 byteCount = ((boolArrayLength * sizeof(bool)) + (8 - sizeof(bool))) / 8;
 
 	StringInfo boolArrayBuffer = makeStringInfo();
 	enlargeStringInfo(boolArrayBuffer, byteCount);


### PR DESCRIPTION
Afaik, `sizeof(bool)` is already equal to `1` but I felt a bit anxious after seeing those three calls.