### PR TITLE
prevent double inclusion of columnar_tableam.h

### DIFF
--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -1,3 +1,5 @@
+#ifndef COLUMNAR_TABLEAM_H
+#define COLUMNAR_TABLEAM_H
 #include "citus_version.h"
 
 #include "postgres.h"
@@ -60,3 +62,6 @@ extern bool ColumnarSupportsIndexAM(char *indexAMName);
 extern bool IsColumnarTableAmTable(Oid relationId);
 extern TableDDLCommand * ColumnarGetTableOptionsDDL(Oid relationId);
 extern char * GetShardedTableDDLCommandColumnar(uint64 shardId, void *context);
+
+
+#endif /* COLUMNAR_TABLEAM_H */


### PR DESCRIPTION
Recently there are some warnings during the compilation of Citus.
Part of the warnings come due to the `columnar_tableam.h` header not being properly guarded with defines and ifndef's.

This PR fixes these warnings.