### PR TITLE
Rename ddlJob->commandString to ddlJob->metadataSyncCommand

### DIFF
--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -464,7 +464,7 @@ GenerateCreateIndexDDLJob(IndexStmt *createIndexStatement, const char *createInd
 
 	ddlJob->targetRelationId = CreateIndexStmtGetRelationId(createIndexStatement);
 	ddlJob->startNewTransaction = createIndexStatement->concurrent;
-	ddlJob->commandString = createIndexCommand;
+	ddlJob->metadataSyncCommand = createIndexCommand;
 	ddlJob->taskList = CreateIndexTaskList(createIndexStatement);
 
 	return ddlJob;
@@ -599,7 +599,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand,
 			ddlJob->targetRelationId = relationId;
 			ddlJob->startNewTransaction = IsReindexWithParam_compat(reindexStatement,
 																	"concurrently");
-			ddlJob->commandString = reindexCommand;
+			ddlJob->metadataSyncCommand = reindexCommand;
 			ddlJob->taskList = CreateReindexTaskList(relationId, reindexStatement);
 
 			ddlJobs = list_make1(ddlJob);
@@ -711,7 +711,7 @@ PreprocessDropIndexStmt(Node *node, const char *dropIndexCommand,
 		 * to be able to repeat the DROP INDEX later.
 		 */
 		ddlJob->startNewTransaction = false;
-		ddlJob->commandString = dropIndexCommand;
+		ddlJob->metadataSyncCommand = dropIndexCommand;
 		ddlJob->taskList = DropIndexTaskList(distributedRelationId, distributedIndexId,
 											 dropIndexStatement);
 

--- a/src/backend/distributed/commands/rename.c
+++ b/src/backend/distributed/commands/rename.c
@@ -128,7 +128,7 @@ PreprocessRenameStmt(Node *node, const char *renameCommand,
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = tableRelationId;
-	ddlJob->commandString = renameCommand;
+	ddlJob->metadataSyncCommand = renameCommand;
 	ddlJob->taskList = DDLTaskList(tableRelationId, renameCommand);
 
 	return list_make1(ddlJob);

--- a/src/backend/distributed/commands/statistics.c
+++ b/src/backend/distributed/commands/statistics.c
@@ -93,7 +93,7 @@ PreprocessCreateStatisticsStmt(Node *node, const char *queryString,
 
 	ddlJob->targetRelationId = relationId;
 	ddlJob->startNewTransaction = false;
-	ddlJob->commandString = ddlCommand;
+	ddlJob->metadataSyncCommand = ddlCommand;
 	ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 	List *ddlJobs = list_make1(ddlJob);
@@ -198,7 +198,7 @@ PreprocessDropStatisticsStmt(Node *node, const char *queryString,
 
 		ddlJob->targetRelationId = relationId;
 		ddlJob->startNewTransaction = false;
-		ddlJob->commandString = ddlCommand;
+		ddlJob->metadataSyncCommand = ddlCommand;
 		ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 		ddlJobs = lappend(ddlJobs, ddlJob);
@@ -237,7 +237,7 @@ PreprocessAlterStatisticsRenameStmt(Node *node, const char *queryString,
 
 	ddlJob->targetRelationId = relationId;
 	ddlJob->startNewTransaction = false;
-	ddlJob->commandString = ddlCommand;
+	ddlJob->metadataSyncCommand = ddlCommand;
 	ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 	List *ddlJobs = list_make1(ddlJob);
@@ -275,7 +275,7 @@ PreprocessAlterStatisticsSchemaStmt(Node *node, const char *queryString,
 
 	ddlJob->targetRelationId = relationId;
 	ddlJob->startNewTransaction = false;
-	ddlJob->commandString = ddlCommand;
+	ddlJob->metadataSyncCommand = ddlCommand;
 	ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 	List *ddlJobs = list_make1(ddlJob);
@@ -366,7 +366,7 @@ PreprocessAlterStatisticsStmt(Node *node, const char *queryString,
 
 	ddlJob->targetRelationId = relationId;
 	ddlJob->startNewTransaction = false;
-	ddlJob->commandString = ddlCommand;
+	ddlJob->metadataSyncCommand = ddlCommand;
 	ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 	List *ddlJobs = list_make1(ddlJob);
@@ -406,7 +406,7 @@ PreprocessAlterStatisticsOwnerStmt(Node *node, const char *queryString,
 
 	ddlJob->targetRelationId = relationId;
 	ddlJob->startNewTransaction = false;
-	ddlJob->commandString = ddlCommand;
+	ddlJob->metadataSyncCommand = ddlCommand;
 	ddlJob->taskList = DDLTaskList(relationId, ddlCommand);
 
 	List *ddlJobs = list_make1(ddlJob);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1119,7 +1119,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 		sqlForTaskList = DeparseTreeNode((Node *) newStmt);
 	}
 
-	ddlJob->commandString = useInitialDDLCommandString ? alterTableCommand : NULL;
+	ddlJob->metadataSyncCommand = useInitialDDLCommandString ? alterTableCommand : NULL;
 
 	if (OidIsValid(rightRelationId))
 	{
@@ -1759,8 +1759,8 @@ PreprocessAlterTableSchemaStmt(Node *node, const char *queryString,
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	QualifyTreeNode((Node *) stmt);
 	ddlJob->targetRelationId = relationId;
-	ddlJob->commandString = DeparseTreeNode((Node *) stmt);
-	ddlJob->taskList = DDLTaskList(relationId, ddlJob->commandString);
+	ddlJob->metadataSyncCommand = DeparseTreeNode((Node *) stmt);
+	ddlJob->taskList = DDLTaskList(relationId, ddlJob->metadataSyncCommand);
 	return list_make1(ddlJob);
 }
 

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -637,7 +637,7 @@ CitusLocalTableTriggerCommandDDLJob(Oid relationId, char *triggerName,
 {
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = relationId;
-	ddlJob->commandString = queryString;
+	ddlJob->metadataSyncCommand = queryString;
 
 	if (!triggerName)
 	{

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -900,9 +900,9 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 				SendCommandToWorkersWithMetadata(setSearchPathCommand);
 			}
 
-			if (ddlJob->commandString != NULL)
+			if (ddlJob->metadataSyncCommand != NULL)
 			{
-				SendCommandToWorkersWithMetadata((char *) ddlJob->commandString);
+				SendCommandToWorkersWithMetadata((char *) ddlJob->metadataSyncCommand);
 			}
 		}
 
@@ -962,7 +962,7 @@ ExecuteDistributedDDLJob(DDLJob *ddlJob)
 					commandList = lappend(commandList, setSearchPathCommand);
 				}
 
-				commandList = lappend(commandList, (char *) ddlJob->commandString);
+				commandList = lappend(commandList, (char *) ddlJob->metadataSyncCommand);
 
 				SendBareCommandListToMetadataWorkers(commandList);
 			}
@@ -1042,7 +1042,7 @@ CreateCustomDDLTaskList(Oid relationId, TableDDLCommand *command)
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = relationId;
-	ddlJob->commandString = GetTableDDLCommand(command);
+	ddlJob->metadataSyncCommand = GetTableDDLCommand(command);
 	ddlJob->taskList = taskList;
 
 	return ddlJob;
@@ -1292,7 +1292,7 @@ NodeDDLTaskList(TargetWorkerSet targets, List *commands)
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ddlJob->targetRelationId = InvalidOid;
-	ddlJob->commandString = NULL;
+	ddlJob->metadataSyncCommand = NULL;
 	ddlJob->taskList = list_make1(task);
 
 	return list_make1(ddlJob);

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -57,7 +57,12 @@ typedef struct DDLJob
 	 */
 	bool startNewTransaction;
 
-	const char *commandString; /* initial (coordinator) DDL command string */
+	/*
+	 * Command to run in MX nodes when metadata is synced
+	 * This is usually the initial (coordinator) DDL command string
+	 */
+	const char *metadataSyncCommand;
+
 	List *taskList;            /* worker DDL tasks to execute */
 } DDLJob;
 


### PR DESCRIPTION
It seems that we only use `ddlJob->commandString` as the metadata sync command for MX nodes.

SHOULD MERGE https://github.com/citusdata/citus-enterprise/pull/694 BEFORE MERGING THIS