### PR TITLE
Give proper error while distributing a temp table

### DIFF
--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -406,4 +406,11 @@ SELECT shardcount FROM pg_dist_colocation WHERE colocationid IN
          13
 (1 row)
 
+CREATE TEMP TABLE temp_table(a int);
+-- make sure temp table cannot be distributed and we give a good error
+select create_distributed_table('temp_table', 'a');
+ERROR:  cannot distribute a temporary table
+select create_reference_table('temp_table');
+ERROR:  cannot distribute a temporary table
+DROP TABLE temp_table;
 DROP TABLE shard_count_table_3;

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -265,4 +265,10 @@ SELECT shardcount FROM pg_dist_colocation WHERE colocationid IN
 	SELECT colocation_id FROM citus_tables WHERE table_name = 'shard_count_table_3'::regclass
 );
 
+CREATE TEMP TABLE temp_table(a int);
+-- make sure temp table cannot be distributed and we give a good error
+select create_distributed_table('temp_table', 'a');
+select create_reference_table('temp_table');
+DROP TABLE temp_table;
+
 DROP TABLE shard_count_table_3;


### PR DESCRIPTION
DESCRIPTION: Improves error message while distributing a temporary table

Fixes #4658 
