### PR TITLE
Columnar bitmap index scan

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2074,7 +2074,6 @@ columnar_bitmap_next_block(TableScanDesc scan, TBMIterateResult *tbmres)
 	ColumnarScanDesc cscan = (ColumnarScanDesc) scan;
 	cscan->tupleindex = 0;
 
-//	ereport(ERROR, (errmsg("bitmap scan not implemented")));
 	return tbmres->blockno == 0;
 }
 
@@ -2085,27 +2084,19 @@ columnar_bitmap_next_tuple(TableScanDesc scan, TBMIterateResult *tbmres,
 {
 	ColumnarScanDesc cscan = (ColumnarScanDesc) scan;
 
-	/**/
 	if (cscan->tupleindex >= tbmres->ntuples)
 	{
 		return false;
 	}
 
-	// TEST!
-
-	ItemPointerData tid = {};
+	ItemPointerData tid = { 0 };
 
 	ItemPointerSet(&tid, tbmres->blockno, tbmres->offsets[cscan->tupleindex]);
 	cscan->tupleindex++;
 
 	ExecClearTuple(slot);
 
-	/* we need all columns */
 	Relation rel = cscan->cs_base.rs_rd;
-//	int natts = rel->rd_att->natts;
-//	Bitmapset *attr_needed = bms_add_range(NULL, 0, natts - 1);
-//	TupleDesc relationTupleDesc = RelationGetDescr(rel);
-//	List *relationColumnList = NeededColumnsList(relationTupleDesc, attr_needed);
 
 	/* initialize read state for the first row */
 	if (cscan->cs_readState == NULL)
@@ -2117,10 +2108,10 @@ columnar_bitmap_next_tuple(TableScanDesc scan, TBMIterateResult *tbmres,
 		/* no quals for index scan */
 		List *scanQual = NIL;
 
-        cscan->cs_readState = init_columnar_read_state(rel, slot->tts_tupleDescriptor,
-                                                       attr_needed, scanQual,
-                                                       cscan->scanContext,
-                                                       cscan->cs_base.rs_snapshot);
+		cscan->cs_readState = init_columnar_read_state(rel, slot->tts_tupleDescriptor,
+													   attr_needed, scanQual,
+													   cscan->scanContext,
+													   cscan->cs_base.rs_snapshot);
 	}
 
 	uint64 rowNumber = tid_to_row_number(tid);
@@ -2136,6 +2127,7 @@ columnar_bitmap_next_tuple(TableScanDesc scan, TBMIterateResult *tbmres,
 
 	return true;
 }
+
 
 static const TableAmRoutine columnar_am_methods = {
 	.type = T_TableAmRoutine,

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2091,6 +2091,8 @@ columnar_bitmap_next_tuple(TableScanDesc scan, TBMIterateResult *tbmres,
 		return false;
 	}
 
+	// TEST!
+
 	ItemPointerData tid = {};
 
 	ItemPointerSet(&tid, tbmres->blockno, tbmres->offsets[cscan->tupleindex]);


### PR DESCRIPTION
DESCRIPTION: Add bitmap scan support to columnar

This is a WIP. Big missing feature is lossy bitmap scans.
During development I was not able to trigger lossy scans to understand what needs to be done for lossy scans.

Design is, for every block, to create a bitmap set of offsets to load during the phase of calling next.
Heap uses an array of offsets to work with, so design is similar, just a different data structure to represent the same.

It seems that a lossy bitmap needs to find all valid offset numbers in the range of a block and populate these in the bitmapset.
However, without a way to trigger this it feels risky to merge this, during an already risky time for a columnar release.