### PR TITLE
Make sure to skip aborted writes when reading the first tuple

### DIFF
--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -566,7 +566,6 @@ BEGIN;
   -- transactions.
   TRUNCATE columnar.chunk, columnar.chunk_group;
   CREATE INDEX ON aborted_write_test (a);
-ERROR:  unexpected chunk group count
 ROLLBACK;
 create table events (event_id bigserial, event_time timestamptz default now(), payload text) using columnar;
 BEGIN;

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -544,6 +544,30 @@ ERROR:  duplicate key value violates unique constraint "aborted_write_test_pkey"
 DETAIL:  Key (a)=(16999) already exists.
 -- since second INSERT already failed, should not throw a "duplicate key" error
 REINDEX TABLE aborted_write_test;
+BEGIN;
+  ALTER TABLE columnar.stripe SET (autovacuum_enabled = false);
+  ALTER TABLE columnar.chunk SET (autovacuum_enabled = false);
+  ALTER TABLE columnar.chunk_group SET (autovacuum_enabled = false);
+  DROP TABLE aborted_write_test;
+  TRUNCATE columnar.stripe, columnar.chunk, columnar.chunk_group;
+  CREATE TABLE aborted_write_test (a INT) USING columnar;
+  SAVEPOINT svpt;
+    INSERT INTO aborted_write_test SELECT i FROM generate_series(1, 2) i;
+    -- force flush write state
+    SELECT FROM aborted_write_test;
+--
+(2 rows)
+
+  ROLLBACK TO SAVEPOINT svpt;
+  -- Already disabled autovacuum for all three metadata tables.
+  -- Here we truncate columnar.chunk and columnar.chunk_group but not
+  -- columnar.stripe to make sure that we properly handle dead tuples
+  -- in columnar.stripe, i.e. stripe metadata entries for aborted
+  -- transactions.
+  TRUNCATE columnar.chunk, columnar.chunk_group;
+  CREATE INDEX ON aborted_write_test (a);
+ERROR:  unexpected chunk group count
+ROLLBACK;
 create table events (event_id bigserial, event_time timestamptz default now(), payload text) using columnar;
 BEGIN;
   -- this wouldn't flush any data


### PR DESCRIPTION
Related: #5244.

With 5825c44d5f45ae78cd51484dfe1828f691eb82ea, we made the changes to
skip aborted writes when scanning a columnar table.

However, looks like we forgot to handle such cases for the very first
call made to columnar_getnextslot. That means, that commit only
considered the intermediate stripe read operations.

However, functions called by columnar_getnextslot to find first stripe
to read (ColumnarBeginRead or ColumnarRescan) were not caring about
those aborted writes.

To fix that, we teach AdvanceStripeRead to find the very first stripe
to read, and then start using it where we were blindly calling
FindNextStripeByRowNumber.
