### PR TITLE
Check if xact id is in progress before checking if aborted

### DIFF
--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -1269,7 +1269,8 @@ BuildStripeMetadata(Relation columnarStripes, HeapTuple heapTuple)
 	 * subtransaction id here.
 	 */
 	TransactionId entryXmin = HeapTupleHeaderGetXmin(heapTuple->t_data);
-	stripeMetadata->aborted = TransactionIdDidAbort(entryXmin);
+	stripeMetadata->aborted = !TransactionIdIsInProgress(entryXmin) &&
+							  TransactionIdDidAbort(entryXmin);
 	stripeMetadata->insertedByCurrentXact =
 		TransactionIdIsCurrentTransactionId(entryXmin);
 


### PR DESCRIPTION
DESCRIPTION: Fixes an unexpected error due to an in-progress columnar table write, whose xact id is not in the clog yet

(Will try to improve the changelog tomorrow)

When investigating an issue reported by a slack user, we thought that we first need to check if transaction is in progress, in case given transaction id is not in the clog yet.