### PR TITLE
Revoke read access to columnar.chunk from unprivileged user

### DIFF
--- a/src/backend/columnar/sql/columnar--10.2-1--10.2-2.sql
+++ b/src/backend/columnar/sql/columnar--10.2-1--10.2-2.sql
@@ -1,0 +1,5 @@
+-- columnar--10.2-1--10.2-2.sql
+
+-- revoke read access for columnar.chunk from unprivileged
+-- user as it contains chunk min/max values
+REVOKE SELECT ON columnar.chunk FROM PUBLIC;

--- a/src/backend/columnar/sql/downgrades/columnar--10.2-2--10.2-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.2-2--10.2-1.sql
@@ -1,0 +1,4 @@
+-- columnar--10.2-2--10.2-1.sql
+
+-- grant read access for columnar.chunk to unprivileged user
+GRANT SELECT ON columnar.chunk TO PUBLIC;

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '10.2-1'
+default_version = '10.2-2'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/sql/citus--10.2-1--10.2-2.sql
+++ b/src/backend/distributed/sql/citus--10.2-1--10.2-2.sql
@@ -1,0 +1,5 @@
+-- citus--10.2-1--10.2-2
+
+-- bump version to 10.2-2
+
+#include "../../columnar/sql/columnar--10.2-1--10.2-2.sql"

--- a/src/backend/distributed/sql/downgrades/citus--10.2-2--10.2-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.2-2--10.2-1.sql
@@ -1,0 +1,3 @@
+-- citus--10.2-2--10.2-1
+
+#include "../../../columnar/sql/downgrades/columnar--10.2-2--10.2-1.sql"

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -848,6 +848,22 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                             | function worker_nextval(regclass) integer
 (16 rows)
 
+-- Test downgrade to 10.2-1 from 10.2-2
+ALTER EXTENSION citus UPDATE TO '10.2-2';
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
+-- Snapshot of state at 10.2-2
+ALTER EXTENSION citus UPDATE TO '10.2-2';
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version
 SHOW citus.version;

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -265,19 +265,26 @@ SELECT * FROM columnar.stripe;
 
 -- alter a columnar setting
 SET columnar.chunk_group_row_limit = 1050;
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE $$
-    -- create columnar table
-    CREATE TABLE columnar_table (a int) USING columnar;
-    -- alter a columnar table that is created by that unprivileged user
-    SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
-    -- and drop it
-    DROP TABLE columnar_table;
-  $$;
-END IF;
-END$proc$;
+-- create columnar table
+CREATE TABLE columnar_table (a int) USING columnar;
+-- alter a columnar table that is created by that unprivileged user
+SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
+ alter_columnar_table_set
+---------------------------------------------------------------------
+
+(1 row)
+
+-- insert some data and read
+INSERT INTO columnar_table VALUES (1), (1);
+SELECT * FROM columnar_table;
+ a
+---------------------------------------------------------------------
+ 1
+ 1
+(2 rows)
+
+-- and drop it
+DROP TABLE columnar_table;
 -- cannot modify columnar metadata table as unprivileged user
 INSERT INTO columnar.stripe VALUES(99);
 ERROR:  permission denied for table stripe
@@ -286,6 +293,9 @@ ERROR:  permission denied for table stripe
 -- (since citus extension has a dependency to it)
 DROP TABLE columnar.chunk;
 ERROR:  must be owner of table chunk
+-- cannot read columnar.chunk since it could expose chunk min/max values
+SELECT * FROM columnar.chunk;
+ERROR:  permission denied for table chunk
 -- test whether a read-only user can read from citus_tables view
 SELECT distribution_column FROM citus_tables WHERE table_name = 'test'::regclass;
  distribution_column

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -346,6 +346,16 @@ SELECT * FROM multi_extension.print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '10.2-1';
 SELECT * FROM multi_extension.print_extension_changes();
 
+-- Test downgrade to 10.2-1 from 10.2-2
+ALTER EXTENSION citus UPDATE TO '10.2-2';
+ALTER EXTENSION citus UPDATE TO '10.2-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+
+-- Snapshot of state at 10.2-2
+ALTER EXTENSION citus UPDATE TO '10.2-2';
+SELECT * FROM multi_extension.print_extension_changes();
+
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 
 -- show running version


### PR DESCRIPTION
Since this could expose chunk min/max values to unprivileged users.

DESCRIPTION: Revokes read access to `columnar.chunk` from unprivileged user
