### PR TITLE
Check more exit codes in upgrade tests

### DIFF
--- a/src/test/regress/upgrade/citus_upgrade_test.py
+++ b/src/test/regress/upgrade/citus_upgrade_test.py
@@ -56,7 +56,7 @@ def main(config):
 
 def install_citus(tar_path):
     with utils.cd('/'):
-        subprocess.call(['tar', 'xvf', tar_path])
+        subprocess.run(['tar', 'xvf', tar_path], check=True)
 
 
 def report_initial_version(config):
@@ -108,7 +108,7 @@ def restart_database(pg_path, abs_data_path, node_name):
         '-o', '-p {}'.format(NODE_PORTS[node_name]),
         '--log', os.path.join(abs_data_path, 'logfile_' + node_name)
     ]
-    subprocess.call(command)
+    subprocess.run(command, check=True)
 
 
 def run_alter_citus(pg_path, mixed_mode):

--- a/src/test/regress/upgrade/pg_upgrade_test.py
+++ b/src/test/regress/upgrade/pg_upgrade_test.py
@@ -45,7 +45,7 @@ def perform_postgres_upgrade(old_bindir, new_bindir, old_datadir, new_datadir):
                 '--old-datadir', abs_old_data_path,
                 '--new-datadir', abs_new_data_path
             ]
-            subprocess.call(command)
+            subprocess.run(command, check=True)
 
 
 def citus_finish_pg_upgrade(pg_path):

--- a/src/test/regress/upgrade/upgrade_common.py
+++ b/src/test/regress/upgrade/upgrade_common.py
@@ -24,7 +24,7 @@ def initialize_temp_dir_if_not_exists(temp_dir):
     os.chmod(temp_dir, 0o777)
 
 def initialize_db_for_cluster(pg_path, rel_data_path, settings):
-    subprocess.call(['mkdir', rel_data_path])
+    subprocess.run(['mkdir', rel_data_path], check=True)
     for node_name in NODE_NAMES:
         abs_data_path = os.path.abspath(os.path.join(rel_data_path, node_name))
         command = [
@@ -32,7 +32,7 @@ def initialize_db_for_cluster(pg_path, rel_data_path, settings):
             '--pgdata', abs_data_path,
             '--username', USER
         ]
-        subprocess.call(command)
+        subprocess.run(command, check=True)
         add_settings(abs_data_path, settings)
 
 
@@ -56,7 +56,7 @@ def start_databases(pg_path, rel_data_path):
             '-o', '-p {}'.format(NODE_PORTS[node_name]),
             '--log', os.path.join(abs_data_path, 'logfile_' + node_name)
         ]
-        subprocess.call(command)
+        subprocess.run(command, check=True)
 
 def create_citus_extension(pg_path):
     for port in NODE_PORTS.values():


### PR DESCRIPTION
We were trying to find the cause for a strange update bug. We thought
`pg_upgrade` succeeded and then were surprised that certain data was not
in the database after the upgrade. Instead `pg_upgrade` had failed
halfway through with an actionable error. It took us pretty long to
realise this.

This commit adds checking of exit codes to a lot more subprocess
executions. That should make debugging in the future much easier.