### PR TITLE
Make (columnar.stripe) first_row_number index a unique constraint

### DIFF
--- a/src/backend/columnar/sql/columnar--10.2-2--10.2-3.sql
+++ b/src/backend/columnar/sql/columnar--10.2-2--10.2-3.sql
@@ -1,0 +1,15 @@
+-- columnar--10.2-2--10.2-3.sql
+
+-- Since stripe_first_row_number_idx is required to scan a columnar table, we
+-- need to make sure that it is created before doing anything with columnar
+-- tables during pg upgrades.
+--
+-- However, a plain btree index is not a dependency of a table, so pg_upgrade
+-- cannot guarantee that stripe_first_row_number_idx gets created when
+-- creating columnar.stripe, unless we make it a unique "constraint".
+--
+-- To do that, drop stripe_first_row_number_idx and create a unique
+-- constraint with the same name to keep the code change at minimum.
+DROP INDEX columnar.stripe_first_row_number_idx;
+ALTER TABLE columnar.stripe ADD CONSTRAINT stripe_first_row_number_idx
+UNIQUE (storage_id, first_row_number);

--- a/src/backend/columnar/sql/downgrades/columnar--10.2-3--10.2-2.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.2-3--10.2-2.sql
@@ -1,0 +1,4 @@
+-- columnar--10.2-3--10.2-2.sql
+
+ALTER TABLE columnar.stripe DROP CONSTRAINT stripe_first_row_number_idx;
+CREATE INDEX stripe_first_row_number_idx ON columnar.stripe USING BTREE(storage_id, first_row_number);

--- a/src/backend/distributed/citus.control
+++ b/src/backend/distributed/citus.control
@@ -1,6 +1,6 @@
 # Citus extension
 comment = 'Citus distributed database'
-default_version = '10.2-2'
+default_version = '10.2-3'
 module_pathname = '$libdir/citus'
 relocatable = false
 schema = pg_catalog

--- a/src/backend/distributed/sql/citus--10.2-2--10.2-3.sql
+++ b/src/backend/distributed/sql/citus--10.2-2--10.2-3.sql
@@ -1,0 +1,5 @@
+-- citus--10.2-2--10.2-3
+
+-- bump version to 10.2-3
+
+#include "../../columnar/sql/columnar--10.2-2--10.2-3.sql"

--- a/src/backend/distributed/sql/downgrades/citus--10.2-3--10.2-2.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.2-3--10.2-2.sql
@@ -1,0 +1,3 @@
+-- citus--10.2-3--10.2-2
+
+#include "../../../columnar/sql/downgrades/columnar--10.2-3--10.2-2.sql"


### PR DESCRIPTION
Maybe we should merge the changes done here together with https://github.com/citusdata/citus/pull/5324.
If we should do so, I'm okay to close this pr.

---

Since stripe_first_row_number_idx is required to scan a columnar
table, we need to make sure that it is created before doing anything
with columnar tables during pg upgrades.

However, a plain btree index is not a dependency of a table, so
pg_upgrade cannot guarantee that stripe_first_row_number_idx gets
created when creating columnar.stripe, unless we make it a unique
"constraint".

Also see how pg_dump handles dependencies between objects:
https://github.com/postgres/postgres/blob/6c450a861f1a928f44c9ae80814ed9a91927c25a/src/bin/pg_dump/pg_dump.c#L892-L922

To do that, drop stripe_first_row_number_idx and create a unique
constraint with the same name to keep the code change at minimum.

DESCRIPTION: Fixes a bug that could cause prerequisite columnarAM objects to not created during pg upgrades