### PR TITLE
(Share) Lock page buffer when reading from columnar storage

### DIFF
--- a/src/backend/columnar/columnar_storage.c
+++ b/src/backend/columnar/columnar_storage.c
@@ -667,6 +667,7 @@ ReadFromBlock(Relation rel, BlockNumber blockno, uint32 offset, char *buf,
 			  uint32 len, bool force)
 {
 	Buffer buffer = ReadBuffer(rel, blockno);
+	LockBuffer(buffer, BUFFER_LOCK_SHARE);
 	Page page = BufferGetPage(buffer);
 	PageHeader phdr = (PageHeader) page;
 
@@ -678,7 +679,7 @@ ReadFromBlock(Relation rel, BlockNumber blockno, uint32 offset, char *buf,
 	}
 
 	memcpy_s(buf, len, page + offset, len);
-	ReleaseBuffer(buffer);
+	UnlockReleaseBuffer(buffer);
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/citusdata/citus/issues/5333.

(Still testing)

Under high write concurrency, we were sometimes reading columnar
metapage as all zeros.

We still couldn't find the exact reason, however
postgres/storage/buffer/README states that:

> Buffer access rules:
>
> 1. To scan a page for tuples, one must hold a pin and either shared or
> exclusive content lock.  To examine the commit status (XIDs and status bits)
> of a tuple in a shared buffer, one must likewise hold a pin and either shared
> or exclusive lock.

That said, it seems quite possible that a transaction that needs to read
metapage might see dirty values if there is a concurrent writer
transaction that needs to update reserved.* fields of metapage.

Plus, when testing this commit, we didn't encounter with all-zero
metapages anymore.

However, it is still strange that we couldn't reproduce this issue on
older versions even if we don't (Share) lock buffer page when reading
columnar tables on those versions too.

On the other hand, with the changes we made around columnar storage
layer and read-path on 10.2, now we are inclined to fetch metapage more
frequently, so this could be the reason why this issue only applies to
10.2.

DESCRIPTION: Fixes a bug that causes reading columnar metapage as all-zeros under high write concurrency 
