### PR TITLE
Future work?: Teach columnar index scan to read local write state, without flushing

### DIFF
--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -228,6 +228,10 @@ extern void ColumnarFlushPendingWrites(ColumnarWriteState *state);
 extern void ColumnarEndWrite(ColumnarWriteState *state);
 extern bool ContainsPendingWrites(ColumnarWriteState *state);
 extern MemoryContext ColumnarWritePerTupleContext(ColumnarWriteState *state);
+extern uint64 ColumnarWriteStripeId(ColumnarWriteState *writeState);
+extern StripeBuffers * ColumnarWriteStripeBuffers(ColumnarWriteState *writeState);
+extern uint64 ColumnarWriteSerializedRowCount(ColumnarWriteState *writeState);
+extern ChunkData *ColumnarWriteChunkData(ColumnarWriteState *writeState);
 
 /* Function declarations for reading from columnar table */
 
@@ -256,6 +260,10 @@ extern void ColumnarReadRowByRowNumberOrError(ColumnarReadState *readState,
 extern bool ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 									   uint64 rowNumber, Datum *columnValues,
 									   bool *columnNulls);
+extern void ColumnarReadBufferByRowNumber(ColumnarReadState *readState,
+			 		    	  			  uint64 rowNumber, Datum *columnValues,
+						   	  			  bool *columnNulls);
+extern Snapshot ColumnarReadSetSnapshot(ColumnarReadState *readState, Snapshot snapshot);
 
 /* Function declarations for common functions */
 extern FmgrInfo * GetFunctionInfoOrNull(Oid typeId, Oid accessMethodId,
@@ -310,6 +318,7 @@ extern Datum columnar_relation_storageid(PG_FUNCTION_ARGS);
 extern ColumnarWriteState * columnar_init_write_state(Relation relation, TupleDesc
 													  tupdesc,
 													  SubTransactionId currentSubXid);
+extern ColumnarWriteState * FindWriteStateByStripeId(Oid relNode, uint64 stripeId);
 extern void FlushWriteStateForRelfilenode(Oid relfilenode, SubTransactionId
 										  currentSubXid);
 extern void FlushWriteStateForAllRels(SubTransactionId currentSubXid, SubTransactionId


### PR DESCRIPTION
From #5247:
> (If we had enough time, then we could teach read-path to read from
> WriteStateMap. If we had done that, then we could guarantee that
> index_fetch_tuple would never flush pending writes, but this seem
> to be too much work for now. I have a somewhat working
> implementation for that in another branch: 8ba8055.)

**Not aiming to work on this any time soon.**
**Just making the work mentioned above a draft pr to let it not get lost.**

-----

This removes the last case that we need to flush pending writes on
master.

Currently, when index scan encounters with a tid that belongs to an
unflushed write of the current backend, then we first flush pending
writes to be able to read the tuple via usual code-path.

With the changes made with this commit, we don't flush pending writes
of the current backend to read such a tuple. Instead, we directly read
the tuple from local write state of the current backend.

However, exclusion constraints always need to read the tuple during
index scan to detect a constraint violation. This is not a problem on
master before the changes made in this commit. This is because, on
master, exclusion constraints always flush single tuple writes since
postgres calls index_fetch_tuple for each tuple inserted. That way,
concurrent writers can easily access unflushed tuples of other backends
for constraint violation checks.

For this reason, now that this commit removes that "flushing-on-read"
logic from index scan, CI fails for some exclusion constraint tests.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
