### PR TITLE
Add install command for Ubuntu 20.04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ why we ask this as well as instructions for how to proceed, see the
   sudo apt-get install -y postgresql-server-dev-14 postgresql-14 \
                           autoconf flex git libcurl4-gnutls-dev libicu-dev \
                           libkrb5-dev liblz4-dev libpam0g-dev libreadline-dev \
-                          libselinux1-dev libssl-dev libxslt-dev libzstd-dev \
+                          libselinux1-dev libssl-dev libxslt1-dev libzstd-dev \
                           make uuid-dev
   ```
 


### PR DESCRIPTION
`libxslt-dev` was renamed to `libxslt1-dev` in Ubuntu 20.04. This is also an
alias for this package on Ubuntu 18.04, so this new command works there
too.
