### PR TITLE
Do not rely on cache on citus_drop_trigger

### DIFF
--- a/src/backend/distributed/commands/drop_distributed_table.c
+++ b/src/backend/distributed/commands/drop_distributed_table.c
@@ -74,7 +74,7 @@ master_remove_partition_metadata(PG_FUNCTION_ARGS)
 	 * user-friendly, but this function is really only meant to be called
 	 * from the trigger.
 	 */
-	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTableViaCatalog(relationId) || !EnableDDLPropagation)
 	{
 		PG_RETURN_VOID();
 	}
@@ -134,14 +134,14 @@ MasterRemoveDistributedTableMetadataFromWorkers(Oid relationId, char *schemaName
 	 * user-friendly, but this function is really only meant to be called
 	 * from the trigger.
 	 */
-	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTableViaCatalog(relationId) || !EnableDDLPropagation)
 	{
 		return;
 	}
 
 	EnsureCoordinator();
 
-	if (!ShouldSyncTableMetadata(relationId))
+	if (!ShouldSyncTableMetadataViaCatalog(relationId))
 	{
 		return;
 	}

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -123,7 +123,7 @@ citus_drop_all_shards(PG_FUNCTION_ARGS)
 	 * The SQL_DROP trigger calls this function even for tables that are
 	 * not distributed. In that case, silently ignore and return -1.
 	 */
-	if (!IsCitusTable(relationId) || !EnableDDLPropagation)
+	if (!IsCitusTableViaCatalog(relationId) || !EnableDDLPropagation)
 	{
 		PG_RETURN_INT32(-1);
 	}
@@ -139,7 +139,7 @@ citus_drop_all_shards(PG_FUNCTION_ARGS)
 	 */
 	LockRelationOid(relationId, AccessExclusiveLock);
 
-	List *shardIntervalList = LoadShardIntervalList(relationId);
+	List *shardIntervalList = LoadUnsortedShardIntervalListViaCatalog(relationId);
 	int droppedShardCount = DropShards(relationId, schemaName, relationName,
 									   shardIntervalList, dropShardsMetadataOnly);
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -144,9 +144,11 @@ extern bool IsCitusTableTypeCacheEntry(CitusTableCacheEntry *tableEtnry,
 									   CitusTableType tableType);
 
 extern bool IsCitusTable(Oid relationId);
+extern bool IsCitusTableViaCatalog(Oid relationId);
 extern char PgDistPartitionViaCatalog(Oid relationId);
 extern List * LookupDistShardTuples(Oid relationId);
 extern char PartitionMethodViaCatalog(Oid relationId);
+extern Var * PartitionColumnViaCatalog(Oid relationId);
 extern bool IsCitusLocalTableByDistParams(char partitionMethod, char replicationModel);
 extern List * CitusTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -31,6 +31,7 @@ typedef enum
 extern void StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort);
 extern bool ClusterHasKnownMetadataWorkers(void);
 extern bool ShouldSyncTableMetadata(Oid relationId);
+extern bool ShouldSyncTableMetadataViaCatalog(Oid relationId);
 extern List * MetadataCreateCommands(void);
 extern List * MetadataDropCommands(void);
 extern char * DistributionCreateCommand(CitusTableCacheEntry *cacheEntry);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -202,6 +202,7 @@ extern Datum citus_relation_size(PG_FUNCTION_ARGS);
 /* Function declarations to read shard and shard placement data */
 extern uint32 TableShardReplicationFactor(Oid relationId);
 extern List * LoadShardIntervalList(Oid relationId);
+extern List * LoadUnsortedShardIntervalListViaCatalog(Oid relationId);
 extern ShardInterval * LoadShardIntervalWithLongestShardName(Oid relationId);
 extern int ShardIntervalCount(Oid relationId);
 extern List * LoadShardList(Oid relationId);

--- a/src/test/regress/expected/issue_5099.out
+++ b/src/test/regress/expected/issue_5099.out
@@ -14,4 +14,3 @@ SELECT create_distributed_table('range_dist_table_2', 'dist_col', 'range');
 \set VERBOSITY TERSE
 DROP SCHEMA issue_5099 CASCADE;
 NOTICE:  drop cascades to 2 other objects
-ERROR:  cache lookup failed for type 17048

--- a/src/test/regress/expected/issue_5099.out
+++ b/src/test/regress/expected/issue_5099.out
@@ -1,0 +1,17 @@
+CREATE SCHEMA issue_5099;
+SET search_path to 'issue_5099';
+CREATE TYPE comp_type AS (
+    int_field_1 BIGINT,
+    int_field_2 BIGINT
+);
+CREATE TABLE range_dist_table_2 (dist_col comp_type);
+SELECT create_distributed_table('range_dist_table_2', 'dist_col', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+\set VERBOSITY TERSE
+DROP SCHEMA issue_5099 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+ERROR:  cache lookup failed for type 17048

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -95,7 +95,7 @@ test: multi_dropped_column_aliases foreign_key_restriction_enforcement
 test: binary_protocol
 test: alter_table_set_access_method
 test: alter_distributed_table
-test: issue_5248
+test: issue_5248 issue_5099
 test: object_propagation_debug
 
 

--- a/src/test/regress/sql/issue_5099.sql
+++ b/src/test/regress/sql/issue_5099.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA issue_5099;
+SET search_path to 'issue_5099';
+CREATE TYPE comp_type AS (
+    int_field_1 BIGINT,
+    int_field_2 BIGINT
+);
+
+CREATE TABLE range_dist_table_2 (dist_col comp_type);
+SELECT create_distributed_table('range_dist_table_2', 'dist_col', 'range');
+\set VERBOSITY TERSE
+DROP SCHEMA issue_5099 CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that prevents DROP SCHEMA CASCADE

Note: the current changes are too intrusive and has a bad impact on performance. I will try to isolate the calls that are made in the `citus_drop_trigger` codepath to remove the impact on performance.

TODO:
- [x] regression tests for #5099 

Fixes: #5099
Fixes: #3741 