### PR TITLE
Drop support Inactive Shard States

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1692,13 +1692,11 @@ CopyLocalDataIntoShards(Oid distributedRelationId)
 	ExprContext *econtext = GetPerTupleExprContext(estate);
 	econtext->ecxt_scantuple = slot;
 
-	bool stopOnFailure = true;
 	DestReceiver *copyDest =
 		(DestReceiver *) CreateCitusCopyDestReceiver(distributedRelationId,
 													 columnNameList,
 													 partitionColumnIndex,
-													 estate, stopOnFailure,
-													 NULL);
+													 estate, NULL);
 
 	/* initialise state for writing to shards, we'll open connections on demand */
 	copyDest->rStartup(copyDest, 0, tupleDescriptor);

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -496,12 +496,6 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 											char *intermediateResultIdPrefix)
 {
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
-	bool stopOnFailure = false;
-
-	if (IsCitusTableType(targetRelationId, REFERENCE_TABLE))
-	{
-		stopOnFailure = true;
-	}
 
 	/* Get column name list and partition column index for the target table */
 	List *columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
@@ -514,7 +508,6 @@ ExecutePlanIntoColocatedIntermediateResults(Oid targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
 																  executorState,
-																  stopOnFailure,
 																  intermediateResultIdPrefix);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
@@ -537,12 +530,6 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 						PlannedStmt *selectPlan, EState *executorState)
 {
 	ParamListInfo paramListInfo = executorState->es_param_list_info;
-	bool stopOnFailure = false;
-
-	if (IsCitusTableType(targetRelationId, REFERENCE_TABLE))
-	{
-		stopOnFailure = true;
-	}
 
 	/* Get column name list and partition column index for the target table */
 	List *columnNameList = BuildColumnNameListFromTargetList(targetRelationId,
@@ -554,8 +541,7 @@ ExecutePlanIntoRelation(Oid targetRelationId, List *insertTargetList,
 	CitusCopyDestReceiver *copyDest = CreateCitusCopyDestReceiver(targetRelationId,
 																  columnNameList,
 																  partitionColumnIndex,
-																  executorState,
-																  stopOnFailure, NULL);
+																  executorState, NULL);
 
 	ExecutePlanIntoDestReceiver(selectPlan, paramListInfo, (DestReceiver *) copyDest);
 

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -1081,7 +1081,17 @@ EnsureShardCanBeRepaired(int64 shardId, const char *sourceNodeName, int32 source
 		shardPlacementList,
 		targetNodeName,
 		targetNodePort);
-	if (targetPlacement->shardState != SHARD_STATE_INACTIVE)
+
+	/*
+	 * shardStateInactive is a legacy state for a placement. As of Citus 11,
+	 * we never mark any placement as INACTIVE.
+	 *
+	 * Still, we prefer to keep this function/code here, as users may need
+	 * to recover placements that are marked as inactive pre Citus 11.
+	 *
+	 */
+	int shardStateInactive = 3;
+	if (targetPlacement->shardState != shardStateInactive)
 	{
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("target placement must be in inactive state")));

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -424,14 +424,6 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			 * fails, which can lead to divergence when not using 2PC.
 			 */
 
-			/*
-			 * Check whether the coordinated transaction is in a state we want
-			 * to persist, or whether we want to error out.  This handles the
-			 * case where iteratively executed commands marked all placements
-			 * as invalid.
-			 */
-			MarkFailedShardPlacements();
-
 			if (ShouldCoordinatedTransactionUse2PC)
 			{
 				CoordinatedRemoteTransactionsPrepare();
@@ -458,9 +450,9 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 			/*
 			 * Check again whether shards/placement successfully
-			 * committed. This handles failure at COMMIT/PREPARE time.
+			 * committed. This handles failure at COMMIT time.
 			 */
-			PostCommitMarkFailedShardPlacements(ShouldCoordinatedTransactionUse2PC);
+			ErrorIfPostCommitFailedShardPlacements();
 			break;
 		}
 

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -108,8 +108,6 @@ typedef struct CitusCopyDestReceiver
 	/* template for COPY statement to send to workers */
 	CopyStmt *copyStatement;
 
-	bool stopOnFailure;
-
 	/*
 	 * shardId to CopyShardState map. Also used in insert_select_executor.c for
 	 * task pruning.
@@ -154,7 +152,6 @@ extern CitusCopyDestReceiver * CreateCitusCopyDestReceiver(Oid relationId,
 														   List *columnNameList,
 														   int partitionColumnIndex,
 														   EState *executorState,
-														   bool stopOnFailure,
 														   char *intermediateResultPrefix);
 extern FmgrInfo * ColumnOutputFunctions(TupleDesc rowDescriptor, bool binaryFormat);
 extern bool CanUseBinaryCopyFormat(TupleDesc tupleDescription);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -237,9 +237,6 @@ extern void InsertIntoPgDistPartition(Oid relationId, char distributionMethod,
 									  char replicationModel);
 extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
-extern void UpdatePartitionShardPlacementStates(ShardPlacement *parentShardPlacement,
-												char shardState);
-extern void MarkShardPlacementInactive(ShardPlacement *shardPlacement);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern void UpdatePlacementGroupId(uint64 placementId, int groupId);
 extern void DeleteShardPlacementRow(uint64 placementId);

--- a/src/include/distributed/placement_connection.h
+++ b/src/include/distributed/placement_connection.h
@@ -32,8 +32,7 @@ extern void AssignPlacementListToConnection(List *placementAccessList,
 											MultiConnection *connection);
 
 extern void ResetPlacementConnectionManagement(void);
-extern void MarkFailedShardPlacements(void);
-extern void PostCommitMarkFailedShardPlacements(bool using2PC);
+extern void ErrorIfPostCommitFailedShardPlacements(void);
 
 extern void CloseShardPlacementAssociation(struct MultiConnection *connection);
 extern void ResetShardPlacementAssociation(struct MultiConnection *connection);

--- a/src/include/distributed/relay_utility.h
+++ b/src/include/distributed/relay_utility.h
@@ -27,12 +27,14 @@
 
 /*
  * ShardState represents last known states of shards on a given node.
+ *
+ * The numbers assigned per state used for historical reason and should
+ * not be changed since they correspond to shardstate in pg_dist_placement.
  */
 typedef enum
 {
 	SHARD_STATE_INVALID_FIRST = 0,
 	SHARD_STATE_ACTIVE = 1,
-	SHARD_STATE_INACTIVE = 3,
 	SHARD_STATE_TO_DELETE = 4,
 } ShardState;
 

--- a/src/test/regress/expected/failure_copy_on_hash.out
+++ b/src/test/regress/expected/failure_copy_on_hash.out
@@ -36,11 +36,9 @@ SELECT citus.mitmproxy('conn.kill()');
 (1 row)
 
 \COPY test_table FROM stdin delimiter ',';
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-CONTEXT:  COPY test_table, line 1: "1,2"
-ERROR:  could not connect to any active placements
 CONTEXT:  COPY test_table, line 1: "1,2"
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
@@ -281,22 +279,10 @@ SELECT citus.mitmproxy('conn.kill()');
 (1 row)
 
 \COPY test_table_2 FROM stdin delimiter ',';
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 CONTEXT:  COPY test_table_2, line 1: "1,2"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-CONTEXT:  COPY test_table_2, line 2: "3,4"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-CONTEXT:  COPY test_table_2, line 3: "6,7"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-CONTEXT:  COPY test_table_2, line 5: "9,10"
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -311,13 +297,13 @@ SELECT pds.logicalrelid, pdsd.shardid, pdsd.shardstate
 	ORDER BY shardid, nodeport;
  logicalrelid | shardid | shardstate
 ---------------------------------------------------------------------
- test_table_2 | 1710004 |          3
  test_table_2 | 1710004 |          1
- test_table_2 | 1710005 |          3
+ test_table_2 | 1710004 |          1
  test_table_2 | 1710005 |          1
- test_table_2 | 1710006 |          3
+ test_table_2 | 1710005 |          1
  test_table_2 | 1710006 |          1
- test_table_2 | 1710007 |          3
+ test_table_2 | 1710006 |          1
+ test_table_2 | 1710007 |          1
  test_table_2 | 1710007 |          1
 (8 rows)
 

--- a/src/test/regress/expected/failure_savepoints.out
+++ b/src/test/regress/expected/failure_savepoints.out
@@ -165,7 +165,7 @@ connection not open
 connection not open
 CONTEXT:  while executing command on localhost:xxxxx
 COMMIT;
-ERROR:  could not make changes to shard xxxxx on any node
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 SELECT * FROM artists WHERE id IN (4, 5);
  id |      name
 ---------------------------------------------------------------------
@@ -255,7 +255,7 @@ connection not open
 connection not open
 CONTEXT:  while executing command on localhost:xxxxx
 COMMIT;
-ERROR:  could not make changes to shard xxxxx on any node
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 SELECT * FROM artists WHERE id IN (4, 5);
  id |      name
 ---------------------------------------------------------------------
@@ -340,7 +340,7 @@ connection not open
 connection not open
 connection not open
 COMMIT;
-ERROR:  could not make changes to shard xxxxx on any node
+ERROR:  failure on connection marked as essential: localhost:xxxxx
 SELECT * FROM artists WHERE id=6;
  id | name
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -377,6 +377,35 @@ COMMIT;
 WARNING:  illegal value
 WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
+-- single row, multi-row INSERTs should also fail
+-- with or without transaction blocks on the COMMIT time
+INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup');
+WARNING:  illegal value
+WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+ERROR:  illegal value
+INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
+WARNING:  illegal value
+WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+ERROR:  illegal value
+BEGIN;
+    INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup');
+COMMIT;
+WARNING:  illegal value
+WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+ERROR:  illegal value
+BEGIN;
+    INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
+COMMIT;
+WARNING:  illegal value
+WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+ERROR:  illegal value
+-- and, rollback should be fine
+BEGIN;
+    INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup');
+ROLLBACK;
+BEGIN;
+    INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
+ROLLBACK;
 \unset VERBOSITY
 -- verify everyhing including delete is rolled back
 SELECT * FROM researchers WHERE lab_id = 6;
@@ -1195,28 +1224,28 @@ ORDER BY s.logicalrelid, sp.shardstate;
  reference_failure_test |          1 |     2
 (1 row)
 
+-- any failure rollbacks the transaction
 BEGIN;
 COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
--- some placements are invalid before abort
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
+ABORT;
+-- none of placements are invalid after abort
 SELECT shardid, shardstate, nodename, nodeport
 FROM pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
 WHERE logicalrelid = 'numbers_hash_failure_test'::regclass
 ORDER BY shardid, nodeport;
  shardid | shardstate | nodename  | nodeport
 ---------------------------------------------------------------------
- 1200016 |          3 | localhost |    57637
+ 1200016 |          1 | localhost |    57637
  1200016 |          1 | localhost |    57638
  1200017 |          1 | localhost |    57637
  1200017 |          1 | localhost |    57638
  1200018 |          1 | localhost |    57637
  1200018 |          1 | localhost |    57638
- 1200019 |          3 | localhost |    57637
+ 1200019 |          1 | localhost |    57637
  1200019 |          1 | localhost |    57638
 (8 rows)
 
-ABORT;
 -- verify nothing is inserted
 SELECT count(*) FROM numbers_hash_failure_test;
 WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
@@ -1243,52 +1272,35 @@ ORDER BY shardid, nodeport;
  1200019 |          1 | localhost |    57638
 (8 rows)
 
+-- all failures roll back the transaction
 BEGIN;
 COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
--- check shard states before commit
-SELECT shardid, shardstate, nodename, nodeport
-FROM pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
-WHERE logicalrelid = 'numbers_hash_failure_test'::regclass
-ORDER BY shardid, nodeport;
- shardid | shardstate | nodename  | nodeport
----------------------------------------------------------------------
- 1200016 |          3 | localhost |    57637
- 1200016 |          1 | localhost |    57638
- 1200017 |          1 | localhost |    57637
- 1200017 |          1 | localhost |    57638
- 1200018 |          1 | localhost |    57637
- 1200018 |          1 | localhost |    57638
- 1200019 |          3 | localhost |    57637
- 1200019 |          1 | localhost |    57638
-(8 rows)
-
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 COMMIT;
--- expect some placements to be market invalid after commit
+-- expect none of the placements to be market invalid after commit
 SELECT shardid, shardstate, nodename, nodeport
 FROM pg_dist_shard_placement JOIN pg_dist_shard USING (shardid)
 WHERE logicalrelid = 'numbers_hash_failure_test'::regclass
 ORDER BY shardid, nodeport;
  shardid | shardstate | nodename  | nodeport
 ---------------------------------------------------------------------
- 1200016 |          3 | localhost |    57637
+ 1200016 |          1 | localhost |    57637
  1200016 |          1 | localhost |    57638
  1200017 |          1 | localhost |    57637
  1200017 |          1 | localhost |    57638
  1200018 |          1 | localhost |    57637
  1200018 |          1 | localhost |    57638
- 1200019 |          3 | localhost |    57637
+ 1200019 |          1 | localhost |    57637
  1200019 |          1 | localhost |    57638
 (8 rows)
 
--- verify data is inserted
+-- verify no data is inserted
 SELECT count(*) FROM numbers_hash_failure_test;
 WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
  count
 ---------------------------------------------------------------------
-     2
+     0
 (1 row)
 
 -- break the other node as well

--- a/src/test/regress/expected/multi_mx_modifying_xacts.out
+++ b/src/test/regress/expected/multi_mx_modifying_xacts.out
@@ -343,9 +343,7 @@ INSERT INTO labs_mx VALUES (9, 'Umbrella Corporation');
 COMMIT;
 WARNING:  illegal value
 WARNING:  failed to commit transaction on localhost:xxxxx
-WARNING:  could not commit transaction for shard xxxxx on any active node
-WARNING:  could not commit transaction for shard xxxxx on any active node
-ERROR:  could not commit transaction on any active node
+ERROR:  could not commit transaction for shard xxxxx on at least one active node
 -- data should NOT be persisted
 SELECT * FROM objects_mx WHERE id = 2;
  id | name
@@ -371,9 +369,7 @@ INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
 WARNING:  failed to commit transaction on localhost:xxxxx
-WARNING:  could not commit transaction for shard xxxxx on any active node
-WARNING:  could not commit transaction for shard xxxxx on any active node
-ERROR:  could not commit transaction on any active node
+ERROR:  could not commit transaction for shard xxxxx on at least one active node
 -- data should NOT be persisted
 SELECT * FROM objects_mx WHERE id = 1;
  id | name
@@ -396,9 +392,7 @@ INSERT INTO labs_mx VALUES (9, 'BAD');
 COMMIT;
 WARNING:  illegal value
 WARNING:  failed to commit transaction on localhost:xxxxx
-WARNING:  could not commit transaction for shard xxxxx on any active node
-WARNING:  could not commit transaction for shard xxxxx on any active node
-ERROR:  could not commit transaction on any active node
+ERROR:  could not commit transaction for shard xxxxx on at least one active node
 -- no data should persists
 SELECT * FROM objects_mx WHERE id = 1;
  id | name

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -577,7 +577,7 @@ SET session_replication_role = DEFAULT;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 
--- reissue copy
+-- reissue copy, and it should fail
 COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
 1,1
 2,2
@@ -589,7 +589,7 @@ COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
 8,8
 \.
 
--- verify shards in the first worker as marked invalid
+-- verify shards in the none of the workers as marked invalid
 SELECT shardid, shardstate, nodename, nodeport
 	FROM pg_dist_shard_placement join pg_dist_shard using(shardid)
 	WHERE logicalrelid = 'numbers_hash'::regclass order by shardid, nodeport;

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -784,29 +784,23 @@ SET session_replication_role = DEFAULT;
 \c - :default_user - :worker_1_port
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
--- reissue copy
+-- reissue copy, and it should fail
 COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
 CONTEXT:  COPY numbers_hash, line 1: "1,1"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
-CONTEXT:  COPY numbers_hash, line 2: "2,2"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
-CONTEXT:  COPY numbers_hash, line 3: "3,3"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
-CONTEXT:  COPY numbers_hash, line 6: "6,6"
--- verify shards in the first worker as marked invalid
+-- verify shards in the none of the workers as marked invalid
 SELECT shardid, shardstate, nodename, nodeport
 	FROM pg_dist_shard_placement join pg_dist_shard using(shardid)
 	WHERE logicalrelid = 'numbers_hash'::regclass order by shardid, nodeport;
  shardid | shardstate | nodename  | nodeport
 ---------------------------------------------------------------------
-  560169 |          3 | localhost |    57637
+  560169 |          1 | localhost |    57637
   560169 |          1 | localhost |    57638
-  560170 |          3 | localhost |    57637
+  560170 |          1 | localhost |    57637
   560170 |          1 | localhost |    57638
-  560171 |          3 | localhost |    57637
+  560171 |          1 | localhost |    57637
   560171 |          1 | localhost |    57638
-  560172 |          3 | localhost |    57637
+  560172 |          1 | localhost |    57637
   560172 |          1 | localhost |    57638
 (8 rows)
 
@@ -828,12 +822,8 @@ SELECT shardid, shardstate, nodename, nodeport
 -- since it can not insert into either copies of a shard. shards are expected to
 -- stay valid since the operation is rolled back.
 COPY numbers_hash_other FROM STDIN WITH (FORMAT 'csv');
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
 CONTEXT:  COPY numbers_hash_other, line 1: "1,1"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
-CONTEXT:  COPY numbers_hash_other, line 2: "2,2"
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
-CONTEXT:  COPY numbers_hash_other, line 3: "3,3"
 -- verify shards for numbers_hash_other are still valid
 -- since copy has failed altogether
 SELECT shardid, shardstate, nodename, nodeport
@@ -841,13 +831,13 @@ SELECT shardid, shardstate, nodename, nodeport
 	WHERE logicalrelid = 'numbers_hash_other'::regclass order by shardid, nodeport;
  shardid | shardstate | nodename  | nodeport
 ---------------------------------------------------------------------
-  560174 |          3 | localhost |    57637
+  560174 |          1 | localhost |    57637
   560174 |          1 | localhost |    57638
-  560175 |          3 | localhost |    57637
+  560175 |          1 | localhost |    57637
   560175 |          1 | localhost |    57638
   560176 |          1 | localhost |    57637
   560176 |          1 | localhost |    57638
-  560177 |          3 | localhost |    57637
+  560177 |          1 | localhost |    57637
   560177 |          1 | localhost |    57638
 (8 rows)
 


### PR DESCRIPTION
Given that all the operations are done via 2PC, there is no
possibility of marking any placement as inactive. So, remove
the concept from the code.

DESCRIPTION: Deprecates Inactive shard state, never marks any placement inactive