### PR TITLE
Use parallelism feature of circleci in arbitrary configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
 
   test-arbitrary-configs:
     description: Runs tests on arbitrary configs
+    parallelism: 6
     parameters:
       pg_major:
         description: 'postgres major version to use'
@@ -207,9 +208,14 @@ jobs:
       - run:
           name: 'Test arbitrary configs'
           command: |
+            TESTS=$(src/test/regress/citus_tests/print_test_names.py | circleci tests split)
+            # Our test suite expects comma separated values
+            TESTS=$(echo $TESTS | tr ' ' ',')
+            # TESTS will contain subset of configs that will be run on a container and we use multiple containers
+            # to run the test suite
             gosu circleci \
               make -C src/test/regress \
-                check-arbitrary-configs parallel=4
+                check-arbitrary-configs parallel=4 CONFIGS=$TESTS
           no_output_timeout: 2m
       - run:
           name: 'Show regressions'

--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -25,7 +25,6 @@ import concurrent.futures
 import multiprocessing
 from docopt import docopt
 import time
-import inspect
 import random
 
 
@@ -173,10 +172,7 @@ def read_configs(docoptRes):
     # We fill the configs from all of the possible classes in config.py so that if we add a new config,
     # we don't need to add it here. And this avoids the problem where we forget to add it here
     for x in cfg.__dict__.values():
-        if inspect.isclass(x) and (
-            issubclass(x, cfg.CitusMXBaseClusterConfig)
-            or issubclass(x, cfg.CitusDefaultClusterConfig)
-        ):
+        if cfg.should_include_config(x):
             configs.append(x(docoptRes))
     return configs
 

--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -5,6 +5,7 @@ from contextlib import closing
 import os
 import threading
 import common
+import inspect
 
 COORDINATOR_NAME = "coordinator"
 WORKER1 = "worker1"
@@ -53,6 +54,16 @@ next_port = 10200
 PORT_UPPER = 32768
 
 port_lock = threading.Lock()
+
+
+def should_include_config(class_name):
+
+    if inspect.isclass(class_name) and (
+        issubclass(class_name, CitusMXBaseClusterConfig)
+        or issubclass(class_name, CitusDefaultClusterConfig)
+    ):
+        return True
+    return False
 
 
 def find_free_port():

--- a/src/test/regress/citus_tests/print_test_names.py
+++ b/src/test/regress/citus_tests/print_test_names.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import config as cfg
+
+
+def read_config_names():
+    config_names = []
+    # We fill the configs from all of the possible classes in config.py so that if we add a new config,
+    # we don't need to add it here. And this avoids the problem where we forget to add it here
+    for x in cfg.__dict__.values():
+        if cfg.should_include_config(x):
+            config_names.append(x.__name__)
+    return config_names
+
+
+def print_config_names():
+    config_names = read_config_names()
+    for config_name in config_names:
+        print(config_name)
+
+
+if __name__ == "__main__":
+    print_config_names()


### PR DESCRIPTION
The idea is to split the configs across different VMs so that we can add more configs easily and more tests easily without creating a bottleneck in the test suite. Increasing the parallelism is very trivial now, we only need to increase parallelism in the config.

High level idea:
- Read all configs and write them to a file in the format of
```
Config1,Config2,Config3
Config4,Config5
..
..
ConfigN-1, ConfigN
```

If the parallelism is X, then there are exactly X lines in the output file.

This is generated with:

```bash
CI_PARALLELISM=6 src/test/regress/citus_tests/ci_generate_configs.py
```
- Each VM reads a line from this generated files with:

```bash
TESTS=$(circleci tests split tests.txt)
```

If there were more lines than X in this file, `circleci cli` would read multiple lines from this file but we don't know how to handle that in the main script at the time of writing this. So we ignore this case for now and always have exactly X lines in this output file.

- Each VM runs the `check-arbitrary-configs` file by setting `CONFIGS` environment variable hence only a subset of the main configs are run on the VM.

An example run: https://app.circleci.com/pipelines/github/citusdata/citus/18428/workflows/67c35169-c1d0-4fa7-a01e-f307eae772e7/jobs/413572/parallel-runs/2?filterBy=ALL

Also Circleci allows splitting by test timing but I didn't want to spend the time to have that for now (we can do that later)