### PR TITLE
Remove EnsureSuperUser from StartMetadataSyncToNode

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -170,7 +170,6 @@ StartMetadataSyncToNode(const char *nodeNameString, int32 nodePort)
 
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
-	EnsureSuperUser();
 	EnsureModificationsCanRun();
 
 	EnsureSequentialModeMetadataOperations();
@@ -289,7 +288,6 @@ stop_metadata_sync_to_node(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 	EnsureCoordinator();
-	EnsureSuperUser();
 
 	text *nodeName = PG_GETARG_TEXT_P(0);
 	int32 nodePort = PG_GETARG_INT32(1);

--- a/src/backend/distributed/sql/citus--10.2-3--11.0-1.sql
+++ b/src/backend/distributed/sql/citus--10.2-3--11.0-1.sql
@@ -9,3 +9,6 @@
 DROP FUNCTION IF EXISTS pg_catalog.master_apply_delete_command(text);
 DROP FUNCTION pg_catalog.master_get_table_metadata(text);
 ALTER TABLE pg_catalog.pg_dist_partition ADD COLUMN autoconverted boolean DEFAULT false;
+
+REVOKE ALL ON FUNCTION start_metadata_sync_to_node(text, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION stop_metadata_sync_to_node(text, integer,bool) FROM PUBLIC;

--- a/src/backend/distributed/sql/downgrades/citus--11.0-1--10.2-3.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.0-1--10.2-3.sql
@@ -25,3 +25,6 @@ CREATE FUNCTION pg_catalog.master_get_table_metadata(
 COMMENT ON FUNCTION master_get_table_metadata(relation_name text)
     IS 'fetch metadata values for the table';
 ALTER TABLE pg_catalog.pg_dist_partition DROP COLUMN autoconverted;
+
+GRANT ALL ON FUNCTION start_metadata_sync_to_node(text, integer) TO PUBLIC;
+GRANT ALL ON FUNCTION stop_metadata_sync_to_node(text, integer,bool) TO PUBLIC;

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -1782,6 +1782,51 @@ DROP TABLE mx_test_schema_1.mx_table_1 CASCADE;
 DROP TABLE mx_testing_schema.mx_test_table;
 DROP TABLE mx_ref;
 DROP TABLE dist_table_1, dist_table_2;
+SET client_min_messages TO ERROR;
+SET citus.enable_ddl_propagation TO off; -- for enterprise
+CREATE USER non_super_metadata_user;
+SET citus.enable_ddl_propagation TO on;
+RESET client_min_messages;
+SELECT run_command_on_workers('CREATE USER non_super_metadata_user');
+      run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+GRANT EXECUTE ON FUNCTION start_metadata_sync_to_node(text,int) TO non_super_metadata_user;
+GRANT EXECUTE ON FUNCTION stop_metadata_sync_to_node(text,int,bool) TO non_super_metadata_user;
+GRANT ALL ON pg_dist_node TO non_super_metadata_user;
+GRANT ALL ON pg_dist_local_group TO non_super_metadata_user;
+SELECT run_command_on_workers('GRANT ALL ON pg_dist_node TO non_super_metadata_user');
+  run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+SELECT run_command_on_workers('GRANT ALL ON pg_dist_local_group TO non_super_metadata_user');
+  run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,GRANT)
+ (localhost,57638,t,GRANT)
+(2 rows)
+
+SET ROLE non_super_metadata_user;
+SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
+NOTICE:  dropping metadata on the node (localhost,57637)
+ stop_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+RESET ROLE;
 RESET citus.shard_count;
 RESET citus.shard_replication_factor;
 ALTER SEQUENCE pg_catalog.pg_dist_groupid_seq RESTART :last_group_id;


### PR DESCRIPTION
DESCRIPTION: Removes superuser requirement for metadata sync

Now the metadata is synced at the node activation we need the users that are able to activate node to be able to sync metadata too. So this PR removes EnsureSuperuser and revokes public access from start and stop metadata sync functions.

We probably still need a user that has the following accesses:
- GRANTs on all the distributed tables?
- GRANTs to metadata tables on the workers?
- GRANTs to the functions

Still, this PR avoids the strict requirement for superuser.