### PR TITLE
Fix duplicate typedef which can cause compile failures

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -85,7 +85,6 @@ typedef struct ColumnarScanDescData
 	List *scanQual;
 } ColumnarScanDescData;
 
-typedef struct ColumnarScanDescData *ColumnarScanDesc;
 
 /*
  * IndexFetchColumnarData is the scan state passed between index_fetch_begin,


### PR DESCRIPTION
DESCRIPTION: Fix issue when compiling Citus from source with some compilers

ColumnarScanDesc is already defined in columnar_tableam.h. Redifining it
again causes a compiler error on some C compilers.

Useful reference: https://bugzilla.redhat.com/show_bug.cgi?id=767538

Fixes #5404