### PR TITLE
Fix docs of arbitrary configs

### DIFF
--- a/src/test/regress/citus_tests/arbitrary_configs/README.md
+++ b/src/test/regress/citus_tests/arbitrary_configs/README.md
@@ -19,7 +19,7 @@ To run only some configs:
 
 ```bash
 # Config names should be comma separated
-make check-arbitrary-base CONFIGS=CitusSingleNodeClusterConfig,CitusSmallSharedPoolSizeConfig
+make check-arbitrary-configs CONFIGS=CitusSingleNodeClusterConfig,CitusSmallSharedPoolSizeConfig
 ```
 
 To run only some test files with some config:


### PR DESCRIPTION
The old command would run none of the tests. The new command runs all of
the tests for the given configs.