### PR TITLE
Refactor/partitioned result destreceiver

### DIFF
--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -482,8 +482,7 @@ PartitionedResultDestReceiverReceive(TupleTableSlot *slot, DestReceiver *dest)
 static void
 PartitionedResultDestReceiverShutdown(DestReceiver *dest)
 {
-	PartitionedResultDestReceiver *self =
-		(PartitionedResultDestReceiver *) dest;
+	PartitionedResultDestReceiver *self = (PartitionedResultDestReceiver *) dest;
 	for (int partitionIndex = 0; partitionIndex < self->partitionCount; partitionIndex++)
 	{
 		DestReceiver *partitionDest =

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -429,10 +429,8 @@ PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
 {
 	PartitionedResultDestReceiver *self = (PartitionedResultDestReceiver *) dest;
 
-	MemoryContext oldContext = MemoryContextSwitchTo(GetMemoryChunkContext(dest));
 	self->startupArguments.tupleDescriptor = CreateTupleDescCopy(inputTupleDescriptor);
 	self->startupArguments.operation = operation;
-	MemoryContextSwitchTo(oldContext);
 
 	if (self->lazyStartup)
 	{

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -47,17 +47,35 @@ typedef struct PartitionedResultDestReceiver
 	/* on lazy startup we only startup the DestReceiver once they receive a tuple */
 	bool lazyStartup;
 
-	/* startup information for use in lazy startup */
+	/*
+	 * Stores the arguments passed to the PartidionedResultDestReceiver's rStarup
+	 * function. These arguments are reused when lazyStartup has been set to true.
+	 * On the processing of a first tuple for a partitionDestReceiver since rStartup it
+	 * will pass the arguments here to the rStartup function of partitionDestReceiver to
+	 * prepare it for receiving tuples.
+	 *
+	 * Even though not used without lazyStartup we just always populate these with the
+	 * last invoked arguments for our rStartup.
+	 */
 	struct
 	{
+		/*
+		 * operation as passed to rStartup, mostly the CmdType of the command being
+		 * streamed into this DestReceiver
+		 */
 		int operation;
+
+		/*
+		 * TupleDesc describing the layout of the tuples being streamed into the
+		 * DestReceiver.
+		 */
 		TupleDesc tupleDescriptor;
 	} startupArguments;
 
-	/* which column of streamed tuples to use as partition column? */
+	/* which column of streamed tuples to use as partition column */
 	int partitionColumnIndex;
 
-	/* how many partitions do we have? */
+	/* The number of partitions being partitioned into */
 	int partitionCount;
 
 	/* used for deciding which partition a shard belongs to. */

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -267,6 +267,8 @@ worker_partition_query_result(PG_FUNCTION_ARGS)
 	PortalDrop(portal, false);
 	FreeExecutorState(estate);
 
+	dest->rDestroy(dest);
+
 	PG_RETURN_INT64(1);
 }
 

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -436,11 +436,12 @@ PartitionedResultDestReceiverStartup(DestReceiver *dest, int operation,
 	}
 
 	/* no lazy startup, lets startup our partitionedDestReceivers */
-	for (int i = 0; i < self->partitionCount; i++)
+	for (int partitionIndex = 0; partitionIndex < self->partitionCount; partitionIndex++)
 	{
-		DestReceiver *partitionDest = self->partitionDestReceivers[i];
+		DestReceiver *partitionDest = self->partitionDestReceivers[partitionIndex];
 		partitionDest->rStartup(partitionDest, operation, inputTupleDescriptor);
-		self->startedDestReceivers = bms_add_member(self->startedDestReceivers, i);
+		self->startedDestReceivers = bms_add_member(self->startedDestReceivers,
+													partitionIndex);
 	}
 }
 

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -493,7 +493,7 @@ PartitionedResultDestReceiverShutdown(DestReceiver *dest)
 	for (int partitionIndex = 0; partitionIndex < self->partitionCount; partitionIndex++)
 	{
 		DestReceiver *partitionDest =
-			self->partitionDestReceivers[partitionIndex];
+			self->partitionDestReceiversStarted[partitionIndex];
 		if (partitionDest != NULL)
 		{
 			partitionDest->rShutdown(partitionDest);
@@ -513,8 +513,7 @@ PartitionedResultDestReceiverDestroy(DestReceiver *dest)
 
 	for (int partitionIndex = 0; partitionIndex < self->partitionCount; partitionIndex++)
 	{
-		/* TODO understand if we should also destroy non-started receivers */
-		DestReceiver *partitionDest = self->partitionDestReceivers[partitionIndex];
+		DestReceiver *partitionDest = self->partitionDestReceiversStarted[partitionIndex];
 		if (partitionDest != NULL)
 		{
 			partitionDest->rDestroy(partitionDest);

--- a/src/backend/distributed/worker/worker_sql_task_protocol.c
+++ b/src/backend/distributed/worker/worker_sql_task_protocol.c
@@ -262,15 +262,20 @@ TaskFileDestReceiverDestroy(DestReceiver *destReceiver)
 	if (taskFileDest->copyOutState)
 	{
 		pfree(taskFileDest->copyOutState);
+		taskFileDest->copyOutState = NULL;
 	}
 
 	if (taskFileDest->columnOutputFunctions)
 	{
 		pfree(taskFileDest->columnOutputFunctions);
+		taskFileDest->columnOutputFunctions = NULL;
 	}
 
-	pfree(taskFileDest->filePath);
-	pfree(taskFileDest);
+	if (taskFileDest->filePath)
+	{
+		pfree(taskFileDest->filePath);
+		taskFileDest->filePath = NULL;
+	}
 }
 
 


### PR DESCRIPTION
This change creates a slightly higher abstraction of the `PartitionedResultDestReceiver` where it decouples the partitioning from writing it to a file. This allows for easier reuse for other `DestReceiver`'s that would like to route different tuples to different `DestReceiver`'s.

Originally there was a lot of state kept in `PartitionedResultDestReceiver` to be able to lazily create `FileDestReceivers` when the first tuple arrived for that target. This convoluted the implementation of the processing of tuples with where they should go.

This refactor changes that where it makes the `PartitionedResultDestReceiver` completely agnostic of what kind of Receivers it is writing to. When constructed you pass it a list of `DestReceiver` compatible pointers with the length of `partitionCount`. Internally the `PartitionedResultDestReceiver` keeps track of which `DestReceiver`'s have been started or not, and start them when they first receive a tuple.

Alternatively, if the instantiating code of the `PartitionedResultDestReceiver` wants, the startup can be turned from lazily to eagerly. When the startup is eager (not lazy) all `rStartup` functions on the list of `DestReceiver`'s are called during the startup of the `PartitionedResultDestReceiver` and marked as such.

A downside of this approach is the following. On highly partitioned destinations we now need to allocate a `FileDestReceiver` for every target, _always_. When the data passed into the `PartitionedResultDestReceiver` is highly skewed to a small set of `FileDestReceiver`'s this will waste some memory. Given the small size of a `FileDestReceiver`, and the fact that actual file handles are only created during the processing of the startup of the `FileDestReceiver` I think this memory waste is not a problem. If this would become a problem we could refactor the source list into some kind of generator object which can generate the `DestReceiver`'s on the fly.