### PR TITLE
Add changelog entries for 9.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### citus v9.5.9 (November 8, 2021) ###
+
+* Fixes a bug preventing `INSERT SELECT .. ON CONFLICT` with a constraint name
+  on local shards
+
+* Fixes a bug with local cached plans on tables with dropped columns
+
+* Fixes a crash in queries with a modifying `CTE` and a `SELECT`
+  without `FROM`
+
+* Fixes a missing `FROM` clause entry error
+
+* Fixes a missing intermediate result when coordinator is in metadata
+
+* Reinstates optimisation for uniform shard interval ranges
+
 ### citus v9.2.8 (November 4, 2021) ###
 
 * Adds a configure flag to enforce security


### PR DESCRIPTION
I went over the commits in `release-9.5` branch, and compiled changelog entries.

Notes:
- #4508 is shipped in `10.0.0` but we just introduced a new changelog entry after discussing it with @SaitTalhaNisanci . See the updated PR description for the new entry.
- #5436 is squash merged and the sha in commit message for 52631ea0fc8c54b764c79c0e84e5d9161ee706ad is broken.