### PR TITLE
Add changelog entries for 9.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### citus v9.5.10 (November 8, 2021) ###
+
+* Fixes a release problem in 9.5.9
+
 ### citus v9.5.9 (November 8, 2021) ###
 
 * Fixes a bug preventing `INSERT SELECT .. ON CONFLICT` with a constraint name


### PR DESCRIPTION
I created a wrong tag for `9.5.9` and hence we need another version bump.