### PR TITLE
Make sure that enterprise tests pass

### DIFF
--- a/src/test/regress/expected/mx_regular_user.out
+++ b/src/test/regress/expected/mx_regular_user.out
@@ -23,7 +23,6 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 -- create a role and give access one each node separately
 -- and increase the error level to prevent enterprise to diverge
 SET client_min_messages TO ERROR;
-SET citus.enable_ddl_propagation TO OFF;
 CREATE USER regular_mx_user WITH LOGIN;
 SELECT 1 FROM run_command_on_workers($$CREATE USER regular_mx_user WITH LOGIN;$$);
  ?column?

--- a/src/test/regress/sql/mx_regular_user.sql
+++ b/src/test/regress/sql/mx_regular_user.sql
@@ -10,7 +10,6 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 -- create a role and give access one each node separately
 -- and increase the error level to prevent enterprise to diverge
 SET client_min_messages TO ERROR;
-SET citus.enable_ddl_propagation TO OFF;
 CREATE USER regular_mx_user WITH LOGIN;
 SELECT 1 FROM run_command_on_workers($$CREATE USER regular_mx_user WITH LOGIN;$$);
 GRANT ALL ON SCHEMA "Mx Regular User" TO regular_mx_user;


### PR DESCRIPTION
We already do the `SELECT 1 FROM run_command_on_workers` trick, so having `SET citus.enable_ddl_propagation TO OFF;` fails the tests on enterprise