### PR TITLE
bump codecov version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.1.1
+  codecov: codecov/codecov@3.2.0
   azure-cli: circleci/azure-cli@1.0.0
 
 parameters:


### PR DESCRIPTION
Codecov is deprecating their bash uploader: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
We were still using the bash uploader https://app.circleci.com/pipelines/github/citusdata/citus/18989/workflows/5120811d-9f6a-4441-a93e-a2f285096975/jobs/438694?invite=true#step-111-2
Lets update to the latest orb: https://circleci.com/developer/orbs/orb/codecov/codecov