### PR TITLE
Add missing downgrade path from 10.2-4 to 11.x

### DIFF
--- a/src/backend/distributed/sql/citus--10.2-4--10.2-3.sql
+++ b/src/backend/distributed/sql/citus--10.2-4--10.2-3.sql
@@ -1,0 +1,5 @@
+-- citus--10.2-4--10.2-3
+
+DROP FUNCTION pg_catalog.fix_all_partition_shard_index_names();
+DROP FUNCTION pg_catalog.fix_partition_shard_index_names(regclass);
+DROP FUNCTION pg_catalog.worker_fix_partition_shard_index_names(regclass, text, text);


### PR DESCRIPTION
We recently introduced 10.2-4 in a patch release for 10.2. This is not a
migration version that exists on our default branch, and hence we do not
have a migration path from 10.2-4 to the current latest 11.0-1.

I intentionally did not place the downgrade script inside the
`downgrades/` folder because we need this migration script to be
installed by `make install`.

## NOTE
I have an alternative solution that creates a better solution. I think I should continue with #5459 and close this one