### PR TITLE
Active placements can only be on active nodes

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1353,7 +1353,17 @@ ActiveShardPlacementList(uint64 shardId)
 	ShardPlacement *shardPlacement = NULL;
 	foreach_ptr(shardPlacement, shardPlacementList)
 	{
-		if (shardPlacement->shardState == SHARD_STATE_ACTIVE)
+		WorkerNode *workerNode =
+			FindWorkerNode(shardPlacement->nodeName, shardPlacement->nodePort);
+
+		/*
+		 * We have already resolved the placement to node, so would have
+		 * errored out earlier.
+		 */
+		Assert(workerNode != NULL);
+
+		if (shardPlacement->shardState == SHARD_STATE_ACTIVE &&
+			workerNode->isActive)
 		{
 			activePlacementList = lappend(activePlacementList, shardPlacement);
 		}


### PR DESCRIPTION
On top of #5469. One of the several steps to make citus_disable_node 
and citus_remove_node tolerant to failures with Citus MX.

We re-define the meaning of active shard placement. It used
to only be defined via shardstate == SHARD_STATE_ACTIVE.

Now, we also add one more check. The worker node that the
placement is on should be active as well.

This is a preparation for supporting citus_disable_node()
for MX with multiple failures at the same time.

With this change, the maintanince daemon only needs to
sync the "node metadata" (e.g., pg_dist_node), not the
shard metadata.
