### PR TITLE
Introduce CI checks for hash comments in specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,12 @@ jobs:
           name: 'Check if changed'
           command: git diff --exit-code
       - run:
+          name: 'Check for comments that start with # character in spec files'
+          command: ci/disallow_hash_comments_in_spec_files.sh
+      - run:
+          name: 'Check if changed'
+          command: git diff --exit-code
+      - run:
           name: 'Check for gitignore entries .for source files'
           command: ci/fix_gitignore.sh
       - run:

--- a/ci/README.md
+++ b/ci/README.md
@@ -293,6 +293,18 @@ Instead use SQL type comments, i.e:
 ```
 See [#3115](https://github.com/citusdata/citus/pull/3115) for more info.
 
+## `disallow_hash_comments_in_spec_files.sh`
+
+We do not use comments starting with # in spec files because it creates errors
+from C preprocessor that expects directives after this character.
+Instead use C type comments, i.e:
+```
+// this is a single line comment
+
+/*
+ * this is a multi line comment
+ */
+```
 
 ## `disallow_long_changelog_entries.sh`
 

--- a/ci/disallow_hash_comments_in_spec_files.sh
+++ b/ci/disallow_hash_comments_in_spec_files.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source ci/ci_helpers.sh
+
+# We do not use comments starting with # in spec files because it creates warnings from
+# preprocessor that expects directives after this character.
+
+# `# ` -> `-- `
+find src/test/regress/spec/*.spec -print0 | xargs -0 sed -i 's!# !// !g'

--- a/ci/fix_style.sh
+++ b/ci/fix_style.sh
@@ -12,6 +12,7 @@ citus_indent . --quiet
 ci/editorconfig.sh
 ci/remove_useless_declarations.sh
 ci/disallow_c_comments_in_migrations.sh
+ci/disallow_hash_comments_in_spec_files.sh
 ci/disallow_long_changelog_entries.sh
 ci/normalize_expected.sh
 ci/fix_gitignore.sh

--- a/src/test/regress/spec/columnar_index_concurrency.spec
+++ b/src/test/regress/spec/columnar_index_concurrency.spec
@@ -171,23 +171,23 @@ step "s5-rollback"
     ROLLBACK;
 }
 
-# CREATE INDEX (without CONCURRENTLY)
+// CREATE INDEX (without CONCURRENTLY)
 permutation "s1-begin" "s1-insert" "s2-create-index" "s3-insert" "s1-commit" "s1-force-index-scan" "s1-check-test-1-2" "s1-reset-table"
 
-# Start a session that executes INSERT in a transaction block before
-# CREATE INDEX / REINDEX CONCURRENTLY so that the latter one blocks.
+// Start a session that executes INSERT in a transaction block before
+// CREATE INDEX / REINDEX CONCURRENTLY so that the latter one blocks.
 
-# CREATE INDEX CONCURRENTLY
+// CREATE INDEX CONCURRENTLY
 permutation "s1-begin" "s1-insert" "s2-create-index-concurrently" "s3-insert" "s1-commit" "s1-force-index-scan" "s1-check-test-1-2" "s1-reset-table"
 permutation "s1-begin" "s1-insert" "s2-create-index-concurrently" "s5-begin" "s5-insert" "s3-begin" "s3-insert" "s1-commit" "s4-insert-1" "s5-commit" "s3-rollback" "s1-force-index-scan" "s1-check-test-3" "s1-reset-table"
 permutation "s4-insert-4" "s1-begin" "s1-insert" "s4-insert-2" "s2-create-index-concurrently" "s4-insert-3" "s5-begin" "s5-insert" "s3-begin" "s3-insert" "s1-rollback" "s4-insert-1" "s5-rollback" "s3-commit" "s1-force-index-scan" "s1-check-test-4" "s1-reset-table"
 permutation "s4-insert-4" "s1-begin" "s1-insert" "s2-create-partial-concurrently" "s4-insert-1" "s1-rollback" "s1-reset-table"
 
-# similar tests with REINDEX INDEX CONCURRENTLY
+// similar tests with REINDEX INDEX CONCURRENTLY
 permutation "s2-create-index" "s1-begin" "s1-insert" "s2-reindex-concurrently" "s3-insert" "s1-commit" "s1-force-index-scan" "s1-check-test-1-2" "s1-reset-table"
 permutation "s2-create-index" "s1-begin" "s1-insert" "s2-reindex-concurrently" "s5-begin" "s5-insert" "s3-begin" "s3-insert" "s1-commit" "s4-insert-1" "s5-commit" "s3-rollback" "s1-force-index-scan" "s1-check-test-3" "s1-reset-table"
 permutation "s2-create-index" "s4-insert-4" "s1-begin" "s1-insert" "s4-insert-2" "s2-reindex-concurrently" "s4-insert-3" "s5-begin" "s5-insert" "s3-begin" "s3-insert" "s1-rollback" "s4-insert-1" "s5-rollback" "s3-commit" "s1-force-index-scan" "s1-check-test-4" "s1-reset-table"
 
-# CREATE INDEX / REINDEX CONCURRENTLY fails due to duplicate values
+// CREATE INDEX / REINDEX CONCURRENTLY fails due to duplicate values
 permutation "s4-insert-5" "s1-begin" "s1-insert" "s2-create-unique-index-concurrently" "s1-commit" "s1-reset-table"
 permutation "s2-create-unique-index" "s4-insert-5" "s1-begin" "s1-insert" "s2-reindex-unique-concurrently" "s1-commit" "s1-reset-table"

--- a/src/test/regress/spec/columnar_write_concurrency_index.spec
+++ b/src/test/regress/spec/columnar_write_concurrency_index.spec
@@ -144,7 +144,7 @@ step "s3-index-select-all-b"
     SELECT b FROM write_concurrency_index ORDER BY 1;
 }
 
-# unique (btree) on int column
+// unique (btree) on int column
 permutation "s1-begin" "s1-insert-1" "s2-copy-1" "s1-commit" "s1-select-all"
 permutation "s1-begin" "s1-copy-1" "s2-insert-1" "s1-rollback" "s1-select-all"
 permutation "s1-begin" "s1-copy-1" "s2-insert-2" "s3-insert-1" "s1-commit" "s1-select-all"
@@ -153,22 +153,22 @@ permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-insert-3" "s3-insert-2" "s1-
 permutation "s1-begin" "s2-begin" "s1-copy-1" "s2-copy-2" "s3-insert-2" "s1-rollback" "s2-commit" "s1-select-all"
 permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-copy-2" "s3-insert-2" "s1-rollback" "s2-rollback" "s1-select-all"
 
-# exclusion (hash) on text column that checks against duplicate values
+// exclusion (hash) on text column that checks against duplicate values
 permutation "s1-begin" "s1-insert-2" "s2-insert-4" "s1-rollback" "s1-select-all"
 permutation "s1-begin" "s1-insert-2" "s2-insert-5" "s3-insert-3" "s1-commit" "s1-select-all"
 permutation "s1-begin" "s2-begin" "s1-insert-2" "s2-insert-6" "s3-insert-4" "s1-commit" "s2-rollback" "s1-select-all"
 permutation "s1-begin" "s2-begin" "s1-insert-2" "s2-insert-6" "s3-insert-4" "s1-rollback" "s2-rollback" "s1-select-all"
 
-# make sure that pending writes are not visible to other backends
+// make sure that pending writes are not visible to other backends
 permutation "s1-begin" "s1-insert-1" "s2-index-select-all-b" "s1-rollback"
 permutation "s1-begin" "s2-begin" "s1-insert-1" "s2-copy-2" "s2-index-select-all-b" "s3-index-select-all-b" "s1-commit" "s2-index-select-all-b" "s2-rollback"
 
-# force flushing write state of s1 before inserting some more data via other sessions
+// force flushing write state of s1 before inserting some more data via other sessions
 permutation "s1-begin" "s2-begin" "s1-insert-1" "s1-select-all" "s2-insert-1" "s1-commit" "s2-rollback"
 permutation "s1-begin" "s2-begin" "s1-insert-1" "s1-select-all" "s2-insert-1" "s1-rollback" "s2-rollback"
 permutation "s1-begin" "s1-copy-1" "s1-select-all" "s2-insert-2" "s3-insert-1" "s1-rollback" "s1-select-all"
 permutation "s1-begin" "s1-insert-2" "s1-select-all" "s2-insert-5" "s3-insert-3" "s1-commit" "s1-select-all"
 permutation "s1-begin" "s2-begin" "s1-insert-2" "s1-select-all" "s2-insert-6" "s3-insert-4" "s1-rollback" "s2-rollback" "s1-select-all"
 
-# test with repeatable read isolation mode
+// test with repeatable read isolation mode
 permutation "s1-begin" "s2-begin-repeatable" "s1-insert-1" "s2-insert-1" "s1-commit" "s2-rollback"


### PR DESCRIPTION
We do not use comments starting with # in spec files because it creates
errors from C preprocessor that expects directives after this character.
Instead use C type comments, i.e:
```c
// single line comment

/*
 * multi line comment
 */
```

## C Preprocessor errors: 
```
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:174:3: error:
invalid preprocessing directive #CREATE
 # CREATE INDEX (without CONCURRENTLY)
   ^~~~~~
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:177:3: error:
invalid preprocessing directive #Start
 # Start a session that executes INSERT in a transaction block before
   ^~~~~
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:178:3: error:
invalid preprocessing directive #CREATE
 # CREATE INDEX / REINDEX CONCURRENTLY so that the latter one blocks.
   ^~~~~~
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:180:3: error:
invalid preprocessing directive #CREATE
 # CREATE INDEX CONCURRENTLY
   ^~~~~~
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:186:3: error:
invalid preprocessing directive #similar
 # similar tests with REINDEX INDEX CONCURRENTLY
   ^~~~~~~
/home/hanefi/code/citus/src/test/regress/spec/columnar_index_concurrency.spec:191:3: error:
invalid preprocessing directive #CREATE
 # CREATE INDEX / REINDEX CONCURRENTLY fails due to duplicate values
   ^~~
```
