### PR TITLE
Remove case block that is identical to its neighbor

### DIFF
--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -4263,19 +4263,6 @@ GetPartitionTypeInputInfo(char *partitionKeyString, char partitionMethod,
 	{
 		case DISTRIBUTE_BY_APPEND:
 		case DISTRIBUTE_BY_RANGE:
-		{
-			Node *partitionNode = stringToNode(partitionKeyString);
-			Var *partitionColumn = (Var *) partitionNode;
-			Assert(IsA(partitionNode, Var));
-
-			GetIntervalTypeInfo(partitionMethod, partitionColumn,
-								intervalTypeId, intervalTypeMod);
-
-			*columnTypeId = partitionColumn->vartype;
-			*columnTypeMod = partitionColumn->vartypmod;
-			break;
-		}
-
 		case DISTRIBUTE_BY_HASH:
 		{
 			Node *partitionNode = stringToNode(partitionKeyString);


### PR DESCRIPTION
We have a shared code block for `DISTRIBUTE_BY_APPEND` and `DISTRIBUTE_BY_RANGE`, followed by the same block for `DISTRIBUTE_BY_HASH`. We can actually remove the duplication.