### PR TITLE
Cluster connectivity check

### DIFF
--- a/src/backend/distributed/sql/citus--10.2-4--11.0-1.sql
+++ b/src/backend/distributed/sql/citus--10.2-4--11.0-1.sql
@@ -4,6 +4,8 @@
 #include "udfs/citus_disable_node/11.0-1.sql"
 
 #include "udfs/citus_check_connection_to_node/11.0-1.sql"
+#include "udfs/citus_check_cluster_node_health/11.0-1.sql"
+
 #include "udfs/citus_internal_add_object_metadata/11.0-1.sql"
 
 DROP FUNCTION IF EXISTS pg_catalog.master_apply_delete_command(text);

--- a/src/backend/distributed/sql/downgrades/citus--11.0-1--10.2-4.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.0-1--10.2-4.sql
@@ -41,4 +41,6 @@ COMMENT ON FUNCTION pg_catalog.citus_disable_node(nodename text, nodeport intege
         IS 'removes node from the cluster temporarily';
 
 DROP FUNCTION pg_catalog.citus_check_connection_to_node (text, integer);
+DROP FUNCTION pg_catalog.citus_check_cluster_node_health ();
+
 DROP FUNCTION pg_catalog.citus_internal_add_object_metadata(text, text[], text[], integer, integer);

--- a/src/backend/distributed/sql/udfs/citus_check_cluster_node_health/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_check_cluster_node_health/11.0-1.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION pg_catalog.citus_check_cluster_node_health (
+    OUT from_nodename text,
+    OUT from_nodeport int,
+    OUT to_nodename text,
+    OUT to_nodeport int,
+    OUT result bool )
+    RETURNS SETOF RECORD
+    LANGUAGE C
+    STRICT
+    AS 'MODULE_PATHNAME', $$citus_check_cluster_node_health$$;
+
+COMMENT ON FUNCTION pg_catalog.citus_check_cluster_node_health ()
+    IS 'checks connections between all nodes in the cluster';

--- a/src/backend/distributed/sql/udfs/citus_check_cluster_node_health/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_check_cluster_node_health/latest.sql
@@ -1,0 +1,13 @@
+CREATE FUNCTION pg_catalog.citus_check_cluster_node_health (
+    OUT from_nodename text,
+    OUT from_nodeport int,
+    OUT to_nodename text,
+    OUT to_nodeport int,
+    OUT result bool )
+    RETURNS SETOF RECORD
+    LANGUAGE C
+    STRICT
+    AS 'MODULE_PATHNAME', $$citus_check_cluster_node_health$$;
+
+COMMENT ON FUNCTION pg_catalog.citus_check_cluster_node_health ()
+    IS 'checks connections between all nodes in the cluster';

--- a/src/test/regress/create_schedule
+++ b/src/test/regress/create_schedule
@@ -3,3 +3,4 @@ test: prepared_statements_create_load ch_benchmarks_create_load
 test: dropped_columns_create_load distributed_planning_create_load
 test: local_dist_join_load
 test: partitioned_indexes_create
+test: connectivity_checks

--- a/src/test/regress/expected/connectivity_checks.out
+++ b/src/test/regress/expected/connectivity_checks.out
@@ -1,0 +1,6 @@
+SELECT bool_and(coalesce(result, false)) FROM citus_check_cluster_node_health();
+ bool_and
+---------------------------------------------------------------------
+ t
+(1 row)
+

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -319,6 +319,121 @@ SELECT * FROM citus_check_connection_to_node('localhost', :worker_2_proxy_port);
  f
 (1 row)
 
+-- tests for citus_check_cluster_node_health
+-- kill all connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |          9060 | localhost   |        9060 |
+ localhost     |          9060 | localhost   |       57637 |
+ localhost     |         57637 | localhost   |        9060 | t
+ localhost     |         57637 | localhost   |       57637 | t
+(4 rows)
+
+-- suggested summary queries for connectivity checks
+SELECT bool_and(coalesce(result, false)) FROM citus_check_cluster_node_health();
+ bool_and
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT result, count(*) FROM citus_check_cluster_node_health() GROUP BY result ORDER BY 1;
+ result | count
+---------------------------------------------------------------------
+ t      |     2
+        |     2
+(2 rows)
+
+-- cancel all connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").cancel(' || pg_backend_pid() || ')');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ERROR:  canceling statement due to user request
+-- kill all but first connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").after(1).kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |          9060 | localhost   |        9060 | t
+ localhost     |          9060 | localhost   |       57637 |
+ localhost     |         57637 | localhost   |        9060 | t
+ localhost     |         57637 | localhost   |       57637 | t
+(4 rows)
+
+-- cancel all but first connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").after(1).cancel(' || pg_backend_pid() || ')');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ERROR:  canceling statement due to user request
+-- kill all connections to this node
+SELECT citus.mitmproxy('conn.onAuthenticationOk().kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |          9060 | localhost   |        9060 |
+ localhost     |          9060 | localhost   |       57637 |
+ localhost     |         57637 | localhost   |        9060 | f
+ localhost     |         57637 | localhost   |       57637 | t
+(4 rows)
+
+-- cancel all connections to this node
+SELECT citus.mitmproxy('conn.onAuthenticationOk().cancel(' || pg_backend_pid() || ')');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ERROR:  canceling statement due to user request
+-- kill connection checks to this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |          9060 | localhost   |        9060 | f
+ localhost     |          9060 | localhost   |       57637 | t
+ localhost     |         57637 | localhost   |        9060 | f
+ localhost     |         57637 | localhost   |       57637 | t
+(4 rows)
+
+-- cancel connection checks to this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").cancel(' || pg_backend_pid() || ')');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM citus_check_cluster_node_health();
+ERROR:  canceling statement due to user request
 RESET client_min_messages;
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy

--- a/src/test/regress/expected/multi_citus_tools.out
+++ b/src/test/regress/expected/multi_citus_tools.out
@@ -629,6 +629,45 @@ SELECT citus_check_connection_to_node('localhost', :worker_2_port);
 (1 row)
 
 \c - - - :master_port
+SELECT * FROM citus_check_cluster_node_health() ORDER BY 1,2,3,4;
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |         57637 | localhost   |       57637 | t
+ localhost     |         57637 | localhost   |       57638 | t
+ localhost     |         57638 | localhost   |       57637 | t
+ localhost     |         57638 | localhost   |       57638 | t
+(4 rows)
+
+-- test cluster connectivity when we have broken nodes
+SET client_min_messages TO ERROR;
+SET citus.node_connection_timeout TO 10;
+BEGIN;
+INSERT INTO pg_dist_node VALUES
+    (123456789, 123456789, 'localhost', 123456789),
+    (1234567890, 1234567890, 'www.citusdata.com', 5432);
+SELECT * FROM citus_check_cluster_node_health() ORDER BY 5,1,2,3,4;
+   from_nodename   | from_nodeport |    to_nodename    | to_nodeport | result
+---------------------------------------------------------------------
+ localhost         |         57637 | localhost         |   123456789 | f
+ localhost         |         57637 | www.citusdata.com |        5432 | f
+ localhost         |         57638 | localhost         |   123456789 | f
+ localhost         |         57638 | www.citusdata.com |        5432 | f
+ localhost         |         57637 | localhost         |       57637 | t
+ localhost         |         57637 | localhost         |       57638 | t
+ localhost         |         57638 | localhost         |       57637 | t
+ localhost         |         57638 | localhost         |       57638 | t
+ localhost         |     123456789 | localhost         |       57637 |
+ localhost         |     123456789 | localhost         |       57638 |
+ localhost         |     123456789 | localhost         |   123456789 |
+ localhost         |     123456789 | www.citusdata.com |        5432 |
+ www.citusdata.com |          5432 | localhost         |       57637 |
+ www.citusdata.com |          5432 | localhost         |       57638 |
+ www.citusdata.com |          5432 | localhost         |   123456789 |
+ www.citusdata.com |          5432 | www.citusdata.com |        5432 |
+(16 rows)
+
+ROLLBACK;
+RESET citus.node_connection_timeout;
 RESET client_min_messages;
 DROP SCHEMA tools CASCADE;
 RESET SEARCH_PATH;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -973,10 +973,11 @@ SELECT * FROM multi_extension.print_extension_changes();
  function master_append_table_to_shard(bigint,text,text,integer) real |
  function master_apply_delete_command(text) integer                   |
  function master_get_table_metadata(text) record                      |
+                                                                      | function citus_check_cluster_node_health() SETOF record
                                                                       | function citus_check_connection_to_node(text,integer) boolean
                                                                       | function citus_disable_node(text,integer,boolean) void
                                                                       | function citus_internal_add_object_metadata(text,text[],text[],integer,integer) void
-(7 rows)
+(8 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/multi_follower_select_statements.out
+++ b/src/test/regress/expected/multi_follower_select_statements.out
@@ -159,6 +159,16 @@ SELECT * FROM the_table;
  1 | 2
 (2 rows)
 
+-- Check for connectivity in the cluster
+SELECT * FROM citus_check_cluster_node_health();
+ from_nodename | from_nodeport | to_nodename | to_nodeport | result
+---------------------------------------------------------------------
+ localhost     |          9071 | localhost   |        9071 | t
+ localhost     |          9071 | localhost   |        9072 | t
+ localhost     |          9072 | localhost   |        9071 | t
+ localhost     |          9072 | localhost   |        9072 | t
+(4 rows)
+
 -- clean up after ourselves
 \c -reuse-previous=off regression - - :master_port
 DROP TABLE the_table;

--- a/src/test/regress/expected/multi_mx_add_coordinator.out
+++ b/src/test/regress/expected/multi_mx_add_coordinator.out
@@ -1,9 +1,5 @@
 CREATE SCHEMA mx_add_coordinator;
 SET search_path TO mx_add_coordinator,public;
-SET citus.shard_replication_factor TO 1;
-SET citus.shard_count TO 8;
-SET citus.next_shard_id TO 7000000;
-SET citus.next_placement_id TO 7000000;
 SET client_min_messages TO WARNING;
 CREATE USER reprefuser WITH LOGIN;
 SELECT run_command_on_workers('CREATE USER reprefuser WITH LOGIN');
@@ -16,12 +12,43 @@ SELECT run_command_on_workers('CREATE USER reprefuser WITH LOGIN');
 SET citus.enable_alter_role_propagation TO ON;
 -- alter role for other than the extension owner works in enterprise, output differs accordingly
 ALTER ROLE reprefuser WITH CREATEDB;
+-- check connectivity in the cluster
+-- verify that we test for 4 node pairs before we add coordinator to metadata
+SELECT bool_and(coalesce(result, false)), count(*) FROM citus_check_cluster_node_health();
+ bool_and | count
+---------------------------------------------------------------------
+ t        |     4
+(1 row)
+
 SELECT 1 FROM master_add_node('localhost', :master_port, groupId => 0);
  ?column?
 ---------------------------------------------------------------------
         1
 (1 row)
 
+-- verify that we test for 9 node pairs after we add coordinator to metadata
+SELECT bool_and(coalesce(result, false)), count(*) FROM citus_check_cluster_node_health();
+ bool_and | count
+---------------------------------------------------------------------
+ t        |     9
+(1 row)
+
+-- test that we can test for connectivity when connected to worker nodes as well
+\c - - - :worker_1_port
+SELECT bool_and(coalesce(result, false)), count(*) FROM citus_check_cluster_node_health();
+ bool_and | count
+---------------------------------------------------------------------
+ t        |     9
+(1 row)
+
+\c - - - :master_port
+-- set the configs after reconnecting to coordinator
+SET search_path TO mx_add_coordinator,public;
+SET citus.shard_replication_factor TO 1;
+SET citus.shard_count TO 8;
+SET citus.next_shard_id TO 7000000;
+SET citus.next_placement_id TO 7000000;
+SET client_min_messages TO WARNING;
 -- test that coordinator pg_dist_node entry is synced to the workers
 SELECT wait_until_metadata_sync(30000);
  wait_until_metadata_sync

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -38,6 +38,7 @@ ORDER BY 1;
  function citus_add_rebalance_strategy(name,regproc,regproc,regproc,real,real,real)
  function citus_add_secondary_node(text,integer,text,integer,name)
  function citus_blocking_pids(integer)
+ function citus_check_cluster_node_health()
  function citus_check_connection_to_node(text,integer)
  function citus_cleanup_orphaned_shards()
  function citus_conninfo_cache_invalidate()
@@ -261,5 +262,5 @@ ORDER BY 1;
  view citus_worker_stat_activity
  view pg_dist_shard_placement
  view time_partitions
-(245 rows)
+(246 rows)
 

--- a/src/test/regress/sql/connectivity_checks.sql
+++ b/src/test/regress/sql/connectivity_checks.sql
@@ -1,0 +1,1 @@
+SELECT bool_and(coalesce(result, false)) FROM citus_check_cluster_node_health();

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -161,6 +161,45 @@ SELECT * FROM citus_check_connection_to_node('localhost', :worker_2_proxy_port);
 SELECT citus.mitmproxy('conn.delay(500)');
 SELECT * FROM citus_check_connection_to_node('localhost', :worker_2_proxy_port);
 
+-- tests for citus_check_cluster_node_health
+
+-- kill all connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").kill()');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- suggested summary queries for connectivity checks
+SELECT bool_and(coalesce(result, false)) FROM citus_check_cluster_node_health();
+SELECT result, count(*) FROM citus_check_cluster_node_health() GROUP BY result ORDER BY 1;
+
+-- cancel all connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").cancel(' || pg_backend_pid() || ')');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- kill all but first connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").after(1).kill()');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- cancel all but first connectivity checks that originate from this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT citus_check_connection_to_node").after(1).cancel(' || pg_backend_pid() || ')');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- kill all connections to this node
+SELECT citus.mitmproxy('conn.onAuthenticationOk().kill()');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- cancel all connections to this node
+SELECT citus.mitmproxy('conn.onAuthenticationOk().cancel(' || pg_backend_pid() || ')');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- kill connection checks to this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").kill()');
+SELECT * FROM citus_check_cluster_node_health();
+
+-- cancel connection checks to this node
+SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").cancel(' || pg_backend_pid() || ')');
+SELECT * FROM citus_check_cluster_node_health();
+
+
 RESET client_min_messages;
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.node_connection_timeout TO DEFAULT;

--- a/src/test/regress/sql/multi_citus_tools.sql
+++ b/src/test/regress/sql/multi_citus_tools.sql
@@ -319,6 +319,20 @@ SELECT citus_check_connection_to_node('localhost', :worker_2_port);
 
 \c - - - :master_port
 
+SELECT * FROM citus_check_cluster_node_health() ORDER BY 1,2,3,4;
+
+-- test cluster connectivity when we have broken nodes
+SET client_min_messages TO ERROR;
+SET citus.node_connection_timeout TO 10;
+
+BEGIN;
+INSERT INTO pg_dist_node VALUES
+    (123456789, 123456789, 'localhost', 123456789),
+    (1234567890, 1234567890, 'www.citusdata.com', 5432);
+SELECT * FROM citus_check_cluster_node_health() ORDER BY 5,1,2,3,4;
+ROLLBACK;
+
+RESET citus.node_connection_timeout;
 RESET client_min_messages;
 DROP SCHEMA tools CASCADE;
 RESET SEARCH_PATH;

--- a/src/test/regress/sql/multi_follower_select_statements.sql
+++ b/src/test/regress/sql/multi_follower_select_statements.sql
@@ -111,6 +111,9 @@ UPDATE pg_dist_node SET nodecluster = 'second-cluster' WHERE noderole = 'seconda
 \c "port=9070 dbname=regression options='-c\ citus.use_secondary_nodes=always\ -c\ citus.cluster_name=second-cluster'"
 SELECT * FROM the_table;
 
+-- Check for connectivity in the cluster
+SELECT * FROM citus_check_cluster_node_health();
+
 -- clean up after ourselves
 \c -reuse-previous=off regression - - :master_port
 DROP TABLE the_table;

--- a/src/test/regress/sql_schedule
+++ b/src/test/regress/sql_schedule
@@ -5,3 +5,4 @@ test: ch_benchmarks_4 ch_benchmarks_5 ch_benchmarks_6
 test: intermediate_result_pruning_queries_1 intermediate_result_pruning_queries_2
 test: dropped_columns_1 distributed_planning
 test: local_dist_join
+test: connectivity_checks


### PR DESCRIPTION
DESCRIPTION: Introduces `citus_check_cluster_node_health` UDF to check cluster connectivity

This PR aims to create an easy to use API for coordinating connectivity checks between all node pairs in the cluster.

# Usage

`citus_check_cluster_node_health()` takes no parameters and checks the connectivity between pairs of nodes sequentially.

e.g.
```
 from_nodename | from_nodeport | to_nodename | to_nodeport | result
--------------------------------------------------------------------
 localhost     |          9700 | localhost   |        9700 | t
 localhost     |          9700 | localhost   |        9701 | t
 localhost     |          9701 | localhost   |        9700 | t
 localhost     |          9701 | localhost   |        9701 | t
(4 rows)
```

## Return value

This UDF returns a set of records indicating the source and target nodes and success status.

There are 3 possible success status:
1. `true` : connection attempt from source to target succeeded.
2. `false`: connection attempt from source to target failed.
3. `NULL` : connection attempt from the current node to source node failed.

In the case of a `NULL` or `false` success value, we log `WARNING` messages for the underlying connection issues.

## Suggested Usage

We suggest operators to use the following command to check connectivity in the cluster.

```sql
SELECT bool_and(coalesce(result, false)) FROM citus_check_cluster_node_health();
 bool_and
---------------------------------------------------------------------
 t
(1 row)

```

# The algorithm

```
for sourceNode in workerNodeList:
	c = connectToNode(sourceNode)
	for targetNode in workerNodeList:
		result = c.execute(
			"SELECT citus_check_connection_to_node(targetNode.name,
												   targetNode.port")
		emit sourceNode.name,
			 sourceNode.port,
			 targetNode.name,
			 targetNode.port,
			 result
```

Related: #5487
Fixes: #5290 