### PR TITLE
Remove redundant arbitrary config class

### DIFF
--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -272,16 +272,6 @@ class CitusUnusualExecutorConfig(CitusMXBaseClusterConfig):
         }
 
 
-class CitusCacheManyConnectionsConfig(CitusMXBaseClusterConfig):
-    def __init__(self, arguments):
-        super().__init__(arguments)
-        self.new_settings = {
-            "citus.copy_switchover_threshold": "1B",
-            "citus.local_copy_flush_threshold": "1B",
-            "citus.remote_copy_flush_threshold": "1B",
-        }
-
-
 class CitusSmallCopyBuffersConfig(CitusMXBaseClusterConfig):
     def __init__(self, arguments):
         super().__init__(arguments)


### PR DESCRIPTION
We had 2 class definitions for `CitusCacheManyConnectionsConfig`, where one of them was a copy of `CitusSmallCopyBuffersConfig`.

This PR leaves the intended class definition that configures caching many connections, and removes the one that is a copy of another class.