### PR TITLE
Do not include return table params in the function arg list

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1328,6 +1328,12 @@ CreateFunctionStmtObjectAddress(Node *node, bool missing_ok)
 	FunctionParameter *funcParam = NULL;
 	foreach_ptr(funcParam, stmt->parameters)
 	{
+		if (funcParam->mode == FUNC_PARAM_TABLE)
+		{
+			/* RETURN TABLE parameters should not be included in the args list */
+			continue;
+		}
+
 		objectWithArgs->objargs = lappend(objectWithArgs->objargs, funcParam->argType);
 	}
 


### PR DESCRIPTION
In `CreateFunctionStmtObjectAddress`, objectId is found = 0 because we include the args of RETURN TABLE part to the function args. We should not include them in order to get the right function oid.

That could be the reason behind the incident that the user gets `function doesn't exists` error with the function signature that includes RETURN TABLE args. Because after `CreateFunctionStmtObjectAddress`, PG function `LookupFuncWithArgs` gets called. That function throws `function doesn't exists` error, with a signature generated using the args we pass to it.