### PR TITLE
Remove NOOP tuplestore_donestoring calls

### DIFF
--- a/src/backend/columnar/columnar_debug.c
+++ b/src/backend/columnar/columnar_debug.c
@@ -70,8 +70,6 @@ columnar_store_memory_stats(PG_FUNCTION_ARGS)
 
 	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
 	tuplestore_putvalues(tupleStore, tupleDescriptor, values, nulls);
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_DATUM(0);
 }
 

--- a/src/backend/distributed/connection/locally_reserved_shared_connections.c
+++ b/src/backend/distributed/connection/locally_reserved_shared_connections.c
@@ -118,9 +118,6 @@ citus_reserved_connection_stats(PG_FUNCTION_ARGS)
 
 	StoreAllReservedConnections(tupleStore, tupleDescriptor);
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }
 

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -143,9 +143,6 @@ citus_remote_connection_stats(PG_FUNCTION_ARGS)
 
 	StoreAllRemoteConnectionStats(tupleStore, tupleDescriptor);
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }
 

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -861,8 +861,6 @@ ReadIntermediateResultsIntoFuncOutput(FunctionCallInfo fcinfo, char *copyFormat,
 								   tupleStore);
 		}
 	}
-
-	tuplestore_donestoring(tupleStore);
 }
 
 

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -262,8 +262,6 @@ worker_partition_query_result(PG_FUNCTION_ARGS)
 
 		tuplestore_putvalues(tupleStore, returnTupleDesc, values, nulls);
 	}
-
-	tuplestore_donestoring(tupleStore);
 	PortalDrop(portal, false);
 	FreeExecutorState(estate);
 

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -245,9 +245,6 @@ citus_shard_sizes(PG_FUNCTION_ARGS)
 
 	ReceiveShardNameAndSizeResults(connectionList, tupleStore, tupleDescriptor);
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }
 

--- a/src/backend/distributed/operations/citus_tools.c
+++ b/src/backend/distributed/operations/citus_tools.c
@@ -592,8 +592,5 @@ CreateTupleStore(TupleDesc tupleDescriptor,
 		pfree(nodeNameText);
 		pfree(resultText);
 	}
-
-	tuplestore_donestoring(tupleStore);
-
 	return tupleStore;
 }

--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1058,8 +1058,6 @@ get_rebalance_table_shards_plan(PG_FUNCTION_ARGS)
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 	}
 
-	tuplestore_donestoring(tupstore);
-
 	return (Datum) 0;
 }
 
@@ -1131,8 +1129,6 @@ get_rebalance_progress(PG_FUNCTION_ARGS)
 			tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 		}
 	}
-
-	tuplestore_donestoring(tupstore);
 
 	DetachFromDSMSegments(segmentList);
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1000,8 +1000,6 @@ worker_last_saved_explain_analyze(PG_FUNCTION_ARGS)
 
 		tuplestore_putvalues(tupleStore, tupleDescriptor, columnValues, columnNulls);
 	}
-
-	tuplestore_donestoring(tupleStore);
 	PG_RETURN_DATUM(0);
 }
 
@@ -1086,8 +1084,6 @@ worker_save_query_explain_analyze(PG_FUNCTION_ARGS)
 					  &planDuration, &executionDurationMillisec);
 
 	ExplainEndOutput(es);
-
-	tuplestore_donestoring(tupleStore);
 
 	/* save EXPLAIN ANALYZE result to be fetched later */
 	MemoryContext oldContext = MemoryContextSwitchTo(TopTransactionContext);

--- a/src/backend/distributed/test/distributed_deadlock_detection.c
+++ b/src/backend/distributed/test/distributed_deadlock_detection.c
@@ -67,8 +67,5 @@ get_adjacency_list_wait_graph(PG_FUNCTION_ARGS)
 		tuplestore_putvalues(tupleStore, tupleDescriptor, values, isNulls);
 	}
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -101,9 +101,6 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 
 		tuplestore_putvalues(tupleStore, tupleDescriptor, columnValues, columnNulls);
 	}
-
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_DATUM(0);
 }
 
@@ -186,8 +183,5 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 
 		tuplestore_putvalues(tupleStore, tupleDescriptor, columnValues, columnNulls);
 	}
-
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_DATUM(0);
 }

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -215,8 +215,5 @@ get_foreign_key_connected_relations(PG_FUNCTION_ARGS)
 
 		tuplestore_putvalues(tupleStore, tupleDescriptor, values, nulls);
 	}
-
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/test/progress_utils.c
+++ b/src/backend/distributed/test/progress_utils.c
@@ -114,8 +114,6 @@ show_progress(PG_FUNCTION_ARGS)
 		}
 	}
 
-	tuplestore_donestoring(tupstore);
-
 	DetachFromDSMSegments(attachedDSMSegments);
 
 	return (Datum) 0;

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -323,9 +323,6 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 		ForgetResults(connection);
 	}
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
-
 	PG_RETURN_VOID();
 }
 
@@ -343,9 +340,6 @@ get_all_active_transactions(PG_FUNCTION_ARGS)
 	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
 
 	StoreAllActiveTransactions(tupleStore, tupleDescriptor);
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/transaction/citus_dist_stat_activity.c
+++ b/src/backend/distributed/transaction/citus_dist_stat_activity.c
@@ -1100,7 +1100,4 @@ ReturnCitusDistStats(List *citusStatsList, FunctionCallInfo fcinfo)
 
 		tuplestore_putvalues(tupleStore, tupleDesc, values, nulls);
 	}
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
 }

--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -322,9 +322,6 @@ ReturnWaitGraph(WaitGraph *waitGraph, FunctionCallInfo fcinfo)
 
 		tuplestore_putvalues(tupleStore, tupleDesc, values, nulls);
 	}
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupleStore);
 }
 
 


### PR DESCRIPTION
PostgreSQL does not need calling this function since 7.4 release, and it
is a NOOP.

For more details, check PostgreSQL commit below :
```
commit dd04e958c8b03c0f0512497651678c7816af3198
Author: Tom Lane <tgl@sss.pgh.pa.us>
Date:   Sun Mar 9 03:34:10 2003 +0000

    tuplestore_donestoring() isn't needed anymore, but provide a no-op
    macro definition so as not to create compatibility problems.

diff --git a/src/include/utils/tuplestore.h b/src/include/utils/tuplestore.h
index b46babacd1..76fe9fb428 100644
--- a/src/include/utils/tuplestore.h
+++ b/src/include/utils/tuplestore.h
@@ -17,7 +17,7 @@
  * Portions Copyright (c) 1996-2002, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California
  *
- * $Id: tuplestore.h,v 1.8 2003/03/09 02:19:13 tgl Exp $
+ * $Id: tuplestore.h,v 1.9 2003/03/09 03:34:10 tgl Exp $
  *
  *-------------------------------------------------------------------------
  */
@@ -41,6 +41,9 @@ extern Tuplestorestate *tuplestore_begin_heap(bool randomAccess,

 extern void tuplestore_puttuple(Tuplestorestate *state, void *tuple);

+/* tuplestore_donestoring() used to be required, but is no longer used */
+#define tuplestore_donestoring(state)  ((void) 0)
+
 /* backwards scan is only allowed if randomAccess was specified 'true' */
 extern void *tuplestore_gettuple(Tuplestorestate *state, bool forward,
                                        bool *should_free);
```