### PR TITLE
Fix one flaky failure test

### DIFF
--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -142,7 +142,7 @@ SELECT count(*) FROM products;
 (1 row)
 
 -- use a filter on connection id so that concurrent operations does not change output
-SELECT * FROM citus.dump_network_traffic() WHERE conn=1;
+SELECT * FROM citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
  conn |   source    |      message
 ---------------------------------------------------------------------
     1 | coordinator | [initial message]

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -141,13 +141,6 @@ SELECT count(*) FROM products;
      0
 (1 row)
 
--- use a filter on connection id so that concurrent operations does not change output
-SELECT * FROM citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
- conn |   source    |      message
----------------------------------------------------------------------
-    1 | coordinator | [initial message]
-(1 row)
-
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -141,12 +141,11 @@ SELECT count(*) FROM products;
      0
 (1 row)
 
--- use OFFSET 1 to prevent printing the line where source
--- is the worker, and LIMIT 1 in case there were multiple connections
-SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
-        dump_network_traffic
+-- use a filter on connection id so that concurrent operations does not change output
+SELECT * FROM citus.dump_network_traffic() WHERE conn=1;
+ conn |   source    |      message
 ---------------------------------------------------------------------
- (1,coordinator,"[initial message]")
+    1 | coordinator | [initial message]
 (1 row)
 
 SELECT citus.mitmproxy('conn.allow()');

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -80,9 +80,6 @@ SELECT citus.mitmproxy('conn.delay(500)');
 SELECT count(*) FROM products;
 SELECT count(*) FROM products;
 
--- use a filter on connection id so that concurrent operations does not change output
-SELECT * FROM citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
-
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE single_replicatated(key int);

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -81,7 +81,7 @@ SELECT count(*) FROM products;
 SELECT count(*) FROM products;
 
 -- use a filter on connection id so that concurrent operations does not change output
-SELECT * FROM citus.dump_network_traffic() WHERE conn=1;
+SELECT * FROM citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
 
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor TO 1;

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -80,9 +80,8 @@ SELECT citus.mitmproxy('conn.delay(500)');
 SELECT count(*) FROM products;
 SELECT count(*) FROM products;
 
--- use OFFSET 1 to prevent printing the line where source
--- is the worker, and LIMIT 1 in case there were multiple connections
-SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
+-- use a filter on connection id so that concurrent operations does not change output
+SELECT * FROM citus.dump_network_traffic() WHERE conn=1;
 
 SELECT citus.mitmproxy('conn.allow()');
 SET citus.shard_replication_factor TO 1;


### PR DESCRIPTION
We have a test where we dump the network traffic. Even though we have filters and offsets to make sure we always have deterministic outputs, we frequently see network activity in other concurrent operations.

I tried to update the tests, introduce more filters and none of those worked. I suggest we remove the flaky test instead.

Some failing diff samples:

```
 -- use OFFSET 1 to prevent printing the line where source
 -- is the worker, and LIMIT 1 in case there were multiple connections
 SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
                            dump_network_traffic                            
 ---------------------------------------------------------------------------
- (1,coordinator,"[initial message]")
+ (29,coordinator,"['Query(query=SELECT * FROM dump_local_wait_edges())']")
 (1 row)
```

```
 -- use OFFSET 1 to prevent printing the line where source
 -- is the worker, and LIMIT 1 in case there were multiple connections
 SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
                            dump_network_traffic                            
 ---------------------------------------------------------------------------
- (1,coordinator,"[initial message]")
+ (28,coordinator,"['Query(query=SELECT * FROM dump_local_wait_edges())']")
 (1 row)
```

```
 -- use OFFSET 1 to prevent printing the line where source
 -- is the worker, and LIMIT 1 in case there were multiple connections
 SELECT citus.dump_network_traffic() ORDER BY 1 LIMIT 1 OFFSET 1;
                            dump_network_traffic                            
 ---------------------------------------------------------------------------
- (1,coordinator,"[initial message]")
+ (31,coordinator,"['Query(query=SELECT * FROM dump_local_wait_edges())']")
 (1 row)
```