### PR TITLE
HAVE_LZ4 -> HAVE_CITUS_LZ4

### DIFF
--- a/configure
+++ b/configure
@@ -4543,7 +4543,9 @@ if test "${with_lz4+set}" = set; then :
   withval=$with_lz4;
   case $withval in
     yes)
-      :
+
+$as_echo "#define HAVE_CITUS_LIBLZ4 1" >>confdefs.h
+
       ;;
     no)
       :
@@ -4555,6 +4557,8 @@ if test "${with_lz4+set}" = set; then :
 
 else
   with_lz4=yes
+
+$as_echo "#define HAVE_CITUS_LIBLZ4 1" >>confdefs.h
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -220,7 +220,8 @@ AC_DEFINE_UNQUOTED(REPORTS_BASE_URL, "$REPORTS_BASE_URL",
 # LZ4
 #
 PGAC_ARG_BOOL(with, lz4, yes,
-              [do not use lz4])
+              [do not use lz4],
+              [AC_DEFINE([HAVE_CITUS_LIBLZ4], 1, [Define to 1 to build with lz4 support. (--with-lz4)])])
 AC_SUBST(with_lz4)
 
 if test "$with_lz4" = yes; then

--- a/src/backend/columnar/columnar.c
+++ b/src/backend/columnar/columnar.c
@@ -29,7 +29,7 @@
 
 #if HAVE_LIBZSTD
 #define DEFAULT_COMPRESSION_TYPE COMPRESSION_ZSTD
-#elif HAVE_LIBLZ4
+#elif HAVE_CITUS_LIBLZ4
 #define DEFAULT_COMPRESSION_TYPE COMPRESSION_LZ4
 #else
 #define DEFAULT_COMPRESSION_TYPE COMPRESSION_PG_LZ
@@ -44,7 +44,7 @@ static const struct config_enum_entry columnar_compression_options[] =
 {
 	{ "none", COMPRESSION_NONE, false },
 	{ "pglz", COMPRESSION_PG_LZ, false },
-#if HAVE_LIBLZ4
+#if HAVE_CITUS_LIBLZ4
 	{ "lz4", COMPRESSION_LZ4, false },
 #endif
 #if HAVE_LIBZSTD

--- a/src/backend/columnar/columnar_compression.c
+++ b/src/backend/columnar/columnar_compression.c
@@ -19,7 +19,7 @@
 
 #include "columnar/columnar_compression.h"
 
-#if HAVE_LIBLZ4
+#if HAVE_CITUS_LIBLZ4
 #include <lz4.h>
 #endif
 
@@ -63,7 +63,7 @@ CompressBuffer(StringInfo inputBuffer,
 {
 	switch (compressionType)
 	{
-#if HAVE_LIBLZ4
+#if HAVE_CITUS_LIBLZ4
 		case COMPRESSION_LZ4:
 		{
 			int maximumLength = LZ4_compressBound(inputBuffer->len);
@@ -170,7 +170,7 @@ DecompressBuffer(StringInfo buffer,
 			return buffer;
 		}
 
-#if HAVE_LIBLZ4
+#if HAVE_CITUS_LIBLZ4
 		case COMPRESSION_LZ4:
 		{
 			StringInfo decompressedBuffer = makeStringInfo();

--- a/src/include/citus_config.h.in
+++ b/src/include/citus_config.h.in
@@ -38,7 +38,7 @@
 #undef HAVE_LIBCURL
 
 /* Define to 1 if you have the `lz4' library (-llz4). */
-#undef HAVE_LIBLZ4
+#undef HAVE_CITUS_LIBLZ4
 
 /* Define to 1 if you have the `zstd' library (-lzstd). */
 #undef HAVE_LIBZSTD

--- a/src/include/citus_version.h.in
+++ b/src/include/citus_version.h.in
@@ -25,7 +25,7 @@
 #undef HAVE_LIBCURL
 
 /* Define to 1 if you have the `liblz4' library (-llz4). */
-#undef HAVE_LIBLZ4
+#undef HAVE_CITUS_LIBLZ4
 
 /* Define to 1 if you have the `libzstd' library (-lzstd). */
 #undef HAVE_LIBZSTD


### PR DESCRIPTION
Postgres also exports `HAVE_LZ4` constant via its configure
script. If user installed postgres from packages, it seems that
this pg constant is already exported (to be equal to 1) by
`postgres.h` (via `pg_config.h->c.h->postgres.h`) to
`columnar_compression.c` since postgres binary has already been
built using lz4 header. In that case, even if we don't have that
header, `columnar_compression.c` attempts including `lz4.h` even
if we passed `--without-lz4` to Citus configure.

For this reason, we rename that constant to `HAVE_CITUS_LZ4`
to prevent collision.

------

Maybe backport to all 10.x branches, but definitely not a critical issue.