### PR TITLE
Turn ddl propagation off in worker on multi_copy

### DIFF
--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -572,6 +572,7 @@ SET session_replication_role = DEFAULT;
 
 -- disable test_user on the first worker
 \c - :default_user - :worker_1_port
+SET citus.enable_object_propagation TO off;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 
@@ -605,6 +606,7 @@ SELECT shardid, shardstate, nodename, nodeport
 
 -- re-enable test_user on the first worker
 \c - :default_user - :worker_1_port
+SET citus.enable_object_propagation TO off;
 ALTER USER test_user WITH login;
 
 \c - test_user - :master_port

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -737,6 +737,7 @@ UPDATE pg_dist_shard_placement SET nodeport = :worker_1_port+10 WHERE shardid = 
 SET session_replication_role = DEFAULT;
 -- disable test_user on the first worker
 \c - :default_user - :worker_1_port
+SET citus.enable_object_propagation TO off;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 -- reissue copy, and it should fail
@@ -795,6 +796,7 @@ SELECT shardid, shardstate, nodename, nodeport
 
 -- re-enable test_user on the first worker
 \c - :default_user - :worker_1_port
+SET citus.enable_object_propagation TO off;
 ALTER USER test_user WITH login;
 \c - test_user - :master_port
 DROP TABLE numbers_hash;


### PR DESCRIPTION
This change is for enterprise repo