### PR TITLE
Document and try to fix flaky tests

### DIFF
--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -105,10 +105,10 @@ SELECT name FROM r1 WHERE id = 2;
 
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
-SELECT citus.dump_network_traffic();
-        dump_network_traffic
+SELECT * FROM citus.dump_network_traffic() WHERE conn=0;
+ conn |   source    |      message
 ---------------------------------------------------------------------
- (0,coordinator,"[initial message]")
+    0 | coordinator | [initial message]
 (1 row)
 
 SELECT citus.mitmproxy('conn.allow()');

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -66,7 +66,7 @@ SELECT name FROM r1 WHERE id = 2;
 
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
-SELECT citus.dump_network_traffic();
+SELECT * FROM citus.dump_network_traffic() WHERE conn=0;
 
 SELECT citus.mitmproxy('conn.allow()');
 


### PR DESCRIPTION
`failure_connection_establishment` sporadically reports some other messages in a network dump.
```diff
 -- verify a connection attempt was made to the intercepted node, this would have cause the
 -- connection to have been delayed and thus caused a timeout
 SELECT citus.dump_network_traffic();
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    dump_network_traffic                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (33,coordinator,"['Query(query=SELECT * FROM dump_local_wait_edges())']")
+ (33,worker,"[""RowDescription(fieldcount=9,fields=['F(name=waiting_pid,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=waiting_node_id,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=waiting_transaction_num,tableoid=0,colattrnum=0,typoid=20,typlen=8,typmod=-1,format_code=0)', 'F(name=waiting_transaction_stamp,tableoid=0,colattrnum=0,typoid=1184,typlen=8,typmod=-1,format_code=0)', 'F(name=blocking_pid,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=blocking_node_id,tableoid=0,colattrnum=0,typoid=23,typlen=4,typmod=-1,format_code=0)', 'F(name=blocking_transaction_num,tableoid=0,colattrnum=0,typoid=20,typlen=8,typmod=-1,format_code=0)', 'F(name=blocking_transaction_stamp,tableoid=0,colattrnum=0,typoid=1184,typlen=8,typmod=-1,format_code=0)', 'F(name=blocking_transaction_waiting,tableoid=0,colattrnum=0,typoid=16,typlen=1,typmod=-1,format_code=0)'])"", 'CommandComplete(command=SELECT 0)', 'ReadyForQuery(state=idle)']")
  (0,coordinator,"[initial message]")
-(1 row)
+(3 rows)
```