### PR TITLE
Sync metadata in new clusters, existing clusters remain un-synced

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1522,7 +1522,9 @@ CountPrimaryWorkersWithMetadata(void)
 
 	while ((workerNode = hash_seq_search(&status)) != NULL)
 	{
-		if (workerNode->hasMetadata && NodeIsPrimary(workerNode))
+		if (workerNode->groupId != COORDINATOR_GROUP_ID &&
+			workerNode->hasMetadata && workerNode->metadataSynced &&
+			NodeIsPrimary(workerNode))
 		{
 			primariesWithMetadata++;
 		}

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -922,8 +922,15 @@ ActivateNode(char *nodeName, int nodePort)
 static bool
 ShouldSyncMetadataToNewNode(WorkerNode *newNode)
 {
-	uint32 primaryWorkerCount = ActivePrimaryNonCoordinatorNodeCount();
+	uint32 primaryWorkerCount =
+		ActivePrimaryNonCoordinatorNodeCount();
 	uint32 primariesWithMetadata = CountPrimaryWorkersWithMetadata();
+
+	/*
+	 * TODO: make this check safer
+	 * exclude the newNode as it is already in the metadata
+	 */
+	primaryWorkerCount -= 1;
 
 	if (primaryWorkerCount != 0 && primariesWithMetadata == 0)
 	{

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -101,7 +101,7 @@ extern WorkerNode * SetWorkerColumnOptional(WorkerNode *workerNode, int columnIn
 											value);
 extern WorkerNode * SetWorkerColumnLocalOnly(WorkerNode *workerNode, int columnIndex,
 											 Datum value);
-extern uint32 CountPrimariesWithMetadata(void);
+extern uint32 CountPrimaryWorkersWithMetadata(void);
 extern WorkerNode * GetFirstPrimaryWorkerNode(void);
 
 /* Function declarations for worker node utilities */


### PR DESCRIPTION
If a user upgrades from an ealier version, and have not synced the
metadata, we should not automatically sync the metadata.

If this is a post Citus 11 cluster, and we are adding a new worker node,
we sync the metadata.

The net effect is that new clusters gets Citus MX by default, existing
clusters should manually trigger metadata syncing.