### PR TITLE
Prevent creating distributed functions when there are out of sync nodes

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -614,18 +614,6 @@ SetUpDistributedTableDependencies(WorkerNode *newWorkerNode)
 			ReplicateAllReferenceTablesToNode(newWorkerNode->workerName,
 											  newWorkerNode->workerPort);
 		}
-
-		/*
-		 * Let the maintenance daemon do the hard work of syncing the metadata.
-		 * We prefer this because otherwise node activation might fail within
-		 * transaction blocks.
-		 */
-		if (ClusterHasDistributedFunctionWithDistArgument())
-		{
-			SetWorkerColumnLocalOnly(newWorkerNode, Anum_pg_dist_node_hasmetadata,
-									 BoolGetDatum(true));
-			TriggerMetadataSyncOnCommit();
-		}
 	}
 }
 
@@ -893,7 +881,7 @@ ActivateNode(char *nodeName, int nodePort)
 		 * not fail just because the current metadata is not synced.
 		 */
 		SetWorkerColumn(workerNode, Anum_pg_dist_node_metadatasynced,
-						BoolGetDatum(isActive));
+						BoolGetDatum(true));
 	}
 
 	SetUpDistributedTableDependencies(workerNode);

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -243,12 +243,6 @@ SELECT * FROM run_command_on_workers($$SELECT function_tests.dup('0123456789ab')
  localhost |    57638 | t       | (01:23:45:67:89:ab,"01:23:45:67:89:ab is text")
 (2 rows)
 
-SELECT public.wait_until_metadata_sync(30000);
- wait_until_metadata_sync
----------------------------------------------------------------------
-
-(1 row)
-
 SELECT create_distributed_function('eq(macaddr,macaddr)', '$1', colocate_with := 'streaming_table');
  create_distributed_function
 ---------------------------------------------------------------------
@@ -586,13 +580,6 @@ SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', dist
 
 (1 row)
 
--- make sure that the primary nodes are now metadata synced
-select bool_and(hasmetadata) from pg_dist_node WHERE isactive AND  noderole = 'primary';
- bool_and
----------------------------------------------------------------------
- t
-(1 row)
-
 -- make sure that both of the nodes have the function because we've succeeded
 SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='eq_with_param_names';$$);
  run_command_on_workers
@@ -610,7 +597,7 @@ SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', dist
 
 -- show that we are able to propagate objects with multiple item on address arrays
 SELECT * FROM (SELECT unnest(master_metadata_snapshot()) as metadata_command  order by 1) as innerResult WHERE metadata_command like '%distributed_object_data%';
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                metadata_command
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   metadata_command
 ---------------------------------------------------------------------
  WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid)  AS (VALUES ('type', ARRAY['public.usage_access_type']::text[], ARRAY[]::text[], -1, 0), ('type', ARRAY['function_tests.dup_result']::text[], ARRAY[]::text[], -1, 0), ('function', ARRAY['public', 'usage_access_func']::text[], ARRAY['public.usage_access_type', 'integer[]']::text[], -1, 0), ('function', ARRAY['public', 'usage_access_func_third']::text[], ARRAY['integer', 'integer[]']::text[], 0, 50), ('function', ARRAY['function_tests', 'notice']::text[], ARRAY['pg_catalog.text']::text[], -1, 0), ('function', ARRAY['function_tests', 'dup']::text[], ARRAY['pg_catalog.macaddr']::text[], 0, 52), ('function', ARRAY['function_tests', 'eq_with_param_names']::text[], ARRAY['pg_catalog.macaddr', 'pg_catalog.macaddr']::text[], 0, 52), ('function', ARRAY['function_tests', 'eq_mi''xed_param_names']::text[], ARRAY['pg_catalog.macaddr', 'pg_catalog.macaddr']::text[], -1, 0), ('function', ARRAY['function_tests', 'agg_sfunc']::text[], ARRAY['integer', 'integer']::text[], -1, 0), ('function', ARRAY['function_tests', 'agg_invfunc']::text[], ARRAY['integer', 'integer']::text[], -1, 0), ('function', ARRAY['function_tests', 'agg_finalfunc']::text[], ARRAY['integer', 'integer']::text[], -1, 0), ('aggregate', ARRAY['function_tests', 'my_rank']::text[], ARRAY['pg_catalog."any"']::text[], -1, 0), ('function', ARRAY['function_tests', 'agg_names_sfunc']::text[], ARRAY['function_tests.dup_result', 'function_tests.dup_result', 'function_tests.dup_result']::text[], -1, 0), ('function', ARRAY['function_tests', 'agg_names_finalfunc']::text[], ARRAY['function_tests.dup_result']::text[], -1, 0), ('aggregate', ARRAY['function_tests', 'agg_names']::text[], ARRAY['function_tests.dup_result', 'function_tests.dup_result']::text[], -1, 0), ('sequence', ARRAY['public', 'user_defined_seq']::text[], ARRAY[]::text[], -1, 0), ('role', ARRAY['postgres']::text[], ARRAY[]::text[], -1, 0), ('database', ARRAY['regression']::text[], ARRAY[]::text[], -1, 0), ('server', ARRAY['fake_fdw_server']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['public']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['mx_testing_schema']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['mx_testing_schema_2']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['mx_test_schema_1']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['mx_test_schema_2']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['schema_colocation']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['function_tests']::text[], ARRAY[]::text[], -1, 0), ('schema', ARRAY['function_tests2']::text[], ARRAY[]::text[], -1, 0), ('extension', ARRAY['plpgsql']::text[], ARRAY[]::text[], -1, 0)) SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex::int, colocationid::int) FROM distributed_object_data;
 (1 row)
@@ -635,12 +622,6 @@ SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', '$1'
 ERROR:  cannot colocate function "eq_with_param_names" and table "replicated_table_func_test"
 DETAIL:  Citus currently only supports colocating function with distributed tables that are created using streaming replication model.
 HINT:  When distributing tables make sure that citus.shard_replication_factor = 1
-SELECT public.wait_until_metadata_sync(30000);
- wait_until_metadata_sync
----------------------------------------------------------------------
-
-(1 row)
-
 -- a function can be colocated with a different distribution argument type
 -- as long as there is a coercion path
 SET citus.shard_replication_factor TO 1;
@@ -767,13 +748,6 @@ SET citus.shard_count TO 55;
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1');
 ERROR:  cannot distribute the function "eq_with_param_names" since there is no table to colocate with
 HINT:  Provide a distributed table via "colocate_with" option to create_distributed_function()
--- sync metadata to workers for consistent results when clearing objects
-SELECT public.wait_until_metadata_sync(30000);
- wait_until_metadata_sync
----------------------------------------------------------------------
-
-(1 row)
-
 SET citus.shard_replication_factor TO 1;
 SET citus.shard_count TO 4;
 CREATE TABLE test (id int, name text);
@@ -1121,5 +1095,13 @@ SELECT run_command_on_workers($$DROP USER functionuser$$);
 ---------------------------------------------------------------------
  (localhost,57637,t,"DROP ROLE")
  (localhost,57638,t,"DROP ROLE")
+(2 rows)
+
+-- sync metadata again
+SELECT start_metadata_sync_to_node(nodename,nodeport) FROM pg_dist_node WHERE isactive AND noderole = 'primary';
+ start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+
 (2 rows)
 

--- a/src/test/regress/expected/distributed_procedure.out
+++ b/src/test/regress/expected/distributed_procedure.out
@@ -20,19 +20,6 @@ BEGIN
     RAISE INFO 'information message %', $1;
 END;
 $proc$;
--- set sync intervals to less than 15s so wait_until_metadata_sync never times out
-ALTER SYSTEM SET citus.metadata_sync_interval TO 3000;
-ALTER SYSTEM SET citus.metadata_sync_retry_interval TO 500;
-SELECT pg_reload_conf();
- pg_reload_conf
----------------------------------------------------------------------
- t
-(1 row)
-
-CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
-    RETURNS void
-    LANGUAGE C STRICT
-    AS 'citus';
 -- procedures are distributed by text arguments, when run in isolation it is not guaranteed a table actually exists.
 CREATE TABLE colocation_table(id text);
 SET citus.shard_replication_factor TO 1;
@@ -44,12 +31,6 @@ SELECT create_distributed_table('colocation_table','id');
 
 SELECT create_distributed_function('raise_info(text)', '$1', colocate_with := 'colocation_table');
  create_distributed_function
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT wait_until_metadata_sync(30000);
- wait_until_metadata_sync
 ---------------------------------------------------------------------
 
 (1 row)
@@ -214,16 +195,4 @@ SELECT run_command_on_workers($$DROP USER procedureuser;$$);
  (localhost,57637,t,"DROP ROLE")
  (localhost,57638,t,"DROP ROLE")
 (2 rows)
-
-SELECT stop_metadata_sync_to_node('localhost', :worker_1_port);
- stop_metadata_sync_to_node
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT stop_metadata_sync_to_node('localhost', :worker_2_port);
- stop_metadata_sync_to_node
----------------------------------------------------------------------
-
-(1 row)
 

--- a/src/test/regress/expected/upgrade_distributed_function_before.out
+++ b/src/test/regress/expected/upgrade_distributed_function_before.out
@@ -25,19 +25,6 @@ SELECT create_distributed_function('count_values(int)', '$1', colocate_with:='t1
 
 (1 row)
 
--- make sure that the metadata synced before running the queries
-SELECT wait_until_metadata_sync(5000);
- wait_until_metadata_sync
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE isactive AND noderole = 'primary';
- bool_and
----------------------------------------------------------------------
- t
-(1 row)
-
 SET client_min_messages TO DEBUG1;
 SELECT count_values(11);
 DEBUG:  pushing down the function call

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -326,8 +326,12 @@ test: ssl_by_default
 test: distributed_types distributed_types_conflict disable_object_propagation distributed_types_xact_add_enum_value
 test: check_mx
 test: distributed_functions distributed_functions_conflict
-test: distributed_collations distributed_collations_conflict
+test: distributed_collations
 test: distributed_procedure
+
+# blocked on #5583
+test: turn_mx_off
+test: distributed_collations_conflict
 test: turn_mx_on
 
 # ---------

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -205,8 +205,6 @@ END;
 SELECT create_distributed_function('dup(macaddr)', '$1', colocate_with := 'streaming_table');
 SELECT * FROM run_command_on_workers($$SELECT function_tests.dup('0123456789ab');$$) ORDER BY 1,2;
 
-SELECT public.wait_until_metadata_sync(30000);
-
 SELECT create_distributed_function('eq(macaddr,macaddr)', '$1', colocate_with := 'streaming_table');
 SELECT * FROM run_command_on_workers($$SELECT function_tests.eq('012345689ab','0123456789ab');$$) ORDER BY 1,2;
 SELECT public.verify_function_is_same_on_workers('function_tests.eq(macaddr,macaddr)');
@@ -352,9 +350,6 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='eq_w
 -- valid distribution with distribution_arg_name
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', distribution_arg_name:='val1');
 
--- make sure that the primary nodes are now metadata synced
-select bool_and(hasmetadata) from pg_dist_node WHERE isactive AND  noderole = 'primary';
-
 -- make sure that both of the nodes have the function because we've succeeded
 SELECT run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname='eq_with_param_names';$$);
 
@@ -372,8 +367,6 @@ SET citus.shard_replication_factor TO 2;
 CREATE TABLE replicated_table_func_test (a macaddr);
 SELECT create_distributed_table('replicated_table_func_test', 'a');
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', '$1', colocate_with:='replicated_table_func_test');
-
-SELECT public.wait_until_metadata_sync(30000);
 
 -- a function can be colocated with a different distribution argument type
 -- as long as there is a coercion path
@@ -440,10 +433,6 @@ SELECT create_distributed_function('add_polygons(polygon,polygon)', '$1', coloca
 -- default colocation group
 SET citus.shard_count TO 55;
 SELECT create_distributed_function('eq_with_param_names(macaddr, macaddr)', 'val1');
-
--- sync metadata to workers for consistent results when clearing objects
-SELECT public.wait_until_metadata_sync(30000);
-
 
 SET citus.shard_replication_factor TO 1;
 SET citus.shard_count TO 4;
@@ -705,3 +694,6 @@ DROP SCHEMA function_tests2 CASCADE;
 
 DROP USER functionuser;
 SELECT run_command_on_workers($$DROP USER functionuser$$);
+
+-- sync metadata again
+SELECT start_metadata_sync_to_node(nodename,nodeport) FROM pg_dist_node WHERE isactive AND noderole = 'primary';

--- a/src/test/regress/sql/upgrade_distributed_function_before.sql
+++ b/src/test/regress/sql/upgrade_distributed_function_before.sql
@@ -18,9 +18,6 @@ $$
 $$ LANGUAGE plpgsql;
 SELECT create_distributed_function('count_values(int)', '$1', colocate_with:='t1');
 
--- make sure that the metadata synced before running the queries
-SELECT wait_until_metadata_sync(5000);
-SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE isactive AND noderole = 'primary';
 SET client_min_messages TO DEBUG1;
 
 SELECT count_values(11);


### PR DESCRIPTION
Before this commit, Citus was triggering metadata syncing
in the background when a function is distributed. However,
with Citus 11, we expect all clusters to have metadata synced
enabled. So, we do not expect any nodes not to have the metadata.

This change:
	(a) pro: simplifies the code and opens up possibilities
		 to simplify further by reducing the scope of
		 bg worker to only sync node metadata
        (b) pro: explicitly asks users to sync the metadata such that
  	    any unforeseen impact can be easily detected
        (c) con: For distributed functions without distribution
		argument, we do not necessarily require the metadata
		synced. However, for completeness and simplicity, we
		do so. This is a slight regression where users used to
                 be able to use `create_distributed_function` without 
                 parameters on nodes where metadata is not synced.
                 Now, they need to use `run_command_on_workers`
                to create the functions.

DESCRIPTION: Prevent creating distributed functions when there are out of sync nodes
