### PR TITLE
Make sure that the community and enterprise tests produce the same output

### DIFF
--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -1,14 +1,14 @@
 SET citus.next_shard_id TO 20020000;
+SET client_min_messages TO ERROR;
 CREATE USER functionuser;
-NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
-HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT run_command_on_workers($$CREATE USER functionuser;$$);
-      run_command_on_workers
+SELECT 1 FROM run_command_on_workers($$CREATE USER functionuser;$$);
+ ?column?
 ---------------------------------------------------------------------
- (localhost,57637,t,"CREATE ROLE")
- (localhost,57638,t,"CREATE ROLE")
+        1
+        1
 (2 rows)
 
+RESET client_min_messages;
 CREATE SCHEMA function_tests AUTHORIZATION functionuser;
 CREATE SCHEMA function_tests2 AUTHORIZATION functionuser;
 SET search_path TO function_tests;
@@ -1089,12 +1089,13 @@ SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA function_tests CASCADE;
 DROP SCHEMA function_tests2 CASCADE;
 \c - - - :master_port
+SET client_min_messages TO ERROR;
 DROP USER functionuser;
-SELECT run_command_on_workers($$DROP USER functionuser$$);
-     run_command_on_workers
+SELECT 1 FROM run_command_on_workers($$DROP USER functionuser$$);
+ ?column?
 ---------------------------------------------------------------------
- (localhost,57637,t,"DROP ROLE")
- (localhost,57638,t,"DROP ROLE")
+        1
+        1
 (2 rows)
 
 -- sync metadata again

--- a/src/test/regress/expected/distributed_procedure.out
+++ b/src/test/regress/expected/distributed_procedure.out
@@ -1,14 +1,14 @@
 SET citus.next_shard_id TO 20030000;
+SET client_min_messages TO ERROR;
 CREATE USER procedureuser;
-NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
-HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
-SELECT run_command_on_workers($$CREATE USER procedureuser;$$);
-      run_command_on_workers
+SELECT 1 FROM run_command_on_workers($$CREATE USER procedureuser;$$);
+ ?column?
 ---------------------------------------------------------------------
- (localhost,57637,t,"CREATE ROLE")
- (localhost,57638,t,"CREATE ROLE")
+        1
+        1
 (2 rows)
 
+RESET client_min_messages;
 CREATE SCHEMA procedure_tests AUTHORIZATION procedureuser;
 CREATE SCHEMA procedure_tests2 AUTHORIZATION procedureuser;
 SET search_path TO procedure_tests;
@@ -189,10 +189,10 @@ SELECT run_command_on_workers($$DROP SCHEMA procedure_tests2 CASCADE;$$);
 (2 rows)
 
 DROP USER procedureuser;
-SELECT run_command_on_workers($$DROP USER procedureuser;$$);
-     run_command_on_workers
+SELECT 1 FROM run_command_on_workers($$DROP USER procedureuser;$$);
+ ?column?
 ---------------------------------------------------------------------
- (localhost,57637,t,"DROP ROLE")
- (localhost,57638,t,"DROP ROLE")
+        1
+        1
 (2 rows)
 

--- a/src/test/regress/sql/distributed_functions.sql
+++ b/src/test/regress/sql/distributed_functions.sql
@@ -1,7 +1,9 @@
 SET citus.next_shard_id TO 20020000;
 
+SET client_min_messages TO ERROR;
 CREATE USER functionuser;
-SELECT run_command_on_workers($$CREATE USER functionuser;$$);
+SELECT 1 FROM run_command_on_workers($$CREATE USER functionuser;$$);
+RESET client_min_messages;
 
 CREATE SCHEMA function_tests AUTHORIZATION functionuser;
 CREATE SCHEMA function_tests2 AUTHORIZATION functionuser;
@@ -692,8 +694,9 @@ DROP SCHEMA function_tests CASCADE;
 DROP SCHEMA function_tests2 CASCADE;
 \c - - - :master_port
 
+SET client_min_messages TO ERROR;
 DROP USER functionuser;
-SELECT run_command_on_workers($$DROP USER functionuser$$);
+SELECT 1 FROM run_command_on_workers($$DROP USER functionuser$$);
 
 -- sync metadata again
 SELECT start_metadata_sync_to_node(nodename,nodeport) FROM pg_dist_node WHERE isactive AND noderole = 'primary';

--- a/src/test/regress/sql/distributed_procedure.sql
+++ b/src/test/regress/sql/distributed_procedure.sql
@@ -1,7 +1,9 @@
 SET citus.next_shard_id TO 20030000;
 
+SET client_min_messages TO ERROR;
 CREATE USER procedureuser;
-SELECT run_command_on_workers($$CREATE USER procedureuser;$$);
+SELECT 1 FROM run_command_on_workers($$CREATE USER procedureuser;$$);
+RESET client_min_messages;
 
 CREATE SCHEMA procedure_tests AUTHORIZATION procedureuser;
 CREATE SCHEMA procedure_tests2 AUTHORIZATION procedureuser;
@@ -81,5 +83,5 @@ SELECT run_command_on_workers($$DROP SCHEMA procedure_tests CASCADE;$$);
 DROP SCHEMA procedure_tests2 CASCADE;
 SELECT run_command_on_workers($$DROP SCHEMA procedure_tests2 CASCADE;$$);
 DROP USER procedureuser;
-SELECT run_command_on_workers($$DROP USER procedureuser;$$);
+SELECT 1 FROM run_command_on_workers($$DROP USER procedureuser;$$);
 


### PR DESCRIPTION
The community and enterprise differs in role management. We should make the tests produce the same output so that we don't have to deal with weird test differences.