### PR TITLE
Fix the default value for DeferShardDeleteOnMove

### DIFF
--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -112,7 +112,7 @@ PG_FUNCTION_INFO_V1(master_copy_shard_placement);
 PG_FUNCTION_INFO_V1(citus_move_shard_placement);
 PG_FUNCTION_INFO_V1(master_move_shard_placement);
 
-bool DeferShardDeleteOnMove = false;
+bool DeferShardDeleteOnMove = true;
 
 double DesiredPercentFreeAfterMove = 10;
 bool CheckAvailableSpaceBeforeMove = true;


### PR DESCRIPTION
The default for GUC citus.defer_drop_after_shard_move is true. However
we initialize the global variable with a false value.

See the GUC definition at https://github.com/citusdata/citus/blob/afd53e4c54c17aea3d858eb1f06be4c7e20c35d4/src/backend/distributed/shared_library_init.c#L661-L678