### PR TITLE
Enable MX for multi_row_router_insert test

### DIFF
--- a/src/test/regress/expected/multi_row_router_insert.out
+++ b/src/test/regress/expected/multi_row_router_insert.out
@@ -70,6 +70,12 @@ CREATE OR REPLACE FUNCTION square(a INT) RETURNS INT AS $$
 BEGIN
     RETURN a*a;
 END; $$ LANGUAGE PLPGSQL STABLE;
+SELECT create_distributed_function('square(int)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
 CREATE TABLE citus_local_table(a int, b int DEFAULT square(10));
 SELECT citus_add_local_table_to_metadata('citus_local_table');
  citus_add_local_table_to_metadata

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -278,8 +278,9 @@ test: foreign_key_to_reference_table
 test: replicate_reference_tables_to_coordinator
 test: turn_mx_off
 test: citus_local_tables
-test: multi_row_router_insert mixed_relkind_tests
+test: mixed_relkind_tests
 test: turn_mx_on
+test: multi_row_router_insert
 test: multi_reference_table citus_local_tables_queries
 test: citus_local_table_triggers
 test: coordinator_shouldhaveshards

--- a/src/test/regress/sql/multi_row_router_insert.sql
+++ b/src/test/regress/sql/multi_row_router_insert.sql
@@ -37,7 +37,7 @@ CREATE OR REPLACE FUNCTION square(a INT) RETURNS INT AS $$
 BEGIN
     RETURN a*a;
 END; $$ LANGUAGE PLPGSQL STABLE;
-
+SELECT create_distributed_function('square(int)');
 CREATE TABLE citus_local_table(a int, b int DEFAULT square(10));
 SELECT citus_add_local_table_to_metadata('citus_local_table');
 


### PR DESCRIPTION
Convert the function to a distributed function so that when metadata is synced, the table is on the worker

