### PR TITLE
Fix a flaky test related with temp columnar table cleanup

### DIFF
--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -77,18 +77,17 @@ INSERT INTO columnar_temp SELECT i FROM generate_series(1,5) i;
 SELECT columnar_test_helpers.columnar_relation_storageid(oid) AS columnar_temp_storage_id
 FROM pg_class WHERE relname='columnar_temp' \gset
 \c - - - :master_port
--- Show that temporary table itself and it's metadata is removed, or
--- table isn't dropped yet and metadata records do also persist.
---
--- This might happen since \c doesn't guarantee immediate cleanup of
--- all the resources.
-SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id)=q.pg_class_has_table
-FROM (
-  SELECT count(*)!=0 AS pg_class_has_table FROM pg_class WHERE relname='columnar_temp'
-) q;
+-- show that temporary table itself and it's metadata is removed
+SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';
  ?column?
 ---------------------------------------------------------------------
  t
+(1 row)
+
+SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id);
+ columnar_metadata_has_storage_id
+---------------------------------------------------------------------
+ f
 (1 row)
 
 -- connect to another session and create a temp table with same name

--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -79,12 +79,12 @@ FROM pg_class WHERE relname='columnar_temp' \gset
 SELECT pg_backend_pid() AS val INTO old_backend_pid;
 \c - - - :master_port
 -- wait until old backend to expire to make sure that temp table cleanup is complete
-DO $$ BEGIN
-  WHILE EXISTS (SELECT * FROM pg_stat_activity WHERE pid IN (SELECT val FROM old_backend_pid))
-  LOOP
-    PERFORM pg_sleep(0.001);
-  END LOOP;
-END $$;
+SELECT columnar_test_helpers.pg_waitpid(val) FROM old_backend_pid;
+ pg_waitpid
+---------------------------------------------------------------------
+
+(1 row)
+
 DROP TABLE old_backend_pid;
 -- show that temporary table itself and it's metadata is removed
 SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';

--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -76,7 +76,16 @@ CREATE TEMPORARY TABLE columnar_temp(i int) USING columnar;
 INSERT INTO columnar_temp SELECT i FROM generate_series(1,5) i;
 SELECT columnar_test_helpers.columnar_relation_storageid(oid) AS columnar_temp_storage_id
 FROM pg_class WHERE relname='columnar_temp' \gset
+SELECT pg_backend_pid() AS val INTO old_backend_pid;
 \c - - - :master_port
+-- wait until old backend to expire to make sure that temp table cleanup is complete
+DO $$ BEGIN
+  WHILE EXISTS (SELECT * FROM pg_stat_activity WHERE pid IN (SELECT val FROM old_backend_pid))
+  LOOP
+    PERFORM pg_sleep(0.001);
+  END LOOP;
+END $$;
+DROP TABLE old_backend_pid;
 -- show that temporary table itself and it's metadata is removed
 SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';
  ?column?

--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -77,17 +77,18 @@ INSERT INTO columnar_temp SELECT i FROM generate_series(1,5) i;
 SELECT columnar_test_helpers.columnar_relation_storageid(oid) AS columnar_temp_storage_id
 FROM pg_class WHERE relname='columnar_temp' \gset
 \c - - - :master_port
--- show that temporary table itself and it's metadata is removed
-SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';
+-- Show that temporary table itself and it's metadata is removed, or
+-- table isn't dropped yet and metadata records do also persist.
+--
+-- This might happen since \c doesn't guarantee immediate cleanup of
+-- all the resources.
+SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id)=q.pg_class_has_table
+FROM (
+  SELECT count(*)!=0 AS pg_class_has_table FROM pg_class WHERE relname='columnar_temp'
+) q;
  ?column?
 ---------------------------------------------------------------------
  t
-(1 row)
-
-SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id);
- columnar_metadata_has_storage_id
----------------------------------------------------------------------
- f
 (1 row)
 
 -- connect to another session and create a temp table with same name

--- a/src/test/regress/expected/columnar_test_helpers.out
+++ b/src/test/regress/expected/columnar_test_helpers.out
@@ -117,3 +117,11 @@ BEGIN
   END LOOP;
   RETURN false;
 END; $$ language plpgsql;
+CREATE OR REPLACE FUNCTION pg_waitpid(p_pid integer)
+RETURNS VOID AS $$
+BEGIN
+  WHILE EXISTS (SELECT * FROM pg_stat_activity WHERE pid=p_pid)
+  LOOP
+    PERFORM pg_sleep(0.001);
+  END LOOP;
+END; $$ language plpgsql;

--- a/src/test/regress/sql/columnar_create.sql
+++ b/src/test/regress/sql/columnar_create.sql
@@ -68,12 +68,7 @@ SELECT pg_backend_pid() AS val INTO old_backend_pid;
 \c - - - :master_port
 
 -- wait until old backend to expire to make sure that temp table cleanup is complete
-DO $$ BEGIN
-  WHILE EXISTS (SELECT * FROM pg_stat_activity WHERE pid IN (SELECT val FROM old_backend_pid))
-  LOOP
-    PERFORM pg_sleep(0.001);
-  END LOOP;
-END $$;
+SELECT columnar_test_helpers.pg_waitpid(val) FROM old_backend_pid;
 
 DROP TABLE old_backend_pid;
 

--- a/src/test/regress/sql/columnar_create.sql
+++ b/src/test/regress/sql/columnar_create.sql
@@ -65,15 +65,9 @@ FROM pg_class WHERE relname='columnar_temp' \gset
 
 \c - - - :master_port
 
--- Show that temporary table itself and it's metadata is removed, or
--- table isn't dropped yet and metadata records do also persist.
---
--- This might happen since \c doesn't guarantee immediate cleanup of
--- all the resources.
-SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id)=q.pg_class_has_table
-FROM (
-  SELECT count(*)!=0 AS pg_class_has_table FROM pg_class WHERE relname='columnar_temp'
-) q;
+-- show that temporary table itself and it's metadata is removed
+SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';
+SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id);
 
 -- connect to another session and create a temp table with same name
 CREATE TEMPORARY TABLE columnar_temp(i int) USING columnar;

--- a/src/test/regress/sql/columnar_create.sql
+++ b/src/test/regress/sql/columnar_create.sql
@@ -65,9 +65,15 @@ FROM pg_class WHERE relname='columnar_temp' \gset
 
 \c - - - :master_port
 
--- show that temporary table itself and it's metadata is removed
-SELECT COUNT(*)=0 FROM pg_class WHERE relname='columnar_temp';
-SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id);
+-- Show that temporary table itself and it's metadata is removed, or
+-- table isn't dropped yet and metadata records do also persist.
+--
+-- This might happen since \c doesn't guarantee immediate cleanup of
+-- all the resources.
+SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_storage_id)=q.pg_class_has_table
+FROM (
+  SELECT count(*)!=0 AS pg_class_has_table FROM pg_class WHERE relname='columnar_temp'
+) q;
 
 -- connect to another session and create a temp table with same name
 CREATE TEMPORARY TABLE columnar_temp(i int) USING columnar;

--- a/src/test/regress/sql/columnar_test_helpers.sql
+++ b/src/test/regress/sql/columnar_test_helpers.sql
@@ -127,3 +127,12 @@ BEGIN
   END LOOP;
   RETURN false;
 END; $$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION pg_waitpid(p_pid integer)
+RETURNS VOID AS $$
+BEGIN
+  WHILE EXISTS (SELECT * FROM pg_stat_activity WHERE pid=p_pid)
+  LOOP
+    PERFORM pg_sleep(0.001);
+  END LOOP;
+END; $$ language plpgsql;


### PR DESCRIPTION
Related https://github.com/citusdata/citus/issues/5569.

Wait until old backend to expire to make sure that temp
table cleanup is complete.