### PR TITLE
Require superuser while activating a node

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -368,8 +368,12 @@ ReplicateAllDependenciesToNode(const char *nodeName, int nodePort)
 	/* since we are executing ddl commands lets disable propagation, primarily for mx */
 	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
-	SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
-											  CitusExtensionOwnerName(), ddlCommands);
+	/* send commands to new workers, the current user should a superuser */
+	Assert(superuser());
+	SendMetadataCommandListToWorkerInCoordinatedTransaction(nodeName,
+															nodePort,
+															CurrentUserName(),
+															ddlCommands);
 }
 
 

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -858,7 +858,9 @@ ActivateNode(char *nodeName, int nodePort)
 	 * propagation.
 	 *
 	 * In order to have a fully transactional semantics with add/activate
-	 * node operations, we require superuser. With that, we can guarantee
+	 * node operations, we require superuser. Note that for creating
+	 * non-owned objects, we already require a superuser connection.
+	 * By ensuring the current user to be a superuser, we can guarantee
 	 * to send all commands within the same remote transaction.
 	 */
 	EnsureSuperUser();

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -270,16 +270,11 @@ ERROR:  permission denied for function master_update_node
 -- try to manipulate node metadata via privileged user
 SET ROLE node_metadata_user;
 SET citus.enable_object_propagation TO off; -- prevent master activate node to actually connect for this test
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ERROR:  operation is not allowed
+HINT:  Run the command with a superuser.
 BEGIN;
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
- ?column?
----------------------------------------------------------------------
-        1
-(1 row)
-
-SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
-WARNING:  citus.enable_object_propagation is off, not creating distributed objects on worker
-DETAIL:  distributed objects are only kept in sync when citus.enable_object_propagation is set to on. Newly activated nodes will not get these objects created
  ?column?
 ---------------------------------------------------------------------
         1
@@ -291,15 +286,7 @@ SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
         1
 (1 row)
 
-SELECT 1 FROM master_add_node('localhost', :worker_2_port);
-WARNING:  citus.enable_object_propagation is off, not creating distributed objects on worker
-DETAIL:  distributed objects are only kept in sync when citus.enable_object_propagation is set to on. Newly activated nodes will not get these objects created
- ?column?
----------------------------------------------------------------------
-        1
-(1 row)
-
-SELECT 1 FROM master_add_secondary_node('localhost', :worker_2_port + 2, 'localhost', :worker_2_port);
+SELECT 1 FROM master_add_secondary_node('localhost', :worker_2_port + 2, 'localhost', :worker_1_port);
  ?column?
 ---------------------------------------------------------------------
         1
@@ -308,16 +295,14 @@ SELECT 1 FROM master_add_secondary_node('localhost', :worker_2_port + 2, 'localh
 SELECT master_update_node(nodeid, 'localhost', :worker_2_port + 3) FROM pg_dist_node WHERE nodeport = :worker_2_port;
  master_update_node
 ---------------------------------------------------------------------
-
-(1 row)
+(0 rows)
 
 SELECT nodename, nodeport, noderole FROM pg_dist_node ORDER BY nodeport;
  nodename  | nodeport | noderole
 ---------------------------------------------------------------------
  localhost |    57637 | primary
  localhost |    57640 | secondary
- localhost |    57641 | primary
-(3 rows)
+(2 rows)
 
 ABORT;
 \c - postgres - :master_port

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -126,12 +126,11 @@ SELECT master_update_node(nodeid, 'localhost', :worker_2_port + 3) FROM pg_dist_
 -- try to manipulate node metadata via privileged user
 SET ROLE node_metadata_user;
 SET citus.enable_object_propagation TO off; -- prevent master activate node to actually connect for this test
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 BEGIN;
 SELECT 1 FROM master_add_inactive_node('localhost', :worker_2_port);
-SELECT 1 FROM master_activate_node('localhost', :worker_2_port);
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
-SELECT 1 FROM master_add_node('localhost', :worker_2_port);
-SELECT 1 FROM master_add_secondary_node('localhost', :worker_2_port + 2, 'localhost', :worker_2_port);
+SELECT 1 FROM master_add_secondary_node('localhost', :worker_2_port + 2, 'localhost', :worker_1_port);
 SELECT master_update_node(nodeid, 'localhost', :worker_2_port + 3) FROM pg_dist_node WHERE nodeport = :worker_2_port;
 SELECT nodename, nodeport, noderole FROM pg_dist_node ORDER BY nodeport;
 ABORT;


### PR DESCRIPTION
DESCRIPTION: Require superuser for citus_add_node()/citus_activate_node()

With this change, we require ActiveNode() (hence citus_add_node(),
citus_activate_node()) explicitly require for a superuser.

Before this commit, these functions were designed to work with
non-superuser roles with the relevant GRANTs given.

However, that is not a widely used way for calling the functions
above.

Due to possibility of non-super user calling the UDFs, they were
designed in a way that some commands were using some additional
short-lived superuser connections. That is:
	(a) breaking transactional behavior (e.g., ROLLBACK
 	    wouldn't fully rollback the whole transaction)
        (b) Making it very complicated to reason about which
	    parts of the node activation goes over which connections,
	    and becoming vulnerable to deadlocks / visibility issues.

