### PR TITLE
Add missing library to dependencies.c

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -23,6 +23,7 @@
 #include "distributed/remote_commands.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
+#include "miscadmin.h"
 #include "storage/lmgr.h"
 #include "utils/lsyscache.h"
 


### PR DESCRIPTION
This missing header causes build to fail.