### PR TITLE
Making Columnar Dependency Free from Citus

### DIFF
--- a/src/backend/columnar/columnar_debug.c
+++ b/src/backend/columnar/columnar_debug.c
@@ -53,7 +53,7 @@ columnar_store_memory_stats(PG_FUNCTION_ARGS)
 					   INT8OID, -1, 0);
 	TupleDescInitEntry(tupleDescriptor, (AttrNumber) 3, "WriteStateContext",
 					   INT8OID, -1, 0);
-	
+
 	tupleDescriptor = BlessTupleDesc(tupleDescriptor);
 
 	MemoryContextCounters transactionCounters = { 0 };
@@ -69,7 +69,7 @@ columnar_store_memory_stats(PG_FUNCTION_ARGS)
 		Int64GetDatum(transactionCounters.totalspace),
 		Int64GetDatum(writeStateCounters.totalspace)
 	};
-	
+
 	HeapTuple tuple = heap_form_tuple(tupleDescriptor, values, nulls);
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(tuple));

--- a/src/backend/columnar/columnar_debug.c
+++ b/src/backend/columnar/columnar_debug.c
@@ -10,13 +10,13 @@
 
 #include "postgres.h"
 
+#include "funcapi.h"
 #include "pg_config.h"
 #include "access/nbtree.h"
 #include "access/table.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_type.h"
 #include "distributed/pg_version_constants.h"
-#include "distributed/tuplestore.h"
 #include "miscadmin.h"
 #include "storage/fd.h"
 #include "storage/smgr.h"
@@ -53,6 +53,8 @@ columnar_store_memory_stats(PG_FUNCTION_ARGS)
 					   INT8OID, -1, 0);
 	TupleDescInitEntry(tupleDescriptor, (AttrNumber) 3, "WriteStateContext",
 					   INT8OID, -1, 0);
+	
+	tupleDescriptor = BlessTupleDesc(tupleDescriptor);
 
 	MemoryContextCounters transactionCounters = { 0 };
 	MemoryContextCounters topCounters = { 0 };
@@ -67,10 +69,10 @@ columnar_store_memory_stats(PG_FUNCTION_ARGS)
 		Int64GetDatum(transactionCounters.totalspace),
 		Int64GetDatum(writeStateCounters.totalspace)
 	};
+	
+	HeapTuple tuple = heap_form_tuple(tupleDescriptor, values, nulls);
 
-	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
-	tuplestore_putvalues(tupleStore, tupleDescriptor, values, nulls);
-	PG_RETURN_DATUM(0);
+	PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
 }
 
 

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -42,7 +42,6 @@
 #include "commands/defrem.h"
 #include "commands/sequence.h"
 #include "commands/trigger.h"
-#include "distributed/metadata_cache.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "miscadmin.h"

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2095,7 +2095,8 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 		IndexStmt *indexStmt = (IndexStmt *) parsetree;
 
 		Relation rel = relation_openrv(indexStmt->relation,
-		indexStmt->concurrent ? ShareUpdateExclusiveLock : ShareLock);
+									   indexStmt->concurrent ? ShareUpdateExclusiveLock :
+									   ShareLock);
 
 		if (rel->rd_tableam == GetColumnarTableAmRoutine())
 		{

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -54,7 +54,6 @@
 #include "columnar/columnar_storage.h"
 #include "columnar/columnar_tableam.h"
 #include "columnar/columnar_version_compat.h"
-#include "distributed/commands.h"
 #include "distributed/commands/utility_hook.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
@@ -2098,7 +2097,8 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 		IndexStmt *indexStmt = (IndexStmt *) parsetree;
 
 		Relation rel = relation_openrv(indexStmt->relation,
-									   GetCreateIndexRelationLockMode(indexStmt));
+		indexStmt->concurrent ? ShareUpdateExclusiveLock : ShareLock);
+
 		if (rel->rd_tableam == GetColumnarTableAmRoutine())
 		{
 			CheckCitusVersion(ERROR);

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -32,6 +32,7 @@
 #include "nodes/makefuncs.h"
 #include "optimizer/plancat.h"
 #include "pgstat.h"
+#include "safe_lib.h"
 #include "storage/bufmgr.h"
 #include "storage/bufpage.h"
 #include "storage/bufmgr.h"
@@ -48,15 +49,12 @@
 #include "utils/relcache.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
-
 #include "columnar/columnar.h"
 #include "columnar/columnar_customscan.h"
 #include "columnar/columnar_storage.h"
 #include "columnar/columnar_tableam.h"
 #include "columnar/columnar_version_compat.h"
-#include "distributed/commands/utility_hook.h"
 #include "distributed/listutils.h"
-#include "distributed/metadata_cache.h"
 
 /*
  * Timing parameters for truncate locking heuristics.

--- a/src/test/regress/expected/columnar_test_helpers.out
+++ b/src/test/regress/expected/columnar_test_helpers.out
@@ -67,10 +67,11 @@ BEGIN
    RETURN false;
 END;
 $$ LANGUAGE plpgsql;
-CREATE OR REPLACE FUNCTION columnar_store_memory_stats()
-    RETURNS TABLE(TopMemoryContext BIGINT,
-				  TopTransactionContext BIGINT,
-				  WriteStateContext BIGINT)
+CREATE OR REPLACE FUNCTION columnar_store_memory_stats(
+                  OUT TopMemoryContext BIGINT,
+		          OUT TopTransactionContext BIGINT,
+		          OUT WriteStateContext BIGINT)
+    RETURNS RECORD
     LANGUAGE C STRICT VOLATILE
     AS 'citus', $$columnar_store_memory_stats$$;
 CREATE FUNCTION top_memory_context_usage()

--- a/src/test/regress/sql/columnar_test_helpers.sql
+++ b/src/test/regress/sql/columnar_test_helpers.sql
@@ -73,10 +73,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION columnar_store_memory_stats()
-    RETURNS TABLE(TopMemoryContext BIGINT,
-				  TopTransactionContext BIGINT,
-				  WriteStateContext BIGINT)
+CREATE OR REPLACE FUNCTION columnar_store_memory_stats(
+                  OUT TopMemoryContext BIGINT,
+		  OUT TopTransactionContext BIGINT,
+		  OUT WriteStateContext BIGINT)
+    RETURNS RECORD
     LANGUAGE C STRICT VOLATILE
     AS 'citus', $$columnar_store_memory_stats$$;
 


### PR DESCRIPTION
Made all files in columnar directory to be dependency free from Citus by removing most header files that were in the distributed directory. Any that remain should not cause a dependency problem.

To remove distributed/tuplestore from Columnar_debug.c, I changed columnar_store_memory_stats() to return a record rather than a tuple store.