### PR TITLE
Not fail over to local execution when it's not supported

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -302,6 +302,12 @@ typedef struct DistributedExecution
 	 */
 	List *jobIdList;
 
+	/*
+	 * Indicates whether we can execute tasks locally during distributed
+	 * execution. In other words, this flag must be set to false when
+	 * executing a command that we surely know that local execution would
+	 * fail, such as CREATE INDEX CONCURRENTLY.
+	 */
 	bool localExecutionSupported;
 } DistributedExecution;
 
@@ -548,6 +554,11 @@ typedef struct ShardCommandExecution
 
 	TaskExecutionState executionState;
 
+	/*
+	 * Indicates whether given shard command can be executed locally on
+	 * placements. Should be inherited from DistributedExecution for the
+	 * shard level execution.
+	 */
 	bool localExecutionSupported;
 } ShardCommandExecution;
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1268,16 +1268,6 @@ DecideTransactionPropertiesForTaskList(RowModifyLevel modLevel, List *taskList, 
 void
 StartDistributedExecution(DistributedExecution *execution)
 {
-	if (!execution->localExecutionSupported)
-	{
-		/*
-		 * Later we may decide failing over to local execution if remote
-		 * execution fails for some reason. However, we shouldn't do that if
-		 * caller told us to avoid from local execution.
-		 */
-		ErrorIfTransactionAccessedPlacementsLocally();
-	}
-
 	TransactionProperties *xactProperties = execution->transactionProperties;
 
 	if (xactProperties->useRemoteTransactionBlocks == TRANSACTION_BLOCKS_REQUIRED)

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -556,8 +556,7 @@ typedef struct ShardCommandExecution
 
 	/*
 	 * Indicates whether given shard command can be executed locally on
-	 * placements. Should be inherited from DistributedExecution for the
-	 * shard level execution.
+	 * placements. Normally determined by DistributedExecution's same field.
 	 */
 	bool localExecutionSupported;
 } ShardCommandExecution;
@@ -2863,14 +2862,15 @@ ManageWorkerPool(WorkerPool *workerPool)
 		{
 			const char *errHint =
 				execution->localExecutionSupported ?
-				"Consider enabling local execution using SET "
-				"citus.enable_local_execution TO true;" :
+				"This command supports local execution. Consider enabling "
+				"local execution using SET citus.enable_local_execution "
+				"TO true;" :
 				"Consider using a higher value for max_connections";
 
 			ereport(ERROR, (errcode(ERRCODE_CONNECTION_FAILURE),
-							errmsg("could not establish any connections to the "
-								   "node %s:%d due to high number connections",
-								   workerPool->nodeName, workerPool->nodePort),
+							errmsg("the total number of connections on the "
+								   "server is more than max_connections(%d)",
+								   MaxConnections),
 							errhint("%s", errHint)));
 		}
 

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -5,6 +5,8 @@ SET citus.shard_replication_factor TO 1;
 SET citus.next_shard_id TO 90630500;
 -- Ensure tuple data in explain analyze output is the same on all PG versions
 SET citus.enable_binary_protocol = TRUE;
+-- do not cache any connections for now, will enable it back soon
+ALTER SYSTEM SET citus.max_cached_conns_per_worker TO 0;
 -- adding the coordinator as inactive is disallowed
 SELECT 1 FROM master_add_inactive_node('localhost', :master_port, groupid => 0);
 ERROR:  coordinator node cannot be added as inactive node
@@ -33,6 +35,49 @@ SELECT count(*) FROM pg_dist_node;
 (1 row)
 
 -- there are no workers now, but we should still be able to create Citus tables
+-- force local execution when creating the index
+ALTER SYSTEM SET citus.local_shared_pool_size TO -1;
+-- Postmaster might not ack SIGHUP signal sent by pg_reload_conf() immediately,
+-- so we need to sleep for some amount of time to do our best to ensure that
+-- postmaster reflects GUC changes.
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE failover_to_local (a int);
+SELECT create_distributed_table('failover_to_local', 'a', shard_count=>32);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE INDEX CONCURRENTLY ON failover_to_local(a);
+WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
+ Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider using a higher value for max_connections
+-- reset global GUC changes
+ALTER SYSTEM RESET citus.local_shared_pool_size;
+ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
+SELECT pg_reload_conf();
+ pg_reload_conf
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SET client_min_messages TO WARNING;
+DROP TABLE failover_to_local;
+RESET client_min_messages;
+-- so that we don't have to update rest of the test output
+SET citus.next_shard_id TO 90630500;
 CREATE TABLE ref(x int, y int);
 SELECT create_reference_table('ref');
  create_reference_table
@@ -2163,24 +2208,24 @@ NOTICE:  executing the command locally: WITH cte_1 AS (UPDATE single_node.anothe
 -- local execution and the queries would fail
 SET citus.enable_local_execution TO  false;
 SELECT count(*) from another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 UPDATE another_schema_table SET b = b;
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table SELECT * FROM another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table SELECT b::int, a::int FROM another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 WITH cte_1 AS (SELECT * FROM another_schema_table LIMIT 1000)
 	SELECT count(*) FROM cte_1;
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table VALUES (1,1), (2,2), (3,3), (4,4), (5,5),(6,6),(7,7);
-ERROR:  could not establish any connections to the node localhost:xxxxx when local execution is also disabled.
-HINT:  Enable local execution via SET citus.enable_local_execution TO true;
+ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
 -- copy fails if local execution is disabled and there is no connection slot
 COPY another_schema_table(a) FROM PROGRAM 'seq 32';
 ERROR:  could not find an available connection

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -62,7 +62,7 @@ SELECT create_distributed_table('failover_to_local', 'a', shard_count=>32);
 CREATE INDEX CONCURRENTLY ON failover_to_local(a);
 WARNING:  CONCURRENTLY-enabled index commands can fail partially, leaving behind an INVALID index.
  Use DROP INDEX CONCURRENTLY IF EXISTS to remove the invalid index.
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
+ERROR:  the total number of connections on the server is more than max_connections(100)
 HINT:  Consider using a higher value for max_connections
 -- reset global GUC changes
 ALTER SYSTEM RESET citus.local_shared_pool_size;
@@ -2208,24 +2208,24 @@ NOTICE:  executing the command locally: WITH cte_1 AS (UPDATE single_node.anothe
 -- local execution and the queries would fail
 SET citus.enable_local_execution TO  false;
 SELECT count(*) from another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 UPDATE another_schema_table SET b = b;
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table SELECT * FROM another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table SELECT b::int, a::int FROM another_schema_table;
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 WITH cte_1 AS (SELECT * FROM another_schema_table LIMIT 1000)
 	SELECT count(*) FROM cte_1;
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 INSERT INTO another_schema_table VALUES (1,1), (2,2), (3,3), (4,4), (5,5),(6,6),(7,7);
-ERROR:  could not establish any connections to the node localhost:xxxxx due to high number connections
-HINT:  Consider enabling local execution using SET citus.enable_local_execution TO true;
+ERROR:  the total number of connections on the server is more than max_connections(100)
+HINT:  This command supports local execution. Consider enabling local execution using SET citus.enable_local_execution TO true;
 -- copy fails if local execution is disabled and there is no connection slot
 COPY another_schema_table(a) FROM PROGRAM 'seq 32';
 ERROR:  could not find an available connection


### PR DESCRIPTION
Fixes https://github.com/citusdata/citus/issues/5624.

DESCRIPTION: Prevents failing over to local execution for DDL's that cannot be executed locally

We fall back to local execution if we cannot establish any more
connections to local node. However, we should not do that for the
commands that we don't know how to execute locally (or we know we
shouldn't execute locally). To fix that, we take `localExecutionSupported`
take into account in `CanFailoverPlacementExecutionToLocalExecution` too.

Moreover, we also prompt a more accurate hint message to inform user
about whether the execution is failed because local execution is
disabled by them, or because local execution wasn't possible for given
command.