### PR TITLE
Drop ruleutils copied for triggers & statistics

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -103,7 +103,6 @@
 /* Pretty flags */
 #define PRETTYFLAG_PAREN		0x0001
 #define PRETTYFLAG_INDENT		0x0002
-#define PRETTYFLAG_SCHEMA		0x0004
 
 /* Default line length for pretty-print wrapping: 0 means wrap always */
 #define WRAP_COLUMN_DEFAULT		0
@@ -111,7 +110,6 @@
 /* macros to test if pretty action needed */
 #define PRETTY_PAREN(context)	((context)->prettyFlags & PRETTYFLAG_PAREN)
 #define PRETTY_INDENT(context)	((context)->prettyFlags & PRETTYFLAG_INDENT)
-#define PRETTY_SCHEMA(context)	((context)->prettyFlags & PRETTYFLAG_SCHEMA)
 
 
 /* ----------
@@ -430,8 +428,6 @@ static void get_from_clause_coldeflist(RangeTblFunction *rtfunc,
 static void get_tablesample_def(TableSampleClause *tablesample,
 					deparse_context *context);
 char *pg_get_statisticsobj_worker(Oid statextid, bool missing_ok);
-static char *pg_get_triggerdef_worker(Oid trigid, bool pretty);
-static void set_simple_column_names(deparse_namespace *dpns);
 static void get_opclass_name(Oid opclass, Oid actual_datatype,
 				 StringInfo buf);
 static Node *processIndirection(Node *node, deparse_context *context);
@@ -7519,16 +7515,6 @@ get_tablesample_def(TableSampleClause *tablesample, deparse_context *context)
 	}
 }
 
-char *
-pg_get_triggerdef_command(Oid triggerId)
-{
-	Assert(OidIsValid(triggerId));
-
-	/* no need to have pretty SQL command */
-	bool prettyOutput = false;
-	return pg_get_triggerdef_worker(triggerId, prettyOutput);
-}
-
 
 char *
 pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
@@ -7650,297 +7636,6 @@ pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
 	return buf.data;
 }
 
-
-static char *
-pg_get_triggerdef_worker(Oid trigid, bool pretty)
-{
-	HeapTuple	ht_trig;
-	Form_pg_trigger trigrec;
-	StringInfoData buf;
-	Relation	tgrel;
-	ScanKeyData skey[1];
-	SysScanDesc tgscan;
-	int			findx = 0;
-	char	   *tgname;
-	char	   *tgoldtable;
-	char	   *tgnewtable;
-	Oid			argtypes[1];	/* dummy */
-	Datum		value;
-	bool		isnull;
-
-	/*
-	 * Fetch the pg_trigger tuple by the Oid of the trigger
-	 */
-	tgrel = table_open(TriggerRelationId, AccessShareLock);
-
-	ScanKeyInit(&skey[0],
-				Anum_pg_trigger_oid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(trigid));
-
-	tgscan = systable_beginscan(tgrel, TriggerOidIndexId, true,
-								NULL, 1, skey);
-
-	ht_trig = systable_getnext(tgscan);
-
-	if (!HeapTupleIsValid(ht_trig))
-	{
-		systable_endscan(tgscan);
-		table_close(tgrel, AccessShareLock);
-		return NULL;
-	}
-
-	trigrec = (Form_pg_trigger) GETSTRUCT(ht_trig);
-
-	/*
-	 * Start the trigger definition. Note that the trigger's name should never
-	 * be schema-qualified, but the trigger rel's name may be.
-	 */
-	initStringInfo(&buf);
-
-	tgname = NameStr(trigrec->tgname);
-	appendStringInfo(&buf, "CREATE %sTRIGGER %s ",
-					 OidIsValid(trigrec->tgconstraint) ? "CONSTRAINT " : "",
-					 quote_identifier(tgname));
-
-	if (TRIGGER_FOR_BEFORE(trigrec->tgtype))
-		appendStringInfoString(&buf, "BEFORE");
-	else if (TRIGGER_FOR_AFTER(trigrec->tgtype))
-		appendStringInfoString(&buf, "AFTER");
-	else if (TRIGGER_FOR_INSTEAD(trigrec->tgtype))
-		appendStringInfoString(&buf, "INSTEAD OF");
-	else
-		elog(ERROR, "unexpected tgtype value: %d", trigrec->tgtype);
-
-	if (TRIGGER_FOR_INSERT(trigrec->tgtype))
-	{
-		appendStringInfoString(&buf, " INSERT");
-		findx++;
-	}
-	if (TRIGGER_FOR_DELETE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR DELETE");
-		else
-			appendStringInfoString(&buf, " DELETE");
-		findx++;
-	}
-	if (TRIGGER_FOR_UPDATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR UPDATE");
-		else
-			appendStringInfoString(&buf, " UPDATE");
-		findx++;
-		/* tgattr is first var-width field, so OK to access directly */
-		if (trigrec->tgattr.dim1 > 0)
-		{
-			int			i;
-
-			appendStringInfoString(&buf, " OF ");
-			for (i = 0; i < trigrec->tgattr.dim1; i++)
-			{
-				char	   *attname;
-
-				if (i > 0)
-					appendStringInfoString(&buf, ", ");
-				attname = get_attname(trigrec->tgrelid,
-									  trigrec->tgattr.values[i], false);
-				appendStringInfoString(&buf, quote_identifier(attname));
-			}
-		}
-	}
-	if (TRIGGER_FOR_TRUNCATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR TRUNCATE");
-		else
-			appendStringInfoString(&buf, " TRUNCATE");
-		findx++;
-	}
-
-	/*
-	 * In non-pretty mode, always schema-qualify the target table name for
-	 * safety.  In pretty mode, schema-qualify only if not visible.
-	 */
-	appendStringInfo(&buf, " ON %s ",
-					 pretty ?
-					 generate_relation_name(trigrec->tgrelid, NIL) :
-					 generate_qualified_relation_name(trigrec->tgrelid));
-
-	if (OidIsValid(trigrec->tgconstraint))
-	{
-		if (OidIsValid(trigrec->tgconstrrelid))
-			appendStringInfo(&buf, "FROM %s ",
-							 generate_relation_name(trigrec->tgconstrrelid, NIL));
-		if (!trigrec->tgdeferrable)
-			appendStringInfoString(&buf, "NOT ");
-		appendStringInfoString(&buf, "DEFERRABLE INITIALLY ");
-		if (trigrec->tginitdeferred)
-			appendStringInfoString(&buf, "DEFERRED ");
-		else
-			appendStringInfoString(&buf, "IMMEDIATE ");
-	}
-
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgoldtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgoldtable = NameStr(*DatumGetName(value));
-	else
-		tgoldtable = NULL;
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgnewtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgnewtable = NameStr(*DatumGetName(value));
-	else
-		tgnewtable = NULL;
-	if (tgoldtable != NULL || tgnewtable != NULL)
-	{
-		appendStringInfoString(&buf, "REFERENCING ");
-		if (tgoldtable != NULL)
-			appendStringInfo(&buf, "OLD TABLE AS %s ",
-							 quote_identifier(tgoldtable));
-		if (tgnewtable != NULL)
-			appendStringInfo(&buf, "NEW TABLE AS %s ",
-							 quote_identifier(tgnewtable));
-	}
-
-	if (TRIGGER_FOR_ROW(trigrec->tgtype))
-		appendStringInfoString(&buf, "FOR EACH ROW ");
-	else
-		appendStringInfoString(&buf, "FOR EACH STATEMENT ");
-
-	/* If the trigger has a WHEN qualification, add that */
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgqual,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-	{
-		Node	   *qual;
-		char		relkind;
-		deparse_context context;
-		deparse_namespace dpns;
-		RangeTblEntry *oldrte;
-		RangeTblEntry *newrte;
-
-		appendStringInfoString(&buf, "WHEN (");
-
-		qual = stringToNode(TextDatumGetCString(value));
-
-		relkind = get_rel_relkind(trigrec->tgrelid);
-
-		/* Build minimal OLD and NEW RTEs for the rel */
-		oldrte = makeNode(RangeTblEntry);
-		oldrte->rtekind = RTE_RELATION;
-		oldrte->relid = trigrec->tgrelid;
-		oldrte->relkind = relkind;
-		oldrte->rellockmode = AccessShareLock;
-		oldrte->alias = makeAlias("old", NIL);
-		oldrte->eref = oldrte->alias;
-		oldrte->lateral = false;
-		oldrte->inh = false;
-		oldrte->inFromCl = true;
-
-		newrte = makeNode(RangeTblEntry);
-		newrte->rtekind = RTE_RELATION;
-		newrte->relid = trigrec->tgrelid;
-		newrte->relkind = relkind;
-		newrte->rellockmode = AccessShareLock;
-		newrte->alias = makeAlias("new", NIL);
-		newrte->eref = newrte->alias;
-		newrte->lateral = false;
-		newrte->inh = false;
-		newrte->inFromCl = true;
-
-		/* Build two-element rtable */
-		memset(&dpns, 0, sizeof(dpns));
-		dpns.rtable = list_make2(oldrte, newrte);
-		dpns.ctes = NIL;
-		set_rtable_names(&dpns, NIL, NULL);
-		set_simple_column_names(&dpns);
-
-		/* Set up context with one-deep namespace stack */
-		context.buf = &buf;
-		context.namespaces = list_make1(&dpns);
-		context.windowClause = NIL;
-		context.windowTList = NIL;
-		context.varprefix = true;
-		context.prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
-		context.wrapColumn = WRAP_COLUMN_DEFAULT;
-		context.indentLevel = PRETTYINDENT_STD;
-		context.special_exprkind = EXPR_KIND_NONE;
-
-		get_rule_expr(qual, &context, false);
-
-		appendStringInfoString(&buf, ") ");
-	}
-
-	appendStringInfo(&buf, "EXECUTE FUNCTION %s(",
-					 generate_function_name(trigrec->tgfoid, 0,
-											NIL, argtypes,
-											false, NULL, EXPR_KIND_NONE));
-
-	if (trigrec->tgnargs > 0)
-	{
-		char	   *p;
-		int			i;
-
-		value = fastgetattr(ht_trig, Anum_pg_trigger_tgargs,
-							tgrel->rd_att, &isnull);
-		if (isnull)
-			elog(ERROR, "tgargs is null for trigger %u", trigid);
-		p = (char *) VARDATA_ANY(DatumGetByteaPP(value));
-		for (i = 0; i < trigrec->tgnargs; i++)
-		{
-			if (i > 0)
-				appendStringInfoString(&buf, ", ");
-			simple_quote_literal(&buf, p);
-			/* advance p to next string embedded in tgargs */
-			while (*p)
-				p++;
-			p++;
-		}
-	}
-
-	/* We deliberately do not put semi-colon at end */
-	appendStringInfoChar(&buf, ')');
-
-	/* Clean up */
-	systable_endscan(tgscan);
-
-	table_close(tgrel, AccessShareLock);
-
-	return buf.data;
-}
-
-/*
- * set_simple_column_names: fill in column aliases for non-query situations
- *
- * This handles EXPLAIN and cases where we only have relation RTEs.  Without
- * a join tree, we can't do anything smart about join RTEs, but we don't
- * need to (note that EXPLAIN should never see join alias Vars anyway).
- * If we do hit a join RTE we'll just process it like a non-table base RTE.
- */
-static void
-set_simple_column_names(deparse_namespace *dpns)
-{
-	ListCell   *lc;
-	ListCell   *lc2;
-
-	/* Initialize dpns->rtable_columns to contain zeroed structs */
-	dpns->rtable_columns = NIL;
-	while (list_length(dpns->rtable_columns) < list_length(dpns->rtable))
-		dpns->rtable_columns = lappend(dpns->rtable_columns,
-									   palloc0(sizeof(deparse_columns)));
-
-	/* Assign unique column aliases within each RTE */
-	forboth(lc, dpns->rtable, lc2, dpns->rtable_columns)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-		deparse_columns *colinfo = (deparse_columns *) lfirst(lc2);
-
-		set_relation_column_names(dpns, rte, colinfo);
-	}
-}
 
 /*
  * get_opclass_name			- fetch name of an index operator class

--- a/src/backend/distributed/deparser/ruleutils_12.c
+++ b/src/backend/distributed/deparser/ruleutils_12.c
@@ -427,7 +427,6 @@ static void get_from_clause_coldeflist(RangeTblFunction *rtfunc,
 						   deparse_context *context);
 static void get_tablesample_def(TableSampleClause *tablesample,
 					deparse_context *context);
-char *pg_get_statisticsobj_worker(Oid statextid, bool missing_ok);
 static void get_opclass_name(Oid opclass, Oid actual_datatype,
 				 StringInfo buf);
 static Node *processIndirection(Node *node, deparse_context *context);
@@ -7513,127 +7512,6 @@ get_tablesample_def(TableSampleClause *tablesample, deparse_context *context)
 		get_rule_expr((Node *) tablesample->repeatable, context, false);
 		appendStringInfoChar(buf, ')');
 	}
-}
-
-
-char *
-pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
-{
-	StringInfoData buf;
-	int colno;
-	bool isnull;
-	int i;
-
-	HeapTuple statexttup = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(statextid));
-
-	if (!HeapTupleIsValid(statexttup))
-	{
-		if (missing_ok)
-		{
-			return NULL;
-		}
-		elog(ERROR, "cache lookup failed for statistics object %u", statextid);
-	}
-
-	Form_pg_statistic_ext statextrec = (Form_pg_statistic_ext) GETSTRUCT(statexttup);
-
-	initStringInfo(&buf);
-
-	char *nsp = get_namespace_name(statextrec->stxnamespace);
-	appendStringInfo(&buf, "CREATE STATISTICS %s",
-					 quote_qualified_identifier(nsp,
-												NameStr(statextrec->stxname)));
-
-	/*
-	 * Decode the stxkind column so that we know which stats types to print.
-	 */
-	Datum datum = SysCacheGetAttr(STATEXTOID, statexttup,
-								  Anum_pg_statistic_ext_stxkind, &isnull);
-	Assert(!isnull);
-	ArrayType *arr = DatumGetArrayTypeP(datum);
-	if (ARR_NDIM(arr) != 1 ||
-		ARR_HASNULL(arr) ||
-		ARR_ELEMTYPE(arr) != CHAROID)
-	{
-		elog(ERROR, "stxkind is not a 1-D char array");
-	}
-	char *enabled = (char *) ARR_DATA_PTR(arr);
-
-	bool ndistinct_enabled = false;
-	bool dependencies_enabled = false;
-	bool mcv_enabled = false;
-
-	for (i = 0; i < ARR_DIMS(arr)[0]; i++)
-	{
-		if (enabled[i] == STATS_EXT_NDISTINCT)
-		{
-			ndistinct_enabled = true;
-		}
-		if (enabled[i] == STATS_EXT_DEPENDENCIES)
-		{
-			dependencies_enabled = true;
-		}
-		if (enabled[i] == STATS_EXT_MCV)
-		{
-			mcv_enabled = true;
-		}
-	}
-
-	/*
-	 * If any option is disabled, then we'll need to append the types clause
-	 * to show which options are enabled.  We omit the types clause on purpose
-	 * when all options are enabled, so a pg_dump/pg_restore will create all
-	 * statistics types on a newer postgres version, if the statistics had all
-	 * options enabled on the original version.
-	 */
-	if (!ndistinct_enabled || !dependencies_enabled || !mcv_enabled)
-	{
-		bool gotone = false;
-
-		appendStringInfoString(&buf, " (");
-
-		if (ndistinct_enabled)
-		{
-			appendStringInfoString(&buf, "ndistinct");
-			gotone = true;
-		}
-
-		if (dependencies_enabled)
-		{
-			appendStringInfo(&buf, "%sdependencies", gotone ? ", " : "");
-			gotone = true;
-		}
-
-		if (mcv_enabled)
-		{
-			appendStringInfo(&buf, "%smcv", gotone ? ", " : "");
-		}
-
-		appendStringInfoChar(&buf, ')');
-	}
-
-	appendStringInfoString(&buf, " ON ");
-
-	for (colno = 0; colno < statextrec->stxkeys.dim1; colno++)
-	{
-		AttrNumber attnum = statextrec->stxkeys.values[colno];
-
-		if (colno > 0)
-		{
-			appendStringInfoString(&buf, ", ");
-		}
-
-		char *attname = get_attname(statextrec->stxrelid, attnum, false);
-
-		appendStringInfoString(&buf, quote_identifier(attname));
-	}
-
-	appendStringInfo(&buf, " FROM %s",
-					 generate_relation_name(statextrec->stxrelid, NIL));
-
-	ReleaseSysCache(statexttup);
-
-	return buf.data;
 }
 
 

--- a/src/backend/distributed/deparser/ruleutils_13.c
+++ b/src/backend/distributed/deparser/ruleutils_13.c
@@ -103,7 +103,6 @@
 /* Pretty flags */
 #define PRETTYFLAG_PAREN		0x0001
 #define PRETTYFLAG_INDENT		0x0002
-#define PRETTYFLAG_SCHEMA		0x0004
 
 /* Default line length for pretty-print wrapping: 0 means wrap always */
 #define WRAP_COLUMN_DEFAULT		0
@@ -111,7 +110,6 @@
 /* macros to test if pretty action needed */
 #define PRETTY_PAREN(context)	((context)->prettyFlags & PRETTYFLAG_PAREN)
 #define PRETTY_INDENT(context)	((context)->prettyFlags & PRETTYFLAG_INDENT)
-#define PRETTY_SCHEMA(context)	((context)->prettyFlags & PRETTYFLAG_SCHEMA)
 
 
 /* ----------
@@ -435,8 +433,6 @@ static void get_from_clause_coldeflist(RangeTblFunction *rtfunc,
 static void get_tablesample_def(TableSampleClause *tablesample,
 					deparse_context *context);
 char *pg_get_statisticsobj_worker(Oid statextid, bool missing_ok);
-static char *pg_get_triggerdef_worker(Oid trigid, bool pretty);
-static void set_simple_column_names(deparse_namespace *dpns);
 static void get_opclass_name(Oid opclass, Oid actual_datatype,
 				 StringInfo buf);
 static Node *processIndirection(Node *node, deparse_context *context);
@@ -7577,16 +7573,6 @@ get_tablesample_def(TableSampleClause *tablesample, deparse_context *context)
 	}
 }
 
-char *
-pg_get_triggerdef_command(Oid triggerId)
-{
-	Assert(OidIsValid(triggerId));
-
-	/* no need to have pretty SQL command */
-	bool prettyOutput = false;
-	return pg_get_triggerdef_worker(triggerId, prettyOutput);
-}
-
 
 char *
 pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
@@ -7708,298 +7694,6 @@ pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
 	return buf.data;
 }
 
-
-static char *
-pg_get_triggerdef_worker(Oid trigid, bool pretty)
-{
-	HeapTuple	ht_trig;
-	Form_pg_trigger trigrec;
-	StringInfoData buf;
-	Relation	tgrel;
-	ScanKeyData skey[1];
-	SysScanDesc tgscan;
-	int			findx = 0;
-	char	   *tgname;
-	char	   *tgoldtable;
-	char	   *tgnewtable;
-	Oid			argtypes[1];	/* dummy */
-	Datum		value;
-	bool		isnull;
-
-	/*
-	 * Fetch the pg_trigger tuple by the Oid of the trigger
-	 */
-	tgrel = table_open(TriggerRelationId, AccessShareLock);
-
-	ScanKeyInit(&skey[0],
-				Anum_pg_trigger_oid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(trigid));
-
-	tgscan = systable_beginscan(tgrel, TriggerOidIndexId, true,
-								NULL, 1, skey);
-
-	ht_trig = systable_getnext(tgscan);
-
-	if (!HeapTupleIsValid(ht_trig))
-	{
-		systable_endscan(tgscan);
-		table_close(tgrel, AccessShareLock);
-		return NULL;
-	}
-
-	trigrec = (Form_pg_trigger) GETSTRUCT(ht_trig);
-
-	/*
-	 * Start the trigger definition. Note that the trigger's name should never
-	 * be schema-qualified, but the trigger rel's name may be.
-	 */
-	initStringInfo(&buf);
-
-	tgname = NameStr(trigrec->tgname);
-	appendStringInfo(&buf, "CREATE %sTRIGGER %s ",
-					 OidIsValid(trigrec->tgconstraint) ? "CONSTRAINT " : "",
-					 quote_identifier(tgname));
-
-	if (TRIGGER_FOR_BEFORE(trigrec->tgtype))
-		appendStringInfoString(&buf, "BEFORE");
-	else if (TRIGGER_FOR_AFTER(trigrec->tgtype))
-		appendStringInfoString(&buf, "AFTER");
-	else if (TRIGGER_FOR_INSTEAD(trigrec->tgtype))
-		appendStringInfoString(&buf, "INSTEAD OF");
-	else
-		elog(ERROR, "unexpected tgtype value: %d", trigrec->tgtype);
-
-	if (TRIGGER_FOR_INSERT(trigrec->tgtype))
-	{
-		appendStringInfoString(&buf, " INSERT");
-		findx++;
-	}
-	if (TRIGGER_FOR_DELETE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR DELETE");
-		else
-			appendStringInfoString(&buf, " DELETE");
-		findx++;
-	}
-	if (TRIGGER_FOR_UPDATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR UPDATE");
-		else
-			appendStringInfoString(&buf, " UPDATE");
-		findx++;
-		/* tgattr is first var-width field, so OK to access directly */
-		if (trigrec->tgattr.dim1 > 0)
-		{
-			int			i;
-
-			appendStringInfoString(&buf, " OF ");
-			for (i = 0; i < trigrec->tgattr.dim1; i++)
-			{
-				char	   *attname;
-
-				if (i > 0)
-					appendStringInfoString(&buf, ", ");
-				attname = get_attname(trigrec->tgrelid,
-									  trigrec->tgattr.values[i], false);
-				appendStringInfoString(&buf, quote_identifier(attname));
-			}
-		}
-	}
-	if (TRIGGER_FOR_TRUNCATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR TRUNCATE");
-		else
-			appendStringInfoString(&buf, " TRUNCATE");
-		findx++;
-	}
-
-	/*
-	 * In non-pretty mode, always schema-qualify the target table name for
-	 * safety.  In pretty mode, schema-qualify only if not visible.
-	 */
-	appendStringInfo(&buf, " ON %s ",
-					 pretty ?
-					 generate_relation_name(trigrec->tgrelid, NIL) :
-					 generate_qualified_relation_name(trigrec->tgrelid));
-
-	if (OidIsValid(trigrec->tgconstraint))
-	{
-		if (OidIsValid(trigrec->tgconstrrelid))
-			appendStringInfo(&buf, "FROM %s ",
-							 generate_relation_name(trigrec->tgconstrrelid, NIL));
-		if (!trigrec->tgdeferrable)
-			appendStringInfoString(&buf, "NOT ");
-		appendStringInfoString(&buf, "DEFERRABLE INITIALLY ");
-		if (trigrec->tginitdeferred)
-			appendStringInfoString(&buf, "DEFERRED ");
-		else
-			appendStringInfoString(&buf, "IMMEDIATE ");
-	}
-
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgoldtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgoldtable = NameStr(*DatumGetName(value));
-	else
-		tgoldtable = NULL;
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgnewtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgnewtable = NameStr(*DatumGetName(value));
-	else
-		tgnewtable = NULL;
-	if (tgoldtable != NULL || tgnewtable != NULL)
-	{
-		appendStringInfoString(&buf, "REFERENCING ");
-		if (tgoldtable != NULL)
-			appendStringInfo(&buf, "OLD TABLE AS %s ",
-							 quote_identifier(tgoldtable));
-		if (tgnewtable != NULL)
-			appendStringInfo(&buf, "NEW TABLE AS %s ",
-							 quote_identifier(tgnewtable));
-	}
-
-	if (TRIGGER_FOR_ROW(trigrec->tgtype))
-		appendStringInfoString(&buf, "FOR EACH ROW ");
-	else
-		appendStringInfoString(&buf, "FOR EACH STATEMENT ");
-
-	/* If the trigger has a WHEN qualification, add that */
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgqual,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-	{
-		Node	   *qual;
-		char		relkind;
-		deparse_context context;
-		deparse_namespace dpns;
-		RangeTblEntry *oldrte;
-		RangeTblEntry *newrte;
-
-		appendStringInfoString(&buf, "WHEN (");
-
-		qual = stringToNode(TextDatumGetCString(value));
-
-		relkind = get_rel_relkind(trigrec->tgrelid);
-
-		/* Build minimal OLD and NEW RTEs for the rel */
-		oldrte = makeNode(RangeTblEntry);
-		oldrte->rtekind = RTE_RELATION;
-		oldrte->relid = trigrec->tgrelid;
-		oldrte->relkind = relkind;
-		oldrte->rellockmode = AccessShareLock;
-		oldrte->alias = makeAlias("old", NIL);
-		oldrte->eref = oldrte->alias;
-		oldrte->lateral = false;
-		oldrte->inh = false;
-		oldrte->inFromCl = true;
-
-		newrte = makeNode(RangeTblEntry);
-		newrte->rtekind = RTE_RELATION;
-		newrte->relid = trigrec->tgrelid;
-		newrte->relkind = relkind;
-		newrte->rellockmode = AccessShareLock;
-		newrte->alias = makeAlias("new", NIL);
-		newrte->eref = newrte->alias;
-		newrte->lateral = false;
-		newrte->inh = false;
-		newrte->inFromCl = true;
-
-		/* Build two-element rtable */
-		memset(&dpns, 0, sizeof(dpns));
-		dpns.rtable = list_make2(oldrte, newrte);
-		dpns.ctes = NIL;
-		set_rtable_names(&dpns, NIL, NULL);
-		set_simple_column_names(&dpns);
-
-		/* Set up context with one-deep namespace stack */
-		context.buf = &buf;
-		context.namespaces = list_make1(&dpns);
-		context.windowClause = NIL;
-		context.windowTList = NIL;
-		context.varprefix = true;
-		context.prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
-		context.wrapColumn = WRAP_COLUMN_DEFAULT;
-		context.indentLevel = PRETTYINDENT_STD;
-		context.special_exprkind = EXPR_KIND_NONE;
-		context.appendparents = NULL;
-
-		get_rule_expr(qual, &context, false);
-
-		appendStringInfoString(&buf, ") ");
-	}
-
-	appendStringInfo(&buf, "EXECUTE FUNCTION %s(",
-					 generate_function_name(trigrec->tgfoid, 0,
-											NIL, argtypes,
-											false, NULL, EXPR_KIND_NONE));
-
-	if (trigrec->tgnargs > 0)
-	{
-		char	   *p;
-		int			i;
-
-		value = fastgetattr(ht_trig, Anum_pg_trigger_tgargs,
-							tgrel->rd_att, &isnull);
-		if (isnull)
-			elog(ERROR, "tgargs is null for trigger %u", trigid);
-		p = (char *) VARDATA_ANY(DatumGetByteaPP(value));
-		for (i = 0; i < trigrec->tgnargs; i++)
-		{
-			if (i > 0)
-				appendStringInfoString(&buf, ", ");
-			simple_quote_literal(&buf, p);
-			/* advance p to next string embedded in tgargs */
-			while (*p)
-				p++;
-			p++;
-		}
-	}
-
-	/* We deliberately do not put semi-colon at end */
-	appendStringInfoChar(&buf, ')');
-
-	/* Clean up */
-	systable_endscan(tgscan);
-
-	table_close(tgrel, AccessShareLock);
-
-	return buf.data;
-}
-
-/*
- * set_simple_column_names: fill in column aliases for non-query situations
- *
- * This handles EXPLAIN and cases where we only have relation RTEs.  Without
- * a join tree, we can't do anything smart about join RTEs, but we don't
- * need to (note that EXPLAIN should never see join alias Vars anyway).
- * If we do hit a join RTE we'll just process it like a non-table base RTE.
- */
-static void
-set_simple_column_names(deparse_namespace *dpns)
-{
-	ListCell   *lc;
-	ListCell   *lc2;
-
-	/* Initialize dpns->rtable_columns to contain zeroed structs */
-	dpns->rtable_columns = NIL;
-	while (list_length(dpns->rtable_columns) < list_length(dpns->rtable))
-		dpns->rtable_columns = lappend(dpns->rtable_columns,
-									   palloc0(sizeof(deparse_columns)));
-
-	/* Assign unique column aliases within each RTE */
-	forboth(lc, dpns->rtable, lc2, dpns->rtable_columns)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-		deparse_columns *colinfo = (deparse_columns *) lfirst(lc2);
-
-		set_relation_column_names(dpns, rte, colinfo);
-	}
-}
 
 /*
  * get_opclass_name			- fetch name of an index operator class

--- a/src/backend/distributed/deparser/ruleutils_13.c
+++ b/src/backend/distributed/deparser/ruleutils_13.c
@@ -432,7 +432,6 @@ static void get_from_clause_coldeflist(RangeTblFunction *rtfunc,
 						   deparse_context *context);
 static void get_tablesample_def(TableSampleClause *tablesample,
 					deparse_context *context);
-char *pg_get_statisticsobj_worker(Oid statextid, bool missing_ok);
 static void get_opclass_name(Oid opclass, Oid actual_datatype,
 				 StringInfo buf);
 static Node *processIndirection(Node *node, deparse_context *context);
@@ -7571,127 +7570,6 @@ get_tablesample_def(TableSampleClause *tablesample, deparse_context *context)
 		get_rule_expr((Node *) tablesample->repeatable, context, false);
 		appendStringInfoChar(buf, ')');
 	}
-}
-
-
-char *
-pg_get_statisticsobj_worker(Oid statextid, bool missing_ok)
-{
-	StringInfoData buf;
-	int colno;
-	bool isnull;
-	int i;
-
-	HeapTuple statexttup = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(statextid));
-
-	if (!HeapTupleIsValid(statexttup))
-	{
-		if (missing_ok)
-		{
-			return NULL;
-		}
-		elog(ERROR, "cache lookup failed for statistics object %u", statextid);
-	}
-
-	Form_pg_statistic_ext statextrec = (Form_pg_statistic_ext) GETSTRUCT(statexttup);
-
-	initStringInfo(&buf);
-
-	char *nsp = get_namespace_name(statextrec->stxnamespace);
-	appendStringInfo(&buf, "CREATE STATISTICS %s",
-					 quote_qualified_identifier(nsp,
-												NameStr(statextrec->stxname)));
-
-	/*
-	 * Decode the stxkind column so that we know which stats types to print.
-	 */
-	Datum datum = SysCacheGetAttr(STATEXTOID, statexttup,
-								  Anum_pg_statistic_ext_stxkind, &isnull);
-	Assert(!isnull);
-	ArrayType *arr = DatumGetArrayTypeP(datum);
-	if (ARR_NDIM(arr) != 1 ||
-		ARR_HASNULL(arr) ||
-		ARR_ELEMTYPE(arr) != CHAROID)
-	{
-		elog(ERROR, "stxkind is not a 1-D char array");
-	}
-	char *enabled = (char *) ARR_DATA_PTR(arr);
-
-	bool ndistinct_enabled = false;
-	bool dependencies_enabled = false;
-	bool mcv_enabled = false;
-
-	for (i = 0; i < ARR_DIMS(arr)[0]; i++)
-	{
-		if (enabled[i] == STATS_EXT_NDISTINCT)
-		{
-			ndistinct_enabled = true;
-		}
-		if (enabled[i] == STATS_EXT_DEPENDENCIES)
-		{
-			dependencies_enabled = true;
-		}
-		if (enabled[i] == STATS_EXT_MCV)
-		{
-			mcv_enabled = true;
-		}
-	}
-
-	/*
-	 * If any option is disabled, then we'll need to append the types clause
-	 * to show which options are enabled.  We omit the types clause on purpose
-	 * when all options are enabled, so a pg_dump/pg_restore will create all
-	 * statistics types on a newer postgres version, if the statistics had all
-	 * options enabled on the original version.
-	 */
-	if (!ndistinct_enabled || !dependencies_enabled || !mcv_enabled)
-	{
-		bool gotone = false;
-
-		appendStringInfoString(&buf, " (");
-
-		if (ndistinct_enabled)
-		{
-			appendStringInfoString(&buf, "ndistinct");
-			gotone = true;
-		}
-
-		if (dependencies_enabled)
-		{
-			appendStringInfo(&buf, "%sdependencies", gotone ? ", " : "");
-			gotone = true;
-		}
-
-		if (mcv_enabled)
-		{
-			appendStringInfo(&buf, "%smcv", gotone ? ", " : "");
-		}
-
-		appendStringInfoChar(&buf, ')');
-	}
-
-	appendStringInfoString(&buf, " ON ");
-
-	for (colno = 0; colno < statextrec->stxkeys.dim1; colno++)
-	{
-		AttrNumber attnum = statextrec->stxkeys.values[colno];
-
-		if (colno > 0)
-		{
-			appendStringInfoString(&buf, ", ");
-		}
-
-		char *attname = get_attname(statextrec->stxrelid, attnum, false);
-
-		appendStringInfoString(&buf, quote_identifier(attname));
-	}
-
-	appendStringInfo(&buf, " FROM %s",
-					 generate_relation_name(statextrec->stxrelid, NIL));
-
-	ReleaseSysCache(statexttup);
-
-	return buf.data;
 }
 
 

--- a/src/backend/distributed/deparser/ruleutils_14.c
+++ b/src/backend/distributed/deparser/ruleutils_14.c
@@ -101,7 +101,6 @@
 /* Pretty flags */
 #define PRETTYFLAG_PAREN		0x0001
 #define PRETTYFLAG_INDENT		0x0002
-#define PRETTYFLAG_SCHEMA		0x0004
 
 /* Default line length for pretty-print wrapping: 0 means wrap always */
 #define WRAP_COLUMN_DEFAULT		0
@@ -109,7 +108,6 @@
 /* macros to test if pretty action needed */
 #define PRETTY_PAREN(context)	((context)->prettyFlags & PRETTYFLAG_PAREN)
 #define PRETTY_INDENT(context)	((context)->prettyFlags & PRETTYFLAG_INDENT)
-#define PRETTY_SCHEMA(context)	((context)->prettyFlags & PRETTYFLAG_SCHEMA)
 
 
 /* ----------
@@ -444,8 +442,6 @@ static void get_tablesample_def(TableSampleClause *tablesample,
 					deparse_context *context);
 char *pg_get_statisticsobj_worker(Oid statextid, bool columns_only,
 								  bool missing_ok);
-static char *pg_get_triggerdef_worker(Oid trigid, bool pretty);
-static void set_simple_column_names(deparse_namespace *dpns);
 static void get_opclass_name(Oid opclass, Oid actual_datatype,
 				 StringInfo buf);
 static Node *processIndirection(Node *node, deparse_context *context);
@@ -8133,16 +8129,6 @@ get_tablesample_def(TableSampleClause *tablesample, deparse_context *context)
 	}
 }
 
-char *
-pg_get_triggerdef_command(Oid triggerId)
-{
-	Assert(OidIsValid(triggerId));
-
-	/* no need to have pretty SQL command */
-	bool prettyOutput = false;
-	return pg_get_triggerdef_worker(triggerId, prettyOutput);
-}
-
 
 char *
 pg_get_statisticsobj_worker(Oid statextid, bool columns_only, bool missing_ok)
@@ -8332,298 +8318,6 @@ pg_get_statisticsobj_worker(Oid statextid, bool columns_only, bool missing_ok)
 	return buf.data;
 }
 
-
-static char *
-pg_get_triggerdef_worker(Oid trigid, bool pretty)
-{
-	HeapTuple	ht_trig;
-	Form_pg_trigger trigrec;
-	StringInfoData buf;
-	Relation	tgrel;
-	ScanKeyData skey[1];
-	SysScanDesc tgscan;
-	int			findx = 0;
-	char	   *tgname;
-	char	   *tgoldtable;
-	char	   *tgnewtable;
-	Oid			argtypes[1];	/* dummy */
-	Datum		value;
-	bool		isnull;
-
-	/*
-	 * Fetch the pg_trigger tuple by the Oid of the trigger
-	 */
-	tgrel = table_open(TriggerRelationId, AccessShareLock);
-
-	ScanKeyInit(&skey[0],
-				Anum_pg_trigger_oid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(trigid));
-
-	tgscan = systable_beginscan(tgrel, TriggerOidIndexId, true,
-								NULL, 1, skey);
-
-	ht_trig = systable_getnext(tgscan);
-
-	if (!HeapTupleIsValid(ht_trig))
-	{
-		systable_endscan(tgscan);
-		table_close(tgrel, AccessShareLock);
-		return NULL;
-	}
-
-	trigrec = (Form_pg_trigger) GETSTRUCT(ht_trig);
-
-	/*
-	 * Start the trigger definition. Note that the trigger's name should never
-	 * be schema-qualified, but the trigger rel's name may be.
-	 */
-	initStringInfo(&buf);
-
-	tgname = NameStr(trigrec->tgname);
-	appendStringInfo(&buf, "CREATE %sTRIGGER %s ",
-					 OidIsValid(trigrec->tgconstraint) ? "CONSTRAINT " : "",
-					 quote_identifier(tgname));
-
-	if (TRIGGER_FOR_BEFORE(trigrec->tgtype))
-		appendStringInfoString(&buf, "BEFORE");
-	else if (TRIGGER_FOR_AFTER(trigrec->tgtype))
-		appendStringInfoString(&buf, "AFTER");
-	else if (TRIGGER_FOR_INSTEAD(trigrec->tgtype))
-		appendStringInfoString(&buf, "INSTEAD OF");
-	else
-		elog(ERROR, "unexpected tgtype value: %d", trigrec->tgtype);
-
-	if (TRIGGER_FOR_INSERT(trigrec->tgtype))
-	{
-		appendStringInfoString(&buf, " INSERT");
-		findx++;
-	}
-	if (TRIGGER_FOR_DELETE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR DELETE");
-		else
-			appendStringInfoString(&buf, " DELETE");
-		findx++;
-	}
-	if (TRIGGER_FOR_UPDATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR UPDATE");
-		else
-			appendStringInfoString(&buf, " UPDATE");
-		findx++;
-		/* tgattr is first var-width field, so OK to access directly */
-		if (trigrec->tgattr.dim1 > 0)
-		{
-			int			i;
-
-			appendStringInfoString(&buf, " OF ");
-			for (i = 0; i < trigrec->tgattr.dim1; i++)
-			{
-				char	   *attname;
-
-				if (i > 0)
-					appendStringInfoString(&buf, ", ");
-				attname = get_attname(trigrec->tgrelid,
-									  trigrec->tgattr.values[i], false);
-				appendStringInfoString(&buf, quote_identifier(attname));
-			}
-		}
-	}
-	if (TRIGGER_FOR_TRUNCATE(trigrec->tgtype))
-	{
-		if (findx > 0)
-			appendStringInfoString(&buf, " OR TRUNCATE");
-		else
-			appendStringInfoString(&buf, " TRUNCATE");
-		findx++;
-	}
-
-	/*
-	 * In non-pretty mode, always schema-qualify the target table name for
-	 * safety.  In pretty mode, schema-qualify only if not visible.
-	 */
-	appendStringInfo(&buf, " ON %s ",
-					 pretty ?
-					 generate_relation_name(trigrec->tgrelid, NIL) :
-					 generate_qualified_relation_name(trigrec->tgrelid));
-
-	if (OidIsValid(trigrec->tgconstraint))
-	{
-		if (OidIsValid(trigrec->tgconstrrelid))
-			appendStringInfo(&buf, "FROM %s ",
-							 generate_relation_name(trigrec->tgconstrrelid, NIL));
-		if (!trigrec->tgdeferrable)
-			appendStringInfoString(&buf, "NOT ");
-		appendStringInfoString(&buf, "DEFERRABLE INITIALLY ");
-		if (trigrec->tginitdeferred)
-			appendStringInfoString(&buf, "DEFERRED ");
-		else
-			appendStringInfoString(&buf, "IMMEDIATE ");
-	}
-
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgoldtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgoldtable = NameStr(*DatumGetName(value));
-	else
-		tgoldtable = NULL;
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgnewtable,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-		tgnewtable = NameStr(*DatumGetName(value));
-	else
-		tgnewtable = NULL;
-	if (tgoldtable != NULL || tgnewtable != NULL)
-	{
-		appendStringInfoString(&buf, "REFERENCING ");
-		if (tgoldtable != NULL)
-			appendStringInfo(&buf, "OLD TABLE AS %s ",
-							 quote_identifier(tgoldtable));
-		if (tgnewtable != NULL)
-			appendStringInfo(&buf, "NEW TABLE AS %s ",
-							 quote_identifier(tgnewtable));
-	}
-
-	if (TRIGGER_FOR_ROW(trigrec->tgtype))
-		appendStringInfoString(&buf, "FOR EACH ROW ");
-	else
-		appendStringInfoString(&buf, "FOR EACH STATEMENT ");
-
-	/* If the trigger has a WHEN qualification, add that */
-	value = fastgetattr(ht_trig, Anum_pg_trigger_tgqual,
-						tgrel->rd_att, &isnull);
-	if (!isnull)
-	{
-		Node	   *qual;
-		char		relkind;
-		deparse_context context;
-		deparse_namespace dpns;
-		RangeTblEntry *oldrte;
-		RangeTblEntry *newrte;
-
-		appendStringInfoString(&buf, "WHEN (");
-
-		qual = stringToNode(TextDatumGetCString(value));
-
-		relkind = get_rel_relkind(trigrec->tgrelid);
-
-		/* Build minimal OLD and NEW RTEs for the rel */
-		oldrte = makeNode(RangeTblEntry);
-		oldrte->rtekind = RTE_RELATION;
-		oldrte->relid = trigrec->tgrelid;
-		oldrte->relkind = relkind;
-		oldrte->rellockmode = AccessShareLock;
-		oldrte->alias = makeAlias("old", NIL);
-		oldrte->eref = oldrte->alias;
-		oldrte->lateral = false;
-		oldrte->inh = false;
-		oldrte->inFromCl = true;
-
-		newrte = makeNode(RangeTblEntry);
-		newrte->rtekind = RTE_RELATION;
-		newrte->relid = trigrec->tgrelid;
-		newrte->relkind = relkind;
-		newrte->rellockmode = AccessShareLock;
-		newrte->alias = makeAlias("new", NIL);
-		newrte->eref = newrte->alias;
-		newrte->lateral = false;
-		newrte->inh = false;
-		newrte->inFromCl = true;
-
-		/* Build two-element rtable */
-		memset(&dpns, 0, sizeof(dpns));
-		dpns.rtable = list_make2(oldrte, newrte);
-		dpns.ctes = NIL;
-		set_rtable_names(&dpns, NIL, NULL);
-		set_simple_column_names(&dpns);
-
-		/* Set up context with one-deep namespace stack */
-		context.buf = &buf;
-		context.namespaces = list_make1(&dpns);
-		context.windowClause = NIL;
-		context.windowTList = NIL;
-		context.varprefix = true;
-		context.prettyFlags = pretty ? (PRETTYFLAG_PAREN | PRETTYFLAG_INDENT | PRETTYFLAG_SCHEMA) : PRETTYFLAG_INDENT;
-		context.wrapColumn = WRAP_COLUMN_DEFAULT;
-		context.indentLevel = PRETTYINDENT_STD;
-		context.special_exprkind = EXPR_KIND_NONE;
-		context.appendparents = NULL;
-
-		get_rule_expr(qual, &context, false);
-
-		appendStringInfoString(&buf, ") ");
-	}
-
-	appendStringInfo(&buf, "EXECUTE FUNCTION %s(",
-					 generate_function_name(trigrec->tgfoid, 0,
-											NIL, argtypes,
-											false, NULL, EXPR_KIND_NONE));
-
-	if (trigrec->tgnargs > 0)
-	{
-		char	   *p;
-		int			i;
-
-		value = fastgetattr(ht_trig, Anum_pg_trigger_tgargs,
-							tgrel->rd_att, &isnull);
-		if (isnull)
-			elog(ERROR, "tgargs is null for trigger %u", trigid);
-		p = (char *) VARDATA_ANY(DatumGetByteaPP(value));
-		for (i = 0; i < trigrec->tgnargs; i++)
-		{
-			if (i > 0)
-				appendStringInfoString(&buf, ", ");
-			simple_quote_literal(&buf, p);
-			/* advance p to next string embedded in tgargs */
-			while (*p)
-				p++;
-			p++;
-		}
-	}
-
-	/* We deliberately do not put semi-colon at end */
-	appendStringInfoChar(&buf, ')');
-
-	/* Clean up */
-	systable_endscan(tgscan);
-
-	table_close(tgrel, AccessShareLock);
-
-	return buf.data;
-}
-
-/*
- * set_simple_column_names: fill in column aliases for non-query situations
- *
- * This handles EXPLAIN and cases where we only have relation RTEs.  Without
- * a join tree, we can't do anything smart about join RTEs, but we don't
- * need to (note that EXPLAIN should never see join alias Vars anyway).
- * If we do hit a join RTE we'll just process it like a non-table base RTE.
- */
-static void
-set_simple_column_names(deparse_namespace *dpns)
-{
-	ListCell   *lc;
-	ListCell   *lc2;
-
-	/* Initialize dpns->rtable_columns to contain zeroed structs */
-	dpns->rtable_columns = NIL;
-	while (list_length(dpns->rtable_columns) < list_length(dpns->rtable))
-		dpns->rtable_columns = lappend(dpns->rtable_columns,
-									   palloc0(sizeof(deparse_columns)));
-
-	/* Assign unique column aliases within each RTE */
-	forboth(lc, dpns->rtable, lc2, dpns->rtable_columns)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-		deparse_columns *colinfo = (deparse_columns *) lfirst(lc2);
-
-		set_relation_column_names(dpns, rte, colinfo);
-	}
-}
 
 /*
  * get_opclass_name			- fetch name of an index operator class

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -54,7 +54,6 @@ bool get_merged_argument_list(CallStmt *stmt, List **mergedNamedArgList,
 char * pg_get_rule_expr(Node *expression);
 extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid,
 								StringInfo buffer);
-extern char * pg_get_triggerdef_command(Oid triggerId);
 #if PG_VERSION_NUM >= PG_VERSION_14
 extern char * pg_get_statisticsobj_worker(Oid statextid, bool columns_only,
 										  bool missing_ok);

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -54,12 +54,6 @@ bool get_merged_argument_list(CallStmt *stmt, List **mergedNamedArgList,
 char * pg_get_rule_expr(Node *expression);
 extern void deparse_shard_query(Query *query, Oid distrelid, int64 shardid,
 								StringInfo buffer);
-#if PG_VERSION_NUM >= PG_VERSION_14
-extern char * pg_get_statisticsobj_worker(Oid statextid, bool columns_only,
-										  bool missing_ok);
-#else
-extern char * pg_get_statisticsobj_worker(Oid statextid, bool missing_ok);
-#endif
 extern char * generate_relation_name(Oid relid, List *namespaces);
 extern char * generate_qualified_relation_name(Oid relid);
 extern char * generate_operator_name(Oid operid, Oid arg1, Oid arg2);

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -35,7 +35,6 @@
 #define RelationGetPartitionDesc_compat(a, b) RelationGetPartitionDesc(a, b)
 #define make_simple_restrictinfo_compat(a, b) make_simple_restrictinfo(a, b)
 #define pull_varnos_compat(a, b) pull_varnos(a, b)
-#define pg_get_statisticsobj_worker_compat(a, b, c) pg_get_statisticsobj_worker(a, b, c)
 #else
 #define AlterTableStmtObjType_compat(a) ((a)->relkind)
 #define F_NEXTVAL F_NEXTVAL_OID
@@ -68,7 +67,6 @@
 #define PQ_LARGE_MESSAGE_LIMIT 0
 #define make_simple_restrictinfo_compat(a, b) make_simple_restrictinfo(b)
 #define pull_varnos_compat(a, b) pull_varnos(b)
-#define pg_get_statisticsobj_worker_compat(a, b, c) pg_get_statisticsobj_worker(a, c)
 #endif
 
 #if PG_VERSION_NUM >= PG_VERSION_13

--- a/src/test/regress/expected/citus_table_triggers.out
+++ b/src/test/regress/expected/citus_table_triggers.out
@@ -141,12 +141,12 @@ CREATE TRIGGER test_table_delete
     FOR EACH STATEMENT
     EXECUTE FUNCTION test_table_trigger_function();
 SELECT master_get_table_ddl_events('test_table');
-                                                                                                                                                                           master_get_table_ddl_events
+                                                                                                                                                      master_get_table_ddl_events
 ---------------------------------------------------------------------
  CREATE TABLE table_triggers_schema.test_table (id integer, text_number text, text_col text)
  ALTER TABLE table_triggers_schema.test_table OWNER TO postgres
  CREATE TRIGGER test_table_delete AFTER DELETE ON table_triggers_schema.test_table FOR EACH STATEMENT EXECUTE FUNCTION table_triggers_schema.test_table_trigger_function()
- CREATE CONSTRAINT TRIGGER test_table_insert AFTER INSERT ON table_triggers_schema.test_table DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN (((new.id OPERATOR(pg_catalog.>) 5) OR ((new.text_col IS NOT NULL) AND ((new.id)::numeric OPERATOR(pg_catalog.<) to_number(new.text_number, '9999'::text))))) EXECUTE FUNCTION table_triggers_schema.test_table_trigger_function()
+ CREATE CONSTRAINT TRIGGER test_table_insert AFTER INSERT ON table_triggers_schema.test_table DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN (((new.id > 5) OR ((new.text_col IS NOT NULL) AND ((new.id)::numeric < to_number(new.text_number, '9999'::text))))) EXECUTE FUNCTION table_triggers_schema.test_table_trigger_function()
  CREATE CONSTRAINT TRIGGER test_table_update AFTER UPDATE OF id ON table_triggers_schema.test_table NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW WHEN (((NOT (old.* IS DISTINCT FROM new.*)) AND (old.text_number IS NOT NULL))) EXECUTE FUNCTION table_triggers_schema.test_table_trigger_function()
 (5 rows)
 


### PR DESCRIPTION
While reading trigger related parts of our code-base, realized that
we actually don't need to copy & paste underlying worker functions
from pg/ruleutils.c since higher level functions for those two are
anyway exposed as SQL callables, so we can delete more than ~1k lines
of code from our `ruleutils_x.c` files.