### PR TITLE
Copy errmsg for distributed deadlock error into heap

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -446,8 +446,16 @@ multi_log_hook(ErrorData *edata)
 		MyBackendGotCancelledDueToDeadlock(clearState))
 	{
 		edata->sqlerrcode = ERRCODE_T_R_DEADLOCK_DETECTED;
-		edata->message = "canceling the transaction since it was "
-						 "involved in a distributed deadlock";
+
+		/*
+		 * This hook is called by EmitErrorReport() when emitting the ereport
+		 * either to frontend or to the server logs. And some callers of
+		 * EmitErrorReport() (e.g.: errfinish()) seems to assume that string
+		 * fields of given ErrorData object needs to be freed. For this reason,
+		 * we copy the message into heap here.
+		 */
+		edata->message = pstrdup("canceling the transaction since it was "
+								 "involved in a distributed deadlock");
 	}
 }
 


### PR DESCRIPTION
Fixes #5638.

multi_log_hook() hook is called by EmitErrorReport() when emitting the
ereport either to frontend or to the server logs. And some callers of
EmitErrorReport() (e.g.: errfinish()) seems to assume that string fields
of given ErrorData object needs to be freed. For this reason, we copy the
message into heap here.

I don't think we have faced with such a problem before but it seems worth
fixing as it is theoretically possible due to the reasoning above.

I also looked into the places in the codebase where we're setting a string
field of an ErrData object into a constant string, but didn't find a similar
potential issue.

DESCRIPTION: Fixes a possible segfault that could happen when reporting distributed deadlock
