### PR TITLE
Made tableam.h file dependency free

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -326,6 +326,10 @@ _PG_init(void)
 	 */
 	ColumnarTableSetOptions_hook = ColumnarTableSetOptionsHook;
 
+	/*
+	 * When Columnar works with Citus, we need to check the Citus Version
+	 */
+	ColumnarCheckCitusVersion_hook = CheckCitusVersion;
 	InitializeMaintenanceDaemon();
 
 	/* initialize coordinated transaction management */

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -211,6 +211,10 @@ extern void columnar_init_gucs(void);
 
 extern CompressionType ParseCompressionType(const char *compressionTypeString);
 
+/* called when columnar needs to check corresponding Citus version */
+typedef bool (*ColumnarCheckCitusVersion_hook_type)(int elevel);
+extern ColumnarCheckCitusVersion_hook_type ColumnarCheckCitusVersion_hook;
+
 /* Function declarations for writing to a columnar table */
 extern ColumnarWriteState * ColumnarBeginWrite(RelFileNode relfilenode,
 											   ColumnarOptions options,

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -1,15 +1,13 @@
 #ifndef COLUMNAR_TABLEAM_H
 #define COLUMNAR_TABLEAM_H
-#include "citus_version.h"
 
 #include "postgres.h"
 #include "fmgr.h"
 #include "access/tableam.h"
 #include "access/skey.h"
 #include "nodes/bitmapset.h"
-
-#include "distributed/coordinator_protocol.h"
-
+#include "access/heapam.h"
+#include "catalog/indexing.h"
 
 /*
  * Number of valid ItemPointer Offset's for "row number" <> "ItemPointer"
@@ -51,6 +49,9 @@ typedef struct ColumnarScanDescData *ColumnarScanDesc;
 const TableAmRoutine * GetColumnarTableAmRoutine(void);
 extern void columnar_tableam_init(void);
 extern void columnar_tableam_finish(void);
+extern void CreateTruncateTrigger(Oid relationId);
+extern void EnsureTableOwner(Oid relationId);
+extern bool CheckCitusVersion(int elevel);
 
 extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot snapshot,
 												 int nkeys, ScanKey key,

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -8,6 +8,7 @@
 #include "nodes/bitmapset.h"
 #include "access/heapam.h"
 #include "catalog/indexing.h"
+#include "utils/acl.h"
 
 /*
  * Number of valid ItemPointer Offset's for "row number" <> "ItemPointer"
@@ -49,9 +50,6 @@ typedef struct ColumnarScanDescData *ColumnarScanDesc;
 const TableAmRoutine * GetColumnarTableAmRoutine(void);
 extern void columnar_tableam_init(void);
 extern void columnar_tableam_finish(void);
-extern void CreateTruncateTrigger(Oid relationId);
-extern void EnsureTableOwner(Oid relationId);
-extern bool CheckCitusVersion(int elevel);
 
 extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot snapshot,
 												 int nkeys, ScanKey key,

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -283,6 +283,14 @@ SELECT * FROM columnar_table;
  1
 (2 rows)
 
+-- Fail to alter a columnar table that is created by a different user
+SET ROLE full_access;
+SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
+ERROR:  must be owner of table columnar_table
+-- Fail to reset a columnar table value created by a different user
+SELECT alter_columnar_table_reset('columnar_table', chunk_group_row_limit => true);
+ERROR:  must be owner of table columnar_table
+SET ROLE read_access;
 -- and drop it
 DROP TABLE columnar_table;
 -- cannot modify columnar metadata table as unprivileged user

--- a/src/test/regress/sql/multi_multiuser.sql
+++ b/src/test/regress/sql/multi_multiuser.sql
@@ -169,6 +169,12 @@ SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000)
 -- insert some data and read
 INSERT INTO columnar_table VALUES (1), (1);
 SELECT * FROM columnar_table;
+-- Fail to alter a columnar table that is created by a different user
+SET ROLE full_access;
+SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
+-- Fail to reset a columnar table value created by a different user
+SELECT alter_columnar_table_reset('columnar_table', chunk_group_row_limit => true);
+SET ROLE read_access;
 -- and drop it
 DROP TABLE columnar_table;
 


### PR DESCRIPTION
Made tableam.h dependency free. This technically makes the include/columnar directory dependency free but there are still some header files that don't have any citus dependencies but are in the distributed directory (pg_version_constants.h and listutils.h)