### PR TITLE
Remove useless param from MyBackendGotCancelledDueToDeadlock

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -441,9 +441,8 @@ multi_log_hook(ErrorData *edata)
 	 * by the distributed deadlock detection. Also reset the state for this,
 	 * since the next cancelation of the backend might have another reason.
 	 */
-	bool clearState = true;
 	if (edata->elevel == ERROR && edata->sqlerrcode == ERRCODE_QUERY_CANCELED &&
-		MyBackendGotCancelledDueToDeadlock(clearState))
+		MyBackendGotCancelledDueToDeadlock())
 	{
 		edata->sqlerrcode = ERRCODE_T_R_DEADLOCK_DETECTED;
 		edata->message = "canceling the transaction since it was "

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -862,12 +862,11 @@ CancelTransactionDueToDeadlock(PGPROC *proc)
  * transaction was cancelled due to a deadlock. If the backend is not in a
  * distributed transaction, the function returns false.
  * We keep some session level state to keep track of if we were cancelled
- * because of a distributed deadlock. When clearState is true, this function
- * also resets that state. So after calling this function with clearState true,
- * a second would always return false.
+ * because of a distributed deadlock. This function also resets that state.
+ * So a second call made to this function would always return false.
  */
 bool
-MyBackendGotCancelledDueToDeadlock(bool clearState)
+MyBackendGotCancelledDueToDeadlock(void)
 {
 	bool cancelledDueToDeadlock = false;
 
@@ -883,10 +882,8 @@ MyBackendGotCancelledDueToDeadlock(bool clearState)
 	{
 		cancelledDueToDeadlock = MyBackendData->cancelledDueToDeadlock;
 	}
-	if (clearState)
-	{
-		MyBackendData->cancelledDueToDeadlock = false;
-	}
+
+	MyBackendData->cancelledDueToDeadlock = false;
 
 	SpinLockRelease(&MyBackendData->mutex);
 

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -65,7 +65,7 @@ extern void AssignDistributedTransactionId(void);
 extern void MarkCitusInitiatedCoordinatorBackend(void);
 extern void GetBackendDataForProc(PGPROC *proc, BackendData *result);
 extern void CancelTransactionDueToDeadlock(PGPROC *proc);
-extern bool MyBackendGotCancelledDueToDeadlock(bool clearState);
+extern bool MyBackendGotCancelledDueToDeadlock(void);
 extern bool MyBackendIsInDisributedTransaction(void);
 extern List * ActiveDistributedTransactionNumbers(void);
 extern LocalTransactionId GetMyProcLocalTransactionId(void);


### PR DESCRIPTION
As we are always passing it to be true.