### PR TITLE
Use a fixed application_name while connecting to remote nodes

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -72,8 +72,8 @@ InitConnParams()
 /*
  * ResetConnParams frees all strings in the keywords and parameters arrays,
  * sets their elements to null, and resets the ConnParamsSize to zero before
- * adding back any hardcoded global connection settings (at present, only the
- * fallback_application_name of 'citus').
+ * adding back any hardcoded global connection settings (at present, there
+ * are no).
  */
 void
 ResetConnParams()
@@ -89,8 +89,6 @@ ResetConnParams()
 	ConnParams.size = 0;
 
 	InvalidateConnParamsHashEntries();
-
-	AddConnParam("fallback_application_name", CITUS_APPLICATION_NAME);
 }
 
 
@@ -253,14 +251,16 @@ GetConnParams(ConnectionHashKey *key, char ***keywords, char ***values,
 		"port",
 		"dbname",
 		"user",
-		"client_encoding"
+		"client_encoding",
+		"application_name"
 	};
 	const char *runtimeValues[] = {
 		key->hostname,
 		nodePortString,
 		key->database,
 		key->user,
-		GetDatabaseEncodingName()
+		GetDatabaseEncodingName(),
+		CITUS_APPLICATION_NAME
 	};
 
 	/*

--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -110,6 +110,7 @@ class CitusBaseClusterConfig(object, metaclass=NewInitCaller):
         }
         self.new_settings = {}
         self.add_coordinator_to_metadata = False
+        self.env_variables = {}
 
     def post_init(self):
         self._init_node_name_ports()
@@ -270,6 +271,10 @@ class CitusUnusualExecutorConfig(CitusMXBaseClusterConfig):
             "citus.enable_binary_protocol": False,
             "citus.local_table_join_policy": "prefer-distributed",
         }
+
+        # this setting does not necessarily need to be here
+        # could go any other test
+        self.env_variables = {'PGAPPNAME' : 'test_app'}
 
 
 class CitusSmallCopyBuffersConfig(CitusMXBaseClusterConfig):

--- a/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
@@ -112,7 +112,7 @@ def main(config):
         config.node_name_to_ports.keys(),
     )
     common.start_databases(
-        config.new_bindir, config.new_datadir, config.node_name_to_ports, config.name
+        config.new_bindir, config.new_datadir, config.node_name_to_ports, config.name, {}
     )
     citus_finish_pg_upgrade(config.new_bindir, config.node_name_to_ports.values())
 


### PR DESCRIPTION
Citus heavily relies on application_name, see
`IsCitusInitiatedRemoteBackend()`.

But if the user set the application name, such as export PGAPPNAME=test_name,
Citus uses that name while connecting to the remote node.

With this commit, we ensure that Citus always connects with
the "citus" user name to the remote nodes.

DESCRIPTION: Use a fixed application_name while connecting to remote nodes

fixes #5656 
fixes #5631
