### PR TITLE
Consider foreign keys between reference tables

### DIFF
--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -350,22 +350,6 @@ ReplicateReferenceTableShardToNode(ShardInterval *shardInterval, char *nodeName,
 	List *ddlCommandList =
 		CopyShardCommandList(shardInterval, srcNodeName, srcNodePort, includeData);
 
-	List *shardPlacementList = ShardPlacementListIncludingOrphanedPlacements(shardId);
-	ShardPlacement *targetPlacement = SearchShardPlacementInList(shardPlacementList,
-																 nodeName, nodePort);
-	if (targetPlacement != NULL)
-	{
-		if (targetPlacement->shardState == SHARD_STATE_ACTIVE)
-		{
-			/* We already have the shard, nothing to do */
-			return;
-		}
-		ereport(ERROR, (errmsg(
-							"Placement for reference table \"%s\" on node %s:%d is not active. This should not be possible, please report this as a bug",
-							get_rel_name(shardInterval->relationId), nodeName,
-							nodePort)));
-	}
-
 	ereport(NOTICE, (errmsg("Replicating reference table \"%s\" to the node %s:%d",
 							get_rel_name(shardInterval->relationId), nodeName,
 							nodePort)));
@@ -572,6 +556,18 @@ ReplicateAllReferenceTablesToNode(char *nodeName, int nodePort)
 		{
 			List *shardIntervalList = LoadShardIntervalList(referenceTableId);
 			ShardInterval *shardInterval = (ShardInterval *) linitial(shardIntervalList);
+
+			List *shardPlacementList =
+				ShardPlacementListIncludingOrphanedPlacements(shardInterval->shardId);
+			ShardPlacement *targetPlacement =
+				SearchShardPlacementInList(shardPlacementList, nodeName, nodePort);
+			if (targetPlacement != NULL &&
+				targetPlacement->shardState == SHARD_STATE_ACTIVE)
+			{
+				/* We already have the shard, nothing to do */
+				continue;
+			}
+
 
 			referenceShardIntervalList = lappend(referenceShardIntervalList,
 												 shardInterval);


### PR DESCRIPTION
On #5071, we avoid edge cases, but below there are foreign key constraints as well

This commit makes sure we cover those as well

Fixes cases like below on #5619, but seems fine to get to master separately
```SQL
CREATE TABLE reference_table_1(col int unique);
CREATE TABLE reference_table_2(col int unique);


ALTER TABLE reference_table_1 ADD CONSTRAINT fkey_1 FOREIGN KEY (col) REFERENCES reference_table_2(col);

SELECT create_reference_table('reference_table_2');
SELECT create_reference_table('reference_table_1');

SELECT citus_activate_node('localhost', 9700);
ERROR:  constraint "fkey_1_102075" for relation "reference_table_1_102075" already exists
CONTEXT:  while executing command on localhost:9700
```

