### PR TITLE
Allow create_distributed_function() on a function owned by an extension

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -396,6 +396,15 @@ ReplicateAllObjectsToNodeCommandList(const char *nodeName, int nodePort)
 	ObjectAddress *dependency = NULL;
 	foreach_ptr(dependency, dependencies)
 	{
+		if (IsObjectAddressOwnedByExtension(dependency, NULL))
+		{
+			/*
+			 * we expect extension-owned objects to be created as a result
+			 * of the extension being created.
+			 */
+			continue;
+		}
+
 		ddlCommands = list_concat(ddlCommands,
 								  GetDependencyCreateDDLCommands(dependency));
 	}

--- a/src/test/regress/expected/distributed_functions.out
+++ b/src/test/regress/expected/distributed_functions.out
@@ -469,8 +469,7 @@ ALTER FUNCTION eq(macaddr,macaddr) DEPENDS ON EXTENSION citus;
 ERROR:  distrtibuted functions are not allowed to depend on an extension
 DETAIL:  Function "function_tests.eq(pg_catalog.macaddr,pg_catalog.macaddr)" is already distributed. Functions from extensions are expected to be created on the workers by the extension they depend on.
 SELECT create_distributed_function('pg_catalog.citus_drop_trigger()');
-ERROR:  unable to create a distributed function from functions owned by an extension
-DETAIL:  Function "pg_catalog.citus_drop_trigger()" has a dependency on extension "citus". Functions depending on an extension cannot be distributed. Create the function by creating the extension on the workers.
+ERROR:  Citus extension functions(citus_drop_trigger) cannot be distributed.
 DROP FUNCTION eq(macaddr,macaddr);
 -- call should fail as function should have been dropped
 SELECT * FROM run_command_on_workers($$SELECT function_tests.eq('0123456789ab','ba9876543210');$$) ORDER BY 1,2;

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -398,10 +398,34 @@ SELECT 1 from master_remove_node('localhost', :worker_2_port);
         1
 (1 row)
 
+-- Test extension function incorrect distribution argument
+CREATE TABLE test_extension_function(col varchar);
+CREATE EXTENSION seg;
+-- Missing distribution argument
+SELECT create_distributed_function('seg_in(cstring)');
+ERROR:  Extension functions(seg_in) without distribution argument are not supported.
+-- Missing colocation argument
+SELECT create_distributed_function('seg_in(cstring)', '$1');
+ERROR:  cannot distribute the function "seg_in" since there is no table to colocate with
+HINT:  Provide a distributed table via "colocate_with" option to create_distributed_function()
+-- Incorrect distribution argument
+SELECT create_distributed_function('seg_in(cstring)', '$2', colocate_with:='test_extension_function');
+ERROR:  cannot distribute the function "seg_in" since the distribution argument is not valid
+HINT:  Either provide a valid function argument name or a valid "$paramIndex" to create_distributed_function()
+-- Colocated table is not distributed
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ERROR:  relation test_extension_function is not distributed
+DROP EXTENSION seg;
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('test_extension_function', 'col', colocate_with := 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 -- now, create a type that depends on another type, which
 -- finally depends on an extension
 BEGIN;
-	SET citus.shard_replication_factor TO 1;
 	CREATE EXTENSION seg;
 	CREATE EXTENSION isn;
 	CREATE TYPE test_type AS (a int, b seg);
@@ -421,7 +445,37 @@ BEGIN;
 
 (1 row)
 
+	-- Distribute an extension-function
+	SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
 COMMIT;
+-- Check the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+ seg_in
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+(1 row)
+
 -- add the node back
 SELECT 1 from master_add_node('localhost', :worker_2_port);
  ?column?
@@ -443,5 +497,145 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname 
  (localhost,57638,t,2)
 (2 rows)
 
+-- Check the pg_dist_object on the both nodes
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+DROP EXTENSION seg CASCADE;
+-- Recheck the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- Distribute an extension-function where extension is not in pg_dist_object
+SET citus.enable_ddl_propagation TO false;
+CREATE EXTENSION seg;
+SET citus.enable_ddl_propagation TO true;
+-- Check the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Recheck the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+ seg_in
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+DROP EXTENSION seg;
+DROP TABLE test_extension_function;
+-- Test extension function altering distribution argument
+BEGIN;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
+SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE EXTENSION cube;
+SELECT create_distributed_function('cube(float8[], float8[])', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+ distribution_argument_index
+---------------------------------------------------------------------
+                           0
+(1 row)
+
+SELECT create_distributed_function('cube(float8[], float8[])', '$2', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+ distribution_argument_index
+---------------------------------------------------------------------
+                           1
+(1 row)
+
+ROLLBACK;
 -- drop the schema and all the objects
 DROP SCHEMA "extension'test" CASCADE;

--- a/src/test/regress/expected/propagate_extension_commands_1.out
+++ b/src/test/regress/expected/propagate_extension_commands_1.out
@@ -397,10 +397,34 @@ SELECT 1 from master_remove_node('localhost', :worker_2_port);
         1
 (1 row)
 
+-- Test extension function incorrect distribution argument
+CREATE TABLE test_extension_function(col varchar);
+CREATE EXTENSION seg;
+-- Missing distribution argument
+SELECT create_distributed_function('seg_in(cstring)');
+ERROR:  Extension functions(seg_in) without distribution argument are not supported.
+-- Missing colocation argument
+SELECT create_distributed_function('seg_in(cstring)', '$1');
+ERROR:  cannot distribute the function "seg_in" since there is no table to colocate with
+HINT:  Provide a distributed table via "colocate_with" option to create_distributed_function()
+-- Incorrect distribution argument
+SELECT create_distributed_function('seg_in(cstring)', '$2', colocate_with:='test_extension_function');
+ERROR:  cannot distribute the function "seg_in" since the distribution argument is not valid
+HINT:  Either provide a valid function argument name or a valid "$paramIndex" to create_distributed_function()
+-- Colocated table is not distributed
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ERROR:  relation test_extension_function is not distributed
+DROP EXTENSION seg;
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('test_extension_function', 'col', colocate_with := 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 -- now, create a type that depends on another type, which
 -- finally depends on an extension
 BEGIN;
-	SET citus.shard_replication_factor TO 1;
 	CREATE EXTENSION seg;
 	CREATE EXTENSION isn;
 	CREATE TYPE test_type AS (a int, b seg);
@@ -420,7 +444,37 @@ BEGIN;
 
 (1 row)
 
+	-- Distribute an extension-function
+	SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
 COMMIT;
+-- Check the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+ seg_in
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+(1 row)
+
 -- add the node back
 SELECT 1 from master_add_node('localhost', :worker_2_port);
  ?column?
@@ -442,5 +496,145 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname 
  (localhost,57638,t,2)
 (2 rows)
 
+-- Check the pg_dist_object on the both nodes
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+DROP EXTENSION seg CASCADE;
+-- Recheck the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- Distribute an extension-function where extension is not in pg_dist_object
+SET citus.enable_ddl_propagation TO false;
+CREATE EXTENSION seg;
+SET citus.enable_ddl_propagation TO true;
+-- Check the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Recheck the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+ distributedfunction
+---------------------------------------------------------------------
+ seg_in
+(1 row)
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+DROP EXTENSION seg;
+DROP TABLE test_extension_function;
+-- Test extension function altering distribution argument
+BEGIN;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
+SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE EXTENSION cube;
+SELECT create_distributed_function('cube(float8[], float8[])', '$1', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+ distribution_argument_index
+---------------------------------------------------------------------
+                           0
+(1 row)
+
+SELECT create_distributed_function('cube(float8[], float8[])', '$2', 'test_extension_function');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+ distribution_argument_index
+---------------------------------------------------------------------
+                           1
+(1 row)
+
+ROLLBACK;
 -- drop the schema and all the objects
 DROP SCHEMA "extension'test" CASCADE;

--- a/src/test/regress/sql/propagate_extension_commands.sql
+++ b/src/test/regress/sql/propagate_extension_commands.sql
@@ -227,10 +227,25 @@ SET search_path TO "extension'test";
 -- remove the node, we'll add back again
 SELECT 1 from master_remove_node('localhost', :worker_2_port);
 
+-- Test extension function incorrect distribution argument
+CREATE TABLE test_extension_function(col varchar);
+CREATE EXTENSION seg;
+-- Missing distribution argument
+SELECT create_distributed_function('seg_in(cstring)');
+-- Missing colocation argument
+SELECT create_distributed_function('seg_in(cstring)', '$1');
+-- Incorrect distribution argument
+SELECT create_distributed_function('seg_in(cstring)', '$2', colocate_with:='test_extension_function');
+-- Colocated table is not distributed
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+DROP EXTENSION seg;
+
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('test_extension_function', 'col', colocate_with := 'none');
+
 -- now, create a type that depends on another type, which
 -- finally depends on an extension
 BEGIN;
-	SET citus.shard_replication_factor TO 1;
 	CREATE EXTENSION seg;
 	CREATE EXTENSION isn;
 	CREATE TYPE test_type AS (a int, b seg);
@@ -243,7 +258,24 @@ BEGIN;
 	CREATE TABLE t3 (a int, b test_type_3);
 	SELECT create_reference_table('t3');
 
+	-- Distribute an extension-function
+	SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
 COMMIT;
+
+-- Check the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
 
 -- add the node back
 SELECT 1 from master_add_node('localhost', :worker_2_port);
@@ -251,6 +283,87 @@ SELECT 1 from master_add_node('localhost', :worker_2_port);
 -- make sure that both extensions are created on both nodes
 SELECT count(*) FROM citus.pg_dist_object WHERE objid IN (SELECT oid FROM pg_extension WHERE extname IN ('seg', 'isn'));
 SELECT run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname IN ('seg', 'isn')$$);
+
+-- Check the pg_dist_object on the both nodes
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+
+DROP EXTENSION seg CASCADE;
+
+-- Recheck the pg_dist_object
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+
+-- Distribute an extension-function where extension is not in pg_dist_object
+SET citus.enable_ddl_propagation TO false;
+CREATE EXTENSION seg;
+SET citus.enable_ddl_propagation TO true;
+
+-- Check the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+
+SELECT create_distributed_function('seg_in(cstring)', '$1', 'test_extension_function');
+
+-- Recheck the extension in pg_dist_object
+SELECT count(*) FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+
+SELECT pg_proc.proname as DistributedFunction
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+
+SELECT run_command_on_workers($$
+SELECT count(*)
+FROM citus.pg_dist_object, pg_proc
+WHERE pg_proc.proname = 'seg_in' and
+pg_proc.oid = citus.pg_dist_object.objid and
+classid = 'pg_proc'::regclass;
+$$);
+DROP EXTENSION seg;
+DROP TABLE test_extension_function;
+
+
+-- Test extension function altering distribution argument
+BEGIN;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
+SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
+CREATE EXTENSION cube;
+
+SELECT create_distributed_function('cube(float8[], float8[])', '$1', 'test_extension_function');
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+
+SELECT create_distributed_function('cube(float8[], float8[])', '$2', 'test_extension_function');
+SELECT distribution_argument_index FROM citus.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::pg_catalog.regclass AND
+objid = (SELECT oid FROM pg_proc WHERE prosrc = 'cube_a_f8_f8');
+ROLLBACK;
 
 -- drop the schema and all the objects
 DROP SCHEMA "extension'test" CASCADE;


### PR DESCRIPTION
Implement #5649
Allow create_distributed_function() on functions owned by extensions

1) Only update pg_dist_object, and do not propagate CREATE FUNCTION.
(Done)

2) Ensure corresponding extension is in pg_dist_object.
(An extension should be in pg_dist_object, only exception is Citus)

3) Verify if dependencies exist on the function they should resolve to the extension.
(This is a generic good to have check, but orthogonal to this PR and should be part of existing extension mechanism)

4) Impact on node-scaling: We build a list of ddl commands based on all objects in pg_dist_object. We need to omit the ddl's for the extension-function, as it will get propagated by the virtue of the extension creation. 
(We do follow the distributed function in the traversal check but will not generate any DDL, this is true for all extension-owned objects)

5) Extra checks for functions coming from extensions, to not propagate changes via ddl commands, even though the function is marked as distributed in pg_dist_object.
(RecurseObjectDependencies in general takes care of eliminating extension-owned objects)

DESCRIPTION: Allow create_distributed_function() on a function owned by an extension.
