### PR TITLE
Removed dependency from EnsureTableOwner

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -1913,13 +1913,6 @@ columnar_tableam_init()
 }
 
 
-void
-columnar_tableam_finish()
-{
-	object_access_hook = PrevObjectAccessHook;
-}
-
-
 /*
  * Get the number of chunks filtered out during the given scan.
  */

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2334,7 +2334,11 @@ alter_columnar_table_set(PG_FUNCTION_ARGS)
 							   quote_identifier(RelationGetRelationName(rel)))));
 	}
 
-	EnsureTableOwner(relationId);
+	if (!pg_class_ownercheck(relationId, GetUserId()))
+	{
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE,
+					   get_rel_name(relationId));
+	}
 
 	ColumnarOptions options = { 0 };
 	if (!ReadColumnarOptions(relationId, &options))
@@ -2454,7 +2458,11 @@ alter_columnar_table_reset(PG_FUNCTION_ARGS)
 							   quote_identifier(RelationGetRelationName(rel)))));
 	}
 
-	EnsureTableOwner(relationId);
+	if (!pg_class_ownercheck(relationId, GetUserId()))
+	{
+		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE,
+					   get_rel_name(relationId));
+	}
 
 	ColumnarOptions options = { 0 };
 	if (!ReadColumnarOptions(relationId, &options))

--- a/src/backend/columnar/mod.c
+++ b/src/backend/columnar/mod.c
@@ -28,10 +28,3 @@ columnar_init(void)
 	columnar_init_gucs();
 	columnar_tableam_init();
 }
-
-
-void
-columnar_fini(void)
-{
-	columnar_tableam_finish();
-}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -108,7 +108,6 @@ static GucStringAssignHook OldApplicationNameAssignHook = NULL;
 
 
 void _PG_init(void);
-void _PG_fini(void);
 
 static void DoInitialCleanup(void);
 static void ResizeStackToMaximumDepth(void);
@@ -355,14 +354,6 @@ _PG_init(void)
 		DoInitialCleanup();
 	}
 	columnar_init();
-}
-
-
-/* shared library deconstruction function */
-void
-_PG_fini(void)
-{
-	columnar_fini();
 }
 
 

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -50,7 +50,6 @@ typedef struct ColumnarScanDescData *ColumnarScanDesc;
 
 const TableAmRoutine * GetColumnarTableAmRoutine(void);
 extern void columnar_tableam_init(void);
-extern void columnar_tableam_finish(void);
 extern bool CheckCitusVersion(int elevel);
 extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot snapshot,
 												 int nkeys, ScanKey key,

--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -7,9 +7,9 @@
 #include "access/tableam.h"
 #include "access/skey.h"
 #include "nodes/bitmapset.h"
-
-#include "distributed/coordinator_protocol.h"
-
+#include "access/heapam.h"
+#include "catalog/indexing.h"
+#include "utils/acl.h"
 
 /*
  * Number of valid ItemPointer Offset's for "row number" <> "ItemPointer"
@@ -51,7 +51,7 @@ typedef struct ColumnarScanDescData *ColumnarScanDesc;
 const TableAmRoutine * GetColumnarTableAmRoutine(void);
 extern void columnar_tableam_init(void);
 extern void columnar_tableam_finish(void);
-
+extern bool CheckCitusVersion(int elevel);
 extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot snapshot,
 												 int nkeys, ScanKey key,
 												 ParallelTableScanDesc parallel_scan,

--- a/src/test/regress/expected/multi_multiuser.out
+++ b/src/test/regress/expected/multi_multiuser.out
@@ -283,6 +283,14 @@ SELECT * FROM columnar_table;
  1
 (2 rows)
 
+-- Fail to alter a columnar table that is created by a different user
+SET ROLE full_access;
+SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
+ERROR:  must be owner of table columnar_table
+-- Fail to reset a columnar table value created by a different user
+SELECT alter_columnar_table_reset('columnar_table', chunk_group_row_limit => true);
+ERROR:  must be owner of table columnar_table
+SET ROLE read_access;
 -- and drop it
 DROP TABLE columnar_table;
 -- cannot modify columnar metadata table as unprivileged user

--- a/src/test/regress/sql/multi_multiuser.sql
+++ b/src/test/regress/sql/multi_multiuser.sql
@@ -169,6 +169,12 @@ SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000)
 -- insert some data and read
 INSERT INTO columnar_table VALUES (1), (1);
 SELECT * FROM columnar_table;
+-- Fail to alter a columnar table that is created by a different user
+SET ROLE full_access;
+SELECT alter_columnar_table_set('columnar_table', chunk_group_row_limit => 2000);
+-- Fail to reset a columnar table value created by a different user
+SELECT alter_columnar_table_reset('columnar_table', chunk_group_row_limit => true);
+SET ROLE read_access;
 -- and drop it
 DROP TABLE columnar_table;
 


### PR DESCRIPTION
Removing dependency on EnsureTableOwner from Columnar. 

By removing distributed/coordinator_protocol.h, access to EnsureTableOwner and CheckCitusVersion is lost. Removing CheckCitusVersion will need more time so will place the extern function in columnar_tableam.h as a buffer for now. Also added two new tests so that the copied function is covered.