### PR TITLE
Update function and extension checks on object distribution UDF

### DIFF
--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -658,11 +658,26 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
     CREATE FUNCTION distribution_test_function(int) RETURNS int
     AS $$ SELECT $1 $$
     LANGUAGE SQL;
+	-- Since creating function grant execute to public directly, user can
+	-- call the citus_internal_add_object_metadata
     SET ROLE metadata_sync_helper_role;
     WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
         AS (VALUES ('function', ARRAY['distribution_test_function']::text[], ARRAY['integer']::text[], -1, 0, false))
     SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
-ERROR:  must be owner of function distribution_test_function
+ citus_internal_add_object_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+	RESET ROLE;
+	REVOKE ALL ON FUNCTION distribution_test_function(int) FROM PUBLIC;
+	-- After revoking it's execute right on the function, user can not
+	-- call the citus_internal_add_object_metadata
+	SET ROLE metadata_sync_helper_role;
+    WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
+        AS (VALUES ('function', ARRAY['distribution_test_function']::text[], ARRAY['integer']::text[], -1, 0, false))
+    SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
+ERROR:  Current user does not have required privileges on function distribution_test_function(integer) to mark it as distributed
 ROLLBACK;
 -- we do not allow wrong partmethod
 -- so manually insert wrong partmethod for the sake of the test

--- a/src/test/regress/expected/non_super_user_object_metadata.out
+++ b/src/test/regress/expected/non_super_user_object_metadata.out
@@ -79,6 +79,21 @@ SELECT create_distributed_function('test_function(int)');
 
 (1 row)
 
+-- Create and distribute plpgsql extension's function
+CREATE OR REPLACE FUNCTION plpgsql_dist_function(text)
+RETURNS void
+LANGUAGE plpgsql AS
+$$
+    BEGIN
+        RAISE NOTICE '%', $1;
+    END;
+$$;
+SELECT create_distributed_function('plpgsql_dist_function(text)');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
 -- show that schema, types, function and sequence has marked as distributed
 -- on the coordinator node
 RESET ROLE;
@@ -122,6 +137,12 @@ SELECT pg_identify_object_as_address(classid, objid, objsubid) from citus.pg_dis
             pg_identify_object_as_address
 ---------------------------------------------------------------------
  (function,"{local_schema,test_function}",{integer})
+(1 row)
+
+SELECT pg_identify_object_as_address(classid, objid, objsubid) from citus.pg_dist_object where objid = 'local_schema.plpgsql_dist_function'::regproc::oid;
+                    pg_identify_object_as_address
+---------------------------------------------------------------------
+ (function,"{local_schema,plpgsql_dist_function}",{pg_catalog.text})
 (1 row)
 
 -- show those objects marked as distributed on metadata worker node as well
@@ -172,6 +193,27 @@ SELECT * FROM run_command_on_workers($$SELECT pg_identify_object_as_address(clas
 ---------------------------------------------------------------------
  localhost |    57637 | t       | (function,"{local_schema,test_function}",{integer})
  localhost |    57638 | t       | (function,"{local_schema,test_function}",{integer})
+(2 rows)
+
+SELECT * FROM run_command_on_workers($$SELECT pg_identify_object_as_address(classid, objid, objsubid) from citus.pg_dist_object where objid = 'local_schema.plpgsql_dist_function'::regproc::oid;$$) ORDER BY 1,2;
+ nodename  | nodeport | success |                               result
+---------------------------------------------------------------------
+ localhost |    57637 | t       | (function,"{local_schema,plpgsql_dist_function}",{pg_catalog.text})
+ localhost |    57638 | t       | (function,"{local_schema,plpgsql_dist_function}",{pg_catalog.text})
+(2 rows)
+
+-- Show that extension plpgsql is also marked as distributed as a dependency of plpgsl_dist_function
+SELECT * FROM (SELECT pg_identify_object_as_address(classid, objid, objsubid) as obj_identifier from citus.pg_dist_object) as obj_identifiers where obj_identifier::text like '%{plpgsql}%';
+      obj_identifier
+---------------------------------------------------------------------
+ (extension,{plpgsql},{})
+(1 row)
+
+SELECT * FROM run_command_on_workers($$SELECT * FROM (SELECT pg_identify_object_as_address(classid, objid, objsubid) as obj_identifier from citus.pg_dist_object) as obj_identifiers where obj_identifier::text like '%{plpgsql}%';$$) ORDER BY 1,2;
+ nodename  | nodeport | success |          result
+---------------------------------------------------------------------
+ localhost |    57637 | t       | (extension,{plpgsql},{})
+ localhost |    57638 | t       | (extension,{plpgsql},{})
 (2 rows)
 
 -- show that schema is owned by the superuser
@@ -372,8 +414,9 @@ SELECT * FROM run_command_on_workers($$ SELECT distribution_argument_index FROM 
 
 -- Show that dropping schema doesn't affect the worker node
 DROP SCHEMA local_schema CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table metadata_dist_test_table
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to function plpgsql_dist_function(text)
+drop cascades to table metadata_dist_test_table
 drop cascades to function metadata_dist_test_proc(integer,integer)
 SELECT * FROM (SELECT pg_identify_object_as_address(classid, objid, objsubid) as obj_identifier from citus.pg_dist_object) as obj_identifiers where obj_identifier::text like '%{local_schema}%';
  obj_identifier


### PR DESCRIPTION
Update function and extension checks within citus_internal_add_object_metadata to relax limitations on them. So users with execute grant will be able to mark functions as distributed and ownership check for extensions have also been removed.
