### PR TITLE
Unify old GUCs into a single one

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -34,8 +34,6 @@ static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 static List * FilterObjectAddressListByPredicate(List *objectAddressList,
 												 AddressPredicate predicate);
 
-bool EnableDependencyCreation = true;
-
 /*
  * EnsureDependenciesExistOnAllNodes finds all the dependencies that we support and makes
  * sure these are available on all workers. If not available they will be created on the
@@ -364,7 +362,7 @@ ReplicateAllObjectsToNodeCommandList(const char *nodeName, int nodePort)
 	List *dependencies = GetDistributedObjectAddressList();
 
 	/*
-	 * Depending on changes in the environment, such as the enable_object_propagation guc
+	 * Depending on changes in the environment, such as the enable_metadata_sync guc
 	 * there might be objects in the distributed object address list that should currently
 	 * not be propagated by citus as they are 'not supported'.
 	 */
@@ -415,7 +413,7 @@ ShouldPropagate(void)
 		return false;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -649,7 +649,7 @@ static bool
 ShouldPropagateExtensionCommand(Node *parseTree)
 {
 	/* if we disabled object propagation, then we should not propagate anything. */
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		return false;
 	}

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -200,8 +200,8 @@ create_distributed_function(PG_FUNCTION_ARGS)
 	const char *createFunctionSQL = GetFunctionDDLCommand(funcOid, true);
 	const char *alterFunctionOwnerSQL = GetFunctionAlterOwnerCommand(funcOid);
 	initStringInfo(&ddlCommand);
-	appendStringInfo(&ddlCommand, "%s;%s;%s;%s", DISABLE_OBJECT_PROPAGATION,
-					 createFunctionSQL, alterFunctionOwnerSQL, ENABLE_OBJECT_PROPAGATION);
+	appendStringInfo(&ddlCommand, "%s;%s;%s;%s", DISABLE_METADATA_SYNC,
+					 createFunctionSQL, alterFunctionOwnerSQL, ENABLE_METADATA_SYNC);
 	SendCommandToWorkersAsUser(NON_COORDINATOR_NODES, CurrentUserName(), ddlCommand.data);
 
 	MarkObjectDistributed(&functionAddress);
@@ -698,7 +698,7 @@ UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 
 	table_close(pgDistObjectRel, NoLock);
 
-	if (EnableDependencyCreation)
+	if (EnableMetadataSync)
 	{
 		List *objectAddressList = list_make1((ObjectAddress *) distAddress);
 		List *distArgumentIndexList = NIL;
@@ -1206,7 +1206,7 @@ ShouldPropagateCreateFunction(CreateFunctionStmt *stmt)
 		return false;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything
@@ -1254,7 +1254,7 @@ ShouldPropagateAlterFunction(const ObjectAddress *address)
 		return false;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything
@@ -1556,7 +1556,7 @@ PreprocessDropFunctionStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything
@@ -1657,7 +1657,7 @@ PreprocessAlterFunctionDependsStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -241,7 +241,7 @@ PreprocessDropSequenceStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * we are configured to disable object propagation, should not propagate anything

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -437,8 +437,12 @@ AcquireDistributedLockOnRelations(List *relationIdList, LOCKMODE lockMode)
 		/*
 		 * We only acquire distributed lock on relation if
 		 * the relation is sync'ed between mx nodes.
+		 *
+		 * Even if users disable metadata sync, we cannot
+		 * allow them not to acquire the remote locks.
+		 * Hence, we have !IsCoordinator() check.
 		 */
-		if (ShouldSyncTableMetadata(relationId))
+		if (ShouldSyncTableMetadata(relationId) || !IsCoordinator())
 		{
 			char *qualifiedRelationName = generate_qualified_relation_name(relationId);
 			StringInfo lockRelationCommand = makeStringInfo();

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -558,7 +558,7 @@ IsObjectAddressCollected(ObjectAddress findAddress,
 bool
 SupportedDependencyByCitus(const ObjectAddress *address)
 {
-	if (!EnableDependencyCreation)
+	if (!EnableMetadataSync)
 	{
 		/*
 		 * If the user has disabled object propagation we need to fall back to the legacy

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -172,7 +172,7 @@ MarkObjectDistributed(const ObjectAddress *distAddress)
 		ereport(ERROR, (errmsg("failed to insert object into citus.pg_dist_object")));
 	}
 
-	if (EnableDependencyCreation)
+	if (EnableMetadataSync)
 	{
 		/* create a list by adding the address of value to not to have warning */
 		List *objectAddressList = list_make1((ObjectAddress *) distAddress);

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -77,7 +77,7 @@ bool ReplicateReferenceTablesOnActivate = true;
 /* did current transaction modify pg_dist_node? */
 bool TransactionModifiedNodeMetadata = false;
 
-bool EnableMetadataSyncByDefault = true;
+bool EnableMetadataSync = true;
 
 typedef struct NodeMetadata
 {
@@ -1095,9 +1095,9 @@ ActivateNode(char *nodeName, int nodePort)
 								 BoolGetDatum(isActive));
 
 	/* TODO: Once all tests will be enabled for MX, we can remove sync by default check */
-	bool syncMetadata = EnableMetadataSyncByDefault && NodeIsPrimary(workerNode);
+	bool syncMetadata = EnableMetadataSync && NodeIsPrimary(workerNode);
 
-	if (syncMetadata && EnableDependencyCreation)
+	if (syncMetadata)
 	{
 		/*
 		 * We are going to sync the metadata anyway in this transaction, so do

--- a/src/backend/distributed/operations/repair_shards.c
+++ b/src/backend/distributed/operations/repair_shards.c
@@ -556,8 +556,12 @@ BlockWritesToShardList(List *shardList)
 	Oid firstDistributedTableId = firstShardInterval->relationId;
 
 	bool shouldSyncMetadata = ShouldSyncTableMetadata(firstDistributedTableId);
-	if (shouldSyncMetadata)
+	if (shouldSyncMetadata || !IsCoordinator())
 	{
+		/*
+		 * Even if users disable metadata sync, we cannot allow them not to
+		 * acquire the remote locks. Hence, we have !IsCoordinator() check.
+		 */
 		LockShardListMetadataOnWorkers(ExclusiveLock, shardList);
 	}
 }

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -911,21 +911,10 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
-		"citus.enable_metadata_sync_by_default",
-		gettext_noop("Enables MX in the new nodes by default"),
+		"citus.enable_metadata_sync",
+		gettext_noop("Enables object and metadata syncing."),
 		NULL,
-		&EnableMetadataSyncByDefault,
-		true,
-		PGC_USERSET,
-		GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL,
-		NULL, NULL, NULL);
-
-	DefineCustomBoolVariable(
-		"citus.enable_object_propagation",
-		gettext_noop("Enables propagating object creation for more complex objects, "
-					 "schema's will always be created"),
-		NULL,
-		&EnableDependencyCreation,
+		&EnableMetadataSync,
 		true,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL,

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -32,7 +32,6 @@ typedef enum
 } PropSetCmdBehavior;
 extern PropSetCmdBehavior PropagateSetCommands;
 extern bool EnableDDLPropagation;
-extern bool EnableDependencyCreation;
 extern bool EnableCreateTypePropagation;
 extern bool EnableAlterRolePropagation;
 extern bool EnableAlterRoleSetPropagation;

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -89,8 +89,8 @@ extern Oid GetAttributeTypeOid(Oid relationId, AttrNumber attnum);
 
 #define DISABLE_DDL_PROPAGATION "SET citus.enable_ddl_propagation TO 'off'"
 #define ENABLE_DDL_PROPAGATION "SET citus.enable_ddl_propagation TO 'on'"
-#define DISABLE_OBJECT_PROPAGATION "SET citus.enable_object_propagation TO 'off'"
-#define ENABLE_OBJECT_PROPAGATION "SET citus.enable_object_propagation TO 'on'"
+#define DISABLE_METADATA_SYNC "SET citus.enable_metadata_sync TO 'off'"
+#define ENABLE_METADATA_SYNC "SET citus.enable_metadata_sync TO 'on'"
 #define WORKER_APPLY_SEQUENCE_COMMAND "SELECT worker_apply_sequence_command (%s,%s)"
 #define UPSERT_PLACEMENT \
 	"INSERT INTO pg_dist_placement " \
@@ -108,6 +108,6 @@ extern Oid GetAttributeTypeOid(Oid relationId, AttrNumber attnum);
 
 /* controlled via GUC */
 extern char *EnableManualMetadataChangesForUser;
-extern bool EnableMetadataSyncByDefault;
+extern bool EnableMetadataSync;
 
 #endif /* METADATA_SYNC_H */

--- a/src/test/regress/expected/check_mx.out
+++ b/src/test/regress/expected/check_mx.out
@@ -1,5 +1,5 @@
-SHOW citus.enable_metadata_sync_by_default;
- citus.enable_metadata_sync_by_default
+SHOW citus.enable_metadata_sync;
+ citus.enable_metadata_sync
 ---------------------------------------------------------------------
  on
 (1 row)

--- a/src/test/regress/expected/disable_object_propagation.out
+++ b/src/test/regress/expected/disable_object_propagation.out
@@ -1,5 +1,5 @@
 SET citus.next_shard_id TO 20030000;
-SET citus.enable_object_propagation TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
+SET citus.enable_metadata_sync TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
 CREATE USER typeowner_for_disabled_object_propagation_guc;
 NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
 HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
@@ -65,7 +65,7 @@ SELECT create_distributed_table('t3', 'a');
 -- verify ALTER TYPE statements are not propagated for types, even though they are marked distributed
 BEGIN;
 -- object propagation is turned off after xact finished, type is already marked distributed by then
-SET LOCAL citus.enable_object_propagation TO on;
+SET LOCAL citus.enable_metadata_sync TO on;
 CREATE TYPE tt3 AS (a int, b int);
 CREATE TABLE t4 (a int PRIMARY KEY, b tt3);
 SELECT create_distributed_table('t4','a');
@@ -120,7 +120,7 @@ $$);
 
 -- suppress any warnings during cleanup
 SET client_min_messages TO error;
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 DROP SCHEMA disabled_object_propagation CASCADE;
 DROP SCHEMA disabled_object_propagation2 CASCADE;
 DROP USER typeowner_for_disabled_object_propagation_guc;

--- a/src/test/regress/expected/distributed_collations_conflict.out
+++ b/src/test/regress/expected/distributed_collations_conflict.out
@@ -8,6 +8,7 @@ SELECT run_command_on_workers($$CREATE SCHEMA collation_conflict;$$);
 
 \c - - - :worker_1_port
 SET search_path TO collation_conflict;
+SET citus.enable_metadata_sync TO off;
 CREATE COLLATION caseinsensitive (
 	provider = icu,
 	locale = 'und-u-ks-level2'
@@ -45,6 +46,7 @@ SET search_path TO collation_conflict;
 DROP TABLE tblcoll;
 DROP COLLATION caseinsensitive;
 \c - - - :worker_1_port
+SET citus.enable_metadata_sync TO off;
 SET search_path TO collation_conflict;
 CREATE COLLATION caseinsensitive (
 	provider = icu,

--- a/src/test/regress/expected/isolation_check_mx.out
+++ b/src/test/regress/expected/isolation_check_mx.out
@@ -2,10 +2,10 @@ Parsed test spec with 1 sessions
 
 starting permutation: check_mx
 step check_mx:
-    SHOW citus.enable_metadata_sync_by_default;
+    SHOW citus.enable_metadata_sync;
     SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
 
-citus.enable_metadata_sync_by_default
+citus.enable_metadata_sync
 ---------------------------------------------------------------------
 on
 (1 row)

--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -2,295 +2,337 @@ Parsed test spec with 2 sessions
 
 starting permutation: s1-begin s2-begin s2-reindex s1-insert s2-commit s1-commit
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-grant s1-begin s2-begin s2-reindex s1-insert s2-insert s2-commit s1-commit
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
 
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-grant s1-begin s2-begin s1-reindex s2-insert s1-insert s1-commit s2-commit
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-begin s2-begin s2-index s1-insert s2-commit s1-commit s2-drop-index
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-grant s1-begin s2-begin s2-insert s1-index s2-insert s2-commit s1-commit s1-drop-index
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
 
 step s1-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
  <waiting ...>
 step s2-insert: 
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-index: <... completed>
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s1-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-grant s1-begin s2-begin s1-index s2-index s1-insert s1-commit s2-commit s1-drop-index s2-drop-index
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 step s2-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 step s2-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-begin s2-begin s2-truncate s1-insert s2-commit s1-commit
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 ERROR:  permission denied for table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-grant s1-begin s2-begin s1-truncate s2-insert s1-insert s1-commit s2-commit
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-grant s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit
 step s1-grant:
- SET ROLE test_user_1;
- SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
+	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 
 bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
 
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,SET)
+(localhost,57638,t,SET)
+(2 rows)
+
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 step s2-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
  <waiting ...>
 step s1-commit: 
- COMMIT;
+	COMMIT;
 
 step s2-truncate: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 

--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -103,8 +103,8 @@ step s2-view-worker:
 
 query                                                                         |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
-UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57638|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
-UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57637|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
+UPDATE public.ref_table_1500803 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57638|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
+UPDATE public.ref_table_1500803 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57637|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
 (2 rows)
 
 step s2-end:

--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -103,8 +103,8 @@ step s2-view-worker:
 
 query                                                                         |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
-UPDATE public.ref_table_1500803 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57638|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
-UPDATE public.ref_table_1500803 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57637|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
+UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57638|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
+UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57637|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
 (2 rows)
 
 step s2-end:

--- a/src/test/regress/expected/isolation_turn_mx_off.out
+++ b/src/test/regress/expected/isolation_turn_mx_off.out
@@ -2,7 +2,7 @@ Parsed test spec with 1 sessions
 
 starting permutation: disable-mx-by-default reload stop-metadata-sync
 step disable-mx-by-default:
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 
 step reload:
   SELECT pg_reload_conf();

--- a/src/test/regress/expected/isolation_turn_mx_off_0.out
+++ b/src/test/regress/expected/isolation_turn_mx_off_0.out
@@ -2,7 +2,7 @@ Parsed test spec with 1 sessions
 
 starting permutation: disable-mx-by-default reload stop-metadata-sync
 step disable-mx-by-default:
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 
 step reload:
   SELECT pg_reload_conf();

--- a/src/test/regress/expected/isolation_turn_mx_on.out
+++ b/src/test/regress/expected/isolation_turn_mx_on.out
@@ -2,7 +2,7 @@ Parsed test spec with 1 sessions
 
 starting permutation: enable-mx-by-default reload start-metadata-sync
 step enable-mx-by-default:
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 
 step reload:
   SELECT pg_reload_conf();

--- a/src/test/regress/expected/isolation_turn_mx_on_0.out
+++ b/src/test/regress/expected/isolation_turn_mx_on_0.out
@@ -2,7 +2,7 @@ Parsed test spec with 1 sessions
 
 starting permutation: enable-mx-by-default reload start-metadata-sync
 step enable-mx-by-default:
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 
 step reload:
   SELECT pg_reload_conf();

--- a/src/test/regress/expected/multi_deparse_function.out
+++ b/src/test/regress/expected/multi_deparse_function.out
@@ -64,14 +64,14 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 -- Since deparse logic on workers can not work for if function
 -- is distributed on workers, we are disabling object propagation
 -- first. Same trick has been applied multiple times in this test.
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('add(int,int)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add CALLED ON NULL INPUT
 $cmd$);
@@ -540,7 +540,7 @@ CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() RETURNS TEXT
 CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text) RETURNS TEXT
     AS $$ SELECT 'Overloaded function called with param: ' || $1 $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"()');
  create_distributed_function
 ---------------------------------------------------------------------
@@ -553,7 +553,7 @@ SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text)');
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() SET SCHEMA "CiTUS.TEEN2"
 $cmd$);
@@ -581,14 +581,14 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line XX at RAISE
 CREATE FUNCTION func_default_param(param INT DEFAULT 0) RETURNS TEXT
     AS $$ SELECT 'supplied param is : ' || param; $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_default_param(INT)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_default_param RENAME TO func_with_default_param;
 $cmd$);
@@ -604,14 +604,14 @@ CONTEXT:  PL/pgSQL function deparse_and_run_on_workers(text) line XX at RAISE
 CREATE FUNCTION func_out_param(IN param INT, OUT result TEXT)
     AS $$ SELECT 'supplied param is : ' || param; $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_out_param(INT)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_out_param RENAME TO func_in_and_out_param;
 $cmd$);
@@ -630,14 +630,14 @@ BEGIN
    a := a * a;
 END; $$
 LANGUAGE plpgsql;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('square(NUMERIC)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION square SET search_path TO DEFAULT;
 $cmd$);
@@ -663,14 +663,14 @@ BEGIN
    FROM generate_subscripts(list, 1) g(i);
 END; $$
 LANGUAGE plpgsql;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('sum_avg(NUMERIC[])');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION sum_avg COST 10000;
 $cmd$);
@@ -689,14 +689,14 @@ RESET citus.enable_ddl_propagation;
 CREATE FUNCTION func_custom_param(IN param intpair, OUT total INT)
     AS $$ SELECT param.x + param.y $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_custom_param(intpair)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_custom_param RENAME TO func_with_custom_param;
 $cmd$);
@@ -713,14 +713,14 @@ CREATE FUNCTION func_returns_table(IN count INT)
     RETURNS TABLE (x INT, y INT)
     AS $$ SELECT i,i FROM generate_series(1,count) i $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_returns_table(INT)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_returns_table ROWS 100;
 $cmd$);

--- a/src/test/regress/expected/multi_deparse_procedure.out
+++ b/src/test/regress/expected/multi_deparse_procedure.out
@@ -49,14 +49,14 @@ BEGIN
   RAISE INFO 'information message %', $1;
 END;
 $proc$;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('raise_info(text)');
  create_distributed_function
 ---------------------------------------------------------------------
 
 (1 row)
 
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT
 $cmd$);

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -105,7 +105,7 @@ ORDER BY 1, 2;
 DROP EXTENSION citus;
 \c
 -- these tests switch between citus versions and call ddl's that require pg_dist_object to be created
-SET citus.enable_object_propagation TO 'false';
+SET citus.enable_metadata_sync TO 'false';
 SET citus.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.0-1';
 ALTER EXTENSION citus UPDATE TO '8.0-2';
@@ -492,7 +492,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 -- Test downgrade to 9.4-1 from 9.5-1
 ALTER EXTENSION citus UPDATE TO '9.5-1';
 BEGIN;
-  SET citus.enable_object_propagation TO on;
+  SET citus.enable_metadata_sync TO on;
   SELECT master_add_node('localhost', :master_port, groupId=>0);
 NOTICE:  localhost:xxxxx is the coordinator and already contains metadata, skipping syncing the metadata
  master_add_node
@@ -508,7 +508,7 @@ NOTICE:  create_citus_local_table is deprecated in favour of citus_add_local_tab
 
 (1 row)
 
-  RESET citus.enable_object_propagation;
+  RESET citus.enable_metadata_sync;
   -- downgrade from 9.5-1 to 9.4-1 should fail as we have a citus local table
   ALTER EXTENSION citus UPDATE TO '9.4-1';
 ERROR:  citus local tables are introduced in Citus 9.5

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -186,7 +186,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- cannot add workers with specific IP as long as I have a placeholder coordinator record
 	SELECT 1 FROM master_add_node('127.0.0.1', :worker_1_port);
 ERROR:  cannot add a worker node when the coordinator hostname is set to localhost
@@ -198,7 +198,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- adding localhost workers is ok
 	SELECT 1 FROM master_add_node('localhost', :worker_1_port);
 NOTICE:  shards are still on the coordinator after adding the new node
@@ -228,7 +228,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- adding workers with specific IP is ok now
 	SELECT 1 FROM master_add_node('127.0.0.1', :worker_1_port);
 NOTICE:  shards are still on the coordinator after adding the new node

--- a/src/test/regress/expected/turn_mx_off.out
+++ b/src/test/regress/expected/turn_mx_off.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/turn_mx_off_0.out
+++ b/src/test/regress/expected/turn_mx_off_0.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/turn_mx_off_1.out
+++ b/src/test/regress/expected/turn_mx_off_1.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/turn_mx_on.out
+++ b/src/test/regress/expected/turn_mx_on.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/turn_mx_on_0.out
+++ b/src/test/regress/expected/turn_mx_on_0.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/turn_mx_on_1.out
+++ b/src/test/regress/expected/turn_mx_on_1.out
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 SELECT pg_reload_conf();
  pg_reload_conf
 ---------------------------------------------------------------------

--- a/src/test/regress/input/multi_copy.source
+++ b/src/test/regress/input/multi_copy.source
@@ -582,7 +582,7 @@ SET session_replication_role = DEFAULT;
 
 -- disable test_user on the first worker
 \c - :default_user - :worker_1_port
-SET citus.enable_object_propagation TO off;
+SET citus.enable_metadata_sync TO off;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 
@@ -616,7 +616,7 @@ SELECT shardid, shardstate, nodename, nodeport
 
 -- re-enable test_user on the first worker
 \c - :default_user - :worker_1_port
-SET citus.enable_object_propagation TO off;
+SET citus.enable_metadata_sync TO off;
 ALTER USER test_user WITH login;
 
 \c - test_user - :master_port

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -89,6 +89,7 @@ test: isolation_ref_update_delete_upsert_vs_all_on_mx
 test: isolation_dis2ref_foreign_keys_on_mx
 test: isolation_metadata_sync_deadlock
 test: isolation_replicated_dist_on_mx
+test: isolation_multiuser_locking
 
 # MXless tests
 test: isolation_check_mx
@@ -96,4 +97,3 @@ test: isolation_replicate_reference_tables_to_coordinator
 test: isolation_turn_mx_off
 test: isolation_reference_copy_vs_all
 test: isolation_ref2ref_foreign_keys
-test: isolation_multiuser_locking

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -89,11 +89,11 @@ test: isolation_ref_update_delete_upsert_vs_all_on_mx
 test: isolation_dis2ref_foreign_keys_on_mx
 test: isolation_metadata_sync_deadlock
 test: isolation_replicated_dist_on_mx
+test: isolation_replicate_reference_tables_to_coordinator
 test: isolation_multiuser_locking
 
 # MXless tests
 test: isolation_check_mx
-test: isolation_replicate_reference_tables_to_coordinator
 test: isolation_turn_mx_off
 test: isolation_reference_copy_vs_all
 test: isolation_ref2ref_foreign_keys

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -319,11 +319,8 @@ test: check_mx
 test: distributed_functions distributed_functions_conflict
 test: distributed_collations
 test: distributed_procedure
-
-# blocked on #5583
-test: turn_mx_off
 test: distributed_collations_conflict
-test: turn_mx_on
+test: check_mx
 
 # ---------
 # deparsing logic tests

--- a/src/test/regress/output/multi_copy.source
+++ b/src/test/regress/output/multi_copy.source
@@ -745,7 +745,7 @@ UPDATE pg_dist_shard_placement SET nodeport = :worker_1_port+10 WHERE shardid = 
 SET session_replication_role = DEFAULT;
 -- disable test_user on the first worker
 \c - :default_user - :worker_1_port
-SET citus.enable_object_propagation TO off;
+SET citus.enable_metadata_sync TO off;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 -- reissue copy, and it should fail
@@ -804,7 +804,7 @@ SELECT shardid, shardstate, nodename, nodeport
 
 -- re-enable test_user on the first worker
 \c - :default_user - :worker_1_port
-SET citus.enable_object_propagation TO off;
+SET citus.enable_metadata_sync TO off;
 ALTER USER test_user WITH login;
 \c - test_user - :master_port
 DROP TABLE numbers_hash;

--- a/src/test/regress/spec/isolation_check_mx.spec
+++ b/src/test/regress/spec/isolation_check_mx.spec
@@ -2,7 +2,7 @@ session "s1"
 
 step "check_mx"
 {
-    SHOW citus.enable_metadata_sync_by_default;
+    SHOW citus.enable_metadata_sync;
 
     SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
 }

--- a/src/test/regress/spec/isolation_multiuser_locking.spec
+++ b/src/test/regress/spec/isolation_multiuser_locking.spec
@@ -1,5 +1,8 @@
 setup
 {
+	SELECT citus_internal.replace_isolation_tester_func();
+	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+
 	SET citus.shard_replication_factor TO 1;
 
 	CREATE USER test_user_1;
@@ -16,6 +19,8 @@ setup
 
 teardown
 {
+	SELECT citus_internal.restore_isolation_tester_func();
+
 	BEGIN;
 	DROP TABLE IF EXISTS test_table;
 	DROP USER test_user_1, test_user_2;
@@ -31,6 +36,7 @@ step "s1-grant"
 	SET ROLE test_user_1;
 	SELECT bool_and(success) FROM run_command_on_placements('test_table', 'GRANT ALL ON TABLE %s TO test_user_2');
 	GRANT ALL ON test_table TO test_user_2;
+	SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off; GRANT ALL ON test_table TO test_user_2;$$);
 }
 
 step "s1-begin"

--- a/src/test/regress/spec/isolation_turn_mx_off.spec
+++ b/src/test/regress/spec/isolation_turn_mx_off.spec
@@ -2,7 +2,7 @@ session "s1"
 
 step "disable-mx-by-default"
 {
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 }
 
 step "reload"

--- a/src/test/regress/spec/isolation_turn_mx_on.spec
+++ b/src/test/regress/spec/isolation_turn_mx_on.spec
@@ -2,7 +2,7 @@ session "s1"
 
 step "enable-mx-by-default"
 {
-  ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+  ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 }
 
 step "reload"

--- a/src/test/regress/sql/check_mx.sql
+++ b/src/test/regress/sql/check_mx.sql
@@ -1,3 +1,3 @@
-SHOW citus.enable_metadata_sync_by_default;
+SHOW citus.enable_metadata_sync;
 
 SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';

--- a/src/test/regress/sql/disable_object_propagation.sql
+++ b/src/test/regress/sql/disable_object_propagation.sql
@@ -1,5 +1,5 @@
 SET citus.next_shard_id TO 20030000;
-SET citus.enable_object_propagation TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
+SET citus.enable_metadata_sync TO false; -- all tests here verify old behaviour without distributing types,functions,etc automatically
 
 CREATE USER typeowner_for_disabled_object_propagation_guc;
 CREATE SCHEMA disabled_object_propagation;
@@ -37,7 +37,7 @@ SELECT create_distributed_table('t3', 'a');
 -- verify ALTER TYPE statements are not propagated for types, even though they are marked distributed
 BEGIN;
 -- object propagation is turned off after xact finished, type is already marked distributed by then
-SET LOCAL citus.enable_object_propagation TO on;
+SET LOCAL citus.enable_metadata_sync TO on;
 CREATE TYPE tt3 AS (a int, b int);
 CREATE TABLE t4 (a int PRIMARY KEY, b tt3);
 SELECT create_distributed_table('t4','a');
@@ -75,7 +75,7 @@ $$);
 
 -- suppress any warnings during cleanup
 SET client_min_messages TO error;
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 DROP SCHEMA disabled_object_propagation CASCADE;
 DROP SCHEMA disabled_object_propagation2 CASCADE;
 DROP USER typeowner_for_disabled_object_propagation_guc;

--- a/src/test/regress/sql/distributed_collations_conflict.sql
+++ b/src/test/regress/sql/distributed_collations_conflict.sql
@@ -4,6 +4,8 @@ SELECT run_command_on_workers($$CREATE SCHEMA collation_conflict;$$);
 \c - - - :worker_1_port
 SET search_path TO collation_conflict;
 
+SET citus.enable_metadata_sync TO off;
+
 CREATE COLLATION caseinsensitive (
 	provider = icu,
 	locale = 'und-u-ks-level2'
@@ -36,6 +38,8 @@ DROP TABLE tblcoll;
 DROP COLLATION caseinsensitive;
 
 \c - - - :worker_1_port
+SET citus.enable_metadata_sync TO off;
+
 SET search_path TO collation_conflict;
 
 CREATE COLLATION caseinsensitive (

--- a/src/test/regress/sql/multi_deparse_function.sql
+++ b/src/test/regress/sql/multi_deparse_function.sql
@@ -70,9 +70,9 @@ CREATE FUNCTION add(integer, integer) RETURNS integer
 -- Since deparse logic on workers can not work for if function
 -- is distributed on workers, we are disabling object propagation
 -- first. Same trick has been applied multiple times in this test.
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('add(int,int)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION  add CALLED ON NULL INPUT
@@ -276,10 +276,10 @@ CREATE FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text) RETURNS TEXT
     AS $$ SELECT 'Overloaded function called with param: ' || $1 $$
     LANGUAGE SQL;
 
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"()');
 SELECT create_distributed_function('"CiTuS.TeeN"."TeeNFunCT10N.1!?!"(text)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION "CiTuS.TeeN"."TeeNFunCT10N.1!?!"() SET SCHEMA "CiTUS.TEEN2"
@@ -294,9 +294,9 @@ $cmd$);
 CREATE FUNCTION func_default_param(param INT DEFAULT 0) RETURNS TEXT
     AS $$ SELECT 'supplied param is : ' || param; $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_default_param(INT)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_default_param RENAME TO func_with_default_param;
@@ -306,9 +306,9 @@ $cmd$);
 CREATE FUNCTION func_out_param(IN param INT, OUT result TEXT)
     AS $$ SELECT 'supplied param is : ' || param; $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_out_param(INT)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_out_param RENAME TO func_in_and_out_param;
@@ -321,9 +321,9 @@ BEGIN
    a := a * a;
 END; $$
 LANGUAGE plpgsql;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('square(NUMERIC)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION square SET search_path TO DEFAULT;
@@ -343,9 +343,9 @@ BEGIN
    FROM generate_subscripts(list, 1) g(i);
 END; $$
 LANGUAGE plpgsql;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('sum_avg(NUMERIC[])');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION sum_avg COST 10000;
@@ -358,9 +358,9 @@ RESET citus.enable_ddl_propagation;
 CREATE FUNCTION func_custom_param(IN param intpair, OUT total INT)
     AS $$ SELECT param.x + param.y $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_custom_param(intpair)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_custom_param RENAME TO func_with_custom_param;
@@ -372,9 +372,9 @@ CREATE FUNCTION func_returns_table(IN count INT)
     RETURNS TABLE (x INT, y INT)
     AS $$ SELECT i,i FROM generate_series(1,count) i $$
     LANGUAGE SQL;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('func_returns_table(INT)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER FUNCTION func_returns_table ROWS 100;

--- a/src/test/regress/sql/multi_deparse_procedure.sql
+++ b/src/test/regress/sql/multi_deparse_procedure.sql
@@ -56,9 +56,9 @@ BEGIN
   RAISE INFO 'information message %', $1;
 END;
 $proc$;
-SET citus.enable_object_propagation TO OFF;
+SET citus.enable_metadata_sync TO OFF;
 SELECT create_distributed_function('raise_info(text)');
-RESET citus.enable_object_propagation;
+RESET citus.enable_metadata_sync;
 
 SELECT deparse_and_run_on_workers($cmd$
 ALTER PROCEDURE  raise_info CALLED ON NULL INPUT

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -101,7 +101,7 @@ DROP EXTENSION citus;
 \c
 
 -- these tests switch between citus versions and call ddl's that require pg_dist_object to be created
-SET citus.enable_object_propagation TO 'false';
+SET citus.enable_metadata_sync TO 'false';
 
 SET citus.enable_version_checks TO 'false';
 
@@ -212,11 +212,11 @@ SELECT * FROM multi_extension.print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '9.5-1';
 
 BEGIN;
-  SET citus.enable_object_propagation TO on;
+  SET citus.enable_metadata_sync TO on;
   SELECT master_add_node('localhost', :master_port, groupId=>0);
   CREATE TABLE citus_local_table (a int);
   SELECT create_citus_local_table('citus_local_table');
-  RESET citus.enable_object_propagation;
+  RESET citus.enable_metadata_sync;
 
   -- downgrade from 9.5-1 to 9.4-1 should fail as we have a citus local table
   ALTER EXTENSION citus UPDATE TO '9.4-1';

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -101,7 +101,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- cannot add workers with specific IP as long as I have a placeholder coordinator record
 	SELECT 1 FROM master_add_node('127.0.0.1', :worker_1_port);
 COMMIT;
@@ -111,7 +111,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- adding localhost workers is ok
 	SELECT 1 FROM master_add_node('localhost', :worker_1_port);
 COMMIT;
@@ -127,7 +127,7 @@ BEGIN;
 	-- it'd spawn a bg worker targeting this node
 	-- and that changes the connection count specific tests
 	-- here
-	SET LOCAL citus.enable_metadata_sync_by_default TO OFF;
+	SET LOCAL citus.enable_metadata_sync TO OFF;
 	-- adding workers with specific IP is ok now
 	SELECT 1 FROM master_add_node('127.0.0.1', :worker_1_port);
 COMMIT;

--- a/src/test/regress/sql/turn_mx_off.sql
+++ b/src/test/regress/sql/turn_mx_off.sql
@@ -1,5 +1,0 @@
-ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
-SELECT pg_reload_conf();
-
-SET client_min_messages TO ERROR;
-SELECT stop_metadata_sync_to_node(nodename, nodeport) FROM pg_dist_node WHERE isactive = 't' and noderole = 'primary';

--- a/src/test/regress/sql/turn_mx_off.sql
+++ b/src/test/regress/sql/turn_mx_off.sql
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO OFF;
+ALTER SYSTEM SET citus.enable_metadata_sync TO OFF;
 SELECT pg_reload_conf();
 
 SET client_min_messages TO ERROR;

--- a/src/test/regress/sql/turn_mx_on.sql
+++ b/src/test/regress/sql/turn_mx_on.sql
@@ -1,4 +1,4 @@
-ALTER SYSTEM SET citus.enable_metadata_sync_by_default TO ON;
+ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
 SELECT pg_reload_conf();
 SELECT pg_sleep(0.1);
 

--- a/src/test/regress/sql/turn_mx_on.sql
+++ b/src/test/regress/sql/turn_mx_on.sql
@@ -1,6 +1,0 @@
-ALTER SYSTEM SET citus.enable_metadata_sync TO ON;
-SELECT pg_reload_conf();
-SELECT pg_sleep(0.1);
-
-SET client_min_messages TO ERROR;
-SELECT start_metadata_sync_to_node(nodename, nodeport) FROM pg_dist_node WHERE isactive = 't' and noderole = 'primary';


### PR DESCRIPTION
DESCRIPTION:Replaces citus.enable_object_propagation with citus.enable_metadata_sync

Also, within Citus 11 release cycle, we added `citus.enable_metadata_sync_by_default`,
that is also replaced with `citus.enable_metadata_sync`.

In essence, when `citus.enable_metadata_sync` is set to true, all the objects
and the metadata is send to the remote node.

We strongly advice that the users never changes the value of
this GUC.
