### PR TITLE
Fix coordinator/worker query targetlists for agg. that we cannot push-down

### DIFF
--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -3082,18 +3082,7 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 		Expr *directarg;
 		foreach_ptr(directarg, originalAggregate->aggdirectargs)
 		{
-			/*
-			 * For the query that we will execute on worker node, we can leave
-			 * only Const nodes as is and can resolve Param's in the runtime.
-			 * For the other type of nodes, we need to execute them on worker
-			 * node.
-			 *
-			 * Note that we should decide those nodes by looking into the actual
-			 * nodes hidden behind coercions, casts etc..
-			 */
-			Expr *strippedDirectArg =
-				(Expr *) strip_implicit_coercions((Node *) directarg);
-			if (IsA(strippedDirectArg, Var))
+			if (!IsA(directarg, Const) && !IsA(directarg, Param))
 			{
 				workerAggregateList = lappend(workerAggregateList, directarg);
 			}

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -1620,6 +1620,13 @@ MasterAggregateExpression(Aggref *originalAggregate,
 			 * Need to replace nodes that contain any Vars with Vars referring
 			 * to the related column of the result set returned for the worker
 			 * aggregation.
+			 *
+			 * When there are no Vars, then the expression can be fully evaluated
+			 * on the coordinator, so we skip it here. This is not just an
+			 * optimization, but the result of the expression might require
+			 * calling the final function of the aggregate, and doing so when
+			 * there are no input rows (i.e.: with an empty tuple slot) is not
+			 * desirable for the node-executor methods.
 			 */
 			if (pull_var_clause_default((Node *) directarg) != NIL)
 			{

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -1628,7 +1628,7 @@ MasterAggregateExpression(Aggref *originalAggregate,
 			 */
 			Expr *strippedDirectArg =
 				(Expr *) strip_implicit_coercions((Node *) directarg);
-			if (!IsA(strippedDirectArg, Const) && !IsA(strippedDirectArg, Param))
+			if (IsA(strippedDirectArg, Var))
 			{
 				Var *var = makeVar(masterTableId, walkerContext->columnId,
 								   exprType((Node *) directarg),
@@ -3093,7 +3093,7 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 			 */
 			Expr *strippedDirectArg =
 				(Expr *) strip_implicit_coercions((Node *) directarg);
-			if (!IsA(strippedDirectArg, Const) && !IsA(strippedDirectArg, Param))
+			if (IsA(strippedDirectArg, Var))
 			{
 				workerAggregateList = lappend(workerAggregateList, directarg);
 			}

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -698,7 +698,7 @@ select key, percentile_cont(key/10.0) within group(order by val) from aggdata gr
  key | percentile_cont
 ---------------------------------------------------------------------
    1 |               2
-   2 |               2
+   2 |             2.4
    3 |               4
    5 |
    6 |

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -695,8 +695,17 @@ select percentile_cont(0.5) within group(order by valf) from aggdata;
 (1 row)
 
 select key, percentile_cont(key/10.0) within group(order by val) from aggdata group by key;
-ERROR:  attribute 2 of type record has wrong type
-DETAIL:  Table has type double precision, but query expects integer.
+ key | percentile_cont
+---------------------------------------------------------------------
+   1 |               2
+   2 |               2
+   3 |               4
+   5 |
+   6 |
+   7 |               8
+   9 |               0
+(7 rows)
+
 select array_agg(val order by valf) from aggdata;
               array_agg
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -695,17 +695,8 @@ select percentile_cont(0.5) within group(order by valf) from aggdata;
 (1 row)
 
 select key, percentile_cont(key/10.0) within group(order by val) from aggdata group by key;
- key | percentile_cont
----------------------------------------------------------------------
-   1 |               2
-   2 |             2.4
-   3 |               4
-   5 |
-   6 |
-   7 |               8
-   9 |               0
-(7 rows)
-
+ERROR:  attribute 2 of type record has wrong type
+DETAIL:  Table has type double precision, but query expects integer.
 select array_agg(val order by valf) from aggdata;
               array_agg
 ---------------------------------------------------------------------
@@ -965,5 +956,10 @@ FROM (SELECT *, random() FROM dist_table) a;
 SELECT PERCENTILE_DISC((.25 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
 FROM dist_table
 LEFT JOIN ref_table ON TRUE;
-SSL SYSCALL error: EOF detected
-connection to server was lost
+ percentile_disc
+---------------------------------------------------------------------
+
+(1 row)
+
+set client_min_messages to error;
+drop schema aggregate_support cascade;

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -932,5 +932,38 @@ SELECT square_func(5), a, count(a) FROM t1 GROUP BY a;
 ERROR:  function aggregate_support.square_func(integer) does not exist
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 CONTEXT:  while executing command on localhost:xxxxx
-set client_min_messages to error;
-drop schema aggregate_support cascade;
+-- Test the cases where the worker agg exec. returns no tuples.
+CREATE TABLE dist_table (dist_col int, agg_col int);
+SELECT create_distributed_table('dist_table', 'dist_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE ref_table (int_col int);
+SELECT create_reference_table('ref_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ percentile_disc
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random() FROM dist_table) a;
+ percentile_disc
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT PERCENTILE_DISC((.25 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+SSL SYSCALL error: EOF detected
+connection to server was lost

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -712,6 +712,19 @@ select array_agg(val order by valf) from aggdata;
  {0,NULL,2,3,5,2,4,NULL,NULL,8,NULL}
 (1 row)
 
+-- test by using some other node types as arguments to agg
+select key, percentile_cont((key - (key > 4)::int) / 10.0) within group(order by val) from aggdata group by key;
+ key | percentile_cont
+---------------------------------------------------------------------
+   1 |               2
+   2 |             2.4
+   3 |               4
+   5 |
+   6 |
+   7 |               8
+   9 |               0
+(7 rows)
+
 -- Test TransformSubqueryNode
 select * FROM (
     SELECT key, mode() within group (order by floor(agg1.val/2)) m from aggdata agg1
@@ -933,7 +946,7 @@ ERROR:  function aggregate_support.square_func(integer) does not exist
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 CONTEXT:  while executing command on localhost:xxxxx
 -- Test the cases where the worker agg exec. returns no tuples.
-CREATE TABLE dist_table (dist_col int, agg_col int);
+CREATE TABLE dist_table (dist_col int, agg_col numeric);
 SELECT create_distributed_table('dist_table', 'dist_col');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -962,12 +975,69 @@ FROM (SELECT *, random() FROM dist_table) a;
 
 (1 row)
 
-SELECT PERCENTILE_DISC((.25 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+SELECT PERCENTILE_DISC((2 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
 FROM dist_table
 LEFT JOIN ref_table ON TRUE;
  percentile_disc
 ---------------------------------------------------------------------
 
+(1 row)
+
+SELECT SUM(COALESCE(agg_col, 3))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ sum
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT AVG(COALESCE(agg_col, 10))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ avg
+---------------------------------------------------------------------
+
+(1 row)
+
+insert into dist_table values (2, 11.2), (3, NULL), (6, 3.22), (3, 4.23), (5, 5.25), (4, 63.4), (75, NULL), (80, NULL), (96, NULL), (8, 1078), (0, 1.19);
+-- run the same queries after loading some data
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ percentile_disc
+---------------------------------------------------------------------
+            3.22
+(1 row)
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random() FROM dist_table) a;
+ percentile_disc
+---------------------------------------------------------------------
+            3.22
+(1 row)
+
+SELECT PERCENTILE_DISC((2 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ percentile_disc
+---------------------------------------------------------------------
+            1.19
+(1 row)
+
+SELECT floor(SUM(COALESCE(agg_col, 3)))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ floor
+---------------------------------------------------------------------
+  1178
+(1 row)
+
+SELECT floor(AVG(COALESCE(agg_col, 10)))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ floor
+---------------------------------------------------------------------
+   109
 (1 row)
 
 set client_min_messages to error;

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -479,6 +479,24 @@ SELECT square_func(5), a FROM t1 GROUP BY a;
 -- the expression will be pushed down.
 SELECT square_func(5), a, count(a) FROM t1 GROUP BY a;
 
+-- Test the cases where the worker agg exec. returns no tuples.
+
+CREATE TABLE dist_table (dist_col int, agg_col int);
+SELECT create_distributed_table('dist_table', 'dist_col');
+
+CREATE TABLE ref_table (int_col int);
+SELECT create_reference_table('ref_table');
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random() FROM dist_table) a;
+
+SELECT PERCENTILE_DISC((.25 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
 
 set client_min_messages to error;
 drop schema aggregate_support cascade;

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -376,6 +376,9 @@ select percentile_cont(0.5) within group(order by valf) from aggdata;
 select key, percentile_cont(key/10.0) within group(order by val) from aggdata group by key;
 select array_agg(val order by valf) from aggdata;
 
+-- test by using some other node types as arguments to agg
+select key, percentile_cont((key - (key > 4)::int) / 10.0) within group(order by val) from aggdata group by key;
+
 -- Test TransformSubqueryNode
 
 select * FROM (
@@ -481,7 +484,7 @@ SELECT square_func(5), a, count(a) FROM t1 GROUP BY a;
 
 -- Test the cases where the worker agg exec. returns no tuples.
 
-CREATE TABLE dist_table (dist_col int, agg_col int);
+CREATE TABLE dist_table (dist_col int, agg_col numeric);
 SELECT create_distributed_table('dist_table', 'dist_col');
 
 CREATE TABLE ref_table (int_col int);
@@ -494,7 +497,37 @@ LEFT JOIN ref_table ON TRUE;
 SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
 FROM (SELECT *, random() FROM dist_table) a;
 
-SELECT PERCENTILE_DISC((.25 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+SELECT PERCENTILE_DISC((2 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT SUM(COALESCE(agg_col, 3))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT AVG(COALESCE(agg_col, 10))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+insert into dist_table values (2, 11.2), (3, NULL), (6, 3.22), (3, 4.23), (5, 5.25), (4, 63.4), (75, NULL), (80, NULL), (96, NULL), (8, 1078), (0, 1.19);
+
+-- run the same queries after loading some data
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random() FROM dist_table) a;
+
+SELECT PERCENTILE_DISC((2 > random())::int::numeric / 10) WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT floor(SUM(COALESCE(agg_col, 3)))
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+
+SELECT floor(AVG(COALESCE(agg_col, 10)))
 FROM dist_table
 LEFT JOIN ref_table ON TRUE;
 


### PR DESCRIPTION
Fixes https://github.com/citusdata/citus-enterprise/issues/744.

DESCRIPTION: Fixes a crash that occurs when the aggregate that cannot be pushed-down returns empty result from a worker

Previously, we were wrapping targetlist nodes with Vars that reference
to the result of the worker query, if the node itself is not `Const` or
not a `Param`. Indeed, we should not do that unless the node itself is
a `Var` node or contains a `Var` within it (e.g.: `OpExpr(Var(column_a) > 2)`).
Otherwise, when worker query returns empty result set, then combine
query exec would crash since the `Var` would be pointing to an empty
tuple slot, which is not desirable for the node-executor methods.

Need to backport to all versions >= 9.2, where we introduced support for such aggregates.