### PR TITLE
Copied CheckCitusVersion into Columnar

### DIFF
--- a/src/include/columnar/columnar_tableam.h
+++ b/src/include/columnar/columnar_tableam.h
@@ -50,7 +50,6 @@ typedef struct ColumnarScanDescData *ColumnarScanDesc;
 
 const TableAmRoutine * GetColumnarTableAmRoutine(void);
 extern void columnar_tableam_init(void);
-extern bool CheckCitusVersion(int elevel);
 extern TableScanDesc columnar_beginscan_extended(Relation relation, Snapshot snapshot,
 												 int nkeys, ScanKey key,
 												 ParallelTableScanDesc parallel_scan,

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -109,6 +109,7 @@ DROP EXTENSION citus;
 -- these tests switch between citus versions and call ddl's that require pg_dist_object to be created
 SET citus.enable_metadata_sync TO 'false';
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.0-1';
 ALTER EXTENSION citus UPDATE TO '8.0-2';
 ALTER EXTENSION citus UPDATE TO '8.0-3';
@@ -759,6 +760,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 \set VERBOSITY terse
 CREATE TABLE columnar_table(a INT, b INT) USING columnar;
 SET citus.enable_version_checks TO ON;
+SET columnar.enable_version_checks TO ON;
 -- all should throw an error due to version mismatch
 VACUUM FULL columnar_table;
 ERROR:  loaded Citus library version differs from installed extension version
@@ -787,6 +789,7 @@ CREATE TABLE new_columnar_table (a int) USING columnar;
 ERROR:  loaded Citus library version differs from installed extension version
 -- do cleanup for the rest of the tests
 SET citus.enable_version_checks TO OFF;
+SET columnar.enable_version_checks TO OFF;
 DROP TABLE columnar_table;
 RESET columnar.enable_custom_scan;
 \set VERBOSITY default
@@ -1043,6 +1046,7 @@ ORDER BY 1, 2;
 
 -- see incompatible version errors out
 RESET citus.enable_version_checks;
+RESET columnar.enable_version_checks;
 DROP EXTENSION citus;
 CREATE EXTENSION citus VERSION '8.0-1';
 ERROR:  specified version incompatible with loaded Citus library
@@ -1050,8 +1054,10 @@ DETAIL:  Loaded library requires 11.0, but 8.0-1 was specified.
 HINT:  If a newer library is present, restart the database and try the command again.
 -- Test non-distributed queries work even in version mismatch
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.1-1';
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 -- Test CREATE TABLE
 CREATE TABLE version_mismatch_table(column1 int);
 -- Test COPY
@@ -1101,15 +1107,18 @@ $function$;
 ERROR:  cannot change return type of existing function
 HINT:  Use DROP FUNCTION relation_is_a_known_shard(regclass) first.
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 -- This will fail because of previous function declaration
 ALTER EXTENSION citus UPDATE TO '8.1-1';
 NOTICE:  version "8.1-1" of extension "citus" is already installed
 -- We can DROP problematic function and continue ALTER EXTENSION even when version checks are on
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 DROP FUNCTION pg_catalog.relation_is_a_known_shard(regclass);
 ERROR:  cannot drop function relation_is_a_known_shard(regclass) because extension citus requires it
 HINT:  You can drop extension citus instead.
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 ALTER EXTENSION citus UPDATE TO '8.1-1';
 NOTICE:  version "8.1-1" of extension "citus" is already installed
 -- Test updating to the latest version without specifying the version number
@@ -1122,8 +1131,10 @@ CREATE EXTENSION citus;
 \c - - - :worker_1_port
 DROP EXTENSION citus;
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.0-1';
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 -- during ALTER EXTENSION, we should invalidate the cache
 ALTER EXTENSION citus UPDATE;
 -- if cache is invalidated succesfull, this \d should work without any problem

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -105,6 +105,8 @@ SET citus.enable_metadata_sync TO 'false';
 
 SET citus.enable_version_checks TO 'false';
 
+SET columnar.enable_version_checks TO 'false';
+
 CREATE EXTENSION citus VERSION '8.0-1';
 ALTER EXTENSION citus UPDATE TO '8.0-2';
 ALTER EXTENSION citus UPDATE TO '8.0-3';
@@ -303,6 +305,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 \set VERBOSITY terse
 CREATE TABLE columnar_table(a INT, b INT) USING columnar;
 SET citus.enable_version_checks TO ON;
+SET columnar.enable_version_checks TO ON;
 
 -- all should throw an error due to version mismatch
 VACUUM FULL columnar_table;
@@ -324,6 +327,7 @@ CREATE TABLE new_columnar_table (a int) USING columnar;
 
 -- do cleanup for the rest of the tests
 SET citus.enable_version_checks TO OFF;
+SET columnar.enable_version_checks TO OFF;
 DROP TABLE columnar_table;
 RESET columnar.enable_custom_scan;
 \set VERBOSITY default
@@ -472,13 +476,16 @@ ORDER BY 1, 2;
 
 -- see incompatible version errors out
 RESET citus.enable_version_checks;
+RESET columnar.enable_version_checks;
 DROP EXTENSION citus;
 CREATE EXTENSION citus VERSION '8.0-1';
 
 -- Test non-distributed queries work even in version mismatch
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.1-1';
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 
 -- Test CREATE TABLE
 CREATE TABLE version_mismatch_table(column1 int);
@@ -517,14 +524,17 @@ END;
 $function$;
 
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 -- This will fail because of previous function declaration
 ALTER EXTENSION citus UPDATE TO '8.1-1';
 
 -- We can DROP problematic function and continue ALTER EXTENSION even when version checks are on
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 DROP FUNCTION pg_catalog.relation_is_a_known_shard(regclass);
 
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 ALTER EXTENSION citus UPDATE TO '8.1-1';
 
 -- Test updating to the latest version without specifying the version number
@@ -540,8 +550,10 @@ CREATE EXTENSION citus;
 
 DROP EXTENSION citus;
 SET citus.enable_version_checks TO 'false';
+SET columnar.enable_version_checks TO 'false';
 CREATE EXTENSION citus VERSION '8.0-1';
 SET citus.enable_version_checks TO 'true';
+SET columnar.enable_version_checks TO 'true';
 -- during ALTER EXTENSION, we should invalidate the cache
 ALTER EXTENSION citus UPDATE;
 


### PR DESCRIPTION
To remove CheckCitusVersion dependency, we copied over the function and its other needed functions and variables into Citus. When/if the extensions are split, we will change it to CheckColumnarVersion.

We also added CheckCitusVersion to beginscan_extended() as there are times we call columnar_beginscan_extended and bypass columnar_beginscan