### PR TITLE
Prevent citus.node_conninfo to use "application_name"

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1984,7 +1984,6 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 {
 	/* this array _must_ be kept in an order usable by bsearch */
 	const char *allowedConninfoKeywords[] = {
-		"application_name",
 		"connect_timeout",
 			#if defined(ENABLE_GSS) && defined(ENABLE_SSPI)
 		"gsslib",

--- a/src/test/regress/expected/node_conninfo_reload.out
+++ b/src/test/regress/expected/node_conninfo_reload.out
@@ -76,6 +76,10 @@ select count(*) from test where a = 0;
 (1 row)
 
 ALTER SYSTEM SET citus.node_conninfo = 'sslmode=doesnotexist';
+-- we cannot set application name
+ALTER SYSTEM SET citus.node_conninfo = 'application_name=XXX';
+ERROR:  invalid value for parameter "citus.node_conninfo": "application_name=XXX"
+DETAIL:  Prohibited conninfo keyword detected: application_name
 BEGIN;
 -- Should still work (no SIGHUP yet);
 select count(*) from test where a = 0;

--- a/src/test/regress/sql/node_conninfo_reload.sql
+++ b/src/test/regress/sql/node_conninfo_reload.sql
@@ -32,6 +32,9 @@ show citus.node_conninfo;
 select count(*) from test where a = 0;
 ALTER SYSTEM SET citus.node_conninfo = 'sslmode=doesnotexist';
 
+-- we cannot set application name
+ALTER SYSTEM SET citus.node_conninfo = 'application_name=XXX';
+
 BEGIN;
 -- Should still work (no SIGHUP yet);
 select count(*) from test where a = 0;


### PR DESCRIPTION
With https://github.com/citusdata/citus/pull/5657, Citus uses
a fixed application_name while connecting to remote nodes
for internal purposes.

It means that we cannot allow users to override it via
citus.node_conninfo.

DESCRIPTION: Prevent citus.node_conninfo to use "application_name"