### PR TITLE
Show IDLE backends in citus_dist_stat_activity

### DIFF
--- a/src/backend/distributed/transaction/citus_dist_stat_activity.c
+++ b/src/backend/distributed/transaction/citus_dist_stat_activity.c
@@ -155,7 +155,12 @@ FROM \
 	get_all_active_transactions() AS dist_txs(database_id, process_id, initiator_node_identifier, worker_query, transaction_number, transaction_stamp, global_pid) \
 	ON pg_stat_activity.pid = dist_txs.process_id \
 WHERE \
-	dist_txs.worker_query = false;"
+	backend_type = 'client backend' \
+	AND \
+	pg_stat_activity.query NOT ILIKE '%stat_activity%' \
+	AND \
+	pg_stat_activity.application_name NOT SIMILAR TO 'citus_internal gpid=\\d+'; \
+"
 
 #define CITUS_WORKER_STAT_ACTIVITY_QUERY \
 	"\
@@ -186,7 +191,7 @@ SELECT \
 	dist_txs.global_id \
 FROM \
 	pg_stat_activity \
-	LEFT JOIN \
+	JOIN \
 	get_all_active_transactions() AS dist_txs(database_id, process_id, initiator_node_identifier, worker_query, transaction_number, transaction_stamp, global_id) \
 	ON pg_stat_activity.pid = dist_txs.process_id \
 WHERE \

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -15,16 +15,16 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
- BEGIN;
+	BEGIN;
 
 step s3-begin:
- BEGIN;
+	BEGIN;
 
 step s1-alter-table:
     ALTER TABLE test_table ADD COLUMN x INT;
 
 step s2-sleep:
- SELECT pg_sleep(0.5);
+	SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -32,7 +32,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' and query not ILIKE '%BEGIN%' and query NOT ILIKE '%pg_catalog.pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
 query                                         |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -42,7 +42,7 @@ query                                         |query_hostname  |query_hostport|d
 (1 row)
 
 step s3-view-worker:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query                                                                                                      |query_hostname|query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -61,13 +61,13 @@ SELECT worker_apply_shard_ddl_command (1300001, 'public', '
 (4 rows)
 
 step s2-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-insert s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -85,16 +85,16 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
- BEGIN;
+	BEGIN;
 
 step s3-begin:
- BEGIN;
+	BEGIN;
 
 step s1-insert:
-  INSERT INTO test_table VALUES (100, 100);
+ 	INSERT INTO test_table VALUES (100, 100);
 
 step s2-sleep:
- SELECT pg_sleep(0.5);
+	SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -102,17 +102,17 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' and query not ILIKE '%BEGIN%' and query NOT ILIKE '%pg_catalog.pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
 query                                        |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
 
-  INSERT INTO test_table VALUES (100, 100);
+ 	INSERT INTO test_table VALUES (100, 100);
 |coordinator_host|         57636|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
 (1 row)
 
 step s3-view-worker:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query                                                                     |query_hostname|query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -120,13 +120,13 @@ INSERT INTO public.test_table_1300008 (column1, column2) VALUES (100, 100)|local
 (1 row)
 
 step s2-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-select s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -144,10 +144,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
- BEGIN;
+	BEGIN;
 
 step s3-begin:
- BEGIN;
+	BEGIN;
 
 step s1-select:
    SELECT count(*) FROM test_table;
@@ -158,7 +158,7 @@ count
 (1 row)
 
 step s2-sleep:
- SELECT pg_sleep(0.5);
+	SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -166,7 +166,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' and query not ILIKE '%BEGIN%' and query NOT ILIKE '%pg_catalog.pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
 query                                |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -176,7 +176,7 @@ query                                |query_hostname  |query_hostport|distribute
 (1 row)
 
 step s3-view-worker:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query                                                                        |query_hostname|query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -187,13 +187,13 @@ SELECT count(*) AS count FROM public.test_table_1300011 test_table WHERE true|lo
 (4 rows)
 
 step s2-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-select-router s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -211,10 +211,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
- BEGIN;
+	BEGIN;
 
 step s3-begin:
- BEGIN;
+	BEGIN;
 
 step s1-select-router:
    SELECT count(*) FROM test_table WHERE column1 = 55;
@@ -225,7 +225,7 @@ count
 (1 row)
 
 step s2-sleep:
- SELECT pg_sleep(0.5);
+	SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -233,7 +233,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' and query not ILIKE '%BEGIN%' and query NOT ILIKE '%pg_catalog.pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
 query                                                   |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -243,7 +243,7 @@ query                                                   |query_hostname  |query_
 (1 row)
 
 step s3-view-worker:
- SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_worker_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
 
 query                                                                                                       |query_hostname|query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -251,11 +251,11 @@ SELECT count(*) AS count FROM public.test_table_1300017 test_table WHERE (column
 (1 row)
 
 step s2-rollback:
- ROLLBACK;
+	ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
- ROLLBACK;
+	ROLLBACK;
 

--- a/src/test/regress/expected/isolation_global_pid.out
+++ b/src/test/regress/expected/isolation_global_pid.out
@@ -31,7 +31,7 @@ run_commands_on_session_level_connection_to_node
 (1 row)
 
 step s2-coordinator-citus_dist_stat_activity:
-    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%';
+    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%' and query NOT ILIKE '%run_commands_on_session_level_connection_to_node%';
 
 ?column?
 ---------------------------------------------------------------------
@@ -93,7 +93,7 @@ a|b
 (0 rows)
 
 step s2-coordinator-citus_dist_stat_activity:
-    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%';
+    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%' and query NOT ILIKE '%run_commands_on_session_level_connection_to_node%';
 
 ?column?
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -83,7 +83,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-        SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' AND query NOT ILIKE '%pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
+        SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' AND query NOT ILIKE '%pg_isolation_test_session_is_blocked%' AND query NOT ILIKE '%BEGIN%' ORDER BY query DESC;
 
 query                                    |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -83,14 +83,17 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+        SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' AND query NOT ILIKE '%pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
-query                                |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
+query                                    |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
 
+  SELECT check_distributed_deadlocks();
+|coordinator_host|         57636|                           |                          0|idle               |Client         |ClientRead|postgres|regression
+
     update ref_table set a = a + 1;
-|coordinator_host|         57636|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
-(1 row)
+    |coordinator_host|         57636|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
+(2 rows)
 
 step s2-view-worker:
 	SELECT query, query_hostname, query_hostport, distributed_query_host_name,
@@ -101,7 +104,7 @@ step s2-view-worker:
           query NOT ILIKE '%dump_local_wait_edges%'
     ORDER BY query, query_hostport DESC;
 
-query                                                                         |query_hostname  |query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
+query                                                                         |query_hostname|query_hostport|distributed_query_host_name|distributed_query_host_port|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
 UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57638|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression
 UPDATE public.ref_table_1500767 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)|localhost     |         57637|coordinator_host           |                      57636|idle in transaction|Client         |ClientRead|postgres|regression

--- a/src/test/regress/spec/isolation_citus_dist_activity.spec
+++ b/src/test/regress/spec/isolation_citus_dist_activity.spec
@@ -71,7 +71,7 @@ step "s2-sleep"
 
 step "s2-view-dist"
 {
-	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' and query not ILIKE '%BEGIN%' and query NOT ILIKE '%pg_catalog.pg_isolation_test_session_is_blocked%' ORDER BY query DESC;
 
 }
 

--- a/src/test/regress/spec/isolation_global_pid.spec
+++ b/src/test/regress/spec/isolation_global_pid.spec
@@ -62,7 +62,7 @@ session "s2"
 
 step "s2-coordinator-citus_dist_stat_activity"
 {
-    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%';
+    SELECT global_pid != 0 FROM citus_dist_stat_activity() WHERE query LIKE '%SELECT * FROM dist\_table%' and query NOT ILIKE '%run_commands_on_session_level_connection_to_node%';
 }
 
 step "s2-coordinator-citus_worker_stat_activity"

--- a/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
+++ b/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
@@ -83,7 +83,7 @@ step "s2-lock-ref-table-placement-on-coordinator"
 
 step "s2-view-dist"
 {
-	SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' ORDER BY query DESC;
+        SELECT query, query_hostname, query_hostport, distributed_query_host_name, distributed_query_host_port, state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE '%pg_prepared_xacts%' AND query NOT ILIKE '%COMMIT%' AND query NOT ILIKE '%pg_isolation_test_session_is_blocked%' AND query NOT ILIKE '%BEGIN%' ORDER BY query DESC;
 }
 
 step "s2-view-worker"
@@ -113,6 +113,7 @@ step "s2-active-transactions"
 // we disable the daemon during the regression tests in order to get consistent results
 // thus we manually issue the deadlock detection
 session "deadlock-checker"
+
 
 // we issue the checker not only when there are deadlocks to ensure that we never cancel
 // backend inappropriately


### PR DESCRIPTION
With this change, we start to show non-distributed backends as well
in citus_dist_stat_activity. I think that
  (a) it is essential for making citus_lock_waits to work for blocked
      on DDL commands.
  (b) it is more expected from the user's perspective. The name of
      the view is a little inconsistent now (e.g., citus_dist_stat_activity)
      but we are already planning to improve the names with followup
      PRs.


Fixes https://github.com/citusdata/citus/issues/5190