### PR TITLE
Refactor worker_create_or_replace_object to accept multiple statements

### DIFF
--- a/src/backend/distributed/sql/citus--10.2-4--11.0-1.sql
+++ b/src/backend/distributed/sql/citus--10.2-4--11.0-1.sql
@@ -18,6 +18,7 @@
 #include "udfs/get_global_active_transactions/11.0-1.sql"
 
 #include "udfs/citus_worker_stat_activity/11.0-1.sql"
+#include "udfs/worker_create_or_replace_object/11.0-1.sql"
 
 CREATE VIEW citus.citus_worker_stat_activity AS
 SELECT * FROM pg_catalog.citus_worker_stat_activity();

--- a/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.3-1--9.0-1.sql
@@ -21,13 +21,7 @@ ALTER FUNCTION citus.restore_isolation_tester_func SET SCHEMA citus_internal;
 GRANT USAGE ON SCHEMA citus TO public;
 
 #include "udfs/pg_dist_shard_placement_trigger_func/9.0-1.sql"
-
-CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
-  RETURNS bool
-  LANGUAGE C STRICT
-  AS 'MODULE_PATHNAME', $$worker_create_or_replace_object$$;
-COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
-    IS 'takes a sql CREATE statement, before executing the create it will check if an object with that name already exists and safely replaces that named object with the new object';
+#include "udfs/worker_create_or_replace_object/9.0-1.sql"
 
 CREATE OR REPLACE FUNCTION pg_catalog.master_unmark_object_distributed(classid oid, objid oid, objsubid int)
     RETURNS void

--- a/src/backend/distributed/sql/udfs/worker_create_or_replace_object/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/worker_create_or_replace_object/11.0-1.sql
@@ -6,10 +6,10 @@ CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement 
 COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
     IS 'takes a sql CREATE statement, before executing the create it will check if an object with that name already exists and safely replaces that named object with the new object';
 
-CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement []text)
+CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statements text[])
   RETURNS bool
   LANGUAGE C STRICT
   AS 'MODULE_PATHNAME', $$worker_create_or_replace_object$$;
 
-COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statement []text)
+COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statements text[])
     IS 'takes a lost of sql statements, before executing these it will check if the object already exists in that exact state otherwise replaces that named object with the new object';

--- a/src/backend/distributed/sql/udfs/worker_create_or_replace_object/9.0-1.sql
+++ b/src/backend/distributed/sql/udfs/worker_create_or_replace_object/9.0-1.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
+  RETURNS bool
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$worker_create_or_replace_object$$;
+COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
+    IS 'takes a sql CREATE statement, before executing the create it will check if an object with that name already exists and safely replaces that named object with the new object';

--- a/src/backend/distributed/sql/udfs/worker_create_or_replace_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/worker_create_or_replace_object/latest.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
+  RETURNS bool
+  LANGUAGE C STRICT
+  AS 'MODULE_PATHNAME', $$worker_create_or_replace_object$$;
+COMMENT ON FUNCTION pg_catalog.worker_create_or_replace_object(statement text)
+    IS 'takes a sql CREATE statement, before executing the create it will check if an object with that name already exists and safely replaces that named object with the new object';


### PR DESCRIPTION
Refactor worker_create_or_replace_object to accept multiple statements.

This facilitates the reuse of existing TEXT SEARCH CONFIGURATION objects, specifically when users use one of the pre-configured configurations that ship with postgres.

Text search configuration objects require a list of create+alter commands to correctly configure the objects to have the same semantic meanings. Postgres comes with a dozen or so preconfigured objects of these. Without the ability to compare the states against each other we would re-create all the objects on first use.

Even worse is that we would keep the original configurations as well, under a backup name. This would seriously pollute the
catalogs on the workers, which would get an issue with MX becoming more common.