### PR TITLE
Prevent any monitoring view/udf to show already exited backends

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -513,6 +513,9 @@ CitusCleanupConnectionsAtExit(int code, Datum arg)
 	 * are already given away.
 	 */
 	DeallocateReservedConnections();
+
+	/* we don't want any monitoring view/udf to show already exited backends */
+	UnSetGlobalPID();
 }
 
 

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -90,7 +90,6 @@ static BackendData *MyBackendData = NULL;
 
 static void BackendManagementShmemInit(void);
 static size_t BackendManagementShmemSize(void);
-static void UnSetGlobalPID(void);
 
 
 PG_FUNCTION_INFO_V1(assign_distributed_transaction_id);
@@ -674,7 +673,7 @@ UnSetDistributedTransactionId(void)
 /*
  * UnSetGlobalPID resets the global pid for the current backend.
  */
-static void
+void
 UnSetGlobalPID(void)
 {
 	/* backend does not exist if the extension is not created */

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -62,6 +62,7 @@ extern void InitializeBackendData(void);
 extern void LockBackendSharedMemory(LWLockMode lockMode);
 extern void UnlockBackendSharedMemory(void);
 extern void UnSetDistributedTransactionId(void);
+extern void UnSetGlobalPID(void);
 extern void AssignDistributedTransactionId(void);
 extern void MarkCitusInitiatedCoordinatorBackend(void);
 extern void AssignGlobalPID(void);


### PR DESCRIPTION
The low-level StoreAllActiveTransactions() function filters out
backends that exited.

Before this commit, if you run a pgbench, after that you'd still
see the backends show up:
```SQL
 select count(*) from get_global_active_transactions();
┌───────┐
│ count │
├───────┤
│   538 │
└───────┘
```

After this patch, only active backends show-up:

```SQL
 select count(*) from get_global_active_transactions();
┌───────┐
│ count │
├───────┤
│    72 │
└───────┘
```

