### PR TITLE
Support TRUNCATE for foreign tables

### DIFF
--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -1012,8 +1012,8 @@ CitusRangeVarCallbackForLockTable(const RangeVar *rangeVar, Oid relationId,
 		return;
 	}
 
-	/* we only allow tables and views to be locked */
-	if (!RegularTable(relationId))
+	/* we only allow tables, views and foreign tables to be locked */
+	if (!RegularTable(relationId) && !IsForeignTable(relationId))
 	{
 		ereport(ERROR, (errcode(ERRCODE_WRONG_OBJECT_TYPE),
 						errmsg("\"%s\" is not a table", rangeVar->relname)));

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -1272,3 +1272,72 @@ SELECT count(*) FROM
 
 set client_min_messages to error;
 drop schema pg14 cascade;
+create schema pg14;
+set search_path to pg14;
+select 1 from citus_add_node('localhost',:master_port,groupid=>0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- test adding foreign table to metadata with the guc
+-- will test truncating foreign tables later
+CREATE TABLE foreign_table_test (id integer NOT NULL, data text, a bigserial);
+INSERT INTO foreign_table_test VALUES (1, 'text_test');
+SELECT citus_add_local_table_to_metadata('foreign_table_test');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER foreign_server
+        FOREIGN DATA WRAPPER postgres_fdw
+        OPTIONS (host 'localhost', port :'master_port', dbname 'regression');
+CREATE USER MAPPING FOR CURRENT_USER
+        SERVER foreign_server
+        OPTIONS (user 'postgres');
+CREATE FOREIGN TABLE foreign_table (
+        id integer NOT NULL,
+        data text,
+        a bigserial
+)
+        SERVER foreign_server
+        OPTIONS (schema_name 'pg14', table_name 'foreign_table_test');
+SELECT citus_add_local_table_to_metadata('foreign_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) FROM foreign_table;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+TRUNCATE foreign_table;
+\c - - - :worker_1_port
+set search_path to pg14;
+-- verify the foreign table is truncated
+SELECT count(*) FROM pg14.foreign_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- should error out
+TRUNCATE foreign_table;
+ERROR:  truncating foreign tables that are added to metadata can only be excuted on the coordinator
+\c - - - :master_port
+-- cleanup
+set client_min_messages to error;
+drop extension postgres_fdw cascade;
+drop schema pg14 cascade;
+reset client_min_messages;
+select 1 from citus_remove_node('localhost',:master_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+


### PR DESCRIPTION
DESCRIPTION: Supports TRUNCATE for foreign tables

fixes: https://github.com/citusdata/citus/issues/5588

This PR removes the limitations around truncating foreign tables. Nothing speacial, just letting pg to handle truncate commands. One thing might be worth to note is that we error out if the user is trying to truncate a foreign table that is added to metadata, on a worker node. We do that by saying that it's only alllowed on the coordinator node.