### PR TITLE
Properly set worker_query and use instead of application name on `citus_[dist/worker]_stat_activity`

### DIFF
--- a/src/backend/distributed/transaction/citus_dist_stat_activity.c
+++ b/src/backend/distributed/transaction/citus_dist_stat_activity.c
@@ -157,10 +157,9 @@ FROM \
 WHERE \
 	backend_type = 'client backend' \
 	AND \
-	pg_stat_activity.query NOT ILIKE '%stat_activity%' \
+	worker_query = False \
 	AND \
-	pg_stat_activity.application_name NOT SIMILAR TO 'citus_internal gpid=\\d+'; \
-"
+	pg_stat_activity.query NOT ILIKE '%stat_activity%';"
 
 #define CITUS_WORKER_STAT_ACTIVITY_QUERY \
 	"\
@@ -195,7 +194,7 @@ FROM \
 	get_all_active_transactions() AS dist_txs(database_id, process_id, initiator_node_identifier, worker_query, transaction_number, transaction_stamp, global_id) \
 	ON pg_stat_activity.pid = dist_txs.process_id \
 WHERE \
-	pg_stat_activity.application_name SIMILAR TO 'citus_internal gpid=\\d+' \
+	worker_query = True \
 	AND \
 	pg_stat_activity.query NOT ILIKE '%stat_activity%';"
 

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -29,7 +29,6 @@
 typedef struct CitusInitiatedBackend
 {
 	int initiatorNodeIdentifier;
-	bool transactionOriginator;
 } CitusInitiatedBackend;
 
 
@@ -51,6 +50,7 @@ typedef struct BackendData
 	slock_t mutex;
 	bool cancelledDueToDeadlock;
 	uint64 globalPID;
+	bool distributedCommandOriginator;
 	CitusInitiatedBackend citusBackend;
 	DistributedTransactionId transactionId;
 } BackendData;
@@ -67,6 +67,8 @@ extern void AssignDistributedTransactionId(void);
 extern void MarkCitusInitiatedCoordinatorBackend(void);
 extern void AssignGlobalPID(void);
 extern uint64 GetGlobalPID(void);
+extern void OverrideBackendDataDistributedCommandOriginator(bool
+															distributedCommandOriginator);
 extern uint64 ExtractGlobalPID(char *applicationName);
 extern int ExtractNodeIdFromGlobalPID(uint64 globalPID);
 extern int ExtractProcessIdFromGlobalPID(uint64 globalPID);

--- a/src/test/regress/spec/isolation_mx_common.include.spec
+++ b/src/test/regress/spec/isolation_mx_common.include.spec
@@ -7,6 +7,16 @@ setup
         LANGUAGE C STRICT VOLATILE
         AS 'citus', $$start_session_level_connection_to_node$$;
 
+    CREATE OR REPLACE FUNCTION override_backend_data_command_originator(bool)
+        RETURNS void
+        LANGUAGE C STRICT IMMUTABLE
+        AS 'citus', $$override_backend_data_command_originator$$;
+
+    SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off;CREATE OR REPLACE FUNCTION override_backend_data_command_originator(bool)
+        RETURNS void
+        LANGUAGE C STRICT IMMUTABLE
+        AS 'citus'$$);
+
     CREATE OR REPLACE FUNCTION run_commands_on_session_level_connection_to_node(text)
         RETURNS void
         LANGUAGE C STRICT VOLATILE


### PR DESCRIPTION
Relying on `pg_stat_activity.application_name` is not useful because if we don't have enough privileges, `pg_stat_activity.application_name == NULL` shown as NULL.

That's why, we properly use `worker_query` field and rely on that again.

This is a step for proper `citus_[extended]_stat_activity` implementation.