### PR TITLE
Update enterprise merge scripts and docs.

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -156,9 +156,9 @@ git merge "community/$PR_BRANCH"
    familiar with the change.
 5. You should rerun the `check-merge-to-enterprise` check on
    `community/$PR_BRANCH`. You can use re-run from failed option in circle CI.
-6. You can now merge the PR on enterprise. Be sure to NOT use "squash and merge",
+6. You can now merge the PR on community. Be sure to NOT use "squash and merge",
    but instead use the regular "merge commit" mode.
-7. You can now merge the PR on community. Be sure to NOT use "squash and merge",
+7. You can now merge the PR on enterprise. Be sure to NOT use "squash and merge",
    but instead use the regular "merge commit" mode.
 
 The subsequent PRs on community will be able to pass the

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -65,6 +65,14 @@ fi
 # undo partial merge
 git merge --abort
 
+# If we have a conflict on enterprise merge on the master branch, we have a problem.
+# Provide an error message to indicate that enterprise merge is needed to fix this check.
+if [[ $PR_BRANCH = master ]]; then
+    echo "ERROR: Master branch has merge conflicts with enterprise-master."
+    echo "Try re-running this CI job after merging your changes into enterprise-master."
+    exit 1
+fi
+
 if ! git fetch enterprise "$PR_BRANCH" ; then
     echo "ERROR: enterprise/$PR_BRANCH was not found and community PR branch could not be merged into enterprise-master"
     exit 1

--- a/ci/check_enterprise_merge.sh
+++ b/ci/check_enterprise_merge.sh
@@ -65,14 +65,6 @@ fi
 # undo partial merge
 git merge --abort
 
-# If we have a conflict on enterprise merge on the master branch, we have a problem.
-# Provide an error message to indicate that enterprise merge is needed.
-if [[ $PR_BRANCH = master ]]; then
-    echo "ERROR: Master branch has merge conlicts with enterprise-master."
-    echo "Try re-running this job if you merged community PR before enterprise PR. Otherwise conflicts need to be resolved as a separate PR on enterprise."
-    exit 1
-fi
-
 if ! git fetch enterprise "$PR_BRANCH" ; then
     echo "ERROR: enterprise/$PR_BRANCH was not found and community PR branch could not be merged into enterprise-master"
     exit 1


### PR DESCRIPTION
After some discussion with the team, we decided that it is not safe to merge the enterprise PR before the community counterpart. That's why I want to revert my changes that I made in #4981

The first commit in this PR reverts commit b649dffabddc99eb4d3b408edb46eabd9fcc2c0c.
The second one re-introduces an updated error message in case of failures on the master branch.

I can happily remove the second commit from this PR. However I think it makes sense to have an error message that suggests away to fix the failing test run.