### PR TITLE
Update dist col for Citus Local Tables, when create_distributed_table

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -421,11 +421,11 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 		if (distributionMethod != DISTRIBUTE_BY_NONE)
 		{
 			/*
-			* Because we create a new table when undistributing the table, attribute
-			* numbers might be changed, because of the dropped columns. To make sure we
-			* have the correct distribution column, we need to build it again, using the
-			* original column name that we have saved before.
-			*/
+			 * Because we create a new table when undistributing the table, attribute
+			 * numbers might be changed, because of the dropped columns. To make sure we
+			 * have the correct distribution column, we need to build it again, using the
+			 * original column name that we have saved before.
+			 */
 			Relation relation = try_relation_open(relationId, ExclusiveLock);
 			if (relation == NULL)
 			{

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -402,9 +402,14 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 	List *originalForeignKeyRecreationCommands = NIL;
 	if (IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
 	{
-		/* save the column name to update the distribution column var later */
-		char *distributionColumnName =
-			ColumnToColumnName(relationId, nodeToString(distributionColumn));
+		char *distributionColumnName = NULL;
+
+		if (distributionMethod != DISTRIBUTE_BY_NONE)
+		{
+			/* save the column name to update the distribution column var later */
+			distributionColumnName =
+				ColumnToColumnName(relationId, nodeToString(distributionColumn));
+		}
 
 		/* store foreign key creation commands that relation is involved */
 		originalForeignKeyRecreationCommands =
@@ -412,23 +417,27 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 																 INCLUDE_ALL_TABLE_TYPES);
 		relationId = DropFKeysAndUndistributeTable(relationId);
 
-		/*
-		 * Because we create a new table when undistributing the table, attribute numbers
-		 * might be changed, because of the dropped columns. To make sure we have the
-		 * correct distribution column, we need to build it again, using the original
-		 * column name that we have saved before.
-		 */
-		Relation relation = try_relation_open(relationId, ExclusiveLock);
-		if (relation == NULL)
+		/* exclude reference tables */
+		if (distributionMethod != DISTRIBUTE_BY_NONE)
 		{
-			ereport(ERROR, (errmsg("could not open the relation %u", relationId),
-							errdetail("When creating the distribution column.")));
+			/*
+			* Because we create a new table when undistributing the table, attribute
+			* numbers might be changed, because of the dropped columns. To make sure we
+			* have the correct distribution column, we need to build it again, using the
+			* original column name that we have saved before.
+			*/
+			Relation relation = try_relation_open(relationId, ExclusiveLock);
+			if (relation == NULL)
+			{
+				ereport(ERROR, (errmsg("could not open the relation %u", relationId),
+								errdetail("When creating the distribution column.")));
+			}
+
+			relation_close(relation, NoLock);
+
+			distributionColumn = BuildDistributionKeyFromColumnName(relation,
+																	distributionColumnName);
 		}
-
-		relation_close(relation, NoLock);
-
-		distributionColumn = BuildDistributionKeyFromColumnName(relation,
-																distributionColumnName);
 	}
 
 	/*

--- a/src/test/regress/expected/citus_local_tables_mx.out
+++ b/src/test/regress/expected/citus_local_tables_mx.out
@@ -724,6 +724,58 @@ $$);
  (localhost,57638,t,0)
 (2 rows)
 
+-- verify that partitioned citus local tables with dropped columns can be distributed. issue: #5577
+CREATE TABLE parent_dropped_col(a int, eventtime date) PARTITION BY RANGE ( eventtime);
+SELECT citus_add_local_table_to_metadata('parent_dropped_col');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE parent_dropped_col DROP column a;
+CREATE TABLE parent_dropped_col_1 PARTITION OF parent_dropped_col for VALUES FROM ('2000-01-01') TO ('2001-01-01');
+SELECT create_distributed_table('parent_dropped_col', 'eventtime');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- another example to test
+CREATE TABLE parent_dropped_col_2(
+  col_to_drop_0 text,
+  col_to_drop_1 text,
+  col_to_drop_2 date,
+  col_to_drop_3 inet,
+  col_to_drop_4 date,
+  measureid integer,
+  eventdatetime date,
+  measure_data jsonb,
+  PRIMARY KEY (measureid, eventdatetime, measure_data))
+  PARTITION BY RANGE(eventdatetime);
+select citus_add_local_table_to_metadata('parent_dropped_col_2');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE parent_dropped_col_2 DROP COLUMN col_to_drop_1;
+CREATE TABLE parent_dropped_col_2_2000 PARTITION OF parent_dropped_col_2 FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+SELECT create_distributed_table('parent_dropped_col_2', 'measureid');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- verify that the partitioned tables are distributed with the correct distribution column
+SELECT logicalrelid, partmethod, partkey FROM pg_dist_partition
+    WHERE logicalrelid IN ('parent_dropped_col'::regclass, 'parent_dropped_col_2'::regclass)
+        ORDER BY logicalrelid;
+     logicalrelid     | partmethod |                                                          partkey
+---------------------------------------------------------------------
+ parent_dropped_col   | h          | {VAR :varno 1 :varattno 1 :vartype 1082 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
+ parent_dropped_col_2 | h          | {VAR :varno 1 :varattno 5 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 5 :location -1}
+(2 rows)
+
 -- cleanup at exit
 set client_min_messages to error;
 DROP SCHEMA citus_local_tables_mx CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes distributing tables that are added to metadata, with dropped columns

fixes: #5577 

Please see #5123 and #5131 for background context.

When a column is dropped, PG doesn't update the attnum fields on `pg_attribute` for that table. i.e it doesn't enumerate the columns again. For example, if the column number 2 is dropped on a 4-column table, the attnum fields will be 1,3 and 4, for the remaining columns.
For a non-Citus example on that, please see: https://github.com/citusdata/citus/issues/5577#issuecomment-1042653118

This made Citus failing `create_distributed_table`, for partitioned tables, as in these cases partitions and parents might have inconsistencies on their attributes.
We normally handled these inconsistencies in PR #5131, but it turned out that we need a special fix for Citus Local Tables (not only partitioned ones, but all Citus Local Tables)

When `create_distributed_table`, we first undistribute the table if it's added to metadata. Since we do create a new table when undistributing a table, the new table might have different attnum fields on `pg_attribute`. In other words, after `UndistributeTable`, the new table's columns will have attnum's set to 1,2 and 3, while the old table had 1,2 and 4. This is because of the PG behavior that is mentioned in the first part of this description comment. Thus, for example if the distribution column is chosen to be the 4th column, it will not be found on the new table when distributing. We will see a cache lookup fail error message for that.
For a real sql example, please see: https://github.com/citusdata/citus/issues/5577#issuecomment-1042661056

With this PR, after undistributing the table, we set a new distribution column using the new table (the one that is created in UndistributeTable). We do that by saving the name of the original distribution column.