### PR TITLE
Refactor CreateDistributedTable to take column name

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -159,29 +159,13 @@ master_create_distributed_table(PG_FUNCTION_ARGS)
 	char *colocateWithTableName = NULL;
 	bool viaDeprecatedAPI = true;
 
-	/*
-	 * Lock target relation with an exclusive lock - there's no way to make
-	 * sense of this table until we've committed, and we don't want multiple
-	 * backends manipulating this relation.
-	 */
-	Relation relation = try_relation_open(relationId, ExclusiveLock);
-
-	if (relation == NULL)
-	{
-		ereport(ERROR, (errmsg("could not create distributed table: "
-							   "relation does not exist")));
-	}
-
 	char *distributionColumnName = text_to_cstring(distributionColumnText);
-	Var *distributionColumn = BuildDistributionKeyFromColumnName(relation,
-																 distributionColumnName);
-	Assert(distributionColumn != NULL);
+	Assert(distributionColumnName != NULL);
+
 	char distributionMethod = LookupDistributionMethod(distributionMethodOid);
 
-	CreateDistributedTable(relationId, distributionColumn, distributionMethod,
+	CreateDistributedTable(relationId, distributionColumnName, distributionMethod,
 						   ShardCount, false, colocateWithTableName, viaDeprecatedAPI);
-
-	relation_close(relation, NoLock);
 
 	PG_RETURN_VOID();
 }
@@ -249,9 +233,8 @@ create_distributed_table(PG_FUNCTION_ARGS)
 	relation_close(relation, NoLock);
 
 	char *distributionColumnName = text_to_cstring(distributionColumnText);
-	Var *distributionColumn = BuildDistributionKeyFromColumnName(relation,
-																 distributionColumnName);
-	Assert(distributionColumn != NULL);
+	Assert(distributionColumnName != NULL);
+
 	char distributionMethod = LookupDistributionMethod(distributionMethodOid);
 
 	if (shardCount < 1 || shardCount > MAX_SHARD_COUNT)
@@ -261,7 +244,7 @@ create_distributed_table(PG_FUNCTION_ARGS)
 							   shardCount, MAX_SHARD_COUNT)));
 	}
 
-	CreateDistributedTable(relationId, distributionColumn, distributionMethod,
+	CreateDistributedTable(relationId, distributionColumnName, distributionMethod,
 						   shardCount, shardCountIsStrict, colocateWithTableName,
 						   viaDeprecatedAPI);
 
@@ -281,7 +264,7 @@ create_reference_table(PG_FUNCTION_ARGS)
 	Oid relationId = PG_GETARG_OID(0);
 
 	char *colocateWithTableName = NULL;
-	Var *distributionColumn = NULL;
+	char *distributionColumnName = NULL;
 
 	bool viaDeprecatedAPI = false;
 
@@ -317,7 +300,7 @@ create_reference_table(PG_FUNCTION_ARGS)
 						errdetail("There are no active worker nodes.")));
 	}
 
-	CreateDistributedTable(relationId, distributionColumn, DISTRIBUTE_BY_NONE,
+	CreateDistributedTable(relationId, distributionColumnName, DISTRIBUTE_BY_NONE,
 						   ShardCount, false, colocateWithTableName, viaDeprecatedAPI);
 	PG_RETURN_VOID();
 }
@@ -385,9 +368,10 @@ EnsureRelationExists(Oid relationId)
  * day, once we deprecate master_create_distribute_table completely.
  */
 void
-CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributionMethod,
-					   int shardCount, bool shardCountIsStrict,
-					   char *colocateWithTableName, bool viaDeprecatedAPI)
+CreateDistributedTable(Oid relationId, char *distributionColumnName,
+					   char distributionMethod, int shardCount,
+					   bool shardCountIsStrict, char *colocateWithTableName,
+					   bool viaDeprecatedAPI)
 {
 	/*
 	 * EnsureTableNotDistributed errors out when relation is a citus table but
@@ -443,6 +427,8 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 		DropFKeysRelationInvolvedWithTableType(relationId, INCLUDE_LOCAL_TABLES);
 	}
 
+	LockRelationOid(relationId, ExclusiveLock);
+
 	/*
 	 * Ensure that the sequences used in column defaults of the table
 	 * have proper types
@@ -463,22 +449,9 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 												   colocateWithTableName,
 												   viaDeprecatedAPI);
 
-	/*
-	 * Due to dropping columns, the parent's distribution key may not match the
-	 * partition's distribution key. The input distributionColumn belongs to
-	 * the parent. That's why we override the distribution column of partitions
-	 * here. See issue #5123 for details.
-	 */
-	if (PartitionTable(relationId))
-	{
-		Oid parentRelationId = PartitionParentOid(relationId);
-		char *distributionColumnName =
-			ColumnToColumnName(parentRelationId, nodeToString(distributionColumn));
-
-		distributionColumn =
-			FindColumnWithNameOnTargetRelation(parentRelationId, distributionColumnName,
-											   relationId);
-	}
+	Var *distributionColumn = BuildDistributionKeyFromColumnName(relationId,
+																 distributionColumnName,
+																 ExclusiveLock);
 
 	/*
 	 * ColocationIdForNewTable assumes caller acquires lock on relationId. In our case,
@@ -567,7 +540,7 @@ CreateDistributedTable(Oid relationId, Var *distributionColumn, char distributio
 
 		foreach_oid(partitionRelationId, partitionList)
 		{
-			CreateDistributedTable(partitionRelationId, distributionColumn,
+			CreateDistributedTable(partitionRelationId, distributionColumnName,
 								   distributionMethod, shardCount, false,
 								   parentRelationName, viaDeprecatedAPI);
 		}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -378,6 +378,8 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 		}
 
 		Var *parentDistributionColumn = DistPartitionKeyOrError(parentRelationId);
+		char *distributionColumnName =
+			ColumnToColumnName(parentRelationId, (Node *) parentDistributionColumn);
 		char parentDistributionMethod = DISTRIBUTE_BY_HASH;
 		char *parentRelationName = generate_qualified_relation_name(parentRelationId);
 		bool viaDeprecatedAPI = false;
@@ -385,7 +387,7 @@ PostprocessCreateTableStmtPartitionOf(CreateStmt *createStatement, const
 		SwitchToSequentialAndLocalExecutionIfPartitionNameTooLong(parentRelationId,
 																  relationId);
 
-		CreateDistributedTable(relationId, parentDistributionColumn,
+		CreateDistributedTable(relationId, distributionColumnName,
 							   parentDistributionMethod, ShardCount, false,
 							   parentRelationName, viaDeprecatedAPI);
 	}
@@ -573,13 +575,8 @@ static void
 DistributePartitionUsingParent(Oid parentCitusRelationId, Oid partitionRelationId)
 {
 	Var *distributionColumn = DistPartitionKeyOrError(parentCitusRelationId);
-	char *distributionColumnName =
-		ColumnToColumnName(parentCitusRelationId,
-						   nodeToString(distributionColumn));
-	distributionColumn =
-		FindColumnWithNameOnTargetRelation(parentCitusRelationId,
-										   distributionColumnName,
-										   partitionRelationId);
+	char *distributionColumnName = ColumnToColumnName(parentCitusRelationId,
+													  (Node *) distributionColumn);
 
 	char distributionMethod = DISTRIBUTE_BY_HASH;
 	char *parentRelationName = generate_qualified_relation_name(parentCitusRelationId);
@@ -588,7 +585,7 @@ DistributePartitionUsingParent(Oid parentCitusRelationId, Oid partitionRelationI
 	SwitchToSequentialAndLocalExecutionIfPartitionNameTooLong(
 		parentCitusRelationId, partitionRelationId);
 
-	CreateDistributedTable(partitionRelationId, distributionColumn,
+	CreateDistributedTable(partitionRelationId, distributionColumnName,
 						   distributionMethod, ShardCount, false,
 						   parentRelationName, viaDeprecatedAPI);
 }

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1022,7 +1022,6 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 	StringInfo insertDistributionCommand = makeStringInfo();
 	Oid relationId = cacheEntry->relationId;
 	char distributionMethod = cacheEntry->partitionMethod;
-	char *partitionKeyString = cacheEntry->partitionKeyString;
 	char *qualifiedRelationName =
 		generate_qualified_relation_name(relationId);
 	uint32 colocationId = cacheEntry->colocationId;
@@ -1036,7 +1035,7 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 	else
 	{
 		char *partitionKeyColumnName =
-			ColumnToColumnName(relationId, partitionKeyString);
+			ColumnToColumnName(relationId, (Node *) cacheEntry->partitionColumn);
 		appendStringInfo(tablePartitionKeyNameString, "%s",
 						 quote_literal_cstr(partitionKeyColumnName));
 	}
@@ -2445,12 +2444,10 @@ citus_internal_add_partition_metadata(PG_FUNCTION_ARGS)
 		distributionColumnText = PG_GETARG_TEXT_P(2);
 		distributionColumnString = text_to_cstring(distributionColumnText);
 
-		Relation relation = relation_open(relationId, AccessShareLock);
 		distributionColumnVar =
-			BuildDistributionKeyFromColumnName(relation, distributionColumnString);
+			BuildDistributionKeyFromColumnName(relationId, distributionColumnString,
+											   AccessShareLock);
 		Assert(distributionColumnVar != NULL);
-
-		relation_close(relation, NoLock);
 	}
 
 	if (!ShouldSkipMetadataChecks())

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1013,9 +1013,9 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 				StringInfo errorHint = makeStringInfo();
 				CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(
 					distributedTableId);
-				char *partitionKeyString = cacheEntry->partitionKeyString;
-				char *partitionColumnName = ColumnToColumnName(distributedTableId,
-															   partitionKeyString);
+				char *partitionColumnName =
+					ColumnToColumnName(distributedTableId,
+									   (Node *) cacheEntry->partitionColumn);
 
 				appendStringInfo(errorHint, "Consider using an equality filter on "
 											"partition column \"%s\" to target a single shard.",
@@ -3053,8 +3053,8 @@ BuildRoutesForInsert(Query *query, DeferredErrorMessage **planningError)
 		if (prunedShardIntervalCount != 1)
 		{
 			char *partitionKeyString = cacheEntry->partitionKeyString;
-			char *partitionColumnName = ColumnToColumnName(distributedTableId,
-														   partitionKeyString);
+			char *partitionColumnName =
+				ColumnToColumnName(distributedTableId, stringToNode(partitionKeyString));
 			StringInfo errorMessage = makeStringInfo();
 			StringInfo errorHint = makeStringInfo();
 			const char *targetCountType = NULL;

--- a/src/include/distributed/distribution_column.h
+++ b/src/include/distributed/distribution_column.h
@@ -19,11 +19,9 @@
 
 
 /* Remaining metadata utility functions  */
-extern Var * FindColumnWithNameOnTargetRelation(Oid sourceRelationId,
-												char *sourceColumnName,
-												Oid targetRelationId);
-extern Var * BuildDistributionKeyFromColumnName(Relation distributedRelation,
-												char *columnName);
-extern char * ColumnToColumnName(Oid relationId, char *columnNodeString);
+extern Var * BuildDistributionKeyFromColumnName(Oid relationId,
+												char *columnName,
+												LOCKMODE lockMode);
+extern char * ColumnToColumnName(Oid relationId, Node *columnNode);
 
 #endif   /* DISTRIBUTION_COLUMN_H */

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -238,7 +238,7 @@ extern void DeleteShardRow(uint64 shardId);
 extern void UpdateShardPlacementState(uint64 placementId, char shardState);
 extern void UpdatePlacementGroupId(uint64 placementId, int groupId);
 extern void DeleteShardPlacementRow(uint64 placementId);
-extern void CreateDistributedTable(Oid relationId, Var *distributionColumn,
+extern void CreateDistributedTable(Oid relationId, char *distributionColumnName,
 								   char distributionMethod, int shardCount,
 								   bool shardCountIsStrict, char *colocateWithTableName,
 								   bool viaDeprecatedAPI);

--- a/src/test/regress/expected/citus_local_tables_mx.out
+++ b/src/test/regress/expected/citus_local_tables_mx.out
@@ -724,6 +724,58 @@ $$);
  (localhost,57638,t,0)
 (2 rows)
 
+-- verify that partitioned citus local tables with dropped columns can be distributed. issue: #5577
+CREATE TABLE parent_dropped_col(a int, eventtime date) PARTITION BY RANGE ( eventtime);
+SELECT citus_add_local_table_to_metadata('parent_dropped_col');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE parent_dropped_col DROP column a;
+CREATE TABLE parent_dropped_col_1 PARTITION OF parent_dropped_col for VALUES FROM ('2000-01-01') TO ('2001-01-01');
+SELECT create_distributed_table('parent_dropped_col', 'eventtime');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- another example to test
+CREATE TABLE parent_dropped_col_2(
+  col_to_drop_0 text,
+  col_to_drop_1 text,
+  col_to_drop_2 date,
+  col_to_drop_3 inet,
+  col_to_drop_4 date,
+  measureid integer,
+  eventdatetime date,
+  measure_data jsonb,
+  PRIMARY KEY (measureid, eventdatetime, measure_data))
+  PARTITION BY RANGE(eventdatetime);
+select citus_add_local_table_to_metadata('parent_dropped_col_2');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE parent_dropped_col_2 DROP COLUMN col_to_drop_1;
+CREATE TABLE parent_dropped_col_2_2000 PARTITION OF parent_dropped_col_2 FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+SELECT create_distributed_table('parent_dropped_col_2', 'measureid');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- verify that the partitioned tables are distributed with the correct distribution column
+SELECT logicalrelid, partmethod, partkey FROM pg_dist_partition
+    WHERE logicalrelid IN ('parent_dropped_col'::regclass, 'parent_dropped_col_2'::regclass)
+        ORDER BY logicalrelid;
+     logicalrelid     | partmethod |                                                          partkey
+---------------------------------------------------------------------
+ parent_dropped_col   | h          | {VAR :varno 1 :varattno 1 :vartype 1082 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}
+ parent_dropped_col_2 | h          | {VAR :varno 1 :varattno 5 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 5 :location -1}
+(2 rows)
+
 -- cleanup at exit
 set client_min_messages to error;
 DROP SCHEMA citus_local_tables_mx CASCADE;

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -220,7 +220,7 @@ SELECT column_to_column_name('pg_dist_node'::regclass,'{FROMEXPR :fromlist ({RAN
 ERROR:  not a valid column
 -- test column_name_to_column with illegal arguments
 SELECT column_name_to_column(1204127312,'');
-ERROR:  could not open relation with OID 1204127312
+ERROR:  relation does not exist
 SELECT column_name_to_column('customers','notacolumn');
 ERROR:  column "notacolumn" of relation "customers" does not exist
 -- make one huge shard and manually inspect shard row


### PR DESCRIPTION
DESCRIPTION: Refactor CreateDistributedTable to take column name

This pr includes some refactor on `CreateDistributedTable` and the functions around it.
We also have some tests for #5577 
fixes: #5577 