### PR TITLE
Check metadata consistency in tests

### DIFF
--- a/src/test/regress/expected/check_mx.out
+++ b/src/test/regress/expected/check_mx.out
@@ -10,3 +10,35 @@ SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
  t
 (1 row)
 
+-- Create the necessary test utility function
+CREATE OR REPLACE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+SELECT create_distributed_function('activate_node_snapshot()');
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Following tests capture the difference between the metadata in the worker nodes and the
+-- coordinator. It is expected to see no rows. However if the tests fail, we list the
+-- problematic queries in the activate_node_snapshot() result set.
+-- list all metadata that is missing in the worker nodes
+SELECT unnest(activate_node_snapshot())
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
+                                                                                                                                                                                                                                                                                   unnest
+---------------------------------------------------------------------
+(0 rows)
+
+-- list all the metadata that is missing on the coordinator
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+SELECT unnest(activate_node_snapshot());
+                                                                                                                                                                                                                                                                        unnested_result
+---------------------------------------------------------------------
+(0 rows)
+

--- a/src/test/regress/expected/isolation_check_mx.out
+++ b/src/test/regress/expected/isolation_check_mx.out
@@ -1,6 +1,11 @@
 Parsed test spec with 1 sessions
 
 starting permutation: check_mx
+create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
 step check_mx:
     SHOW citus.enable_metadata_sync;
     SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
@@ -14,4 +19,34 @@ bool_and
 ---------------------------------------------------------------------
 t
 (1 row)
+
+
+starting permutation: compare-metadata
+create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+step compare-metadata:
+    -- Following tests capture the difference between the metadata in the worker nodes and the
+    -- coordinator. It is expected to see no rows. However if the tests fail, we list the
+    -- problematic queries in the activate_node_snapshot() result set.
+    -- list all metadata that is missing in the worker nodes
+    SELECT unnest(activate_node_snapshot())
+        EXCEPT
+    SELECT unnest(result::text[]) AS unnested_result
+    FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
+    -- list all the metadata that is missing on the coordinator
+    SELECT unnest(result::text[]) AS unnested_result
+    FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+        EXCEPT
+    SELECT unnest(activate_node_snapshot());
+
+unnest
+---------------------------------------------------------------------
+(0 rows)
+
+unnested_result
+---------------------------------------------------------------------
+(0 rows)
 

--- a/src/test/regress/spec/isolation_check_mx.spec
+++ b/src/test/regress/spec/isolation_check_mx.spec
@@ -1,3 +1,13 @@
+setup
+{
+    -- Create the necessary test utility function
+    CREATE OR REPLACE FUNCTION activate_node_snapshot()
+        RETURNS text[]
+        LANGUAGE C STRICT
+        AS 'citus';
+    SELECT create_distributed_function('activate_node_snapshot()');
+}
+
 session "s1"
 
 step "check_mx"
@@ -7,4 +17,24 @@ step "check_mx"
     SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
 }
 
+step "compare-metadata"
+{
+    -- Following tests capture the difference between the metadata in the worker nodes and the
+    -- coordinator. It is expected to see no rows. However if the tests fail, we list the
+    -- problematic queries in the activate_node_snapshot() result set.
+
+    -- list all metadata that is missing in the worker nodes
+    SELECT unnest(activate_node_snapshot())
+        EXCEPT
+    SELECT unnest(result::text[]) AS unnested_result
+    FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
+
+    -- list all the metadata that is missing on the coordinator
+    SELECT unnest(result::text[]) AS unnested_result
+    FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+        EXCEPT
+    SELECT unnest(activate_node_snapshot());
+}
+
 permutation "check_mx"
+permutation "compare-metadata"

--- a/src/test/regress/sql/check_mx.sql
+++ b/src/test/regress/sql/check_mx.sql
@@ -1,3 +1,26 @@
 SHOW citus.enable_metadata_sync;
 
 SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
+
+-- Create the necessary test utility function
+CREATE OR REPLACE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+SELECT create_distributed_function('activate_node_snapshot()');
+
+-- Following tests capture the difference between the metadata in the worker nodes and the
+-- coordinator. It is expected to see no rows. However if the tests fail, we list the
+-- problematic queries in the activate_node_snapshot() result set.
+
+-- list all metadata that is missing in the worker nodes
+SELECT unnest(activate_node_snapshot())
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
+
+-- list all the metadata that is missing on the coordinator
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+SELECT unnest(activate_node_snapshot());


### PR DESCRIPTION
After testing various scenarios, we may end up with inconsistent metadata in some of the nodes. This PR aims to capture those cases by comparing the metadata in the worker nodes, and the coordinator node.

Note: This PR has a high risk of breaking the tests on enterprise.

Currently, we have several failures.

a) Some oid references are no longer valid for relations/roles/etc

```diff
 -- list all metadata that is missing in the worker nodes
 SELECT unnest(activate_node_snapshot())
     EXCEPT
 SELECT unnest(result::text[]) AS unnested_result
 FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
-                                                                                                                                                                                                                                                                                   unnest
----------------------------------------------------------------------
-(0 rows)
-
+ERROR:  malformed array literal: "ERROR:  cache lookup failed for relation 17315"
+DETAIL:  Array value must start with "{" or dimension information.
```

b) We have slightly different `pg_dist_node` records. On some cases, we have differing `nodecluster` values.

```diff
 -- list all metadata that is missing in the worker nodes
 SELECT unnest(activate_node_snapshot())
     EXCEPT
 SELECT unnest(result::text[]) AS unnested_result
 FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
                                                                                                                                                                                                                                                                                    unnest                                                                                                                                                                                                                                                                                    
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-(0 rows)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster, shouldhaveshards) VALUES (5, 1, 'localhost', 9071, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'second-cluster', TRUE),(6, 2, 'localhost', 9072, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'second-cluster', TRUE),(3, 1, 'localhost', 57637, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default', TRUE),(4, 2, 'localhost', 57638, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default', TRUE)
+(1 row)
 
 -- list all the metadata that is missing on the coordinator
 SELECT unnest(result::text[]) AS unnested_result
 FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
     EXCEPT
 SELECT unnest(activate_node_snapshot());
                                                                                                                                                                                                                                                                         unnested_result                                                                                                                                                                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-(0 rows)
+ INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, noderack, hasmetadata, metadatasynced, isactive, noderole, nodecluster, shouldhaveshards) VALUES (5, 1, 'localhost', 9071, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'default', TRUE),(6, 2, 'localhost', 9072, 'default', FALSE, FALSE, TRUE, 'secondary'::noderole, 'default', TRUE),(3, 1, 'localhost', 57637, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default', TRUE),(4, 2, 'localhost', 57638, 'default', TRUE, TRUE, TRUE, 'primary'::noderole, 'default', TRUE)
+(1 row)
``` 

c) We have different definitions for sequences that break the current tests. This behaviour is expected, and the tests need to be improved somehow to stop giving false positive errors.

```diff
 -- list all metadata that is missing in the worker nodes
 SELECT unnest(activate_node_snapshot())
     EXCEPT
 SELECT unnest(result::text[]) AS unnested_result
 FROM run_command_on_workers($$SELECT activate_node_snapshot()$$);
                                                                                                                                                                                                                                                                                    unnest                                                                                                                                                                                                                                                                                    
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-(0 rows)
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.the_replicated_table_z_seq AS bigint INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1 NO CYCLE','bigint')
+(1 row)
 
 -- list all the metadata that is missing on the coordinator
 SELECT unnest(result::text[]) AS unnested_result
 FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
     EXCEPT
 SELECT unnest(activate_node_snapshot());
                                                                                                                                                                                                                                                                         unnested_result                                                                                                                                                                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-(0 rows)
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.the_replicated_table_z_seq AS bigint INCREMENT BY 1 MINVALUE 562949953421313 MAXVALUE 844424930131969 START WITH 562949953421313 CACHE 1 NO CYCLE','bigint')
+ SELECT worker_apply_sequence_command ('CREATE SEQUENCE IF NOT EXISTS public.the_replicated_table_z_seq AS bigint INCREMENT BY 1 MINVALUE 281474976710657 MAXVALUE 562949953421313 START WITH 281474976710657 CACHE 1 NO CYCLE','bigint')
+(2 rows)
```