### PR TITLE
Do distributed check first, for DropSchema stmts

### DIFF
--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -86,19 +86,19 @@ PreprocessDropSchemaStmt(Node *node, const char *queryString,
 	DropStmt *dropStatement = castNode(DropStmt, node);
 	Assert(dropStatement->removeType == OBJECT_SCHEMA);
 
-	if (!ShouldPropagate())
-	{
-		return NIL;
-	}
-
-	EnsureCoordinator();
-
 	List *distributedSchemas = FilterDistributedSchemas(dropStatement->objects);
 
 	if (list_length(distributedSchemas) < 1)
 	{
 		return NIL;
 	}
+
+	if (!ShouldPropagate())
+	{
+		return NIL;
+	}
+
+	EnsureCoordinator();
 
 	EnsureSequentialMode(OBJECT_SCHEMA);
 

--- a/src/test/regress/expected/multi_mx_schema_support.out
+++ b/src/test/regress/expected/multi_mx_schema_support.out
@@ -515,12 +515,30 @@ SELECT table_schema AS "Shards' Schema"
  mx_new_schema
 (1 row)
 
+-- check that we can drop a user-defined schema from workers
+SET citus.enable_ddl_propagation TO OFF;
+CREATE SCHEMA localschema;
+RESET citus.enable_ddl_propagation;
+DROP SCHEMA localschema;
 \c - - - :master_port
 SELECT * FROM mx_new_schema.table_set_schema;
  id
 ---------------------------------------------------------------------
 (0 rows)
 
+-- verify local schema does not exist on the worker
+-- worker errors out as "schema does not exist"
+SET citus.enable_ddl_propagation TO OFF;
+CREATE SCHEMA localschema;
+-- should error out
+SELECT run_command_on_workers($$DROP SCHEMA localschema;$$);
+                       run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,f,"ERROR:  schema ""localschema"" does not exist")
+ (localhost,57638,f,"ERROR:  schema ""localschema"" does not exist")
+(2 rows)
+
+RESET citus.enable_ddl_propagation;
 DROP SCHEMA mx_old_schema CASCADE;
 DROP SCHEMA mx_new_schema CASCADE;
 NOTICE:  drop cascades to table mx_new_schema.table_set_schema


### PR DESCRIPTION
Before that PR we used to check if the given schemas are distributed or not, after `ShouldPropagate` check. That caused throwing `operation not allowed on this node` errors for non-distributed schemas. With this PR, we move the 'distributed' check to be before the `ShouldPropagate` check