### PR TITLE
Lock nodes when building ddl task lists

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -149,16 +149,6 @@ PostprocessCreateExtensionStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 
 	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will have the extension, because they will
-	 * either get it now, or get it in citus_add_node after this transaction finishes and
-	 * the pg_dist_object record becomes visible.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
-
-	/*
 	 * Make sure that the current transaction is already in sequential mode,
 	 * or can still safely be put in sequential mode
 	 */
@@ -258,16 +248,6 @@ PreprocessDropExtensionStmt(Node *node, const char *queryString,
 
 	/* extension management can only be done via coordinator node */
 	EnsureCoordinator();
-
-	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will drop the extension, because they will
-	 * either get it now, or get it in citus_add_node after this transaction finishes and
-	 * the pg_dist_object record becomes visible.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
 	/*
 	 * Make sure that the current transaction is already in sequential mode,
@@ -396,15 +376,6 @@ PreprocessAlterExtensionSchemaStmt(Node *node, const char *queryString,
 	EnsureCoordinator();
 
 	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will update the extension schema after
-	 * this transaction finishes and the pg_dist_object record becomes visible.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
-
-	/*
 	 * Make sure that the current transaction is already in sequential mode,
 	 * or can still safely be put in sequential mode
 	 */
@@ -462,16 +433,6 @@ PreprocessAlterExtensionUpdateStmt(Node *node, const char *queryString,
 
 	/* extension management can only be done via coordinator node */
 	EnsureCoordinator();
-
-	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will update the extension version, because
-	 * they will either get it now, or get it in citus_add_node after this transaction
-	 * finishes and the pg_dist_object record becomes visible.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
 	/*
 	 * Make sure that the current transaction is already in sequential mode,

--- a/src/backend/distributed/commands/role.c
+++ b/src/backend/distributed/commands/role.c
@@ -140,13 +140,6 @@ PostprocessAlterRoleStmt(Node *node, const char *queryString)
 
 	AlterRoleStmt *stmt = castNode(AlterRoleStmt, node);
 
-	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
-
 	DefElem *option = NULL;
 	foreach_ptr(option, stmt->options)
 	{

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -129,16 +129,6 @@ PreprocessCompositeTypeStmt(Node *node, const char *queryString,
 	 */
 	EnsureCoordinator();
 
-	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will have the object, because they will
-	 * either get it now, or get it in citus_add_node after this transaction finishes and
-	 * the pg_dist_object record becomes visible.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
-
 	/* fully qualify before lookup and later deparsing */
 	QualifyTreeNode(node);
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -1563,7 +1563,8 @@ DDLTaskList(Oid relationId, const char *commandString)
 List *
 NodeDDLTaskList(TargetWorkerSet targets, List *commands)
 {
-	List *workerNodes = TargetWorkerSetNodeList(targets, NoLock);
+	/* don't allow concurrent node list changes that require an exclusive lock */
+	List *workerNodes = TargetWorkerSetNodeList(targets, RowShareLock);
 
 	if (list_length(workerNodes) <= 0)
 	{

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -188,9 +188,6 @@ citus_set_coordinator_host(PG_FUNCTION_ARGS)
 	Name nodeClusterName = PG_GETARG_NAME(3);
 	nodeMetadata.nodeCluster = NameStr(*nodeClusterName);
 
-	/* prevent concurrent modification */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
-
 	bool isCoordinatorInMetadata = false;
 	WorkerNode *coordinatorNode = PrimaryNodeForGroup(COORDINATOR_GROUP_ID,
 													  &isCoordinatorInMetadata);
@@ -1779,12 +1776,6 @@ AddNodeMetadata(char *nodeName, int32 nodePort,
 	EnsureCoordinator();
 
 	*nodeAlreadyExists = false;
-
-	/*
-	 * Prevent / wait for concurrent modification before checking whether
-	 * the worker already exists in pg_dist_node.
-	 */
-	LockRelationOid(DistNodeRelationId(), RowShareLock);
 
 	WorkerNode *workerNode = FindWorkerNodeAnyCluster(nodeName, nodePort);
 	if (workerNode != NULL)

--- a/src/test/regress/expected/isolation_drop_vs_all.out
+++ b/src/test/regress/expected/isolation_drop_vs_all.out
@@ -1,12 +1,13 @@
 Parsed test spec with 2 sessions
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-drop s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-drop s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -23,13 +24,60 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop-schema s2-drop-schema s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop-schema: DROP SCHEMA drop_tests CASCADE;
+step s2-drop-schema: DROP SCHEMA drop_tests CASCADE; <waiting ...>
+step s1-commit: COMMIT;
+step s2-drop-schema: <... completed>
+ERROR:  schema "drop_tests" does not exist
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+---------------------------------------------------------------------
+
+(1 row)
+
+
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop-schema s2-drop-schema-2 s1-commit s2-commit s1-select-count
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
+step s1-begin: BEGIN;
+step s2-begin: BEGIN;
+step s1-drop-schema: DROP SCHEMA drop_tests CASCADE;
+step s2-drop-schema-2: DROP SCHEMA drop_tests_2 CASCADE;
+step s1-commit: COMMIT;
+step s2-commit: COMMIT;
+step s1-select-count: SELECT COUNT(*) FROM drop_hash;
+ERROR:  relation "drop_hash" does not exist
+restore_isolation_tester_func
+---------------------------------------------------------------------
+
+(1 row)
+
+
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-ddl-create-index s1-commit s2-commit s1-select-count s1-show-indexes
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -53,13 +101,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-drop s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s2-initialize s1-ddl-create-index s1-begin s2-begin s1-drop s2-ddl-drop-index s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
@@ -84,13 +133,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s1-drop s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s2-initialize s1-begin s1-drop s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
 step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY drop_hash_index ON drop_hash(id); <waiting ...>
@@ -112,13 +162,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-ddl-add-column s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -142,13 +193,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-drop s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-ddl-add-column s1-begin s2-begin s1-drop s2-ddl-drop-column s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
@@ -173,13 +225,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-ddl-rename-column s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -203,13 +256,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-drop s2-table-size s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-table-size s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -226,7 +280,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-drop s2-distribute-table s1-commit s2-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s2-initialize s1-begin s2-begin s1-drop s2-distribute-table s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -234,7 +288,8 @@ create_distributed_table
 
 step s1-drop: DROP TABLE drop_hash;
 step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-drop: DROP TABLE drop_hash;
@@ -251,13 +306,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-ddl-create-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-ddl-create-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
@@ -280,13 +336,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s2-initialize s1-ddl-create-index s1-begin s2-begin s1-ddl-drop-index s2-drop s1-commit s2-commit s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-ddl-create-index: CREATE INDEX drop_hash_index ON drop_hash(id);
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
@@ -310,13 +367,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-ddl-add-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-ddl-add-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
@@ -339,13 +397,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-ddl-add-column s1-begin s2-begin s1-ddl-drop-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-ddl-add-column: ALTER TABLE drop_hash ADD new_column int DEFAULT 0;
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
@@ -369,13 +428,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-ddl-rename-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-ddl-rename-column s2-drop s1-commit s2-commit s1-select-count s1-show-columns
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-ddl-rename-column: ALTER TABLE drop_hash RENAME data TO new_column;
@@ -398,13 +458,14 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s2-begin s1-table-size s2-drop s1-commit s2-commit s1-select-count
+starting permutation: s1-initialize s2-initialize s1-begin s2-begin s1-table-size s2-drop s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-table-size: SELECT citus_total_relation_size('drop_hash');
@@ -424,7 +485,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s2-begin s1-distribute-table s2-drop s1-commit s2-commit s1-select-count
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s2-initialize s1-begin s2-begin s1-distribute-table s2-drop s1-commit s2-commit s1-select-count
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -432,7 +493,8 @@ create_distributed_table
 
 step s1-drop: DROP TABLE drop_hash;
 step s1-create-non-distributed-table: CREATE TABLE drop_hash(id integer, data text); COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
-step s1-initialize: COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s1-initialize: SET search_path TO 'drop_tests'; COPY drop_hash FROM PROGRAM 'echo 0, a && echo 1, b && echo 2, c && echo 3, d && echo 4, e' WITH CSV;
+step s2-initialize: SET search_path TO 'drop_tests';
 step s1-begin: BEGIN;
 step s2-begin: BEGIN;
 step s1-distribute-table: SELECT create_distributed_table('drop_hash', 'id');

--- a/src/test/regress/expected/isolation_metadata_sync_vs_all.out
+++ b/src/test/regress/expected/isolation_metadata_sync_vs_all.out
@@ -237,6 +237,126 @@ t
 (1 row)
 
 
+starting permutation: s1-begin s2-begin s1-start-metadata-sync s2-create-schema s1-commit s2-commit s3-compare-snapshot s2-drop-schema
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-create-schema:
+ CREATE SCHEMA dist_schema
+  CREATE TABLE dist_table_in_schema(id int, data int);
+ SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-create-schema: <... completed>
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-commit:
+ COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s2-drop-schema:
+ DROP SCHEMA dist_schema CASCADE;
+
+
+starting permutation: s2-create-schema s1-begin s2-begin s1-start-metadata-sync s2-drop-schema s1-commit s2-commit s3-compare-snapshot
+step s2-create-schema:
+ CREATE SCHEMA dist_schema
+  CREATE TABLE dist_table_in_schema(id int, data int);
+ SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
+
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-drop-schema:
+ DROP SCHEMA dist_schema CASCADE;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-drop-schema: <... completed>
+step s2-commit:
+ COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
 starting permutation: s1-begin s2-begin s1-start-metadata-sync s2-create-dist-table s1-commit s2-commit s3-compare-snapshot
 step s1-begin:
     BEGIN;
@@ -606,6 +726,415 @@ same_metadata_in_workers
 ---------------------------------------------------------------------
 t
 (1 row)
+
+
+starting permutation: s2-create-type s1-begin s2-begin s1-start-metadata-sync s2-drop-type s1-commit s2-commit s3-compare-snapshot
+step s2-create-type:
+ CREATE TYPE my_type AS (a int, b int);
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-drop-type:
+ DROP TYPE my_type;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-drop-type: <... completed>
+step s2-commit:
+ COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
+starting permutation: s2-create-dist-func s1-begin s2-begin s1-start-metadata-sync s2-drop-dist-func s1-commit s2-commit s3-compare-snapshot
+step s2-create-dist-func:
+ CREATE FUNCTION squares(int) RETURNS SETOF RECORD
+    AS $$ SELECT i, i * i FROM generate_series(1, $1) i $$
+    LANGUAGE SQL;
+ SELECT create_distributed_function('squares(int)');
+
+create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-drop-dist-func:
+ DROP FUNCTION squares(int);
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-drop-dist-func: <... completed>
+step s2-commit:
+ COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
+starting permutation: s2-create-type s1-begin s1-start-metadata-sync s2-alter-type s1-commit s3-compare-snapshot s3-compare-type-definition
+step s2-create-type:
+ CREATE TYPE my_type AS (a int, b int);
+
+step s1-begin:
+    BEGIN;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-alter-type:
+ ALTER TYPE my_type ADD ATTRIBUTE x int;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+step s2-alter-type: <... completed>
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s3-compare-type-definition:
+ SELECT run_command_on_workers($$SELECT '(1,1,1)'::my_type$$);
+
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,"(1,1,1)")
+(localhost,57638,t,"(1,1,1)")
+(2 rows)
+
+
+starting permutation: s1-begin s2-begin s2-create-dist-table s1-start-metadata-sync s2-commit s1-commit s3-compare-snapshot
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s2-create-dist-table:
+ CREATE TABLE new_dist_table(id int, data int);
+ SELECT create_distributed_table('new_dist_table', 'id');
+
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
+
+step s1-start-metadata-sync: <... completed>
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+    COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
+starting permutation: s2-create-dist-func s1-begin s2-begin s2-drop-dist-func s1-start-metadata-sync s2-commit s1-commit s3-compare-snapshot
+step s2-create-dist-func:
+ CREATE FUNCTION squares(int) RETURNS SETOF RECORD
+    AS $$ SELECT i, i * i FROM generate_series(1, $1) i $$
+    LANGUAGE SQL;
+ SELECT create_distributed_function('squares(int)');
+
+create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s2-drop-dist-func:
+ DROP FUNCTION squares(int);
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
+
+step s1-start-metadata-sync: <... completed>
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+    COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
+starting permutation: s2-create-schema s1-begin s2-begin s2-drop-schema s1-start-metadata-sync s2-commit s1-commit s3-compare-snapshot
+step s2-create-schema:
+ CREATE SCHEMA dist_schema
+  CREATE TABLE dist_table_in_schema(id int, data int);
+ SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
+
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s2-drop-schema:
+ DROP SCHEMA dist_schema CASCADE;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
+
+step s1-start-metadata-sync: <... completed>
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+    COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+
+starting permutation: s2-create-type s1-begin s2-begin s2-alter-type s1-start-metadata-sync s2-commit s1-commit s3-compare-snapshot s3-compare-type-definition
+step s2-create-type:
+ CREATE TYPE my_type AS (a int, b int);
+
+step s1-begin:
+    BEGIN;
+
+step s2-begin:
+ BEGIN;
+
+step s2-alter-type:
+ ALTER TYPE my_type ADD ATTRIBUTE x int;
+
+step s1-start-metadata-sync:
+ SELECT start_metadata_sync_to_node('localhost', 57638);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
+
+step s1-start-metadata-sync: <... completed>
+start_metadata_sync_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+    COMMIT;
+
+step s3-compare-snapshot:
+ SELECT count(*) = 0 AS same_metadata_in_workers
+ FROM
+ (
+  (
+   SELECT unnest(activate_node_snapshot())
+    EXCEPT
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+  )
+ UNION
+  (
+   SELECT unnest(result::text[]) AS unnested_result
+   FROM run_command_on_workers($$SELECT activate_node_snapshot()$$)
+    EXCEPT
+   SELECT unnest(activate_node_snapshot())
+  )
+ ) AS foo;
+
+same_metadata_in_workers
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s3-compare-type-definition:
+ SELECT run_command_on_workers($$SELECT '(1,1,1)'::my_type$$);
+
+run_command_on_workers
+---------------------------------------------------------------------
+(localhost,57637,t,"(1,1,1)")
+(localhost,57638,t,"(1,1,1)")
+(2 rows)
 
 
 starting permutation: s1-begin s2-begin s1-start-metadata-sync s2-create-type s1-commit s2-commit s3-compare-snapshot

--- a/src/test/regress/spec/isolation_metadata_sync_vs_all.spec
+++ b/src/test/regress/spec/isolation_metadata_sync_vs_all.spec
@@ -110,6 +110,19 @@ step "s2-create-dist-table"
 	SELECT create_distributed_table('new_dist_table', 'id');
 }
 
+step "s2-create-schema"
+{
+	CREATE SCHEMA dist_schema
+		CREATE TABLE dist_table_in_schema(id int, data int);
+
+	SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
+}
+
+step "s2-drop-schema"
+{
+	DROP SCHEMA dist_schema CASCADE;
+}
+
 step "s2-create-ref-table"
 {
 	CREATE TABLE new_ref_table(id int, data int);
@@ -136,6 +149,16 @@ step "s2-create-type"
 	CREATE TYPE my_type AS (a int, b int);
 }
 
+step "s2-drop-type"
+{
+	DROP TYPE my_type;
+}
+
+step "s2-alter-type"
+{
+	ALTER TYPE my_type ADD ATTRIBUTE x int;
+}
+
 step "s2-create-dist-func"
 {
 	CREATE FUNCTION squares(int) RETURNS SETOF RECORD
@@ -143,6 +166,11 @@ step "s2-create-dist-func"
     LANGUAGE SQL;
 
 	SELECT create_distributed_function('squares(int)');
+}
+
+step "s2-drop-dist-func"
+{
+	DROP FUNCTION squares(int);
 }
 
 session "s3"
@@ -168,6 +196,11 @@ step "s3-compare-snapshot"
 	) AS foo;
 }
 
+step "s3-compare-type-definition"
+{
+	SELECT run_command_on_workers($$SELECT '(1,1,1)'::my_type$$);
+}
+
 step "s3-debug"
 {
 	SELECT unnest(activate_node_snapshot());
@@ -186,6 +219,8 @@ permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-start-metadata-sy
 // the following operations get blocked when a concurrent metadata sync is in progress
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-alter-table" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-drop-table" "s1-commit" "s2-commit" "s3-compare-snapshot"
+permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-create-schema" "s1-commit" "s2-commit" "s3-compare-snapshot" "s2-drop-schema"
+permutation "s2-create-schema" "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-drop-schema" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-create-dist-table" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-create-ref-table" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-attach-partition" "s1-commit" "s2-commit" "s3-compare-snapshot"
@@ -193,6 +228,16 @@ permutation "s2-attach-partition" "s1-begin" "s2-begin" "s1-start-metadata-sync"
 permutation "s2-attach-partition" "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-create-partition-of" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-add-fk" "s1-commit" "s2-commit" "s3-compare-snapshot"
 permutation "s2-add-fk" "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-drop-fk" "s1-commit" "s2-commit" "s3-compare-snapshot"
+permutation "s2-create-type" "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-drop-type" "s1-commit" "s2-commit" "s3-compare-snapshot"
+permutation "s2-create-dist-func" "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-drop-dist-func" "s1-commit" "s2-commit" "s3-compare-snapshot"
+permutation "s2-create-type" "s1-begin" "s1-start-metadata-sync" "s2-alter-type" "s1-commit" "s3-compare-snapshot" "s3-compare-type-definition"
+
+// the following operations block concurrent metadata sync calls
+permutation "s1-begin" "s2-begin" "s2-create-dist-table" "s1-start-metadata-sync" "s2-commit" "s1-commit" "s3-compare-snapshot"
+permutation "s2-create-dist-func" "s1-begin" "s2-begin" "s2-drop-dist-func" "s1-start-metadata-sync" "s2-commit" "s1-commit" "s3-compare-snapshot"
+permutation "s2-create-schema" "s1-begin" "s2-begin" "s2-drop-schema" "s1-start-metadata-sync" "s2-commit" "s1-commit" "s3-compare-snapshot"
+permutation "s2-create-type" "s1-begin" "s2-begin" "s2-alter-type" "s1-start-metadata-sync" "s2-commit" "s1-commit" "s3-compare-snapshot" "s3-compare-type-definition"
+
 
 // the following operations do not get blocked
 permutation "s1-begin" "s2-begin" "s1-start-metadata-sync" "s2-create-type" "s1-commit" "s2-commit" "s3-compare-snapshot"


### PR DESCRIPTION
DESCRIPTION: Improves concurrent metadata syncing and metadata changing DDL operations

When building a task list for a ddl job, we go over the current list of nodes. We need to block all changes to the node list until the list of ddl jobs complete. Therefore, we start to acquire `RowShareLock` on `NodeDDLTasklist` that contradicts with `ExclusiveLock` on `citus_add_node`.

A distributed query can have preprocess and/or postprocess steps that both use this function. The first call will acquire a lock and we will block concurrent node changes that require `ExclusiveLock`.

Fixes #1199, Fixes #3190, Fixes #5608 

## Caveats:
Many DDL operations will block `citus_add_node calls` and vice-a-versa. Long running `citus_add_node` calls can potentially block all DDL commands in the cluster. This is especially significant when the cluster uses the current default `false` value for `citus.replicate_reference_tables_on_activate`.

On earlier versions of Citus that do not have this GUC, I think it does not make sense to backport this change due to high impact and no easy way to unblock DDL commands when there is an ongoing scale out operation.

## How to backport:
This PR contains 3 major commits:
1. A simple commit that contains a one line change to start acquiring `RowShareLock` on `NodeDDLTasklist`
2. A commit that removes many `LockRelationOid` calls that are now redundant.
3. Introduction of new tests that check various isolation scenarios.

It makes sense to backport a subset of these commits to earlier branches of Citus.
Commit 1: Backport to all releases where we have `citus.replicate_reference_tables_on_activate` GUC available
Commit 2: Attempt to backport when possible. For earlier releases, it makes sense to go over all `LockRelationOid` calls, and remove those as well. It is possible that we have some extra calls in earlier releases.
Commit 3: Do not backport, as the updated tests are not shipped in any release yet. 

## TODO:
- [x] Add tests
	- [x] for #5608
	- [x] for #3190
	- [x] isolation tests where DDL commands block `citus_add_node()` calls. e.g. drop 
	- [x] concurrent DDL commands. e.g. drop schema vs drop schema, drop dist table vs drop dist table
		- [x] drop table vs drop table already in `isolation_drop_vs_all.spec`
		- [x] drop schema vs drop schema introduced in `isolation_drop_vs_all.spec`
- [x] Go over all other DDL commands that do not use `NodeDDLTasklist` function to generate task lists.
	- [x] `DROP TABLE` uses `ShareLock` instead of the proposed `RowShareLock` in this PR.
	- [x] Check other DDL commands that use different code paths.