### PR TITLE
Speed up test runs on WSL2 a lot

### DIFF
--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -19,12 +19,19 @@ test=$(basename "$file1" .out | sed -E "s/_[0-9]+$//")
 args=${@:1:$#-2}
 BASEDIR=$(dirname "$0")
 
-# whereis searches for standard unix places before $PATH. So select the first
-# entry as the original diff tool.
-DIFF=$(whereis diff | sed "s/diff://g" | awk '{print $1}')
-if [ -z "$DIFF" ]
+DIFF=/usr/bin/diff
+if [ ! -f "$DIFF" ]
 then
-    DIFF=/usr/bin/diff
+	# whereis searches for standard unix places before $PATH. So select the
+	# first entry as the original diff tool.
+	# With the default WSL2 configuration whereis is very slow though ~400ms,
+	# so we only use it if /usr/bin/diff does not exist.
+	DIFF=$(whereis diff | sed "s/diff://g" | awk '{print $1}')
+	if [ -z "$DIFF" ]
+	then
+		echo "ERROR: could not find diff command" 1>&2
+		exit 1
+	fi
 fi
 
 if test -z "${VANILLATEST:-}"


### PR DESCRIPTION
It turns out `whereis` is incredibly slow on WSL2 (at least on my
machine):

```
$ time whereis diff
diff: /usr/bin/diff /usr/share/man/man1/diff.1.gz

real    0m0.408s
user    0m0.010s
sys 0m0.101s
```

This command is run by our custom `diff` script, which is run for every
test file that is run. So this adds lots of unnecessary runtime time to
tests.

This changes our custom `diff` script to only call `whereis` in the
strange case that `/usr/bin/diff` does not exist.

The impact of this small change on the total runtime of the tests on WSL
is huge. As an example the following command takes 18 seconds without
this change and 7 seconds with it:
```
make -C src/test/regress/ check-arbitrary-configs CONFIGS=PostgresConfig
```