### PR TITLE
Fix: partitioned index dependencies

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -247,7 +247,8 @@ GetDependencyCreateDDLCommands(const ObjectAddress *dependency)
 			 * The commands will be added to both shards and metadata tables via the table
 			 * creation commands.
 			 */
-			if (relKind == RELKIND_INDEX)
+			if (relKind == RELKIND_INDEX ||
+				relKind == RELKIND_PARTITIONED_INDEX)
 			{
 				return NIL;
 			}

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -722,7 +722,8 @@ SupportedDependencyByCitus(const ObjectAddress *address)
 				relKind == RELKIND_PARTITIONED_TABLE ||
 				relKind == RELKIND_FOREIGN_TABLE ||
 				relKind == RELKIND_SEQUENCE ||
-				relKind == RELKIND_INDEX)
+				relKind == RELKIND_INDEX ||
+				relKind == RELKIND_PARTITIONED_INDEX)
 			{
 				return true;
 			}

--- a/src/test/regress/expected/text_search.out
+++ b/src/test/regress/expected/text_search.out
@@ -484,6 +484,26 @@ SELECT create_distributed_table('t5', 'name');
 
 (1 row)
 
+-- make sure partial indices propagate their dependencies
+-- first have a TEXT SEARCH CONFIGURATION that is not distributed
+SET citus.enable_ddl_propagation TO off;
+CREATE TEXT SEARCH CONFIGURATION partial_index_test_config ( parser = default );
+RESET citus.enable_ddl_propagation;
+CREATE TABLE sensors(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+    name text,
+    PRIMARY KEY (measureid, eventdatetime, measure_data)
+) PARTITION BY RANGE(eventdatetime);
+CREATE TABLE sensors_a_partition PARTITION OF sensors FOR VALUES FROM ('2000-01-01') TO ('2020-01-01');
+CREATE INDEX sensors_search_name ON sensors USING gin (to_tsvector('partial_index_test_config'::regconfig, (COALESCE(name, ''::character varying))::text));
+SELECT create_distributed_table('sensors', 'measureid');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 SET client_min_messages TO 'warning';
 DROP SCHEMA text_search, text_search2, "Text Search Requiring Quote's" CASCADE;
 DROP ROLE text_search_owner;

--- a/src/test/regress/sql/text_search.sql
+++ b/src/test/regress/sql/text_search.sql
@@ -258,6 +258,23 @@ CREATE TABLE t5(id int, name text);
 CREATE INDEX t5_search_name ON t5 USING gin (to_tsvector('"Text Search Requiring Quote''s"."Quoted Config Name"'::regconfig, (COALESCE(name, ''::character varying))::text));
 SELECT create_distributed_table('t5', 'name');
 
+-- make sure partial indices propagate their dependencies
+-- first have a TEXT SEARCH CONFIGURATION that is not distributed
+SET citus.enable_ddl_propagation TO off;
+CREATE TEXT SEARCH CONFIGURATION partial_index_test_config ( parser = default );
+RESET citus.enable_ddl_propagation;
+
+CREATE TABLE sensors(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+    name text,
+    PRIMARY KEY (measureid, eventdatetime, measure_data)
+) PARTITION BY RANGE(eventdatetime);
+CREATE TABLE sensors_a_partition PARTITION OF sensors FOR VALUES FROM ('2000-01-01') TO ('2020-01-01');
+CREATE INDEX sensors_search_name ON sensors USING gin (to_tsvector('partial_index_test_config'::regconfig, (COALESCE(name, ''::character varying))::text));
+SELECT create_distributed_table('sensors', 'measureid');
+
 SET client_min_messages TO 'warning';
 DROP SCHEMA text_search, text_search2, "Text Search Requiring Quote's" CASCADE;
 DROP ROLE text_search_owner;


### PR DESCRIPTION
#5685 introduced the resolution of dependencies for indices. This missed support for indices on partitioned tables. This change adds support for partitioned indices to the dependency resolution code.