### PR TITLE
Unblock enterprise regression test failures

### DIFF
--- a/src/test/regress/expected/distributed_triggers.out
+++ b/src/test/regress/expected/distributed_triggers.out
@@ -386,7 +386,7 @@ ORDER BY shard_key_value, object_id, change_id;
 -- Triggers (tables) which are not colocated
 --
 CREATE TABLE emptest (
-    empname           text NOT NULL,
+    empname           text NOT NULL PRIMARY KEY,
     salary            integer
 );
 CREATE TABLE emptest_audit(
@@ -394,7 +394,8 @@ CREATE TABLE emptest_audit(
     stamp             timestamp NOT NULL,
     userid            text      NOT NULL,
     empname           text      NOT NULL,
-    salary integer
+    salary            integer,
+    PRIMARY KEY (empname, userid, stamp, operation, salary)
 );
 SELECT create_distributed_table('emptest','empname',colocate_with :='none');
  create_distributed_table
@@ -477,6 +478,7 @@ CREATE TABLE record_op (
     operation_type text not null,
     stamp          timestamp NOT NULL
 );
+ALTER TABLE record_op REPLICA IDENTITY FULL;
 SELECT create_distributed_table('record_op', 'empname', colocate_with := 'emptest');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -654,7 +656,7 @@ PARTITION BY list (state_code);
 ALTER TABLE sale ADD CONSTRAINT sale_pk PRIMARY KEY (state_code, sale_date);
 CREATE TABLE sale_newyork PARTITION OF sale FOR VALUES IN ('NY');
 CREATE TABLE sale_california PARTITION OF sale FOR VALUES IN ('CA');
-CREATE TABLE record_sale(operation_type text not null, product_sku text, state_code text);
+CREATE TABLE record_sale(operation_type text not null, product_sku text, state_code text, units integer, PRIMARY KEY(state_code, product_sku, operation_type, units));
 SELECT create_distributed_table('sale', 'state_code');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -671,8 +673,8 @@ CREATE OR REPLACE FUNCTION record_sale()
 RETURNS trigger
 AS $$
 BEGIN
-    INSERT INTO distributed_triggers.record_sale(operation_type, product_sku, state_code)
-    VALUES (TG_OP, NEW.product_sku, NEW.state_code);
+    INSERT INTO distributed_triggers.record_sale(operation_type, product_sku, state_code, units)
+    VALUES (TG_OP, NEW.product_sku, NEW.state_code, NEW.units);
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -697,7 +699,7 @@ TABLE sale ORDER BY state_code, sale_date;
  02-03-2019 | NY         | AZ-000A1    |    47
 (6 rows)
 
-TABLE record_sale ORDER BY 1,2,3;
+SELECT operation_type, product_sku, state_code FROM record_sale ORDER BY 1,2,3;
  operation_type | product_sku | state_code
 ---------------------------------------------------------------------
  INSERT         | AZ-000A1    | CA


### PR DESCRIPTION
Otherwise enterprise tests fail.
```SQL
+ERROR:  cannot use logical replication to transfer shards of the relation record_sale since it doesn't have a REPLICA IDENTITY or PRIMARY KEY
+DETAIL:  UPDATE and DELETE commands on the shard will error out during logical replication unless there is a REPLICA IDENTITY or PRIMARY KEY.
+HINT:  If you wish to continue without a replica identity set the shard_transfer_mode to 'force_logical' or 'block_writes'.
```

cc @tejeswarm, fyi, for future such changes. Currently, check-enterprise CI job does NOT run the regression tests on the enterprise repo. (Which @thanodnl wants to fix via https://github.com/citusdata/citus/pull/5706)

So, some tests might break on that repository, especially rebalancer ones, as rebalancer behaves differently there. Seem like the tests added here is vulnerable to this subtle issue: https://github.com/citusdata/citus/pull/5705


