### PR TITLE
Add a GUC to require coordinator in the metadata

### DIFF
--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -201,6 +201,9 @@ CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys, bool autoConve
 	/* enable citus_add_local_table_to_metadata on an empty node */
 	InsertCoordinatorIfClusterEmpty();
 
+	/* make sure the coordinator is in the metadata */
+	EnsureCoordinatorInMetadata();
+
 	/*
 	 * Creating Citus local tables relies on functions that accesses
 	 * shards locally (e.g., ExecuteAndLogUtilityCommand()). As long as

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -218,6 +218,9 @@ create_distributed_table(PG_FUNCTION_ARGS)
 	/* enable create_distributed_table on an empty node */
 	InsertCoordinatorIfClusterEmpty();
 
+	/* make sure the coordinator is in the metadata */
+	EnsureCoordinatorInMetadata();
+
 	/*
 	 * Lock target relation with an exclusive lock - there's no way to make
 	 * sense of this table until we've committed, and we don't want multiple
@@ -272,6 +275,9 @@ create_reference_table(PG_FUNCTION_ARGS)
 
 	/* enable create_reference_table on an empty node */
 	InsertCoordinatorIfClusterEmpty();
+
+	/* make sure the coordinator is in the metadata */
+	EnsureCoordinatorInMetadata();
 
 	/*
 	 * Lock target relation with an exclusive lock - there's no way to make

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1643,6 +1643,21 @@ RegisterCitusConfigVariables(void)
 		WarnIfReplicationModelIsSet, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.require_coordinator_in_metadata",
+		gettext_noop("Sets whether Citus requires that the coordinator is in the "
+					 "metadata"),
+		gettext_noop("Various Citus features depend on the coordinator being in the "
+					 "metadata. By default, we check whether this is the case when "
+					 "creating a Citus table. You can circumvent this check by "
+					 "disabling this setting."),
+		&IsCoordinatorInMetadataRequired,
+		true,
+		PGC_SUSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+
+	DefineCustomBoolVariable(
 		"citus.running_under_isolation_test",
 		gettext_noop(
 			"Only useful for testing purposes, when set to true, Citus does some "

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -62,6 +62,7 @@ extern int MaxWorkerNodesTracked;
 extern char *WorkerListFileName;
 extern char *CurrentCluster;
 extern bool ReplicateReferenceTablesOnActivate;
+extern bool IsCoordinatorInMetadataRequired;
 
 extern int ActivateNode(char *nodeName, int nodePort);
 
@@ -89,6 +90,7 @@ extern WorkerNode * FindWorkerNodeAnyCluster(const char *nodeName, int32 nodePor
 extern WorkerNode * FindNodeWithNodeId(int nodeId, bool missingOk);
 extern List * ReadDistNode(bool includeNodesFromOtherClusters);
 extern void EnsureCoordinator(void);
+void EnsureCoordinatorInMetadata(void);
 extern void InsertCoordinatorIfClusterEmpty(void);
 extern uint32 GroupForNode(char *nodeName, int32 nodePort);
 extern WorkerNode * PrimaryNodeForGroup(int32 groupId, bool *groupContainsNodes);

--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -179,7 +179,10 @@ class CitusUpgradeConfig(CitusBaseClusterConfig):
         self.pre_tar_path = arguments["--citus-pre-tar"]
         self.post_tar_path = arguments["--citus-post-tar"]
         self.temp_dir = "./tmp_citus_upgrade"
-        self.new_settings = {"citus.enable_version_checks": "false"}
+        self.new_settings = {
+			"citus.enable_version_checks": "false",
+			"citus.require_coordinator_in_metadata": "false"
+		}
         self.user = SUPER_USER_NAME
         self.mixed_mode = arguments["--mixed"]
         self.fixed_port = 57635

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -115,6 +115,13 @@ SELECT 1 FROM citus_activate_node('localhost', :worker_2_port);
 (1 row)
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
+-- coordinator was not yet added to the metadata yet, should fail
+SET citus.require_coordinator_in_metadata TO on;
+SELECT create_distributed_table('cluster_management_test', 'col_1', 'hash');
+ERROR:  coordinator is not yet added to the Citus node metadata
+DETAIL:  Worker nodes need to be able to connect to the coordinator to transfer data.
+HINT:  Use SELECT citus_set_coordinator_host('<hostname>') to configure the coordinator hostname
+RESET citus.require_coordinator_in_metadata;
 SELECT create_distributed_table('cluster_management_test', 'col_1', 'hash');
  create_distributed_table
 ---------------------------------------------------------------------

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -465,6 +465,9 @@ push(@pgOptions, "citus.node_connection_timeout=${connectionTimeout}");
 push(@pgOptions, "citus.explain_analyze_sort_method='taskId'");
 push(@pgOptions, "citus.enable_manual_changes_to_shards=on");
 
+# We currently have too many tests that omit coordinator from metadata
+push(@pgOptions, "citus.require_coordinator_in_metadata=off");
+
 # Some tests look at shards in pg_class, make sure we can usually see them:
 push(@pgOptions, "citus.hide_shards_from_app_name_prefixes='psql,pg_dump'");
 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -52,6 +52,12 @@ ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1390000;
 SELECT 1 FROM citus_activate_node('localhost', :worker_2_port);
 
 CREATE TABLE cluster_management_test (col_1 text, col_2 int);
+
+-- coordinator was not yet added to the metadata yet, should fail
+SET citus.require_coordinator_in_metadata TO on;
+SELECT create_distributed_table('cluster_management_test', 'col_1', 'hash');
+RESET citus.require_coordinator_in_metadata;
+
 SELECT create_distributed_table('cluster_management_test', 'col_1', 'hash');
 
 -- see that there are some active placements in the candidate node


### PR DESCRIPTION
DESCRIPTION: Add a GUC to require coordinator in the metadata

This requires some major test changes, but it would be good to start requiring coordinator in the metadata.
