### PR TITLE
Revert upgrade script changes

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-4.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-4.sql
@@ -12,22 +12,15 @@ BEGIN
 
     IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
     EXECUTE $cmd$
-        -- disable propagation to prevent EnsureCoordinator errors
-        -- the aggregate created here does not depend on Citus extension (yet)
-        -- since we add the dependency with the next command
-        SET citus.enable_ddl_propagation TO OFF;
         CREATE AGGREGATE array_cat_agg(anycompatiblearray) (SFUNC = array_cat, STYPE = anycompatiblearray);
         COMMENT ON AGGREGATE array_cat_agg(anycompatiblearray)
         IS 'concatenate input arrays into a single array';
-        RESET citus.enable_ddl_propagation;
     $cmd$;
     ELSE
     EXECUTE $cmd$
-        SET citus.enable_ddl_propagation TO OFF;
         CREATE AGGREGATE array_cat_agg(anyarray) (SFUNC = array_cat, STYPE = anyarray);
         COMMENT ON AGGREGATE array_cat_agg(anyarray)
         IS 'concatenate input arrays into a single array';
-        RESET citus.enable_ddl_propagation;
     $cmd$;
     END IF;
 


### PR DESCRIPTION
No need to add it into changelog.
Reverts the incorrect changes made on [citus_finish_pg_upgrade/10.2-4.sql](https://github.com/citusdata/citus/pull/5757/files#diff-b8d9b6a35dce826ac25d9356bcb16279930dcea9e7d40106abd508eb7edc9e36)