### PR TITLE
Handle dropping the partitioned tables properly

### DIFF
--- a/src/test/regress/expected/drop_partitioned_table.out
+++ b/src/test/regress/expected/drop_partitioned_table.out
@@ -395,3 +395,117 @@ NOTICE:  issuing ROLLBACK
 DROP SCHEMA drop_partitioned_table CASCADE;
 NOTICE:  drop cascades to 3 other objects
 SET search_path TO public;
+-- dropping the schema should drop the metadata on the workers
+CREATE SCHEMA partitioning_schema;
+SET search_path TO partitioning_schema;
+CREATE TABLE part_table (
+      col timestamp
+  ) PARTITION BY RANGE (col);
+CREATE TABLE part_table_1
+  PARTITION OF part_table
+  FOR VALUES FROM ('2010-01-01') TO ('2015-01-01');
+SELECT create_distributed_table('part_table', 'col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- show we have pg_dist_partition entries on the workers
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_partition where exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,2)
+ (localhost,57638,t,2)
+(2 rows)
+
+-- show we have pg_dist_object entries on the workers
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_object as obj where classid = 1259 AND exists(select * from pg_class where pg_class.oid=obj.objid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,2)
+ (localhost,57638,t,2)
+(2 rows)
+
+DROP SCHEMA partitioning_schema CASCADE;
+NOTICE:  drop cascades to table part_table
+-- show we don't have pg_dist_partition entries on the workers after dropping the schema
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_partition where exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- show we don't have pg_dist_object entries on the workers after dropping the schema
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_object as obj where classid = 1259 AND exists(select * from pg_class where pg_class.oid=obj.objid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- dropping the parent should drop the metadata on the workers
+CREATE SCHEMA partitioning_schema;
+SET search_path TO partitioning_schema;
+CREATE TABLE part_table (
+      col timestamp
+  ) PARTITION BY RANGE (col);
+CREATE TABLE part_table_1
+  PARTITION OF part_table
+  FOR VALUES FROM ('2010-01-01') TO ('2015-01-01');
+SELECT create_distributed_table('part_table', 'col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP TABLE part_table;
+-- show we don't have pg_dist_partition entries on the workers after dropping the parent
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_partition where exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+-- show we don't have pg_dist_object entries on the workers after dropping the parent
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_object as obj where classid = 1259 AND exists(select * from pg_class where pg_class.oid=obj.objid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SET search_path TO partitioning_schema;
+CREATE TABLE part_table (
+      col timestamp
+  ) PARTITION BY RANGE (col);
+CREATE TABLE part_table_1
+  PARTITION OF part_table
+  FOR VALUES FROM ('2010-01-01') TO ('2015-01-01');
+SELECT create_distributed_table('part_table', 'col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP TABLE part_table_1;
+-- show we have pg_dist_partition entries for the parent on the workers after dropping the partition
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_partition where exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+-- show we have pg_dist_object entries for the parent on the workers after dropping the partition
+SELECT run_command_on_workers($$SELECT count(*) FROM  pg_dist_object as obj where classid = 1259 AND exists(select * from pg_class where pg_class.oid=obj.objid AND relname ILIKE '%part_table%');$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+-- clean-up
+DROP SCHEMA partitioning_schema CASCADE;
+NOTICE:  drop cascades to table part_table

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -61,16 +61,6 @@ CREATE FUNCTION find_shard_interval_index(bigint)
     RETURNS int
     AS 'citus'
     LANGUAGE C STRICT;
--- remove tables from pg_dist_partition, if they don't exist i.e not found in pg_class
-delete from pg_dist_partition where not exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid);
-select 1 from run_command_on_workers($$
-    delete from pg_dist_partition where not exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid);$$);
- ?column?
----------------------------------------------------------------------
-        1
-        1
-(2 rows)
-
 -- ===================================================================
 -- test co-location util functions
 -- ===================================================================

--- a/src/test/regress/sql/multi_colocation_utils.sql
+++ b/src/test/regress/sql/multi_colocation_utils.sql
@@ -66,11 +66,6 @@ CREATE FUNCTION find_shard_interval_index(bigint)
     AS 'citus'
     LANGUAGE C STRICT;
 
--- remove tables from pg_dist_partition, if they don't exist i.e not found in pg_class
-delete from pg_dist_partition where not exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid);
-select 1 from run_command_on_workers($$
-    delete from pg_dist_partition where not exists(select * from pg_class where pg_class.oid=pg_dist_partition.logicalrelid);$$);
-
 -- ===================================================================
 -- test co-location util functions
 -- ===================================================================


### PR DESCRIPTION
Before this commit, we might be leaving some metadata on the workers.
Now, we handle DROP SCHEMA .. CASCADE properly to avoid any metadata
leakage.

Fixes #5644