### PR TITLE
Add support for TEXT SEARCH DICTIONARY objects

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -398,6 +398,11 @@ GetDependencyCreateDDLCommands(const ObjectAddress *dependency)
 			return CreateTextSearchConfigDDLCommandsIdempotent(dependency);
 		}
 
+		case OCLASS_TSDICT:
+		{
+			return CreateTextSearchDictDDLCommandsIdempotent(dependency);
+		}
+
 		case OCLASS_TYPE:
 		{
 			return CreateTypeDDLCommandsIdempotent(dependency);

--- a/src/backend/distributed/commands/distribute_object_ops.c
+++ b/src/backend/distributed/commands/distribute_object_ops.c
@@ -538,7 +538,7 @@ static DistributeObjectOps TextSearchConfig_Comment = {
 	.markDistributed = false,
 };
 static DistributeObjectOps TextSearchConfig_Define = {
-	.deparse = DeparseCreateTextSearchStmt,
+	.deparse = DeparseCreateTextSearchConfigurationStmt,
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateTextSearchConfigurationStmt,
@@ -559,6 +559,62 @@ static DistributeObjectOps TextSearchConfig_Rename = {
 	.preprocess = PreprocessRenameTextSearchConfigurationStmt,
 	.postprocess = NULL,
 	.address = RenameTextSearchConfigurationStmtObjectAddress,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_Alter = {
+	.deparse = DeparseAlterTextSearchDictionaryStmt,
+	.qualify = QualifyAlterTextSearchDictionaryStmt,
+	.preprocess = PreprocessAlterTextSearchDictionaryStmt,
+	.postprocess = NULL,
+	.address = AlterTextSearchDictionaryStmtObjectAddress,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_AlterObjectSchema = {
+	.deparse = DeparseAlterTextSearchDictionarySchemaStmt,
+	.qualify = QualifyAlterTextSearchDictionarySchemaStmt,
+	.preprocess = PreprocessAlterTextSearchDictionarySchemaStmt,
+	.postprocess = PostprocessAlterTextSearchDictionarySchemaStmt,
+	.address = AlterTextSearchDictionarySchemaStmtObjectAddress,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_AlterOwner = {
+	.deparse = DeparseAlterTextSearchDictionaryOwnerStmt,
+	.qualify = QualifyAlterTextSearchDictionaryOwnerStmt,
+	.preprocess = PreprocessAlterTextSearchDictionaryOwnerStmt,
+	.postprocess = PostprocessAlterTextSearchDictionaryOwnerStmt,
+	.address = AlterTextSearchDictOwnerObjectAddress,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_Comment = {
+	.deparse = DeparseTextSearchDictionaryCommentStmt,
+	.qualify = QualifyTextSearchDictionaryCommentStmt,
+	.preprocess = PreprocessTextSearchDictionaryCommentStmt,
+	.postprocess = NULL,
+	.address = TextSearchDictCommentObjectAddress,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_Define = {
+	.deparse = DeparseCreateTextSearchDictionaryStmt,
+	.qualify = NULL,
+	.preprocess = NULL,
+	.postprocess = PostprocessCreateTextSearchDictionaryStmt,
+	.address = CreateTextSearchDictObjectAddress,
+	.markDistributed = true,
+};
+static DistributeObjectOps TextSearchDict_Drop = {
+	.deparse = DeparseDropTextSearchDictionaryStmt,
+	.qualify = QualifyDropTextSearchDictionaryStmt,
+	.preprocess = PreprocessDropTextSearchDictionaryStmt,
+	.postprocess = NULL,
+	.address = NULL,
+	.markDistributed = false,
+};
+static DistributeObjectOps TextSearchDict_Rename = {
+	.deparse = DeparseRenameTextSearchDictionaryStmt,
+	.qualify = QualifyRenameTextSearchDictionaryStmt,
+	.preprocess = PreprocessRenameTextSearchDictionaryStmt,
+	.postprocess = NULL,
+	.address = RenameTextSearchDictionaryStmtObjectAddress,
 	.markDistributed = false,
 };
 static DistributeObjectOps Trigger_AlterObjectDepends = {
@@ -872,6 +928,11 @@ GetDistributeObjectOps(Node *node)
 					return &TextSearchConfig_AlterObjectSchema;
 				}
 
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_AlterObjectSchema;
+				}
+
 				case OBJECT_TYPE:
 				{
 					return &Type_AlterObjectSchema;
@@ -932,6 +993,11 @@ GetDistributeObjectOps(Node *node)
 				case OBJECT_TSCONFIGURATION:
 				{
 					return &TextSearchConfig_AlterOwner;
+				}
+
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_AlterOwner;
 				}
 
 				case OBJECT_TYPE:
@@ -1020,6 +1086,11 @@ GetDistributeObjectOps(Node *node)
 			return &TextSearchConfig_Alter;
 		}
 
+		case T_AlterTSDictionaryStmt:
+		{
+			return &TextSearchDict_Alter;
+		}
+
 		case T_ClusterStmt:
 		{
 			return &Any_Cluster;
@@ -1033,6 +1104,11 @@ GetDistributeObjectOps(Node *node)
 				case OBJECT_TSCONFIGURATION:
 				{
 					return &TextSearchConfig_Comment;
+				}
+
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_Comment;
 				}
 
 				default:
@@ -1105,6 +1181,11 @@ GetDistributeObjectOps(Node *node)
 				case OBJECT_TSCONFIGURATION:
 				{
 					return &TextSearchConfig_Define;
+				}
+
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_Define;
 				}
 
 				default:
@@ -1187,6 +1268,11 @@ GetDistributeObjectOps(Node *node)
 				case OBJECT_TSCONFIGURATION:
 				{
 					return &TextSearchConfig_Drop;
+				}
+
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_Drop;
 				}
 
 				case OBJECT_TYPE:
@@ -1291,6 +1377,11 @@ GetDistributeObjectOps(Node *node)
 				case OBJECT_TSCONFIGURATION:
 				{
 					return &TextSearchConfig_Rename;
+				}
+
+				case OBJECT_TSDICTIONARY:
+				{
+					return &TextSearchDict_Rename;
 				}
 
 				case OBJECT_TYPE:

--- a/src/backend/distributed/deparser/deparse_text_search.c
+++ b/src/backend/distributed/deparser/deparse_text_search.c
@@ -18,21 +18,21 @@
 #include "distributed/deparser.h"
 #include "distributed/listutils.h"
 
-static void AppendDefElemList(StringInfo buf, List *defelms);
+static void AppendDefElemList(StringInfo buf, List *defelems, char *objectName);
 
 static void AppendStringInfoTokentypeList(StringInfo buf, List *tokentypes);
 static void AppendStringInfoDictnames(StringInfo buf, List *dicts);
 
 
 /*
- * DeparseCreateTextSearchStmt returns the sql for a DefineStmt defining a TEXT SEARCH
- * CONFIGURATION
+ * DeparseCreateTextSearchConfigurationStmt returns the sql for a DefineStmt defining a
+ * TEXT SEARCH CONFIGURATION
  *
  * Although the syntax is mutually exclusive on the two arguments that can be passed in
  * the deparser will syntactically correct multiple definitions if provided. *
  */
 char *
-DeparseCreateTextSearchStmt(Node *node)
+DeparseCreateTextSearchConfigurationStmt(Node *node)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 
@@ -42,7 +42,7 @@ DeparseCreateTextSearchStmt(Node *node)
 	const char *identifier = NameListToQuotedString(stmt->defnames);
 	appendStringInfo(&buf, "CREATE TEXT SEARCH CONFIGURATION %s ", identifier);
 	appendStringInfoString(&buf, "(");
-	AppendDefElemList(&buf, stmt->definition);
+	AppendDefElemList(&buf, stmt->definition, "CONFIGURATION");
 	appendStringInfoString(&buf, ");");
 
 	return buf.data;
@@ -50,13 +50,40 @@ DeparseCreateTextSearchStmt(Node *node)
 
 
 /*
- * AppendDefElemList specialization to append a comma separated list of definitions to a
+ * DeparseCreateTextSearchDictionaryStmt returns the sql for a DefineStmt defining a
+ * TEXT SEARCH DICTIONARY
+ *
+ * Although the syntax is mutually exclusive on the two arguments that can be passed in
+ * the deparser will syntactically correct multiple definitions if provided. *
+ */
+char *
+DeparseCreateTextSearchDictionaryStmt(Node *node)
+{
+	DefineStmt *stmt = castNode(DefineStmt, node);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	const char *identifier = NameListToQuotedString(stmt->defnames);
+	appendStringInfo(&buf, "CREATE TEXT SEARCH DICTIONARY %s ", identifier);
+	appendStringInfoString(&buf, "(");
+	AppendDefElemList(&buf, stmt->definition, "DICTIONARY");
+	appendStringInfoString(&buf, ");");
+
+	return buf.data;
+}
+
+
+/*
+ * AppendDefElemList is a helper to append a comma separated list of definitions to a
  * define statement.
  *
  * Currently only supports String and TypeName entries. Will error on others.
+ *
+ * The extra objectName parameter is used to create meaningful error messages.
  */
 static void
-AppendDefElemList(StringInfo buf, List *defelems)
+AppendDefElemList(StringInfo buf, List *defelems, char *objectName)
 {
 	DefElem *defelem = NULL;
 	bool first = true;
@@ -67,6 +94,20 @@ AppendDefElemList(StringInfo buf, List *defelems)
 			appendStringInfoString(buf, ", ");
 		}
 		first = false;
+
+		/*
+		 * There are some operations that can omit the argument. In that case, we only use
+		 * the defname.
+		 *
+		 * For example, omitting [ = value ] in the next query results in resetting the
+		 * option to defaults:
+		 * ALTER TEXT SEARCH DICTIONARY name ( option [ = value ] );
+		 */
+		if (defelem->arg == NULL)
+		{
+			appendStringInfo(buf, "%s", defelem->defname);
+			continue;
+		}
 
 		/* extract identifier from defelem */
 		const char *identifier = NULL;
@@ -88,7 +129,7 @@ AppendDefElemList(StringInfo buf, List *defelems)
 			default:
 			{
 				ereport(ERROR, (errmsg("unexpected argument during deparsing of "
-									   "TEXT SEARCH CONFIGURATION definition")));
+									   "TEXT SEARCH %s definition", objectName)));
 			}
 		}
 
@@ -137,6 +178,44 @@ DeparseDropTextSearchConfigurationStmt(Node *node)
 
 
 /*
+ * DeparseDropTextSearchDictionaryStmt returns the sql representation for a DROP TEXT SEARCH
+ * DICTIONARY ... statment. Supports dropping multiple dictionaries at once.
+ */
+char *
+DeparseDropTextSearchDictionaryStmt(Node *node)
+{
+	DropStmt *stmt = castNode(DropStmt, node);
+	Assert(stmt->removeType == OBJECT_TSDICTIONARY);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	appendStringInfoString(&buf, "DROP TEXT SEARCH DICTIONARY ");
+	List *nameList = NIL;
+	bool first = true;
+	foreach_ptr(nameList, stmt->objects)
+	{
+		if (!first)
+		{
+			appendStringInfoString(&buf, ", ");
+		}
+		first = false;
+
+		appendStringInfoString(&buf, NameListToQuotedString(nameList));
+	}
+
+	if (stmt->behavior == DROP_CASCADE)
+	{
+		appendStringInfoString(&buf, " CASCADE");
+	}
+
+	appendStringInfoString(&buf, ";");
+
+	return buf.data;
+}
+
+
+/*
  * DeparseRenameTextSearchConfigurationStmt returns the sql representation of a ALTER TEXT
  * SEARCH CONFIGURATION ... RENAME TO ... statement.
  */
@@ -158,7 +237,28 @@ DeparseRenameTextSearchConfigurationStmt(Node *node)
 
 
 /*
- * DeparseAlterTextSearchConfigurationStmt returns the ql representation of any generic
+ * DeparseRenameTextSearchDictionaryStmt returns the sql representation of a ALTER TEXT SEARCH
+ * DICTIONARY ... RENAME TO ... statement.
+ */
+char *
+DeparseRenameTextSearchDictionaryStmt(Node *node)
+{
+	RenameStmt *stmt = castNode(RenameStmt, node);
+	Assert(stmt->renameType == OBJECT_TSDICTIONARY);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	char *identifier = NameListToQuotedString(castNode(List, stmt->object));
+	appendStringInfo(&buf, "ALTER TEXT SEARCH DICTIONARY %s RENAME TO %s;",
+					 identifier, quote_identifier(stmt->newname));
+
+	return buf.data;
+}
+
+
+/*
+ * DeparseAlterTextSearchConfigurationStmt returns the sql representation of any generic
  * ALTER TEXT SEARCH CONFIGURATION .... statement. The statements supported include:
  *  - ALTER TEXT SEARCH CONFIGURATIONS ... ADD MAPPING FOR [, ...] WITH [, ...]
  *  - ALTER TEXT SEARCH CONFIGURATIONS ... ALTER MAPPING FOR [, ...] WITH [, ...]
@@ -254,6 +354,28 @@ DeparseAlterTextSearchConfigurationStmt(Node *node)
 
 
 /*
+ * DeparseAlterTextSearchConfigurationStmt returns the sql representation of any generic
+ * ALTER TEXT SEARCH DICTIONARY .... statement. The statements supported include
+ * - ALTER TEXT SEARCH DICTIONARY name ( option [ = value ] [, ... ] )
+ */
+char *
+DeparseAlterTextSearchDictionaryStmt(Node *node)
+{
+	AlterTSDictionaryStmt *stmt = castNode(AlterTSDictionaryStmt, node);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	char *identifier = NameListToQuotedString(castNode(List, stmt->dictname));
+	appendStringInfo(&buf, "ALTER TEXT SEARCH DICTIONARY %s ( ", identifier);
+
+	AppendDefElemList(&buf, stmt->options, "DICTIONARY");
+	appendStringInfoString(&buf, " );");
+	return buf.data;
+}
+
+
+/*
  * DeparseAlterTextSearchConfigurationSchemaStmt returns the sql statement representing
  * ALTER TEXT SEARCH CONFIGURATION ... SET SCHEMA ... statements.
  */
@@ -275,6 +397,27 @@ DeparseAlterTextSearchConfigurationSchemaStmt(Node *node)
 
 
 /*
+ * DeparseAlterTextSearchDictionarySchemaStmt returns the sql statement representing ALTER TEXT
+ * SEARCH DICTIONARY ... SET SCHEMA ... statements.
+ */
+char *
+DeparseAlterTextSearchDictionarySchemaStmt(Node *node)
+{
+	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
+	Assert(stmt->objectType == OBJECT_TSDICTIONARY);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	appendStringInfo(&buf, "ALTER TEXT SEARCH DICTIONARY %s SET SCHEMA %s;",
+					 NameListToQuotedString(castNode(List, stmt->object)),
+					 quote_identifier(stmt->newschema));
+
+	return buf.data;
+}
+
+
+/*
  * DeparseTextSearchConfigurationCommentStmt returns the sql statement representing
  * COMMENT ON TEXT SEARCH CONFIGURATION ... IS ...
  */
@@ -288,6 +431,37 @@ DeparseTextSearchConfigurationCommentStmt(Node *node)
 	initStringInfo(&buf);
 
 	appendStringInfo(&buf, "COMMENT ON TEXT SEARCH CONFIGURATION %s IS ",
+					 NameListToQuotedString(castNode(List, stmt->object)));
+
+	if (stmt->comment == NULL)
+	{
+		appendStringInfoString(&buf, "NULL");
+	}
+	else
+	{
+		appendStringInfoString(&buf, quote_literal_cstr(stmt->comment));
+	}
+
+	appendStringInfoString(&buf, ";");
+
+	return buf.data;
+}
+
+
+/*
+ * DeparseTextSearchDictionaryCommentStmt returns the sql statement representing
+ * COMMENT ON TEXT SEARCH DICTIONARY ... IS ...
+ */
+char *
+DeparseTextSearchDictionaryCommentStmt(Node *node)
+{
+	CommentStmt *stmt = castNode(CommentStmt, node);
+	Assert(stmt->objtype == OBJECT_TSDICTIONARY);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	appendStringInfo(&buf, "COMMENT ON TEXT SEARCH DICTIONARY %s IS ",
 					 NameListToQuotedString(castNode(List, stmt->object)));
 
 	if (stmt->comment == NULL)
@@ -370,6 +544,27 @@ DeparseAlterTextSearchConfigurationOwnerStmt(Node *node)
 	initStringInfo(&buf);
 
 	appendStringInfo(&buf, "ALTER TEXT SEARCH CONFIGURATION %s OWNER TO %s;",
+					 NameListToQuotedString(castNode(List, stmt->object)),
+					 RoleSpecString(stmt->newowner, true));
+
+	return buf.data;
+}
+
+
+/*
+ * DeparseAlterTextSearchDictionaryOwnerStmt returns the sql statement representing ALTER TEXT
+ * SEARCH DICTIONARY ... ONWER TO ... commands.
+ */
+char *
+DeparseAlterTextSearchDictionaryOwnerStmt(Node *node)
+{
+	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
+	Assert(stmt->objectType == OBJECT_TSDICTIONARY);
+
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	appendStringInfo(&buf, "ALTER TEXT SEARCH DICTIONARY %s OWNER TO %s;",
 					 NameListToQuotedString(castNode(List, stmt->object)),
 					 RoleSpecString(stmt->newowner, true));
 

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -788,6 +788,11 @@ GetObjectTypeString(ObjectType objType)
 			return "text search configuration";
 		}
 
+		case OBJECT_TSDICTIONARY:
+		{
+			return "text search dictionary";
+		}
+
 		case OBJECT_TYPE:
 		{
 			return "type";

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -676,6 +676,11 @@ SupportedDependencyByCitus(const ObjectAddress *address)
 			return true;
 		}
 
+		case OCLASS_TSDICT:
+		{
+			return true;
+		}
+
 		case OCLASS_TYPE:
 		{
 			switch (get_typtype(address->objectId))
@@ -857,9 +862,13 @@ GetUndistributableDependency(const ObjectAddress *objectAddress)
 		if (!SupportedDependencyByCitus(dependency))
 		{
 			/*
-			 * Since roles should be handled manually with Citus community, skip them.
+			 * Skip roles and text search templates.
+			 *
+			 * Roles should be handled manually with Citus community whereas text search
+			 * templates should be handled manually in both community and enterprise
 			 */
-			if (getObjectClass(dependency) != OCLASS_ROLE)
+			if (getObjectClass(dependency) != OCLASS_ROLE &&
+				getObjectClass(dependency) != OCLASS_TSTEMPLATE)
 			{
 				return dependency;
 			}

--- a/src/backend/distributed/metadata/pg_get_object_address_12_13_14.c
+++ b/src/backend/distributed/metadata/pg_get_object_address_12_13_14.c
@@ -411,6 +411,7 @@ ErrorIfCurrentUserCanNotDistributeObject(ObjectType type, ObjectAddress *addr,
 		case OBJECT_PROCEDURE:
 		case OBJECT_AGGREGATE:
 		case OBJECT_TSCONFIGURATION:
+		case OBJECT_TSDICTIONARY:
 		case OBJECT_TYPE:
 		case OBJECT_FOREIGN_SERVER:
 		case OBJECT_SEQUENCE:

--- a/src/backend/distributed/worker/worker_create_or_replace.c
+++ b/src/backend/distributed/worker/worker_create_or_replace.c
@@ -286,15 +286,13 @@ CreateStmtListByObjectAddress(const ObjectAddress *address)
 
 		case OCLASS_TSCONFIG:
 		{
-			/*
-			 * We do support TEXT SEARCH CONFIGURATION, however, we can't recreate the
-			 * object in 1 command. Since the returned text is compared to the create
-			 * statement sql we always want the sql to be different compared to the
-			 * canonical creation sql we return here, hence we return an empty string, as
-			 * that should never match the sql we have passed in for the creation.
-			 */
-
 			List *stmts = GetCreateTextSearchConfigStatements(address);
+			return DeparseTreeNodes(stmts);
+		}
+
+		case OCLASS_TSDICT:
+		{
+			List *stmts = GetCreateTextSearchDictionaryStatements(address);
 			return DeparseTreeNodes(stmts);
 		}
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -479,49 +479,94 @@ extern bool ConstrTypeUsesIndex(ConstrType constrType);
 /* text_search.c - forward declarations */
 extern List * PostprocessCreateTextSearchConfigurationStmt(Node *node,
 														   const char *queryString);
+extern List * PostprocessCreateTextSearchDictionaryStmt(Node *node,
+														const char *queryString);
 extern List * GetCreateTextSearchConfigStatements(const ObjectAddress *address);
+extern List * GetCreateTextSearchDictionaryStatements(const ObjectAddress *address);
 extern List * CreateTextSearchConfigDDLCommandsIdempotent(const ObjectAddress *address);
+extern List * CreateTextSearchDictDDLCommandsIdempotent(const ObjectAddress *address);
 extern List * PreprocessDropTextSearchConfigurationStmt(Node *node,
 														const char *queryString,
 														ProcessUtilityContext
 														processUtilityContext);
+extern List * PreprocessDropTextSearchDictionaryStmt(Node *node,
+													 const char *queryString,
+													 ProcessUtilityContext
+													 processUtilityContext);
 extern List * PreprocessAlterTextSearchConfigurationStmt(Node *node,
 														 const char *queryString,
 														 ProcessUtilityContext
 														 processUtilityContext);
+extern List * PreprocessAlterTextSearchDictionaryStmt(Node *node,
+													  const char *queryString,
+													  ProcessUtilityContext
+													  processUtilityContext);
 extern List * PreprocessRenameTextSearchConfigurationStmt(Node *node,
 														  const char *queryString,
 														  ProcessUtilityContext
 														  processUtilityContext);
+extern List * PreprocessRenameTextSearchDictionaryStmt(Node *node,
+													   const char *queryString,
+													   ProcessUtilityContext
+													   processUtilityContext);
 extern List * PreprocessAlterTextSearchConfigurationSchemaStmt(Node *node,
 															   const char *queryString,
 															   ProcessUtilityContext
 															   processUtilityContext);
+extern List * PreprocessAlterTextSearchDictionarySchemaStmt(Node *node,
+															const char *queryString,
+															ProcessUtilityContext
+															processUtilityContext);
 extern List * PostprocessAlterTextSearchConfigurationSchemaStmt(Node *node,
 																const char *queryString);
+extern List * PostprocessAlterTextSearchDictionarySchemaStmt(Node *node,
+															 const char *queryString);
 extern List * PreprocessTextSearchConfigurationCommentStmt(Node *node,
 														   const char *queryString,
 														   ProcessUtilityContext
 														   processUtilityContext);
+extern List * PreprocessTextSearchDictionaryCommentStmt(Node *node,
+														const char *queryString,
+														ProcessUtilityContext
+														processUtilityContext);
 extern List * PreprocessAlterTextSearchConfigurationOwnerStmt(Node *node,
 															  const char *queryString,
 															  ProcessUtilityContext
 															  processUtilityContext);
+extern List * PreprocessAlterTextSearchDictionaryOwnerStmt(Node *node,
+														   const char *queryString,
+														   ProcessUtilityContext
+														   processUtilityContext);
 extern List * PostprocessAlterTextSearchConfigurationOwnerStmt(Node *node,
 															   const char *queryString);
+extern List * PostprocessAlterTextSearchDictionaryOwnerStmt(Node *node,
+															const char *queryString);
 extern ObjectAddress CreateTextSearchConfigurationObjectAddress(Node *node,
 																bool missing_ok);
+extern ObjectAddress CreateTextSearchDictObjectAddress(Node *node,
+													   bool missing_ok);
 extern ObjectAddress RenameTextSearchConfigurationStmtObjectAddress(Node *node,
 																	bool missing_ok);
+extern ObjectAddress RenameTextSearchDictionaryStmtObjectAddress(Node *node,
+																 bool missing_ok);
 extern ObjectAddress AlterTextSearchConfigurationStmtObjectAddress(Node *node,
 																   bool missing_ok);
+extern ObjectAddress AlterTextSearchDictionaryStmtObjectAddress(Node *node,
+																bool missing_ok);
 extern ObjectAddress AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node,
 																		 bool missing_ok);
+extern ObjectAddress AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node,
+																	  bool missing_ok);
 extern ObjectAddress TextSearchConfigurationCommentObjectAddress(Node *node,
 																 bool missing_ok);
+extern ObjectAddress TextSearchDictCommentObjectAddress(Node *node,
+														bool missing_ok);
 extern ObjectAddress AlterTextSearchConfigurationOwnerObjectAddress(Node *node,
 																	bool missing_ok);
+extern ObjectAddress AlterTextSearchDictOwnerObjectAddress(Node *node,
+														   bool missing_ok);
 extern char * GenerateBackupNameForTextSearchConfiguration(const ObjectAddress *address);
+extern char * GenerateBackupNameForTextSearchDict(const ObjectAddress *address);
 extern List * get_ts_config_namelist(Oid tsconfigOid);
 
 /* truncate.c - forward declarations */

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -63,14 +63,21 @@ extern char * DeparseAlterTableStmt(Node *node);
 
 extern void QualifyAlterTableSchemaStmt(Node *stmt);
 
-/* foward declarations fro deparse_text_search.c */
-extern char * DeparseCreateTextSearchStmt(Node *node);
-extern char * DeparseDropTextSearchConfigurationStmt(Node *node);
-extern char * DeparseRenameTextSearchConfigurationStmt(Node *node);
-extern char * DeparseAlterTextSearchConfigurationStmt(Node *node);
-extern char * DeparseAlterTextSearchConfigurationSchemaStmt(Node *node);
-extern char * DeparseTextSearchConfigurationCommentStmt(Node *node);
+/* forward declarations for deparse_text_search.c */
 extern char * DeparseAlterTextSearchConfigurationOwnerStmt(Node *node);
+extern char * DeparseAlterTextSearchConfigurationSchemaStmt(Node *node);
+extern char * DeparseAlterTextSearchConfigurationStmt(Node *node);
+extern char * DeparseAlterTextSearchDictionaryOwnerStmt(Node *node);
+extern char * DeparseAlterTextSearchDictionarySchemaStmt(Node *node);
+extern char * DeparseAlterTextSearchDictionaryStmt(Node *node);
+extern char * DeparseCreateTextSearchConfigurationStmt(Node *node);
+extern char * DeparseCreateTextSearchDictionaryStmt(Node *node);
+extern char * DeparseDropTextSearchConfigurationStmt(Node *node);
+extern char * DeparseDropTextSearchDictionaryStmt(Node *node);
+extern char * DeparseRenameTextSearchConfigurationStmt(Node *node);
+extern char * DeparseRenameTextSearchDictionaryStmt(Node *node);
+extern char * DeparseTextSearchConfigurationCommentStmt(Node *node);
+extern char * DeparseTextSearchDictionaryCommentStmt(Node *node);
 
 /* forward declarations for deparse_schema_stmts.c */
 extern char * DeparseCreateSchemaStmt(Node *node);
@@ -153,13 +160,19 @@ extern char * DeparseAlterExtensionStmt(Node *stmt);
 /* forward declarations for deparse_database_stmts.c */
 extern char * DeparseAlterDatabaseOwnerStmt(Node *node);
 
-/* forward declatations for depatse_text_search_stmts.c */
-extern void QualifyDropTextSearchConfigurationStmt(Node *node);
-extern void QualifyAlterTextSearchConfigurationStmt(Node *node);
-extern void QualifyRenameTextSearchConfigurationStmt(Node *node);
-extern void QualifyAlterTextSearchConfigurationSchemaStmt(Node *node);
-extern void QualifyTextSearchConfigurationCommentStmt(Node *node);
+/* forward declatations for deparse_text_search_stmts.c */
 extern void QualifyAlterTextSearchConfigurationOwnerStmt(Node *node);
+extern void QualifyAlterTextSearchConfigurationSchemaStmt(Node *node);
+extern void QualifyAlterTextSearchConfigurationStmt(Node *node);
+extern void QualifyAlterTextSearchDictionaryOwnerStmt(Node *node);
+extern void QualifyAlterTextSearchDictionarySchemaStmt(Node *node);
+extern void QualifyAlterTextSearchDictionaryStmt(Node *node);
+extern void QualifyDropTextSearchConfigurationStmt(Node *node);
+extern void QualifyDropTextSearchDictionaryStmt(Node *node);
+extern void QualifyRenameTextSearchConfigurationStmt(Node *node);
+extern void QualifyRenameTextSearchDictionaryStmt(Node *node);
+extern void QualifyTextSearchConfigurationCommentStmt(Node *node);
+extern void QualifyTextSearchDictionaryCommentStmt(Node *node);
 
 /* forward declarations for deparse_sequence_stmts.c */
 extern char * DeparseDropSequenceStmt(Node *node);

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -1,3 +1,11 @@
+-- print whether we're using version > 12 to make version-specific tests clear
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int > 12 AS version_above_twelve;
+ version_above_twelve
+---------------------------------------------------------------------
+ t
+(1 row)
+
 CREATE SCHEMA "extension'test";
 -- use  a schema name with escape character
 SET search_path TO "extension'test";
@@ -184,8 +192,6 @@ SELECT create_reference_table('ref_table_2');
 CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
 CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
 CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
-CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
-COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
 SELECT run_command_on_workers($$
 CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
 $$);
@@ -194,22 +200,8 @@ $$);
  (localhost,57637,t,"CREATE TEXT SEARCH TEMPLATE")
 (1 row)
 
-SELECT run_command_on_workers($$
 CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
-$$);
-               run_command_on_workers
----------------------------------------------------------------------
- (localhost,57637,t,"CREATE TEXT SEARCH DICTIONARY")
-(1 row)
-
-SELECT run_command_on_workers($$
 COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
-$$);
-   run_command_on_workers
----------------------------------------------------------------------
- (localhost,57637,t,COMMENT)
-(1 row)
-
 CREATE EXTENSION dict_int FROM unpackaged;
 ERROR:  CREATE EXTENSION ... FROM is no longer supported
 SELECT run_command_on_workers($$SELECT count(extnamespace) FROM pg_extension WHERE extname = 'dict_int'$$);
@@ -224,7 +216,20 @@ SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extnam
  (localhost,57637,t,"")
 (1 row)
 
--- and add the other node
+-- adding the second node will fail as the text search template needs to be created manually
+SELECT 1 from master_add_node('localhost', :worker_2_port);
+ERROR:  text search template "public.intdict_template" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+-- create the text search template manually on the worker
+\c - - - :worker_2_port
+SET citus.enable_metadata_sync TO false;
+CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
+RESET citus.enable_metadata_sync;
+\c - - - :master_port
+SET client_min_messages TO WARNING;
+-- add the second node now
 SELECT 1 from master_add_node('localhost', :worker_2_port);
  ?column?
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/propagate_extension_commands_1.out
+++ b/src/test/regress/expected/propagate_extension_commands_1.out
@@ -1,3 +1,11 @@
+-- print whether we're using version > 12 to make version-specific tests clear
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int > 12 AS version_above_twelve;
+ version_above_twelve
+---------------------------------------------------------------------
+ f
+(1 row)
+
 CREATE SCHEMA "extension'test";
 -- use  a schema name with escape character
 SET search_path TO "extension'test";
@@ -184,8 +192,6 @@ SELECT create_reference_table('ref_table_2');
 CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
 CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
 CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
-CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
-COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
 SELECT run_command_on_workers($$
 CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
 $$);
@@ -194,22 +200,8 @@ $$);
  (localhost,57637,t,"CREATE TEXT SEARCH TEMPLATE")
 (1 row)
 
-SELECT run_command_on_workers($$
 CREATE TEXT SEARCH DICTIONARY intdict (TEMPLATE = intdict_template);
-$$);
-               run_command_on_workers
----------------------------------------------------------------------
- (localhost,57637,t,"CREATE TEXT SEARCH DICTIONARY")
-(1 row)
-
-SELECT run_command_on_workers($$
 COMMENT ON TEXT SEARCH DICTIONARY intdict IS 'dictionary for integers';
-$$);
-   run_command_on_workers
----------------------------------------------------------------------
- (localhost,57637,t,COMMENT)
-(1 row)
-
 CREATE EXTENSION dict_int FROM unpackaged;
 SELECT run_command_on_workers($$SELECT count(extnamespace) FROM pg_extension WHERE extname = 'dict_int'$$);
  run_command_on_workers
@@ -223,7 +215,27 @@ SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extnam
  (localhost,57637,t,1.0)
 (1 row)
 
--- and add the other node
+-- adding the second node will fail as the text search template needs to be created manually
+SELECT 1 from master_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- create the text search template manually on the worker
+\c - - - :worker_2_port
+SET citus.enable_metadata_sync TO false;
+CREATE FUNCTION dintdict_init(internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+ERROR:  function "dintdict_init" already exists with same argument types
+CREATE FUNCTION dintdict_lexize(internal, internal, internal, internal) RETURNS internal AS 'dict_int.so' LANGUAGE C STRICT;
+ERROR:  function "dintdict_lexize" already exists with same argument types
+CREATE TEXT SEARCH TEMPLATE intdict_template (LEXIZE = dintdict_lexize, INIT   = dintdict_init );
+ERROR:  duplicate key value violates unique constraint "pg_ts_template_tmplname_index"
+DETAIL:  Key (tmplname, tmplnamespace)=(intdict_template, 2200) already exists.
+RESET citus.enable_metadata_sync;
+\c - - - :master_port
+SET client_min_messages TO WARNING;
+-- add the second node now
 SELECT 1 from master_add_node('localhost', :worker_2_port);
  ?column?
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/text_search.out
+++ b/src/test/regress/expected/text_search.out
@@ -503,6 +503,122 @@ SELECT create_distributed_table('sensors', 'measureid');
 
 (1 row)
 
+--  create a new dictionary from scratch
+CREATE TEXT SEARCH DICTIONARY my_english_dict (
+    template = snowball,
+    language = english,
+    stopwords = english
+);
+-- verify that the dictionary definition is the same in all nodes
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT ROW(dictname, dictnamespace::regnamespace, dictowner::regrole, tmplname, dictinitoption)
+    FROM pg_ts_dict d JOIN pg_ts_template t ON ( d.dicttemplate = t.oid )
+    WHERE dictname = 'my_english_dict';
+$$);
+                                            result
+---------------------------------------------------------------------
+ (my_english_dict,text_search,postgres,snowball,"language = 'english', stopwords = 'english'")
+ (my_english_dict,text_search,postgres,snowball,"language = 'english', stopwords = 'english'")
+ (my_english_dict,text_search,postgres,snowball,"language = 'english', stopwords = 'english'")
+(3 rows)
+
+-- use the new dictionary in a configuration mapping
+CREATE TEXT SEARCH CONFIGURATION my_english_config ( COPY = english );
+ALTER TEXT SEARCH CONFIGURATION my_english_config ALTER MAPPING FOR asciiword WITH my_english_dict;
+-- verify that the dictionary is available on the worker nodes
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT ROW(alias,dictionary) FROM ts_debug('text_search.my_english_config', 'The Brightest supernovaes') WHERE alias = 'asciiword' LIMIT 1;
+$$);
+                 result
+---------------------------------------------------------------------
+ (asciiword,text_search.my_english_dict)
+ (asciiword,text_search.my_english_dict)
+ (asciiword,text_search.my_english_dict)
+(3 rows)
+
+-- comment on a text search dictionary
+COMMENT ON TEXT SEARCH DICTIONARY my_english_dict IS 'a text search dictionary that is butchered to test all edge cases';
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT obj_description('text_search.my_english_dict'::regdictionary);
+$$);
+                              result
+---------------------------------------------------------------------
+ a text search dictionary that is butchered to test all edge cases
+ a text search dictionary that is butchered to test all edge cases
+ a text search dictionary that is butchered to test all edge cases
+(3 rows)
+
+-- remove a comment
+COMMENT ON TEXT SEARCH DICTIONARY my_english_dict IS NULL;
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT obj_description('text_search.my_english_dict'::regdictionary);
+$$);
+ result
+---------------------------------------------------------------------
+
+
+
+(3 rows)
+
+-- test various ALTER TEXT SEARCH DICTIONARY commands
+ALTER TEXT SEARCH DICTIONARY my_english_dict RENAME TO my_turkish_dict;
+ALTER TEXT SEARCH DICTIONARY my_turkish_dict (language = turkish, stopwords);
+ALTER TEXT SEARCH DICTIONARY my_turkish_dict OWNER TO text_search_owner;
+ALTER TEXT SEARCH DICTIONARY my_turkish_dict SET SCHEMA "Text Search Requiring Quote's";
+-- verify that the dictionary definition is the same in all nodes
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT ROW(dictname, dictnamespace::regnamespace, dictowner::regrole, tmplname, dictinitoption)
+    FROM pg_ts_dict d JOIN pg_ts_template t ON ( d.dicttemplate = t.oid )
+    WHERE dictname = 'my_turkish_dict';
+$$);
+                                                 result
+---------------------------------------------------------------------
+ (my_turkish_dict,"""Text Search Requiring Quote's""",text_search_owner,snowball,"language = 'turkish'")
+ (my_turkish_dict,"""Text Search Requiring Quote's""",text_search_owner,snowball,"language = 'turkish'")
+ (my_turkish_dict,"""Text Search Requiring Quote's""",text_search_owner,snowball,"language = 'turkish'")
+(3 rows)
+
+-- verify that the configuration dictionary is changed in all nodes
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT ROW(alias,dictionary) FROM ts_debug('text_search.my_english_config', 'The Brightest supernovaes') WHERE alias = 'asciiword' LIMIT 1;
+$$);
+                             result
+---------------------------------------------------------------------
+ (asciiword,"""Text Search Requiring Quote's"".my_turkish_dict")
+ (asciiword,"""Text Search Requiring Quote's"".my_turkish_dict")
+ (asciiword,"""Text Search Requiring Quote's"".my_turkish_dict")
+(3 rows)
+
+-- before testing drops, check that the dictionary exists on all nodes
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT '"Text Search Requiring Quote''s".my_turkish_dict'::regdictionary;
+$$);
+                     result
+---------------------------------------------------------------------
+ "Text Search Requiring Quote's".my_turkish_dict
+ "Text Search Requiring Quote's".my_turkish_dict
+ "Text Search Requiring Quote's".my_turkish_dict
+(3 rows)
+
+ALTER TEXT SEARCH DICTIONARY "Text Search Requiring Quote's".my_turkish_dict SET SCHEMA text_search;
+-- verify that we can drop the dictionary only with cascade option
+DROP TEXT SEARCH DICTIONARY my_turkish_dict;
+ERROR:  cannot drop text search dictionary my_turkish_dict because other objects depend on it
+DETAIL:  text search configuration my_english_config depends on text search dictionary my_turkish_dict
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+DROP TEXT SEARCH DICTIONARY my_turkish_dict CASCADE;
+NOTICE:  drop cascades to text search configuration my_english_config
+-- verify that it is dropped now
+SELECT result FROM run_command_on_all_nodes($$
+    SELECT 'my_turkish_dict'::regdictionary;
+$$);
+                             result
+---------------------------------------------------------------------
+ ERROR:  text search dictionary "my_turkish_dict" does not exist
+ ERROR:  text search dictionary "my_turkish_dict" does not exist
+ ERROR:  text search dictionary "my_turkish_dict" does not exist
+(3 rows)
+
 SET client_min_messages TO 'warning';
 DROP SCHEMA text_search, text_search2, "Text Search Requiring Quote's" CASCADE;
 DROP ROLE text_search_owner;


### PR DESCRIPTION
The change adds support to Citus for propagating TEXT SEARCH DICTIONARY
objects.

DESCRIPTION: Implement TEXT SEARCH DICTIONARY propagation

TODO:
- [x] implement the missing 2 functions
	- [x] `DeparseAlterTextSearchDictionaryStmt`
	- [x] `QualifyAlterTextSearchDictionaryStmt`
- [x] Add tests

fixes #5607