### PR TITLE
Change create_object_propagation default to immediate

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -769,12 +769,22 @@ RecreateExtensionStmt(Oid extensionOid)
 
 	/* make DefEleme for extensionSchemaName */
 	Node *schemaNameArg = (Node *) makeString(extensionSchemaName);
-
 	DefElem *schemaDefElement = makeDefElem("schema", schemaNameArg, location);
 
 	/* append the schema name DefElem finally */
 	createExtensionStmt->options = lappend(createExtensionStmt->options,
 										   schemaDefElement);
+
+	char *extensionVersion = get_extension_version(extensionOid);
+	if (extensionVersion != NULL)
+	{
+		Node *extensionVersionArg = (Node *) makeString(extensionVersion);
+		DefElem *extensionVersionElement =
+			makeDefElem("new_version", extensionVersionArg, location);
+
+		createExtensionStmt->options = lappend(createExtensionStmt->options,
+											   extensionVersionElement);
+	}
 
 	return (Node *) createExtensionStmt;
 }

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -78,7 +78,7 @@
 #include "utils/syscache.h"
 
 bool EnableDDLPropagation = true; /* ddl propagation is enabled */
-int CreateObjectPropagationMode = CREATE_OBJECT_PROPAGATION_DEFERRED;
+int CreateObjectPropagationMode = CREATE_OBJECT_PROPAGATION_IMMEDIATE;
 PropSetCmdBehavior PropagateSetCommands = PROPSETCMD_NONE; /* SET prop off */
 static bool shouldInvalidateForeignKeyGraph = false;
 static int activeAlterTables = 0;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -693,7 +693,7 @@ RegisterCitusConfigVariables(void)
 					 "off performance for full transactional consistency on the creation "
 					 "of new objects."),
 		&CreateObjectPropagationMode,
-		CREATE_OBJECT_PROPAGATION_DEFERRED, create_object_propagation_options,
+		CREATE_OBJECT_PROPAGATION_IMMEDIATE, create_object_propagation_options,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);

--- a/src/include/distributed/citus_ruleutils.h
+++ b/src/include/distributed/citus_ruleutils.h
@@ -29,6 +29,7 @@
 /* Function declarations for version independent Citus ruleutils wrapper functions */
 extern char * pg_get_extensiondef_string(Oid tableRelationId);
 extern Oid get_extension_schema(Oid ext_oid);
+extern char * get_extension_version(Oid extensionId);
 extern char * pg_get_serverdef_string(Oid tableRelationId);
 extern char * pg_get_sequencedef_string(Oid sequenceRelid);
 extern Form_pg_sequence pg_get_sequencedef(Oid sequenceRelationId);

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -1114,6 +1114,7 @@ create function dummy_fnc(a dummy_tbl, d double precision) RETURNS dummy_tbl
 -- test in tx block
 -- shouldn't distribute, as citus.create_object_propagation is set to deferred
 BEGIN;
+SET LOCAL citus.create_object_propagation TO deferred;
 create aggregate dependent_agg (float8) (stype=dummy_tbl, sfunc=dummy_fnc);
 COMMIT;
 -- verify not distributed

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -88,6 +88,7 @@ SELECT * FROM t3;
  4 | (5,6)
 (1 row)
 
+COMMIT;
 -- verify typmod was propagated
 SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum = 1 AND attrelid = (SELECT typrelid FROM pg_type WHERE typname = 'tc2');$$);
  run_command_on_workers
@@ -96,7 +97,6 @@ SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum 
  (localhost,57638,t,14)
 (2 rows)
 
-COMMIT;
 -- transaction block with simple type
 BEGIN;
 CREATE TYPE te2 AS ENUM ('yes', 'no');

--- a/src/test/regress/expected/function_propagation.out
+++ b/src/test/regress/expected/function_propagation.out
@@ -92,6 +92,7 @@ SELECT * FROM run_command_on_workers($$SELECT pg_identify_object_as_address(clas
 
 -- Have a separate check for type created in transaction
 BEGIN;
+    SET LOCAL citus.create_object_propagation TO deferred;
     CREATE TYPE function_prop_type_3 AS (a int, b int);
 COMMIT;
 -- Objects in the body part is not found as dependency
@@ -209,16 +210,17 @@ BEGIN;
         return 1;
     END;
     $$;
-    -- Within transaction functions are not distributed
     SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid = 'function_propagation_schema.type_in_transaction'::regtype::oid;
- pg_identify_object_as_address
+                pg_identify_object_as_address
 ---------------------------------------------------------------------
-(0 rows)
+ (type,{function_propagation_schema.type_in_transaction},{})
+(1 row)
 
     SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid = 'function_propagation_schema.func_in_transaction'::regproc::oid;
- pg_identify_object_as_address
+                                          pg_identify_object_as_address
 ---------------------------------------------------------------------
-(0 rows)
+ (function,"{function_propagation_schema,func_in_transaction}",{function_propagation_schema.type_in_transaction})
+(1 row)
 
 COMMIT;
 -- Show that recreating it outside transaction distributes the function and dependencies

--- a/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
+++ b/src/test/regress/expected/isolation_ensure_dependency_activate_node.out
@@ -14,7 +14,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -75,7 +75,7 @@ step s1-begin:
     BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -86,10 +86,10 @@ step s2-public-schema:
     SET search_path TO public;
 
 step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
@@ -107,7 +107,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -185,7 +185,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -246,10 +246,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -260,10 +260,10 @@ step s2-public-schema:
     SET search_path TO public;
 
 step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
@@ -275,7 +275,7 @@ create_distributed_table
 (1 row)
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s2-print-distributed-objects:
     -- print an overview of all distributed objects
@@ -284,7 +284,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -362,7 +362,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -423,16 +423,16 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-public-schema:
     SET search_path TO public;
 
 step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -440,10 +440,10 @@ create_distributed_table
 (1 row)
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+    COMMIT;
 
 step s1-add-worker: <... completed>
 ?column?
@@ -461,7 +461,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -525,7 +525,7 @@ master_remove_node
 (2 rows)
 
 
-starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-create-schema s2-create-table s1-commit s2-print-distributed-objects s3-drop-coordinator-schemas
+starting permutation: s1-print-distributed-objects s1-begin s1-add-worker s2-create-schema s1-commit s2-create-table s2-print-distributed-objects s3-drop-coordinator-schemas
 ?column?
 ---------------------------------------------------------------------
        1
@@ -539,7 +539,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -600,7 +600,7 @@ step s1-begin:
     BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -610,17 +610,17 @@ step s1-add-worker:
 step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
-
-step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-step s2-create-table: <... completed>
+step s2-create-schema: <... completed>
+step s2-create-table:
+    CREATE TABLE t1 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
+
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -633,7 +633,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -698,7 +698,7 @@ master_remove_node
 (2 rows)
 
 
-starting permutation: s1-print-distributed-objects s1-begin s2-begin s1-add-worker s2-create-schema s2-create-table s1-commit s2-commit s2-print-distributed-objects s3-drop-coordinator-schemas
+starting permutation: s1-print-distributed-objects s1-begin s2-begin s1-add-worker s2-create-schema s1-commit s2-create-table s2-commit s2-print-distributed-objects s3-drop-coordinator-schemas
 ?column?
 ---------------------------------------------------------------------
        1
@@ -712,7 +712,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -773,10 +773,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -786,24 +786,24 @@ step s1-add-worker:
 step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
-
-step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-step s2-create-table: <... completed>
+step s2-create-schema: <... completed>
+step s2-create-table:
+    CREATE TABLE t1 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
+
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s2-print-distributed-objects:
     -- print an overview of all distributed objects
@@ -812,7 +812,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -877,7 +877,7 @@ master_remove_node
 (2 rows)
 
 
-starting permutation: s1-print-distributed-objects s1-begin s2-begin s2-create-schema s2-create-table s1-add-worker s2-commit s1-commit s2-print-distributed-objects s3-drop-coordinator-schemas
+starting permutation: s1-print-distributed-objects s1-begin s2-begin s2-create-schema s1-add-worker s2-create-table s2-commit s1-commit s2-print-distributed-objects s3-drop-coordinator-schemas
 ?column?
 ---------------------------------------------------------------------
        1
@@ -891,7 +891,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -952,28 +952,28 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
 
-step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+step s1-add-worker:
+    SELECT 1 FROM master_add_node('localhost', 57638);
+ <waiting ...>
+step s2-create-table: 
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
- <waiting ...>
-step s2-commit: 
-	COMMIT;
+step s2-commit:
+    COMMIT;
 
 step s1-add-worker: <... completed>
 ?column?
@@ -991,7 +991,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1070,7 +1070,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1135,10 +1135,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -1146,10 +1146,10 @@ step s1-add-worker:
 (1 row)
 
 step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
@@ -1161,7 +1161,7 @@ create_distributed_table
 (1 row)
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s2-print-distributed-objects:
     -- print an overview of all distributed objects
@@ -1170,7 +1170,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1249,7 +1249,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1307,7 +1307,7 @@ master_remove_node
 (1 row)
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -1319,19 +1319,19 @@ step s2-create-schema:
     SET search_path TO myschema;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s3-begin:
-	BEGIN;
+    BEGIN;
 
 step s3-use-schema:
     SET search_path TO myschema;
 
 step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -1339,22 +1339,21 @@ create_distributed_table
 (1 row)
 
 step s3-create-table:
-	CREATE TABLE t2 (a int, b int);
+    CREATE TABLE t2 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t2', 'a');
- <waiting ...>
-step s2-commit: 
-	COMMIT;
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t2', 'a');
 
-step s3-create-table: <... completed>
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
+step s2-commit:
+    COMMIT;
+
 step s3-commit:
-	COMMIT;
+    COMMIT;
 
 step s2-print-distributed-objects:
     -- print an overview of all distributed objects
@@ -1363,7 +1362,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1429,7 +1428,7 @@ master_remove_node
 (2 rows)
 
 
-starting permutation: s1-print-distributed-objects s1-begin s2-begin s3-begin s1-add-worker s2-create-schema s3-create-schema2 s2-create-table s3-create-table s1-commit s3-commit s2-commit s2-print-distributed-objects s3-drop-coordinator-schemas
+starting permutation: s1-print-distributed-objects s1-begin s2-begin s3-begin s1-add-worker s2-create-schema s3-create-schema2 s1-commit s2-create-table s2-commit s3-create-table s3-commit s2-print-distributed-objects s3-drop-coordinator-schemas
 ?column?
 ---------------------------------------------------------------------
        1
@@ -1443,7 +1442,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1504,13 +1503,13 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s3-begin:
-	BEGIN;
+    BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -1520,43 +1519,43 @@ step s1-add-worker:
 step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
-
-step s3-create-schema2:
+ <waiting ...>
+step s3-create-schema2: 
     CREATE SCHEMA myschema2;
     SET search_path TO myschema2;
-
-step s2-create-table:
-	CREATE TABLE t1 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
- <waiting ...>
-step s3-create-table: 
-	CREATE TABLE t2 (a int, b int);
-    -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t2', 'a');
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-step s2-create-table: <... completed>
+step s2-create-schema: <... completed>
+step s3-create-schema2: <... completed>
+step s2-create-table:
+    CREATE TABLE t1 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
+
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s3-create-table: <... completed>
+step s2-commit:
+    COMMIT;
+
+step s3-create-table:
+    CREATE TABLE t2 (a int, b int);
+    -- session needs to have replication factor set to 1, can't do in setup
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t2', 'a');
+
 create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 step s3-commit:
-	COMMIT;
-
-step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s2-print-distributed-objects:
     -- print an overview of all distributed objects
@@ -1565,7 +1564,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1646,7 +1645,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1707,7 +1706,7 @@ step s1-begin:
     BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -1718,7 +1717,7 @@ step s2-public-schema:
     SET search_path TO public;
 
 step s2-create-type:
-	CREATE TYPE tt1 AS (a int, b int);
+    CREATE TYPE tt1 AS (a int, b int);
  <waiting ...>
 step s1-commit: 
     COMMIT;
@@ -1731,7 +1730,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1809,7 +1808,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1873,10 +1872,10 @@ step s2-public-schema:
     SET search_path TO public;
 
 step s2-create-type:
-	CREATE TYPE tt1 AS (a int, b int);
+    CREATE TYPE tt1 AS (a int, b int);
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -1893,7 +1892,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -1971,7 +1970,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2032,20 +2031,20 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-create-schema:
     CREATE SCHEMA myschema;
     SET search_path TO myschema;
 
 step s2-create-type:
-	CREATE TYPE tt1 AS (a int, b int);
+    CREATE TYPE tt1 AS (a int, b int);
 
 step s2-create-table-with-type:
-	CREATE TABLE t1 (a int, b tt1);
+    CREATE TABLE t1 (a int, b tt1);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -2053,10 +2052,10 @@ create_distributed_table
 (1 row)
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+    COMMIT;
 
 step s1-add-worker: <... completed>
 ?column?
@@ -2074,7 +2073,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2154,7 +2153,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2215,7 +2214,7 @@ step s1-begin:
     BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -2239,10 +2238,10 @@ create_distributed_function
 (1 row)
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s3-wait-for-metadata-sync:
     SELECT public.wait_until_metadata_sync(5000);
@@ -2259,7 +2258,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2337,7 +2336,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2410,10 +2409,10 @@ create_distributed_function
 (1 row)
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s3-wait-for-metadata-sync:
     SELECT public.wait_until_metadata_sync(5000);
@@ -2424,7 +2423,7 @@ wait_until_metadata_sync
 (1 row)
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -2449,7 +2448,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2527,7 +2526,7 @@ step s1-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';
@@ -2585,7 +2584,7 @@ master_remove_node
 (1 row)
 
 step s2-begin:
-	BEGIN;
+    BEGIN;
 
 step s2-create-schema:
     CREATE SCHEMA myschema;
@@ -2601,7 +2600,7 @@ create_distributed_function
 (1 row)
 
 step s2-commit:
-	COMMIT;
+    COMMIT;
 
 step s3-wait-for-metadata-sync:
     SELECT public.wait_until_metadata_sync(5000);
@@ -2615,7 +2614,7 @@ step s1-begin:
     BEGIN;
 
 step s1-add-worker:
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 
 ?column?
 ---------------------------------------------------------------------
@@ -2640,7 +2639,7 @@ step s2-print-distributed-objects:
     SELECT count(*) FROM pg_namespace where nspname = 'myschema';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
     -- print if the function has been created
     SELECT count(*) FROM pg_proc WHERE proname='add';

--- a/src/test/regress/expected/isolation_extension_commands.out
+++ b/src/test/regress/expected/isolation_extension_commands.out
@@ -506,7 +506,7 @@ run_command_on_workers
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,1.3)
+(localhost,57637,t,1.1)
 (localhost,57638,t,1.1)
 (2 rows)
 
@@ -589,7 +589,7 @@ run_command_on_workers
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,1.3)
+(localhost,57637,t,1.1)
 (localhost,57638,t,1.2)
 (2 rows)
 

--- a/src/test/regress/expected/isolation_extension_commands.out
+++ b/src/test/regress/expected/isolation_extension_commands.out
@@ -471,14 +471,15 @@ step s2-create-extension-version-11:
 
 step s1-add-node-1:
  SELECT 1 FROM master_add_node('localhost', 57637);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
 
+step s1-add-node-1: <... completed>
 ?column?
 ---------------------------------------------------------------------
        1
 (1 row)
-
-step s2-commit:
- COMMIT;
 
 step s1-print:
  select count(*) from pg_catalog.pg_dist_object ;
@@ -489,7 +490,7 @@ step s1-print:
 
 count
 ---------------------------------------------------------------------
-    6
+    7
 (1 row)
 
 extname|extversion|nspname
@@ -499,20 +500,20 @@ seg    |       1.1|public
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,seg)
+(localhost,57638,t,seg)
 (2 rows)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,1.3)
+(localhost,57638,t,1.1)
 (2 rows)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,public)
+(localhost,57638,t,public)
 (2 rows)
 
 master_remove_node
@@ -588,7 +589,7 @@ run_command_on_workers
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,1.1)
+(localhost,57637,t,1.3)
 (localhost,57638,t,1.2)
 (2 rows)
 
@@ -678,14 +679,15 @@ step s2-create-extension-with-schema1:
 
 step s1-add-node-1:
  SELECT 1 FROM master_add_node('localhost', 57637);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
 
+step s1-add-node-1: <... completed>
 ?column?
 ---------------------------------------------------------------------
        1
 (1 row)
-
-step s2-commit:
- COMMIT;
 
 step s1-print:
  select count(*) from pg_catalog.pg_dist_object ;
@@ -696,7 +698,7 @@ step s1-print:
 
 count
 ---------------------------------------------------------------------
-    6
+    7
 (1 row)
 
 extname|extversion|nspname
@@ -706,20 +708,20 @@ seg    |       1.3|schema1
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,seg)
+(localhost,57638,t,seg)
 (2 rows)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,1.3)
+(localhost,57638,t,1.3)
 (2 rows)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,"")
-(localhost,57638,t,"")
+(localhost,57637,t,schema1)
+(localhost,57638,t,schema1)
 (2 rows)
 
 master_remove_node
@@ -820,14 +822,15 @@ step s2-create-extension-version-11:
 
 step s1-remove-node-1:
  SELECT 1 FROM master_remove_node('localhost', 57637);
+ <waiting ...>
+step s2-commit: 
+ COMMIT;
 
+step s1-remove-node-1: <... completed>
 ?column?
 ---------------------------------------------------------------------
        1
 (1 row)
-
-step s2-commit:
- COMMIT;
 
 step s1-print:
  select count(*) from pg_catalog.pg_dist_object ;
@@ -838,7 +841,7 @@ step s1-print:
 
 count
 ---------------------------------------------------------------------
-    6
+    7
 (1 row)
 
 extname|extversion|nspname
@@ -848,17 +851,17 @@ seg    |       1.1|public
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57638,t,"")
+(localhost,57638,t,seg)
 (1 row)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57638,t,"")
+(localhost,57638,t,1.1)
 (1 row)
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57638,t,"")
+(localhost,57638,t,public)
 (1 row)
 
 master_remove_node
@@ -938,7 +941,7 @@ run_command_on_workers
 
 run_command_on_workers
 ---------------------------------------------------------------------
-(localhost,57637,t,schema2)
+(localhost,57637,t,schema1)
 (localhost,57638,t,"")
 (2 rows)
 

--- a/src/test/regress/expected/isolation_metadata_sync_vs_all.out
+++ b/src/test/regress/expected/isolation_metadata_sync_vs_all.out
@@ -253,8 +253,8 @@ start_metadata_sync_to_node
 (1 row)
 
 step s2-create-schema:
- CREATE SCHEMA dist_schema
-  CREATE TABLE dist_table_in_schema(id int, data int);
+ CREATE SCHEMA dist_schema;
+ CREATE TABLE dist_schema.dist_table_in_schema(id int, data int);
  SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
  <waiting ...>
 step s1-commit: 
@@ -290,7 +290,7 @@ step s3-compare-snapshot:
 
 same_metadata_in_workers
 ---------------------------------------------------------------------
-t
+f
 (1 row)
 
 step s2-drop-schema:
@@ -299,8 +299,8 @@ step s2-drop-schema:
 
 starting permutation: s2-create-schema s1-begin s2-begin s1-start-metadata-sync s2-drop-schema s1-commit s2-commit s3-compare-snapshot
 step s2-create-schema:
- CREATE SCHEMA dist_schema
-  CREATE TABLE dist_table_in_schema(id int, data int);
+ CREATE SCHEMA dist_schema;
+ CREATE TABLE dist_schema.dist_table_in_schema(id int, data int);
  SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
 
 create_distributed_table
@@ -1017,8 +1017,8 @@ t
 
 starting permutation: s2-create-schema s1-begin s2-begin s2-drop-schema s1-start-metadata-sync s2-commit s1-commit s3-compare-snapshot
 step s2-create-schema:
- CREATE SCHEMA dist_schema
-  CREATE TABLE dist_table_in_schema(id int, data int);
+ CREATE SCHEMA dist_schema;
+ CREATE TABLE dist_schema.dist_table_in_schema(id int, data int);
  SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
 
 create_distributed_table
@@ -1154,10 +1154,11 @@ start_metadata_sync_to_node
 
 step s2-create-type:
  CREATE TYPE my_type AS (a int, b int);
-
-step s1-commit:
+ <waiting ...>
+step s1-commit: 
     COMMIT;
 
+step s2-create-type: <... completed>
 step s2-commit:
  COMMIT;
 

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -593,11 +593,11 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
 (1 row)
 
- SET application_name to 'citus_internal gpid=10000000001';
- \set VERBOSITY terse
- WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
-   AS (VALUES ('non_existing_type', ARRAY['non_existing_user']::text[], ARRAY[]::text[], -1, 0, false))
- SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
+		AS (VALUES ('non_existing_type', ARRAY['non_existing_user']::text[], ARRAY[]::text[], -1, 0, false))
+	SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
 ERROR:  unrecognized object type "non_existing_type"
 ROLLBACK;
 -- check the sanity of distributionArgumentIndex and colocationId
@@ -637,11 +637,11 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
 (1 row)
 
- SET application_name to 'citus_internal gpid=10000000001';
- \set VERBOSITY terse
- WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
-   AS (VALUES ('role', ARRAY['non_existing_user']::text[], ARRAY[]::text[], -1, 0, false))
- SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
+		AS (VALUES ('role', ARRAY['non_existing_user']::text[], ARRAY[]::text[], -1, 0, false))
+	SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
 ERROR:  role "non_existing_user" does not exist
 ROLLBACK;
 -- since citus_internal_add_object_metadata is strict function returns NULL
@@ -653,11 +653,11 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
 (1 row)
 
- SET application_name to 'citus_internal gpid=10000000001';
- \set VERBOSITY terse
- WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
-   AS (VALUES ('role', ARRAY['metadata_sync_helper_role']::text[], ARRAY[]::text[], 0, NULL::int, false))
- SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
+		AS (VALUES ('role', ARRAY['metadata_sync_helper_role']::text[], ARRAY[]::text[], 0, NULL::int, false))
+	SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
  citus_internal_add_object_metadata
 ---------------------------------------------------------------------
 
@@ -711,6 +711,7 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 (1 row)
 
     SET application_name to 'citus_internal gpid=10000000001';
+    SET citus.enable_ddl_propagation TO OFF;
     \set VERBOSITY terse
     CREATE TYPE distributed_test_type AS (a int, b int);
     SET ROLE metadata_sync_helper_role;
@@ -1323,6 +1324,7 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 ERROR:  cannot colocate tables test_6 and test_5
 ROLLBACK;
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    SET citus.enable_ddl_propagation TO OFF;
 	CREATE COLLATION collation_t1 (provider = icu, locale = 'de-u-co-phonebk');
 	CREATE COLLATION caseinsensitive (provider = icu, locale = 'und-u-ks-level2');
 	-- colocated hash distributed table should have the same dist key collations

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -344,6 +344,7 @@ SET search_path TO "extension'test";
 -- check restriction for sequential execution
 -- enable it and see that create command errors but continues its execution by changing citus.multi_shard_modify_mode TO 'off
 BEGIN;
+    SET LOCAL citus.create_object_propagation TO deferred;
 	CREATE TABLE some_random_table (a int);
 	SELECT create_distributed_table('some_random_table', 'a');
  create_distributed_table
@@ -586,6 +587,7 @@ DROP TABLE test_extension_function;
 -- Test extension function altering distribution argument
 BEGIN;
 SET citus.shard_replication_factor = 1;
+SET citus.multi_shard_modify_mode TO sequential;
 CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
 SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
  create_distributed_table

--- a/src/test/regress/expected/propagate_extension_commands_1.out
+++ b/src/test/regress/expected/propagate_extension_commands_1.out
@@ -343,6 +343,7 @@ SET search_path TO "extension'test";
 -- check restriction for sequential execution
 -- enable it and see that create command errors but continues its execution by changing citus.multi_shard_modify_mode TO 'off
 BEGIN;
+    SET LOCAL citus.create_object_propagation TO deferred;
 	CREATE TABLE some_random_table (a int);
 	SELECT create_distributed_table('some_random_table', 'a');
  create_distributed_table
@@ -585,6 +586,7 @@ DROP TABLE test_extension_function;
 -- Test extension function altering distribution argument
 BEGIN;
 SET citus.shard_replication_factor = 1;
+SET citus.multi_shard_modify_mode TO sequential;
 CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
 SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
  create_distributed_table

--- a/src/test/regress/expected/text_search.out
+++ b/src/test/regress/expected/text_search.out
@@ -37,21 +37,19 @@ SELECT create_distributed_table('t1', 'name');
 
 (1 row)
 
+-- verify that we can change the object
+COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config  IS 'this comment can be set right now';
+COMMIT;
 SELECT * FROM run_command_on_workers($$
     SELECT obj_description('text_search.my_text_search_config'::regconfig);
 $$) ORDER BY 1,2;
- nodename  | nodeport | success |                           result
+ nodename  | nodeport | success |              result
 ---------------------------------------------------------------------
- localhost |    57637 | t       | on demand propagation of text search object with a comment
- localhost |    57638 | t       | on demand propagation of text search object with a comment
+ localhost |    57637 | t       | this comment can be set right now
+ localhost |    57638 | t       | this comment can be set right now
 (2 rows)
 
--- verify that changing anything on a managed TEXT SEARCH CONFIGURATION fails after parallel execution
-COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config  IS 'this comment can''t be set right now';
-ERROR:  cannot run text search configuration command because there was a parallel operation on a distributed table in the transaction
-DETAIL:  When running command on/for a distributed text search configuration, Citus needs to perform all operations over a single connection per node to ensure consistency.
-HINT:  Try re-running the transaction with "SET LOCAL citus.multi_shard_modify_mode TO 'sequential';"
-ABORT;
+DROP TABLE t1;
 -- create an index on an already distributed table
 BEGIN;
 CREATE TEXT SEARCH CONFIGURATION my_text_search_config2 ( parser = default );
@@ -64,6 +62,7 @@ SELECT create_distributed_table('t1', 'name');
 (1 row)
 
 CREATE INDEX t1_search_name ON t1 USING gin (to_tsvector('text_search.my_text_search_config2'::regconfig, (COALESCE(name, ''::character varying))::text));
+COMMIT;
 SELECT * FROM run_command_on_workers($$
     SELECT obj_description('text_search.my_text_search_config2'::regconfig);
 $$) ORDER BY 1,2;
@@ -73,7 +72,7 @@ $$) ORDER BY 1,2;
  localhost |    57638 | t       | on demand propagation of text search object with a comment 2
 (2 rows)
 
-ABORT;
+DROP TABLE t1;
 -- should be able to create a configuration based on a copy of an existing configuration
 CREATE TEXT SEARCH CONFIGURATION french_noaccent ( COPY = french );
 CREATE TABLE t2(id int, name text);

--- a/src/test/regress/spec/isolation_drop_vs_all.spec
+++ b/src/test/regress/spec/isolation_drop_vs_all.spec
@@ -9,12 +9,12 @@ setup
 	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
 
 	SET citus.shard_replication_factor TO 1;
-	CREATE SCHEMA drop_tests
-		CREATE TABLE drop_hash(id integer, data text);
+	CREATE SCHEMA drop_tests;
+	CREATE TABLE drop_tests.drop_hash(id integer, data text);
 	SELECT create_distributed_table('drop_tests.drop_hash', 'id');
 
-	CREATE SCHEMA drop_tests_2
-		CREATE TABLE drop_hash_2(id integer, data text);
+	CREATE SCHEMA drop_tests_2;
+	CREATE TABLE drop_tests_2.drop_hash_2(id integer, data text);
 	SELECT create_distributed_table('drop_tests_2.drop_hash_2', 'id');
 }
 

--- a/src/test/regress/spec/isolation_ensure_dependency_activate_node.spec
+++ b/src/test/regress/spec/isolation_ensure_dependency_activate_node.spec
@@ -36,7 +36,7 @@ step "s1-begin"
 
 step "s1-add-worker"
 {
-	SELECT 1 FROM master_add_node('localhost', 57638);
+    SELECT 1 FROM master_add_node('localhost', 57638);
 }
 
 step "s1-commit"
@@ -58,7 +58,7 @@ step "s1-print-distributed-objects"
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
 
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
 
     -- print if the function has been created
@@ -83,23 +83,23 @@ step "s2-create-schema"
 
 step "s2-create-table"
 {
-	CREATE TABLE t1 (a int, b int);
+    CREATE TABLE t1 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 }
 
 step "s2-create-type"
 {
-	CREATE TYPE tt1 AS (a int, b int);
+    CREATE TYPE tt1 AS (a int, b int);
 }
 
 step "s2-create-table-with-type"
 {
-	CREATE TABLE t1 (a int, b tt1);
+    CREATE TABLE t1 (a int, b tt1);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t1', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t1', 'a');
 }
 
 step "s2-distribute-function"
@@ -110,12 +110,12 @@ step "s2-distribute-function"
 
 step "s2-begin"
 {
-	BEGIN;
+    BEGIN;
 }
 
 step "s2-commit"
 {
-	COMMIT;
+    COMMIT;
 }
 
 // prints from session 2 are run at the end when the worker has already been added by the
@@ -130,7 +130,7 @@ step "s2-print-distributed-objects"
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_namespace where nspname = 'myschema';$$);
 
     -- print if the type has been created
-	SELECT count(*) FROM pg_type where typname = 'tt1';
+    SELECT count(*) FROM pg_type where typname = 'tt1';
     SELECT run_command_on_workers($$SELECT count(*) FROM pg_type where typname = 'tt1';$$);
 
     -- print if the function has been created
@@ -148,10 +148,10 @@ step "s3-use-schema"
 
 step "s3-create-table"
 {
-	CREATE TABLE t2 (a int, b int);
+    CREATE TABLE t2 (a int, b int);
     -- session needs to have replication factor set to 1, can't do in setup
-	SET citus.shard_replication_factor TO 1;
-	SELECT create_distributed_table('t2', 'a');
+    SET citus.shard_replication_factor TO 1;
+    SELECT create_distributed_table('t2', 'a');
 }
 
 step "s3-wait-for-metadata-sync"
@@ -168,12 +168,12 @@ step "s3-create-schema2"
 
 step "s3-begin"
 {
-	BEGIN;
+    BEGIN;
 }
 
 step "s3-commit"
 {
-	COMMIT;
+    COMMIT;
 }
 
 step "s3-drop-coordinator-schemas"
@@ -193,14 +193,14 @@ step "s3-drop-coordinator-schemas"
 permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-public-schema" "s2-create-table" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
 permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s1-add-worker" "s2-public-schema" "s2-create-table" "s1-commit" "s2-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
 permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s2-public-schema" "s2-create-table" "s1-add-worker" "s2-commit" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
-permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-create-schema" "s2-create-table" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
-permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s1-add-worker" "s2-create-schema" "s2-create-table" "s1-commit" "s2-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
-permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s2-create-schema" "s2-create-table" "s1-add-worker" "s2-commit" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
+permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-create-schema" "s1-commit" "s2-create-table" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
+permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s1-add-worker" "s2-create-schema" "s1-commit" "s2-create-table" "s2-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
+permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s2-create-schema" "s1-add-worker" "s2-create-table" "s2-commit" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
 
 // concurrency tests with multi schema distribution
 permutation "s1-print-distributed-objects" "s2-create-schema" "s1-begin" "s2-begin" "s1-add-worker" "s2-create-table" "s1-commit" "s2-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
 permutation "s1-print-distributed-objects" "s1-add-worker" "s2-create-schema" "s2-begin" "s3-begin" "s3-use-schema" "s2-create-table" "s3-create-table" "s2-commit" "s3-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
-permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s3-begin" "s1-add-worker" "s2-create-schema" "s3-create-schema2" "s2-create-table" "s3-create-table" "s1-commit" "s3-commit" "s2-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
+permutation "s1-print-distributed-objects" "s1-begin" "s2-begin" "s3-begin" "s1-add-worker" "s2-create-schema" "s3-create-schema2" "s1-commit" "s2-create-table" "s2-commit" "s3-create-table" "s3-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"
 
 // type and schema tests
 permutation "s1-print-distributed-objects" "s1-begin" "s1-add-worker" "s2-public-schema" "s2-create-type" "s1-commit" "s2-print-distributed-objects" "s3-drop-coordinator-schemas"

--- a/src/test/regress/spec/isolation_metadata_sync_vs_all.spec
+++ b/src/test/regress/spec/isolation_metadata_sync_vs_all.spec
@@ -110,8 +110,8 @@ step "s2-create-dist-table"
 
 step "s2-create-schema"
 {
-	CREATE SCHEMA dist_schema
-		CREATE TABLE dist_table_in_schema(id int, data int);
+	CREATE SCHEMA dist_schema;
+	CREATE TABLE dist_schema.dist_table_in_schema(id int, data int);
 
 	SELECT create_distributed_table('dist_schema.dist_table_in_schema', 'id');
 }

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -556,6 +556,7 @@ create function dummy_fnc(a dummy_tbl, d double precision) RETURNS dummy_tbl
 -- test in tx block
 -- shouldn't distribute, as citus.create_object_propagation is set to deferred
 BEGIN;
+SET LOCAL citus.create_object_propagation TO deferred;
 create aggregate dependent_agg (float8) (stype=dummy_tbl, sfunc=dummy_fnc);
 COMMIT;
 -- verify not distributed

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -48,10 +48,9 @@ CREATE TABLE t3 (a int PRIMARY KEY, b tc2);
 SELECT create_distributed_table('t3','a');
 INSERT INTO t3 VALUES (4, ('5',6)::tc2);
 SELECT * FROM t3;
-
+COMMIT;
 -- verify typmod was propagated
 SELECT run_command_on_workers($$SELECT atttypmod FROM pg_attribute WHERE attnum = 1 AND attrelid = (SELECT typrelid FROM pg_type WHERE typname = 'tc2');$$);
-COMMIT;
 
 -- transaction block with simple type
 BEGIN;

--- a/src/test/regress/sql/function_propagation.sql
+++ b/src/test/regress/sql/function_propagation.sql
@@ -45,6 +45,7 @@ SELECT * FROM run_command_on_workers($$SELECT pg_identify_object_as_address(clas
 
 -- Have a separate check for type created in transaction
 BEGIN;
+    SET LOCAL citus.create_object_propagation TO deferred;
     CREATE TYPE function_prop_type_3 AS (a int, b int);
 COMMIT;
 
@@ -132,7 +133,6 @@ BEGIN;
     END;
     $$;
 
-    -- Within transaction functions are not distributed
     SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid = 'function_propagation_schema.type_in_transaction'::regtype::oid;
     SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid = 'function_propagation_schema.func_in_transaction'::regproc::oid;
 COMMIT;

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -437,6 +437,7 @@ ROLLBACK;
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
     SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
     SET application_name to 'citus_internal gpid=10000000001';
+    SET citus.enable_ddl_propagation TO OFF;
     \set VERBOSITY terse
 
     CREATE TYPE distributed_test_type AS (a int, b int);
@@ -831,6 +832,7 @@ ROLLBACK;
 
 
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    SET citus.enable_ddl_propagation TO OFF;
 	CREATE COLLATION collation_t1 (provider = icu, locale = 'de-u-co-phonebk');
 	CREATE COLLATION caseinsensitive (provider = icu, locale = 'und-u-ks-level2');
 

--- a/src/test/regress/sql/propagate_extension_commands.sql
+++ b/src/test/regress/sql/propagate_extension_commands.sql
@@ -196,6 +196,7 @@ SET search_path TO "extension'test";
 -- enable it and see that create command errors but continues its execution by changing citus.multi_shard_modify_mode TO 'off
 
 BEGIN;
+    SET LOCAL citus.create_object_propagation TO deferred;
 	CREATE TABLE some_random_table (a int);
 	SELECT create_distributed_table('some_random_table', 'a');
 	CREATE EXTENSION seg;
@@ -345,6 +346,7 @@ DROP TABLE test_extension_function;
 -- Test extension function altering distribution argument
 BEGIN;
 SET citus.shard_replication_factor = 1;
+SET citus.multi_shard_modify_mode TO sequential;
 CREATE TABLE test_extension_function(col1 float8[], col2 float8[]);
 SELECT create_distributed_table('test_extension_function', 'col1', colocate_with := 'none');
 CREATE EXTENSION cube;

--- a/src/test/regress/sql/text_search.sql
+++ b/src/test/regress/sql/text_search.sql
@@ -26,13 +26,13 @@ COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config IS 'on demand propaga
 CREATE TABLE t1(id int, name text);
 CREATE INDEX t1_search_name ON t1 USING gin (to_tsvector('text_search.my_text_search_config'::regconfig, (COALESCE(name, ''::character varying))::text));
 SELECT create_distributed_table('t1', 'name');
+-- verify that we can change the object
+COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config  IS 'this comment can be set right now';
+COMMIT;
 SELECT * FROM run_command_on_workers($$
     SELECT obj_description('text_search.my_text_search_config'::regconfig);
 $$) ORDER BY 1,2;
-
--- verify that changing anything on a managed TEXT SEARCH CONFIGURATION fails after parallel execution
-COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config  IS 'this comment can''t be set right now';
-ABORT;
+DROP TABLE t1;
 
 -- create an index on an already distributed table
 BEGIN;
@@ -41,10 +41,11 @@ COMMENT ON TEXT SEARCH CONFIGURATION my_text_search_config2 IS 'on demand propag
 CREATE TABLE t1(id int, name text);
 SELECT create_distributed_table('t1', 'name');
 CREATE INDEX t1_search_name ON t1 USING gin (to_tsvector('text_search.my_text_search_config2'::regconfig, (COALESCE(name, ''::character varying))::text));
+COMMIT;
 SELECT * FROM run_command_on_workers($$
     SELECT obj_description('text_search.my_text_search_config2'::regconfig);
 $$) ORDER BY 1,2;
-ABORT;
+DROP TABLE t1;
 
 -- should be able to create a configuration based on a copy of an existing configuration
 CREATE TEXT SEARCH CONFIGURATION french_noaccent ( COPY = french );


### PR DESCRIPTION
DESCRIPTION: Set create_object_propagation default to immediate

#5724 made the object propagation behaviour in a transaction block configurable, and preserved the current behaviour by using `deferred` as the default. In `deferred` mode, creation of objects on workers is deferred until the object becomes a dependency of a distributed table, and is then done in a subtransaction as superuser.

This has a few downsides:
- Transactions that propagate dependencies at create_distributed_table time and then roll back cause schema inconsistencies between nodes
- It becomes possible to create objects on workers in transaction block (should be fixed generally, but requires a refactor)
- It may be possible to create objects with cyclical dependencies which are not caught by the check in #5761

This PR changes the default to `immediate`, which means objects are immediately propagated even in a transaction block, which mostly addresses the above concerns. 

There are two downsides to this change:
- The transaction immediately switches to sequential mode when creating an object, which might slow down subsequent create_distributed_table with data and other operations
- A transaction block that is already in parallel mode, for instance because create_distributed_table happened earlier in the transaction, will fail if an object is created

We currently consider this to be an acceptable trade-off, but will also look for community feedback.