### PR TITLE
Ensure worker_save_query_explain_analyze always fully qualifies types

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1483,7 +1483,9 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 		}
 
 		Form_pg_attribute attr = &tupleDesc->attrs[columnIndex];
-		char *attrType = format_type_with_typemod(attr->atttypid, attr->atttypmod);
+		char *attrType = format_type_extended(attr->atttypid, attr->atttypmod,
+											  FORMAT_TYPE_TYPEMOD_GIVEN |
+											  FORMAT_TYPE_FORCE_QUALIFY);
 
 		appendStringInfo(columnDef, "field_%d %s", columnIndex, attrType);
 	}

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1485,19 +1485,7 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc)
 		Form_pg_attribute attr = &tupleDesc->attrs[columnIndex];
 		char *attrType = format_type_extended(attr->atttypid, attr->atttypmod,
 											  FORMAT_TYPE_TYPEMOD_GIVEN |
-											  FORMAT_TYPE_INVALID_AS_NULL |
 											  FORMAT_TYPE_FORCE_QUALIFY);
-
-		/*
-		 * Since we passed FORMAT_TYPE_INVALID_AS_NULL flag, format_type_extended
-		 * would return NULL instead of ??? or such when the type OID is invalid
-		 * or unknown. To be on the safe side, throw an error if that is the case.
-		 */
-		if (!attrType)
-		{
-			ereport(ERROR, (errmsg("got unknown format type when preparing "
-								   "task list for EXPLAIN ANALYZE")));
-		}
 
 		appendStringInfo(columnDef, "field_%d %s", columnIndex, attrType);
 	}

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -3048,8 +3048,14 @@ CREATE TABLE tbl (a multi_explain.int_wrapper_type);
 SELECT create_distributed_table('tbl', 'a');
 
 EXPLAIN :default_analyze_flags SELECT * FROM tbl;
-ERROR:  type "int_wrapper_type" does not exist
-CONTEXT:  while executing command on localhost:xxxxx
+Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+  Task Count: 2
+  Tuple data received from nodes: 0 bytes
+  Tasks Shown: One of 2
+  ->  Task
+        Tuple data received from node: 0 bytes
+        Node: host=localhost port=xxxxx dbname=regression
+        ->  Seq Scan on tbl_570036 tbl (actual rows=0 loops=1)
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;
 ERROR:  cache lookup failed for type 17628

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -3043,5 +3043,15 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
   ->  Task
         Node: host=localhost port=xxxxx dbname=regression
         ->  Seq Scan on distributed_table_1_570032 distributed_table_xxx (actual rows=1 loops=1)
+CREATE TYPE multi_explain.int_wrapper_type AS (int_field int);
+CREATE TABLE tbl (a multi_explain.int_wrapper_type);
+SELECT create_distributed_table('tbl', 'a');
+
+EXPLAIN :default_analyze_flags SELECT * FROM tbl;
+ERROR:  type "int_wrapper_type" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;
+ERROR:  cache lookup failed for type 17628
+CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
+PL/pgSQL function citus_drop_trigger() line XX at PERFORM

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -3044,7 +3044,7 @@ Custom Scan (Citus Adaptive) (actual rows=1 loops=1)
         Node: host=localhost port=xxxxx dbname=regression
         ->  Seq Scan on distributed_table_1_570032 distributed_table_xxx (actual rows=1 loops=1)
 CREATE TYPE multi_explain.int_wrapper_type AS (int_field int);
-CREATE TABLE tbl (a multi_explain.int_wrapper_type);
+CREATE TABLE tbl (a int, b multi_explain.int_wrapper_type);
 SELECT create_distributed_table('tbl', 'a');
 
 EXPLAIN :default_analyze_flags SELECT * FROM tbl;
@@ -3058,6 +3058,3 @@ Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
         ->  Seq Scan on tbl_570036 tbl (actual rows=0 loops=1)
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;
-ERROR:  cache lookup failed for type 17628
-CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
-PL/pgSQL function citus_drop_trigger() line XX at PERFORM

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -1084,5 +1084,11 @@ EXPLAIN :default_analyze_flags SELECT FROM (SELECT * FROM reference_table) subqu
 PREPARE dummy_prep_stmt(int) AS SELECT FROM distributed_table_1;
 EXPLAIN :default_analyze_flags EXECUTE dummy_prep_stmt(50);
 
+CREATE TYPE multi_explain.int_wrapper_type AS (int_field int);
+CREATE TABLE tbl (a multi_explain.int_wrapper_type);
+SELECT create_distributed_table('tbl', 'a');
+
+EXPLAIN :default_analyze_flags SELECT * FROM tbl;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -1085,7 +1085,7 @@ PREPARE dummy_prep_stmt(int) AS SELECT FROM distributed_table_1;
 EXPLAIN :default_analyze_flags EXECUTE dummy_prep_stmt(50);
 
 CREATE TYPE multi_explain.int_wrapper_type AS (int_field int);
-CREATE TABLE tbl (a multi_explain.int_wrapper_type);
+CREATE TABLE tbl (a int, b multi_explain.int_wrapper_type);
 SELECT create_distributed_table('tbl', 'a');
 
 EXPLAIN :default_analyze_flags SELECT * FROM tbl;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could cause worker_save_query_explain_analyze to fail on custom types

We've seen cases where EXPLAIN ANALYZE fails when the query returns a type that is on the search_path on the coordinator, but not on the worker, because format_type does not qualify the name in that case.