### PR TITLE
Support CREATE SCHEMA without name

### DIFF
--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -223,7 +223,24 @@ CreateSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CreateSchemaStmt *stmt = castNode(CreateSchemaStmt, node);
 
-	return GetObjectAddressBySchemaName(stmt->schemaname, missing_ok);
+	StringInfoData schemaName = { 0 };
+	initStringInfo(&schemaName);
+
+	if (stmt->schemaname == NULL)
+	{
+		/*
+		 * If the schema name is not provided, the schema will be created
+		 * with the name of the authorizated user.
+		 */
+		Assert(stmt->authrole != NULL);
+		appendStringInfoString(&schemaName, RoleSpecString(stmt->authrole, true));
+	}
+	else
+	{
+		appendStringInfoString(&schemaName, stmt->schemaname);
+	}
+
+	return GetObjectAddressBySchemaName(schemaName.data, missing_ok);
 }
 
 

--- a/src/backend/distributed/deparser/deparse_schema_stmts.c
+++ b/src/backend/distributed/deparser/deparse_schema_stmts.c
@@ -92,11 +92,6 @@ AppendCreateSchemaStmt(StringInfo buf, CreateSchemaStmt *stmt)
 		elog(ERROR, "schema creating is not supported with other create commands");
 	}
 
-	if (stmt->schemaname == NULL)
-	{
-		elog(ERROR, "schema name should be specified");
-	}
-
 	appendStringInfoString(buf, "CREATE SCHEMA ");
 
 	if (stmt->if_not_exists)
@@ -104,7 +99,19 @@ AppendCreateSchemaStmt(StringInfo buf, CreateSchemaStmt *stmt)
 		appendStringInfoString(buf, "IF NOT EXISTS ");
 	}
 
-	appendStringInfo(buf, "%s ", quote_identifier(stmt->schemaname));
+	if (stmt->schemaname != NULL)
+	{
+		appendStringInfo(buf, "%s ", quote_identifier(stmt->schemaname));
+	}
+	else
+	{
+		/*
+		 * If the schema name is not provided, the schema will be created
+		 * with the name of the authorizated user.
+		 */
+		Assert(stmt->authrole != NULL);
+		appendStringInfo(buf, "%s ", RoleSpecString(stmt->authrole, true));
+	}
 
 	if (stmt->authrole != NULL)
 	{

--- a/src/test/regress/expected/multi_mx_schema_support.out
+++ b/src/test/regress/expected/multi_mx_schema_support.out
@@ -538,7 +538,28 @@ SELECT run_command_on_workers($$DROP SCHEMA localschema;$$);
  (localhost,57638,f,"ERROR:  schema ""localschema"" does not exist")
 (2 rows)
 
+CREATE ROLE schema_owner WITH LOGIN;
+NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
+HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+SELECT run_command_on_workers($$CREATE ROLE schema_owner WITH LOGIN;$$);
+      run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
 RESET citus.enable_ddl_propagation;
+-- create schema with the name of the owner
+CREATE SCHEMA AUTHORIZATION schema_owner;
+-- verify the schema is created on workers
+SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_namespace WHERE nspname='schema_owner';$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,1)
+ (localhost,57638,t,1)
+(2 rows)
+
+DROP SCHEMA schema_owner;
 DROP SCHEMA mx_old_schema CASCADE;
 DROP SCHEMA mx_new_schema CASCADE;
 NOTICE:  drop cascades to table mx_new_schema.table_set_schema

--- a/src/test/regress/sql/multi_mx_schema_support.sql
+++ b/src/test/regress/sql/multi_mx_schema_support.sql
@@ -351,7 +351,15 @@ CREATE SCHEMA localschema;
 -- should error out
 SELECT run_command_on_workers($$DROP SCHEMA localschema;$$);
 
+CREATE ROLE schema_owner WITH LOGIN;
+SELECT run_command_on_workers($$CREATE ROLE schema_owner WITH LOGIN;$$);
 RESET citus.enable_ddl_propagation;
+-- create schema with the name of the owner
+CREATE SCHEMA AUTHORIZATION schema_owner;
+-- verify the schema is created on workers
+SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_namespace WHERE nspname='schema_owner';$$);
+
+DROP SCHEMA schema_owner;
 
 DROP SCHEMA mx_old_schema CASCADE;
 DROP SCHEMA mx_new_schema CASCADE;


### PR DESCRIPTION
DESCRIPTION: Supports CREATE SCHEMA AUTHORIZATION statements without schema name

If the schema name is not provided, PG creates the schema with the owner user's name. We used to error out for that cases before this PR.

With this PR, we support CREATE SCHEMA statements without schema name. This PR also adds a small test to verify these statements work and create schemas on the workers.