### PR TITLE
Support GRANT ON SCHEMA commands in CREATE SCHEMA statements

### DIFF
--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -399,6 +399,11 @@ ShouldPropagateCreateSchemaStmt()
 }
 
 
+/*
+ * GetGrantOnSchemaCommandsFromCreateSchemaStmt takes a CreateSchemaStmt and returns the
+ * list of deparsed queries of the inner GRANT ON SCHEMA commands of the given statement.
+ * Ignores commands other than GRANT ON SCHEMA statements.
+ */
 static List *
 GetGrantOnSchemaCommandsFromCreateSchemaStmt(Node *node)
 {
@@ -408,7 +413,7 @@ GetGrantOnSchemaCommandsFromCreateSchemaStmt(Node *node)
 	Node *element = NULL;
 	foreach_ptr(element, stmt->schemaElts)
 	{
-		if (nodeTag(element) != T_GrantStmt)
+		if (!IsA(element, GrantStmt))
 		{
 			continue;
 		}

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -420,6 +420,7 @@ GetGrantOnSchemaCommandsFromCreateSchemaStmt(Node *node)
 
 		GrantStmt *grantStmt = castNode(GrantStmt, element);
 
+		/* we only propagate GRANT ON SCHEMA in community */
 		if (grantStmt->objtype == OBJECT_SCHEMA)
 		{
 			commands = lappend(commands, DeparseGrantOnSchemaStmt(element));

--- a/src/backend/distributed/deparser/deparse_schema_stmts.c
+++ b/src/backend/distributed/deparser/deparse_schema_stmts.c
@@ -87,11 +87,6 @@ DeparseAlterSchemaRenameStmt(Node *node)
 static void
 AppendCreateSchemaStmt(StringInfo buf, CreateSchemaStmt *stmt)
 {
-	if (stmt->schemaElts != NIL)
-	{
-		elog(ERROR, "schema creating is not supported with other create commands");
-	}
-
 	appendStringInfoString(buf, "CREATE SCHEMA ");
 
 	if (stmt->if_not_exists)

--- a/src/test/regress/expected/multi_mx_schema_support.out
+++ b/src/test/regress/expected/multi_mx_schema_support.out
@@ -538,9 +538,9 @@ SELECT run_command_on_workers($$DROP SCHEMA localschema;$$);
  (localhost,57638,f,"ERROR:  schema ""localschema"" does not exist")
 (2 rows)
 
+SET client_min_messages TO ERROR;
 CREATE ROLE schema_owner WITH LOGIN;
-NOTICE:  not propagating CREATE ROLE/USER commands to worker nodes
-HINT:  Connect to worker nodes directly to manually create all necessary users and roles.
+RESET client_min_messages;
 SELECT run_command_on_workers($$CREATE ROLE schema_owner WITH LOGIN;$$);
       run_command_on_workers
 ---------------------------------------------------------------------
@@ -560,6 +560,59 @@ SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_namespace WHERE nspname=
 (2 rows)
 
 DROP SCHEMA schema_owner;
+-- test CREATE SCHEMA .. GRANT ON SCHEMA commands
+-- first create the role to be granted
+SET citus.enable_ddl_propagation TO OFF;
+SET client_min_messages TO ERROR;
+CREATE ROLE role_to_be_granted WITH LOGIN;
+RESET client_min_messages;
+SELECT run_command_on_workers($$CREATE ROLE role_to_be_granted WITH LOGIN;$$);
+      run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"CREATE ROLE")
+ (localhost,57638,t,"CREATE ROLE")
+(2 rows)
+
+RESET citus.enable_ddl_propagation;
+CREATE SCHEMA old_schema;
+CREATE SCHEMA new_schema
+    CREATE TABLE t1 (a int)
+    GRANT ALL ON SCHEMA old_schema TO role_to_be_granted
+    GRANT ALL ON SCHEMA new_schema TO role_to_be_granted;
+-- the role should be granted on both the new and the old schema
+SELECT nspacl FROM pg_namespace WHERE nspname='old_schema' OR nspname='new_schema';
+                        nspacl
+---------------------------------------------------------------------
+ {postgres=UC/postgres,role_to_be_granted=UC/postgres}
+ {postgres=UC/postgres,role_to_be_granted=UC/postgres}
+(2 rows)
+
+-- verify on workers
+SELECT run_command_on_workers($$SELECT nspacl FROM pg_namespace WHERE nspname='new_schema';$$);
+                           run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"{postgres=UC/postgres,role_to_be_granted=UC/postgres}")
+ (localhost,57638,t,"{postgres=UC/postgres,role_to_be_granted=UC/postgres}")
+(2 rows)
+
+SELECT run_command_on_workers($$SELECT nspacl FROM pg_namespace WHERE nspname='old_schema';$$);
+                           run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,"{postgres=UC/postgres,role_to_be_granted=UC/postgres}")
+ (localhost,57638,t,"{postgres=UC/postgres,role_to_be_granted=UC/postgres}")
+(2 rows)
+
+-- verify the table t1 is created as a local pg table
+-- this might be changed after some improvements on use_citus_managed_tables
+-- if so, please verify that t1 is added to metadata
+SELECT COUNT(*)=0 FROM pg_dist_partition WHERE logicalrelid='new_schema.t1'::regclass;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SCHEMA old_schema, new_schema CASCADE;
+NOTICE:  drop cascades to table new_schema.t1
 DROP SCHEMA mx_old_schema CASCADE;
 DROP SCHEMA mx_new_schema CASCADE;
 NOTICE:  drop cascades to table mx_new_schema.table_set_schema


### PR DESCRIPTION
DESCRIPTION: Propagates CREATE SCHEMA .. GRANT ON SCHEMA .. commands

This PR adds support for only GRANT ON SCHEMA commands given in a CREATE SCHEMA statement. We currently don't support others (CREATE commands with CREATE SCHEMA command)

For now, during the preprocess of CREATE SCHEMA statements, we capture the inner GRANT ON SCHEMA commands and propagate them as well, after propagating the main CREATE SCHEMA command.