### PR TITLE
Fix a misleading error message related with fkeys between replicated dist tables

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -410,9 +410,8 @@ EnsureReferencingTableNotReplicated(Oid referencingTableId)
 	{
 		ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("cannot create foreign key constraint"),
-						errdetail("Citus Community Edition currently supports "
-								  "foreign key constraints only for "
-								  "\"citus.shard_replication_factor = 1\"."),
+						errdetail("Citus currently supports foreign key constraints "
+								  "only for \"citus.shard_replication_factor = 1\"."),
 						errhint("Please change \"citus.shard_replication_factor to "
 								"1\". To learn more about using foreign keys with "
 								"other replication factors, please contact us at "


### PR DESCRIPTION
This is not supported in enterprise too.

