### PR TITLE
Propagate text search commands to all worker nodes

### DIFF
--- a/src/backend/distributed/commands/text_search.c
+++ b/src/backend/distributed/commands/text_search.c
@@ -264,7 +264,7 @@ PreprocessDropTextSearchConfigurationStmt(Node *node, const char *queryString,
 								(void *) dropStmtSql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -315,7 +315,7 @@ PreprocessDropTextSearchDictionaryStmt(Node *node, const char *queryString,
 								(void *) dropStmtSql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -406,7 +406,7 @@ PreprocessAlterTextSearchConfigurationStmt(Node *node, const char *queryString,
 								(void *) alterStmtSql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -437,7 +437,7 @@ PreprocessAlterTextSearchDictionaryStmt(Node *node, const char *queryString,
 								(void *) alterStmtSql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -470,7 +470,7 @@ PreprocessRenameTextSearchConfigurationStmt(Node *node, const char *queryString,
 								(void *) ddlCommand,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -503,7 +503,7 @@ PreprocessRenameTextSearchDictionaryStmt(Node *node, const char *queryString,
 								(void *) ddlCommand,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -537,7 +537,7 @@ PreprocessAlterTextSearchConfigurationSchemaStmt(Node *node, const char *querySt
 								(void *) sql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -571,7 +571,7 @@ PreprocessAlterTextSearchDictionarySchemaStmt(Node *node, const char *queryStrin
 								(void *) sql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -658,7 +658,7 @@ PreprocessTextSearchConfigurationCommentStmt(Node *node, const char *queryString
 								(void *) sql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 
@@ -691,7 +691,7 @@ PreprocessTextSearchDictionaryCommentStmt(Node *node, const char *queryString,
 								(void *) sql,
 								ENABLE_DDL_PROPAGATION);
 
-	return NodeDDLTaskList(NON_COORDINATOR_METADATA_NODES, commands);
+	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
 }
 
 


### PR DESCRIPTION
Here is a list of some functions, and the `TargetWorkerSet` parameters they supply to `NodeDDLTaskList`:

<table>
<tr>
	<td> PostprocessCreateTextSearchConfigurationStmt
	<td> NON_COORDINATOR_NODES
<tr>
	<td> PreprocessDropTextSearchConfigurationStmt
	<td> NON_COORDINATOR_METADATA_NODES
<tr>
	<td> PreprocessAlterTextSearchConfigurationSchemaStmt
	<td> NON_COORDINATOR_METADATA_NODES
</table>

I guess this means that, if metadata syncing is disabled on the node, we may have some issues. Consider the following:

Let's assume the user has metadata syncing disabled. 2 workers.

`CREATE TEXT SEARCH CONFIGURATION ...` will get propagated to all workers.
`ALTER ... CONFIGURATION ...` will not get propagated to workers.

After adding a new non-metadata node, the new node will get the altered configuration as it reads from catalog. At this point CONFIGURATION definitions got diverged in the cluster.

I suggest that we always use `NON_COORDINATOR_METADATA_NODES` in all the TEXT SEARCH operations here.