### PR TITLE
Always use RowShareLock in pg_dist_node when syncing metadata

### DIFF
--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -72,7 +72,7 @@ void
 SendCommandToWorkersAsUser(TargetWorkerSet targetWorkerSet, const char *nodeUser,
 						   const char *command)
 {
-	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, ShareLock);
+	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, RowShareLock);
 
 	/* run commands serially */
 	WorkerNode *workerNode = NULL;
@@ -185,7 +185,7 @@ void
 SendBareCommandListToMetadataWorkers(List *commandList)
 {
 	TargetWorkerSet targetWorkerSet = NON_COORDINATOR_METADATA_NODES;
-	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, ShareLock);
+	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, RowShareLock);
 	char *nodeUser = CurrentUserName();
 
 	ErrorIfAnyMetadataNodeOutOfSync(workerNodeList);
@@ -226,7 +226,7 @@ SendCommandToMetadataWorkersParams(const char *command,
 								   const char *const *parameterValues)
 {
 	List *workerNodeList = TargetWorkerSetNodeList(NON_COORDINATOR_METADATA_NODES,
-												   ShareLock);
+												   RowShareLock);
 
 	ErrorIfAnyMetadataNodeOutOfSync(workerNodeList);
 
@@ -305,7 +305,7 @@ OpenConnectionsToWorkersInParallel(TargetWorkerSet targetWorkerSet, const char *
 {
 	List *connectionList = NIL;
 
-	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, ShareLock);
+	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, RowShareLock);
 
 	WorkerNode *workerNode = NULL;
 	foreach_ptr(workerNode, workerNodeList)
@@ -374,7 +374,7 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 								   const char *const *parameterValues)
 {
 	List *connectionList = NIL;
-	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, ShareLock);
+	List *workerNodeList = TargetWorkerSetNodeList(targetWorkerSet, RowShareLock);
 
 	UseCoordinatedTransaction();
 	Use2PCForCoordinatedTransaction();

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -1819,7 +1819,13 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-UPDATE pg_dist_node SET metadatasynced=true WHERE nodeport=:worker_1_port;
+-- make sure that all the nodes have valid metadata before moving forward
+SELECT wait_until_metadata_sync(60000);
+ wait_until_metadata_sync
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT master_add_node('localhost', :worker_2_port);
  master_add_node
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -779,7 +779,8 @@ ALTER SYSTEM SET citus.metadata_sync_interval TO DEFAULT;
 ALTER SYSTEM SET citus.metadata_sync_retry_interval TO DEFAULT;
 SELECT pg_reload_conf();
 
-UPDATE pg_dist_node SET metadatasynced=true WHERE nodeport=:worker_1_port;
+-- make sure that all the nodes have valid metadata before moving forward
+SELECT wait_until_metadata_sync(60000);
 
 SELECT master_add_node('localhost', :worker_2_port);
 


### PR DESCRIPTION
We inadvertently used ShareLock for some of our metadata syncing operations, when we should be using RowShareLock to only conflict with citus_*_node(..), which use ExclusiveLock.