### PR TITLE
Use good initdb options in arbitrary configs tests

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -45,6 +45,12 @@ def initialize_db_for_cluster(pg_path, rel_data_path, settings, node_names):
             abs_data_path,
             "--username",
             USER,
+            "--no-sync",
+            # --allow-group-access is used to ensure we set permissions on
+            # private keys correctly
+            "--allow-group-access",
+            "--encoding",
+            "UTF8"
         ]
         subprocess.run(command, check=True)
         add_settings(abs_data_path, settings)

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -669,14 +669,14 @@ if (!$conninfo)
     # Create new data directories, copy workers for speed
     # --allow-group-access is used to ensure we set permissions on private keys
     # correctly
-    system(catfile("$bindir", "initdb"), ("--nosync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
+    system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
         or die "Could not create $MASTERDIR data directory";
 
     if ($usingWindows)
     {
         for my $port (@workerPorts)
         {
-            system(catfile("$bindir", "initdb"), ("--nosync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", catfile($TMP_CHECKDIR, "worker.$port", "data"))) == 0
+            system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", catfile($TMP_CHECKDIR, "worker.$port", "data"))) == 0
                 or die "Could not create worker data directory";
         }
     }


### PR DESCRIPTION
In `pg_regress_multi.pl` we're running `initdb` with some options that
the `common.py` `initdb` is currently not using. All these flags seem
reasonable, so this brings `common.py` in line with
`pg_regress_multi.pl`.

In passing change the `--nosync` flag to `--no-sync`, since that's what
the PG documentation lists as the official option name (but both work).