### PR TITLE
Drop distributed table on worker with ProcessUtilityParseTree

### DIFF
--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -1189,6 +1189,17 @@ DROP TABLE dummy_tbl CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function dummy_fnc(dummy_tbl,double precision)
 drop cascades to function dependent_agg(double precision)
+-- Show that after dropping a table on which functions and aggregates depending on
+-- pg_dist_object is consistent on coordinator and worker node.
+SELECT pg_identify_object_as_address(classid, objid, objsubid)::text
+FROM pg_catalog.pg_dist_object
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT array_agg(pg_identify_object_as_address(classid, objid, objsubid)) from pg_catalog.pg_dist_object$$);
+ pg_identify_object_as_address
+---------------------------------------------------------------------
+(0 rows)
+
 SET citus.create_object_propagation TO automatic;
 begin;
     create type typ1 as (a int);

--- a/src/test/regress/expected/check_mx.out
+++ b/src/test/regress/expected/check_mx.out
@@ -10,3 +10,13 @@ SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
  t
 (1 row)
 
+-- Show that pg_dist_object entities are same on all nodes
+SELECT pg_identify_object_as_address(classid, objid, objsubid)::text
+FROM pg_catalog.pg_dist_object
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT array_agg(pg_identify_object_as_address(classid, objid, objsubid)) from pg_catalog.pg_dist_object$$);
+ pg_identify_object_as_address
+---------------------------------------------------------------------
+(0 rows)
+

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -603,6 +603,14 @@ SELECT run_command_on_workers($$select aggfnoid from pg_aggregate where aggfnoid
 
 DROP TABLE dummy_tbl CASCADE;
 
+-- Show that after dropping a table on which functions and aggregates depending on
+-- pg_dist_object is consistent on coordinator and worker node.
+SELECT pg_identify_object_as_address(classid, objid, objsubid)::text
+FROM pg_catalog.pg_dist_object
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT array_agg(pg_identify_object_as_address(classid, objid, objsubid)) from pg_catalog.pg_dist_object$$);
+
 SET citus.create_object_propagation TO automatic;
 begin;
     create type typ1 as (a int);

--- a/src/test/regress/sql/check_mx.sql
+++ b/src/test/regress/sql/check_mx.sql
@@ -1,3 +1,10 @@
 SHOW citus.enable_metadata_sync;
 
 SELECT bool_and(metadatasynced) FROM pg_dist_node WHERE noderole = 'primary';
+
+-- Show that pg_dist_object entities are same on all nodes
+SELECT pg_identify_object_as_address(classid, objid, objsubid)::text
+FROM pg_catalog.pg_dist_object
+    EXCEPT
+SELECT unnest(result::text[]) AS unnested_result
+FROM run_command_on_workers($$SELECT array_agg(pg_identify_object_as_address(classid, objid, objsubid)) from pg_catalog.pg_dist_object$$);


### PR DESCRIPTION
Drop distributed table on worker with ProcessUtilityParseTree to make sure that drop event trigger will be fired. Citus uses drop event trigger to unmark distributed objects. Remaining logic of drop event trigger will be no-op since we remove metadata of objects which will be dropped first before calling ProcessUtilityParseTree
