### PR TITLE
Fix worker node version check in the Citus 11 upgrade function

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
@@ -117,10 +117,9 @@ END;
 
          -- first, check if all nodes have the same versions
           SELECT
-            count(*) INTO worker_node_version_count
+            count(distinct result) INTO worker_node_version_count
           FROM
-            run_command_on_workers('SELECT extversion from pg_extension WHERE extname = ''citus'';')
-          GROUP BY result;
+            run_command_on_workers('SELECT extversion from pg_extension WHERE extname = ''citus''');
           IF enforce_version_check AND worker_node_version_count != 1 THEN
                     RAISE EXCEPTION 'All nodes should have the same Citus version installed. Currently '
                                      'some of the workers have different versions.';

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
@@ -123,7 +123,7 @@ END;
           GROUP BY result;
           IF enforce_version_check AND worker_node_version_count != 1 THEN
                     RAISE EXCEPTION 'All nodes should have the same Citus version installed. Currently '
-                                     'the some of the workers has version different versions';
+                                     'some of the workers have different versions.';
           ELSE
                     RAISE DEBUG 'All worker nodes have the same Citus version';
           END IF;

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
@@ -117,10 +117,9 @@ END;
 
          -- first, check if all nodes have the same versions
           SELECT
-            count(*) INTO worker_node_version_count
+            count(distinct result) INTO worker_node_version_count
           FROM
-            run_command_on_workers('SELECT extversion from pg_extension WHERE extname = ''citus'';')
-          GROUP BY result;
+            run_command_on_workers('SELECT extversion from pg_extension WHERE extname = ''citus''');
           IF enforce_version_check AND worker_node_version_count != 1 THEN
                     RAISE EXCEPTION 'All nodes should have the same Citus version installed. Currently '
                                      'some of the workers have different versions.';

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
@@ -123,7 +123,7 @@ END;
           GROUP BY result;
           IF enforce_version_check AND worker_node_version_count != 1 THEN
                     RAISE EXCEPTION 'All nodes should have the same Citus version installed. Currently '
-                                     'the some of the workers has version different versions';
+                                     'some of the workers have different versions.';
           ELSE
                     RAISE DEBUG 'All worker nodes have the same Citus version';
           END IF;


### PR DESCRIPTION
The query did not give the expected result and error message was weird.