### PR TITLE
Avoid locks in relation_is_a_known_shard

### DIFF
--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -202,12 +202,15 @@ RelationIsAKnownShard(Oid shardRelationId)
 		}
 	}
 
-	Relation relation = try_relation_open(shardRelationId, AccessShareLock);
-	if (relation == NULL)
+	/*
+	 * We do not take locks here, because that might block a query on pg_class.
+	 */
+
+	if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(shardRelationId)))
 	{
+		/* relation does not exist */
 		return false;
 	}
-	relation_close(relation, NoLock);
 
 	/*
 	 * If the input relation is an index we simply replace the

--- a/src/test/regress/expected/multi_mx_hide_shard_names.out
+++ b/src/test/regress/expected/multi_mx_hide_shard_names.out
@@ -71,6 +71,10 @@ SELECT * FROM citus_shard_indexes_on_worker WHERE "Schema" = 'mx_hide_shard_name
 ---------------------------------------------------------------------
 (0 rows)
 
+-- make sure that pg_class queries do not get blocked on table locks
+begin;
+lock table test_table in access exclusive mode;
+prepare transaction 'take-aggressive-lock';
 -- shards are hidden when using psql as application_name
 SELECT relname FROM pg_catalog.pg_class WHERE relnamespace = 'mx_hide_shard_names'::regnamespace ORDER BY relname;
   relname
@@ -78,6 +82,7 @@ SELECT relname FROM pg_catalog.pg_class WHERE relnamespace = 'mx_hide_shard_name
  test_table
 (1 row)
 
+commit prepared 'take-aggressive-lock';
 -- now create an index
 \c - - - :master_port
 SET search_path TO 'mx_hide_shard_names';

--- a/src/test/regress/sql/multi_mx_hide_shard_names.sql
+++ b/src/test/regress/sql/multi_mx_hide_shard_names.sql
@@ -41,8 +41,15 @@ SET search_path TO 'mx_hide_shard_names';
 SELECT * FROM citus_shards_on_worker WHERE "Schema" = 'mx_hide_shard_names' ORDER BY 2;
 SELECT * FROM citus_shard_indexes_on_worker WHERE "Schema" = 'mx_hide_shard_names' ORDER BY 2;
 
+-- make sure that pg_class queries do not get blocked on table locks
+begin;
+lock table test_table in access exclusive mode;
+prepare transaction 'take-aggressive-lock';
+
 -- shards are hidden when using psql as application_name
 SELECT relname FROM pg_catalog.pg_class WHERE relnamespace = 'mx_hide_shard_names'::regnamespace ORDER BY relname;
+
+commit prepared 'take-aggressive-lock';
 
 -- now create an index
 \c - - - :master_port


### PR DESCRIPTION
Fixes #5826

relation_is_a_known_shard is injected into pg_class queries and should therefore not take any locks, otherwise it might get stuck indefinitely waiting for AccessExclusive locks. 