### PR TITLE
Disallow re-partition joins when no hash function defined

### DIFF
--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -16,6 +16,7 @@
 #include "miscadmin.h"
 #include "port.h"
 
+#include "access/hash.h"
 #include "access/nbtree.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_type.h"
@@ -349,6 +350,12 @@ QueryTupleShardSearchInfo(ArrayType *minValuesArray, ArrayType *maxValuesArray,
 
 		hashFunction = palloc0(sizeof(FmgrInfo));
 		fmgr_info_copy(hashFunction, &(typeEntry->hash_proc_finfo), CurrentMemoryContext);
+
+		if (!OidIsValid(hashFunction->fn_oid))
+		{
+			ereport(ERROR, (errmsg("no hash function defined for type %s",
+								   format_type_be(partitionColumn->vartype))));
+		}
 	}
 
 	ShardInterval **shardIntervalArray = palloc0(partitionCount *

--- a/src/test/regress/expected/sqlancer_failures.out
+++ b/src/test/regress/expected/sqlancer_failures.out
@@ -194,6 +194,26 @@ ERROR:  cannot pushdown the subquery
 DETAIL:  Complex subqueries, CTEs and local tables cannot be in the outer part of an outer join with a distributed table
 -- drop existing sqlancer tables before next tests
 DROP TABLE t0, t1, t2, t3, t4 CASCADE;
+CREATE TABLE tbl1(a REAL, b FLOAT, c money);
+CREATE TABLE tbl2(a REAL, b FLOAT, c money);
+SELECT create_distributed_table('tbl1', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('tbl2', 'b');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO tbl1 VALUES(1, 1, 1);
+SET citus.enable_repartition_joins to ON;
+SELECT * FROM tbl1, tbl2 WHERE tbl2.c=tbl1.c;
+ERROR:  no hash function defined for type money
+CONTEXT:  while executing command on localhost:xxxxx
+DROP TABLE tbl1, tbl2 CASCADE;
 CREATE TABLE IF NOT EXISTS t0(c0 TEXT CHECK (TRUE), c1 money ) WITH (autovacuum_vacuum_threshold=1180014707, autovacuum_freeze_table_age=13771154, autovacuum_vacuum_cost_delay=23, autovacuum_analyze_threshold=1935153914, autovacuum_freeze_min_age=721733768, autovacuum_enabled=0, autovacuum_vacuum_cost_limit=9983);
 CREATE UNLOGGED TABLE IF NOT EXISTS t1(LIKE t0);
 CREATE TABLE t2(LIKE t0 INCLUDING INDEXES);

--- a/src/test/regress/sql/sqlancer_failures.sql
+++ b/src/test/regress/sql/sqlancer_failures.sql
@@ -91,6 +91,20 @@ RIGHT JOIN (SELECT * FROM reference_table OFFSET 0) c ON (c.id > 0);
 -- drop existing sqlancer tables before next tests
 DROP TABLE t0, t1, t2, t3, t4 CASCADE;
 
+CREATE TABLE tbl1(a REAL, b FLOAT, c money);
+CREATE TABLE tbl2(a REAL, b FLOAT, c money);
+
+SELECT create_distributed_table('tbl1', 'a');
+SELECT create_distributed_table('tbl2', 'b');
+
+INSERT INTO tbl1 VALUES(1, 1, 1);
+
+SET citus.enable_repartition_joins to ON;
+
+SELECT * FROM tbl1, tbl2 WHERE tbl2.c=tbl1.c;
+
+DROP TABLE tbl1, tbl2 CASCADE;
+
 CREATE TABLE IF NOT EXISTS t0(c0 TEXT CHECK (TRUE), c1 money ) WITH (autovacuum_vacuum_threshold=1180014707, autovacuum_freeze_table_age=13771154, autovacuum_vacuum_cost_delay=23, autovacuum_analyze_threshold=1935153914, autovacuum_freeze_min_age=721733768, autovacuum_enabled=0, autovacuum_vacuum_cost_limit=9983);
 CREATE UNLOGGED TABLE IF NOT EXISTS t1(LIKE t0);
 CREATE TABLE t2(LIKE t0 INCLUDING INDEXES);


### PR DESCRIPTION
Fixes #5813

We currently crash when doing a re-partition join on a type that does not have a hash function defined for a type. This PR changes it to an error.