### PR TITLE
Remove citus.enable_cte_inlining GUC

### DIFF
--- a/src/backend/distributed/planner/cte_inline.c
+++ b/src/backend/distributed/planner/cte_inline.c
@@ -45,9 +45,6 @@ static void InlineCTEsInQueryTree(Query *query);
 static bool QueryTreeContainsInlinableCteWalker(Node *node);
 
 
-/* controlled via GUC */
-bool EnableCTEInlining = true;
-
 /*
  * RecursivelyInlineCtesInQueryTree gets a query and recursively traverses the
  * tree from top to bottom. On each level, the CTEs that are eligable for

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -752,19 +752,6 @@ static PlannedStmt *
 InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
 										  DistributedPlanningContext *planContext)
 {
-	if (!EnableCTEInlining)
-	{
-		/*
-		 * In Postgres 12+, users can adjust whether to inline/not inline CTEs
-		 * by [NOT] MATERIALIZED keywords. However, in PG 11, that's not possible.
-		 * So, with this we provide a way to prevent CTE inlining on Postgres 11.
-		 *
-		 * The main use-case for this is not to have divergent test outputs between
-		 * PG 11 vs PG 12, so not very much intended for users.
-		 */
-		return NULL;
-	}
-
 	/*
 	 * We'll inline the CTEs and try distributed planning, preserve the original
 	 * query in case the planning fails and we fallback to recursive planning of

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -828,25 +828,6 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
-	/*
-	 * We shouldn't need this variable after we drop support to PostgreSQL 11 and
-	 * below. So, noting it here with PG_VERSION_NUM < PG_VERSION_12
-	 */
-	DefineCustomBoolVariable(
-		"citus.enable_cte_inlining",
-		gettext_noop("When set to false, CTE inlining feature is disabled."),
-		gettext_noop(
-			"This feature is not intended for users and it is deprecated. It is developed "
-			"to get consistent regression test outputs between Postgres 11"
-			"and Postgres 12. In Postgres 12+, the user can control the behaviour"
-			"by [NOT] MATERIALIZED keyword on CTEs. However, in PG 11, we cannot do "
-			"that."),
-		&EnableCTEInlining,
-		true,
-		PGC_SUSET,
-		GUC_NO_SHOW_ALL,
-		NULL, NULL, NULL);
-
 	DefineCustomBoolVariable(
 		"citus.enable_ddl_propagation",
 		gettext_noop("Enables propagating DDL statements to worker shards"),

--- a/src/include/distributed/cte_inline.h
+++ b/src/include/distributed/cte_inline.h
@@ -13,8 +13,6 @@
 
 #include "nodes/parsenodes.h"
 
-extern bool EnableCTEInlining;
-
 extern void RecursivelyInlineCtesInQueryTree(Query *query);
 extern bool QueryTreeContainsInlinableCTE(Query *queryTree);
 


### PR DESCRIPTION
DESCRIPTION: Drop GUC citus.enable_cte_inlining 

In Postgres 12+, users can adjust whether to inline/not inline CTEs
by [NOT] MATERIALIZED keywords. So, this GUC is already useless.

We already noted this as deprecated for several versions already

Tests already adjusted in https://github.com/citusdata/citus/pull/4799/files#diff-fb5ab5918b842d47b1af6534dd8a449676f9fb459f6e20687ef57697d375f849L175
