### PR TITLE
Fix aggregate signature bug

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1454,7 +1454,16 @@ DefineAggregateStmtObjectAddress(Node *node, bool missing_ok)
 	}
 	else
 	{
-		objectWithArgs->objargs = list_make1(makeTypeName("anyelement"));
+		DefElem *defItem = NULL;
+		foreach_ptr(defItem, stmt->definition)
+		{
+			/* if no explicit args are given, pg includes basetype in the signature */
+			if (strcmp(defItem->defname, "basetype") == 0 && IsA(defItem->arg, TypeName))
+			{
+				objectWithArgs->objargs = lappend(objectWithArgs->objargs,
+												  defItem->arg);
+			}
+		}
 	}
 
 	return FunctionToObjectAddress(OBJECT_AGGREGATE, objectWithArgs, missing_ok);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1457,7 +1457,12 @@ DefineAggregateStmtObjectAddress(Node *node, bool missing_ok)
 		DefElem *defItem = NULL;
 		foreach_ptr(defItem, stmt->definition)
 		{
-			/* if no explicit args are given, pg includes basetype in the signature */
+			/*
+			 * If no explicit args are given, pg includes basetype in the signature.
+			 * If the basetype given is a type, like int4, we should include it in the
+			 * signature. In that case, defItem->arg would be a TypeName.
+			 * If the basetype given is a string, like "ANY", we shouldn't include it.
+			 */
 			if (strcmp(defItem->defname, "basetype") == 0 && IsA(defItem->arg, TypeName))
 			{
 				objectWithArgs->objargs = lappend(objectWithArgs->objargs,

--- a/src/test/regress/expected/aggregate_support.out
+++ b/src/test/regress/expected/aggregate_support.out
@@ -1236,5 +1236,17 @@ SELECT run_command_on_workers($$select aggfnoid from pg_aggregate where aggfnoid
  (localhost,57638,t,aggregate_support.dependent_agg)
 (2 rows)
 
+CREATE AGGREGATE newavg (
+   sfunc = int4_avg_accum, basetype = int4, stype = _int8,
+   finalfunc = int8_avg,
+   initcond1 = '{0,0}'
+);
+SELECT run_command_on_workers($$select aggfnoid from pg_aggregate where aggfnoid::text like '%newavg%';$$);
+               run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,aggregate_support.newavg)
+ (localhost,57638,t,aggregate_support.newavg)
+(2 rows)
+
 set client_min_messages to error;
 drop schema aggregate_support cascade;

--- a/src/test/regress/sql/aggregate_support.sql
+++ b/src/test/regress/sql/aggregate_support.sql
@@ -638,5 +638,13 @@ RESET citus.create_object_propagation;
 
 SELECT run_command_on_workers($$select aggfnoid from pg_aggregate where aggfnoid::text like '%dependent_agg%';$$);
 
+CREATE AGGREGATE newavg (
+   sfunc = int4_avg_accum, basetype = int4, stype = _int8,
+   finalfunc = int8_avg,
+   initcond1 = '{0,0}'
+);
+
+SELECT run_command_on_workers($$select aggfnoid from pg_aggregate where aggfnoid::text like '%newavg%';$$);
+
 set client_min_messages to error;
 drop schema aggregate_support cascade;


### PR DESCRIPTION
When no explicit args are given, pg includes basetype in the signature. If the basetype given is a type, like int4, we should include it in the signature. In that case, the input argument would be a TypeName. If the basetype given is a string, like "ANY", we shouldn't include it.