### PR TITLE
Fix description of citus.distributed_deadlock_detection_factor

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -913,8 +913,8 @@ RegisterCitusConfigVariables(void)
 		"citus.distributed_deadlock_detection_factor",
 		gettext_noop("Sets the time to wait before checking for distributed "
 					 "deadlocks. Postgres' deadlock_timeout setting is "
-					 "multiplied with the value. If the value is set to"
-					 "1000, distributed deadlock detection is disabled."),
+					 "multiplied with the value. If the value is set to -1, "
+					 "distributed deadlock detection is disabled."),
 		NULL,
 		&DistributedDeadlockDetectionTimeoutFactor,
 		2.0, -1.0, 1000.0,


### PR DESCRIPTION
DESCRIPTION: Fix description of citus.distributed_deadlock_detection_factor

The long description of the `citus.distributed_deadlock_detection_factor` 
setting was incorrectly stating that 1000 would disable it. Instead -1 
is the value that disables distributed deadlock detection.