### PR TITLE
Better test failure debugging for arbitrary-configs

### DIFF
--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -104,6 +104,7 @@ class CitusBaseClusterConfig(object, metaclass=NewInitCaller):
             "citus.node_conninfo": "sslmode=prefer",
             "citus.enable_repartition_joins": True,
             "citus.repartition_join_bucket_count_per_node": 2,
+            "citus.log_distributed_deadlock_detection": True,
             "max_connections": 600,
         }
         self.new_settings = {}

--- a/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
@@ -74,11 +74,11 @@ def report_initial_version(config):
 
 
 def get_version_number(version):
-    return re.findall("\d+.\d+", version)[0]
+    return re.findall(r"\d+.\d+", version)[0]
 
 
 def get_actual_citus_version(pg_path, port):
-    citus_version = utils.psql(pg_path, port, CITUS_VERSION_SQL)
+    citus_version = utils.psql_capture(pg_path, port, CITUS_VERSION_SQL)
     citus_version = citus_version.decode("utf-8")
     return get_version_number(citus_version)
 

--- a/src/test/regress/citus_tests/utils.py
+++ b/src/test/regress/citus_tests/utils.py
@@ -6,8 +6,38 @@ USER = "postgres"
 
 
 def psql(pg_path, port, command):
+    return subprocess.run(
+        [
+            os.path.join(pg_path, "psql"),
+            "-U",
+            USER,
+            "-p",
+            str(port),
+            "-c",
+            command,
+            "-P",
+            "pager=off",
+            "--no-psqlrc",
+        ],
+        check=True,
+    )
+
+
+def psql_capture(pg_path, port, command):
     return subprocess.check_output(
-        [os.path.join(pg_path, "psql"), "-U", USER, "-p", str(port), "-c", command],
+        [
+            os.path.join(pg_path, "psql"),
+            "-U",
+            USER,
+            "-p",
+            str(port),
+            "-c",
+            command,
+            "-P",
+            "pager=off",
+            "--no-psqlrc",
+            "--tuples-only",
+        ],
     )
 
 


### PR DESCRIPTION
This improves debugging of arbitrary configs in two ways:
1. Enable logging of distributed deadlock detection
2. Show output of `psql` commands