### PR TITLE
Fix typo in error message for truncating foreign tables

### DIFF
--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -277,7 +277,7 @@ ErrorIfUnsupportedTruncateStmt(TruncateStmt *truncateStatement)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("truncating foreign tables that are added to metadata "
-								   "can only be excuted on the coordinator")));
+								   "can only be executed on the coordinator")));
 		}
 	}
 }

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -1330,7 +1330,7 @@ SELECT count(*) FROM pg14.foreign_table;
 
 -- should error out
 TRUNCATE foreign_table;
-ERROR:  truncating foreign tables that are added to metadata can only be excuted on the coordinator
+ERROR:  truncating foreign tables that are added to metadata can only be executed on the coordinator
 \c - - - :master_port
 -- cleanup
 set client_min_messages to error;


### PR DESCRIPTION
Nothing special. Just a fix for an error message typo.