### PR TITLE
Use consistent naming for tap test workflows in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,7 +593,7 @@ workflows:
           make: check-columnar-isolation
           requires: [build-13]
       - tap-test-citus:
-          name: 'test_13_tap-recovery'
+          name: 'test-13_tap-recovery'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           suite: recovery
@@ -661,7 +661,7 @@ workflows:
           make: check-columnar-isolation
           requires: [build-14]
       - tap-test-citus:
-          name: 'test_14_tap-recovery'
+          name: 'test-14_tap-recovery'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           suite: recovery


### PR DESCRIPTION
All the job names in our CI config are of the form `test-1[34]_.*` except for tap-recovery tests.

I was going over the branch protection rules, when I realized that we do not yet require all status checks to pass before merging a PR. We also have an inconsistent naming scheme for tap tests.

TODO:
- [x] Go over all the tests, and mark them as required with some exceptions
	- [x] Leave `check-merge-to-enterprise` as optional as we allow that to fail from time to time.
	- [x] Make `test_14_tap-recovery` and `test_13_tap-recovery` optional now, as they won't use that name anymore.
- [ ] Make the newly renamed `test-14_tap-recovery` and `test-13_tap-recovery` required only after this PR is merged. If I make it required now, I will block all other PRs and create confusion.