### PR TITLE
Fix EXPLAIN ANALYZE JSON format for subplans

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -316,6 +316,8 @@ ExplainSubPlans(DistributedPlan *distributedPlan, ExplainState *es)
 			es->indent += 3;
 		}
 
+		ExplainOpenGroup("Subplan", NULL, true, es);
+
 		if (es->analyze)
 		{
 			if (es->timing)
@@ -358,8 +360,13 @@ ExplainSubPlans(DistributedPlan *distributedPlan, ExplainState *es)
 		}
 		#endif
 
+		ExplainOpenGroup("PlannedStmt", "PlannedStmt", false, es);
+
 		ExplainOnePlanCompat(plan, into, es, queryString, params, NULL, &planduration,
 							 (es->buffers ? &bufusage : NULL));
+
+		ExplainCloseGroup("PlannedStmt", "PlannedStmt", false, es);
+		ExplainCloseGroup("Subplan", NULL, true, es);
 
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 		{

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -18,6 +18,16 @@ BEGIN
   RETURN result;
 END;
 $BODY$ LANGUAGE plpgsql;
+CREATE FUNCTION explain_analyze_json(query text)
+RETURNS jsonb
+AS $BODY$
+DECLARE
+  result jsonb;
+BEGIN
+  EXECUTE format('EXPLAIN (ANALYZE TRUE, FORMAT JSON) %s', query) INTO result;
+  RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
 -- Function that parses explain output as XML
 CREATE FUNCTION explain_xml(query text)
 RETURNS xml
@@ -26,6 +36,17 @@ DECLARE
   result xml;
 BEGIN
   EXECUTE format('EXPLAIN (FORMAT XML) %s', query) INTO result;
+  RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
+-- Function that parses explain output as XML
+CREATE FUNCTION explain_analyze_xml(query text)
+RETURNS xml
+AS $BODY$
+DECLARE
+  result xml;
+BEGIN
+  EXECUTE format('EXPLAIN (ANALYZE true, FORMAT XML) %s', query) INTO result;
   RETURN result;
 END;
 $BODY$ LANGUAGE plpgsql;
@@ -135,6 +156,13 @@ SELECT true AS valid FROM explain_json($$
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity$$);
 t
+SELECT true AS valid FROM explain_analyze_json($$
+	WITH a AS (
+		SELECT l_quantity, count(*) count_quantity FROM lineitem
+		GROUP BY l_quantity ORDER BY count_quantity, l_quantity LIMIT 10)
+	SELECT count(*) FROM a
+$$);
+t
 -- Test XML format
 EXPLAIN (COSTS FALSE, FORMAT XML)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
@@ -207,6 +235,13 @@ EXPLAIN (COSTS FALSE, FORMAT XML)
 SELECT true AS valid FROM explain_xml($$
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity$$);
+t
+SELECT true AS valid FROM explain_analyze_xml($$
+	WITH a AS (
+		SELECT l_quantity, count(*) count_quantity FROM lineitem
+		GROUP BY l_quantity ORDER BY count_quantity, l_quantity LIMIT 10)
+	SELECT count(*) FROM a
+$$);
 t
 -- Test YAML format
 EXPLAIN (COSTS FALSE, FORMAT YAML)

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -24,6 +24,17 @@ BEGIN
 END;
 $BODY$ LANGUAGE plpgsql;
 
+CREATE FUNCTION explain_analyze_json(query text)
+RETURNS jsonb
+AS $BODY$
+DECLARE
+  result jsonb;
+BEGIN
+  EXECUTE format('EXPLAIN (ANALYZE TRUE, FORMAT JSON) %s', query) INTO result;
+  RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
+
 -- Function that parses explain output as XML
 CREATE FUNCTION explain_xml(query text)
 RETURNS xml
@@ -35,6 +46,19 @@ BEGIN
   RETURN result;
 END;
 $BODY$ LANGUAGE plpgsql;
+
+-- Function that parses explain output as XML
+CREATE FUNCTION explain_analyze_xml(query text)
+RETURNS xml
+AS $BODY$
+DECLARE
+  result xml;
+BEGIN
+  EXECUTE format('EXPLAIN (ANALYZE true, FORMAT XML) %s', query) INTO result;
+  RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
+
 
 -- VACUMM related tables to ensure test outputs are stable
 VACUUM ANALYZE lineitem;
@@ -63,6 +87,13 @@ SELECT true AS valid FROM explain_json($$
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity$$);
 
+SELECT true AS valid FROM explain_analyze_json($$
+	WITH a AS (
+		SELECT l_quantity, count(*) count_quantity FROM lineitem
+		GROUP BY l_quantity ORDER BY count_quantity, l_quantity LIMIT 10)
+	SELECT count(*) FROM a
+$$);
+
 -- Test XML format
 EXPLAIN (COSTS FALSE, FORMAT XML)
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
@@ -72,6 +103,13 @@ EXPLAIN (COSTS FALSE, FORMAT XML)
 SELECT true AS valid FROM explain_xml($$
 	SELECT l_quantity, count(*) count_quantity FROM lineitem
 	GROUP BY l_quantity ORDER BY count_quantity, l_quantity$$);
+
+SELECT true AS valid FROM explain_analyze_xml($$
+	WITH a AS (
+		SELECT l_quantity, count(*) count_quantity FROM lineitem
+		GROUP BY l_quantity ORDER BY count_quantity, l_quantity LIMIT 10)
+	SELECT count(*) FROM a
+$$);
 
 -- Test YAML format
 EXPLAIN (COSTS FALSE, FORMAT YAML)


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could cause invalid JSON when running EXPLAIN ANALYZE with subplans

Fixes #4867