### PR TITLE
Fix flaky isolation - 1

### DIFF
--- a/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/isolation_replicate_reference_tables_to_coordinator.out
@@ -120,7 +120,8 @@ step s2-view-worker:
       ('%dump_local_%'),
       ('%citus_internal_local_blocked_processes%'),
       ('%add_node%'),
-      ('%csa_from_one_node%'))
+      ('%csa_from_one_node%'),
+      ('%pg_locks%'))
     AND is_worker_query = true
     AND backend_type = 'client backend'
     AND query != ''

--- a/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
+++ b/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
@@ -94,7 +94,8 @@ step "s2-view-worker"
       ('%dump_local_%'),
       ('%citus_internal_local_blocked_processes%'),
       ('%add_node%'),
-      ('%csa_from_one_node%'))
+      ('%csa_from_one_node%'),
+      ('%pg_locks%'))
     AND is_worker_query = true
     AND backend_type = 'client backend'
     AND query != ''


### PR DESCRIPTION
Postgres isolation tester is sometimes running some internal queries, hide them from the output.
fixes diffs like:
```SQL
UPDATE public.ref_table_1500777 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |idle in transaction|Client         |ClientRead|postgres|regression
 UPDATE public.ref_table_1500777 ref_table SET a = (a OPERATOR(pg_catalog.+) 1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |idle in transaction|Client         |ClientRead|postgres|regression
-(2 rows)
+
+        SELECT blocked_activity.application_name AS blocked_application
+           FROM pg_catalog.pg_locks blocked_locks
+            JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+            JOIN pg_catalog.pg_locks blocking_locks
+                ON blocking_locks.locktype = blocked_locks.locktype
+                AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+                AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                AND blocking_locks.objid IS NOT DISTINCT FRO|active             |               |          |postgres|regression
+
+        SELECT blocked_activity.application_name AS blocked_application
+           FROM pg_catalog.pg_locks blocked_locks
+            JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+            JOIN pg_catalog.pg_locks blocking_locks
+                ON blocking_locks.locktype = blocked_locks.locktype
+                AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+                AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                AND blocking_locks.objid IS NOT DISTINCT FRO|active             |               |          |postgres|regression
+(4 rows)
 
 step s2-end
```