### PR TITLE
Do not set coordinator's metadatasynced column to false

### DIFF
--- a/src/test/regress/expected/multi_remove_node_reference_table.out
+++ b/src/test/regress/expected/multi_remove_node_reference_table.out
@@ -978,6 +978,12 @@ ORDER BY shardid ASC;
 (0 rows)
 
 \c - - - :master_port
+SELECT 1 FROM citus_set_coordinator_host('localhost', :master_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
 SELECT citus_disable_node('localhost', :worker_2_port);
  citus_disable_node
 ---------------------------------------------------------------------
@@ -995,6 +1001,19 @@ SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
  count
 ---------------------------------------------------------------------
      1
+(1 row)
+
+-- never mark coordinator metadatasynced = false
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport = :master_port;
+ hasmetadata | metadatasynced
+---------------------------------------------------------------------
+ t           | t
+(1 row)
+
+SELECT 1 FROM citus_remove_node('localhost', :master_port);
+ ?column?
+---------------------------------------------------------------------
+        1
 (1 row)
 
 SELECT

--- a/src/test/regress/sql/multi_remove_node_reference_table.sql
+++ b/src/test/regress/sql/multi_remove_node_reference_table.sql
@@ -580,12 +580,18 @@ WHERE
 ORDER BY shardid ASC;
 
 \c - - - :master_port
-
+SELECT 1 FROM citus_set_coordinator_host('localhost', :master_port);
 SELECT citus_disable_node('localhost', :worker_2_port);
 SELECT public.wait_until_metadata_sync();
 
 -- status after citus_disable_node_and_wait
 SELECT COUNT(*) FROM pg_dist_node WHERE nodeport = :worker_2_port;
+
+-- never mark coordinator metadatasynced = false
+SELECT hasmetadata, metadatasynced FROM pg_dist_node WHERE nodeport = :master_port;
+
+SELECT 1 FROM citus_remove_node('localhost', :master_port);
+
 
 SELECT
     shardid, shardstate, shardlength, nodename, nodeport


### PR DESCRIPTION
After a disable_node

Fixes https://github.com/citusdata/citus/issues/5905

DESCRIPTION: Fixes a bug that marks metadatasynced of coordinator

[ ] Add 1 test