### PR TITLE
CI: Build pg15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,10 @@ workflows:
           name: build-14
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
+      - build:
+          name: build-15
+          pg_major: 15
+          image_tag: '15-source-dev-202205021637'
 
       - check-style
       - check-sql-snapshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,16 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-vabaecad'
+    default: '-dev-6385a38'
   pg13_version:
     type: string
     default: '13.4'
   pg14_version:
     type: string
     default: '14.0'
+  pg15_version:
+    type: string
+    default: '15devel'
   upgrade_pg_versions:
     type: string
     default: '13.4-14.0'
@@ -537,7 +540,7 @@ workflows:
       - build:
           name: build-15
           pg_major: 15
-          image_tag: '15-source-dev-202205021637'
+          image_tag: '<< pipeline.parameters.pg15_version >>'
 
       - check-style
       - check-sql-snapshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-6385a38'
+    default: '-dev-56d1258'
   pg13_version:
     type: string
     default: '13.4'

--- a/ci/build-citus.sh
+++ b/ci/build-citus.sh
@@ -10,6 +10,12 @@ source ci/ci_helpers.sh
 # read pg major version, error if not provided
 PG_MAJOR=${PG_MAJOR:?please provide the postgres major version}
 
+EXTRA_CONFIGURE_FLAGS=
+if [ $PG_MAJOR -eq 15 ]
+then
+  EXTRA_CONFIGURE_FLAGS+='--without-pg-version-check'
+fi
+
 # get codename from release file
 . /etc/os-release
 codename=${VERSION#*(}
@@ -33,7 +39,7 @@ build_ext() {
   # do everything in a subdirectory to avoid clutter in current directory
   mkdir -p "${builddir}" && cd "${builddir}"
 
-  CFLAGS=-Werror "${basedir}/configure" PG_CONFIG="/usr/lib/postgresql/${pg_major}/bin/pg_config" --enable-coverage --with-security-flags
+  CFLAGS=-Werror "${basedir}/configure" PG_CONFIG="/usr/lib/postgresql/${pg_major}/bin/pg_config" --enable-coverage --with-security-flags $EXTRA_CONFIGURE_FLAGS
 
   installdir="${builddir}/install"
   make -j$(nproc) && mkdir -p "${installdir}" && { make DESTDIR="${installdir}" install-all || make DESTDIR="${installdir}" install ; }

--- a/configure
+++ b/configure
@@ -644,6 +644,7 @@ LDFLAGS
 CFLAGS
 CC
 vpath_build
+with_pg_version_check
 PATH
 PG_CONFIG
 FLEX
@@ -692,6 +693,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_extra_version
+with_pg_version_check
 enable_coverage
 with_libcurl
 with_reports_hostname
@@ -1337,6 +1339,8 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-extra-version=STRING
                           append STRING to version
+  --without-pg-version-check
+                          do not check postgres version during build
   --without-libcurl       do not use libcurl for anonymous statistics
                           collection
   --with-reports-hostname=HOSTNAME
@@ -2555,7 +2559,37 @@ if test -z "$version_num"; then
   as_fn_error $? "Could not detect PostgreSQL version from pg_config." "$LINENO" 5
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14'; then
+
+
+
+# Check whether --with-pg-version-check was given.
+if test ${with_pg_version_check+y}
+then :
+  withval=$with_pg_version_check;
+  case $withval in
+    yes)
+      :
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --with-pg-version-check option" "$LINENO" 5
+      ;;
+  esac
+
+else $as_nop
+  with_pg_version_check=yes
+
+fi
+
+
+
+
+if test "$with_pg_version_check" = no; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num (skipped compatibility check)" >&5
+printf "%s\n" "$as_me: building against PostgreSQL $version_num (skipped compatibility check)" >&6;}
+elif test "$version_num" != '13' -a "$version_num" != '14'; then
    as_fn_error $? "Citus is not compatible with the detected PostgreSQL version ${version_num}." "$LINENO" 5
 else
    { $as_echo "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num" >&5

--- a/configure.in
+++ b/configure.in
@@ -74,7 +74,13 @@ if test -z "$version_num"; then
   AC_MSG_ERROR([Could not detect PostgreSQL version from pg_config.])
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14'; then
+PGAC_ARG_BOOL(with, pg-version-check, yes,
+              [do not check postgres version during build])
+AC_SUBST(with_pg_version_check)
+
+if test "$with_pg_version_check" = no; then
+    AC_MSG_NOTICE([building against PostgreSQL $version_num (skipped compatibility check)])
+elif test "$version_num" != '13' -a "$version_num" != '14'; then
    AC_MSG_ERROR([Citus is not compatible with the detected PostgreSQL version ${version_num}.])
 else
    AC_MSG_NOTICE([building against PostgreSQL $version_num])


### PR DESCRIPTION
Changes to start building Citus against postgres 15.

Also introduce a configure flag `--without-pg-version-check` to skip compatibility checks during configure. This allows us to start building against postgres 15 without completely supporting it.

TODO
- [ ] Depends on changes in https://github.com/citusdata/the-process/pull/76 to land before merging.
