### PR TITLE
Refrain reading the metadata cache for all tables during upgrade

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -513,7 +513,8 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 		ObjectAddress tableAddress = { 0 };
 		ObjectAddressSet(tableAddress, RelationRelationId, citusTableId);
 
-		if (ShouldSyncTableMetadata(citusTableId))
+		/* refrain reading the metadata cache for all tables */
+		if (ShouldSyncTableMetadataViaCatalog(citusTableId))
 		{
 			/* we need to pass pointer allocated in the heap */
 			ObjectAddress *addressPointer = palloc0(sizeof(ObjectAddress));


### PR DESCRIPTION
First, it is not needed. Second, in the past we had issues regarding
this: https://github.com/citusdata/citus/pull/4344

When I create 10k tables, ~120K shards, this saves
40Mb of memory during ALTER EXTENSION citus UPDATE.

Before the change:  MetadataCacheMemoryContext: 41943040 ~ 40MB
After the change:  MetadataCacheMemoryContext: 8192

DESCRIPTION: Refrain reading the metadata cache for all tables during upgrade
