### PR TITLE
Introduce new UDFs that skip self locks in isolation tests

### DIFF
--- a/src/backend/distributed/sql/citus--11.0-2--11.1-1.sql
+++ b/src/backend/distributed/sql/citus--11.0-2--11.1-1.sql
@@ -6,3 +6,7 @@ DROP FUNCTION pg_catalog.worker_hash_partition_table(bigint, integer, text, text
 DROP FUNCTION pg_catalog.worker_merge_files_into_table(bigint, integer, text[], text[]);
 DROP FUNCTION pg_catalog.worker_range_partition_table(bigint, integer, text, text, oid, anyarray);
 DROP FUNCTION pg_catalog.worker_repartition_cleanup(bigint);
+
+#include "udfs/citus_isolation_test_session_is_blocked_skip_self_local_blocks/11.1-1.sql"
+#include "udfs/replace_isolation_tester_func_skip_self_local_blocks/11.1-1.sql"
+#include "udfs/restore_isolation_tester_func_skip_self_local_blocks/11.1-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--11.1-1--11.0-2.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.1-1--11.0-2.sql
@@ -45,3 +45,7 @@ CREATE FUNCTION pg_catalog.worker_repartition_cleanup(bigint)
  LANGUAGE c
  STRICT
 AS 'MODULE_PATHNAME', $function$worker_repartition_cleanup$function$
+
+DROP FUNCTION citus_internal.citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer,integer[]);
+DROP FUNCTION citus_internal.replace_isolation_tester_func_skip_self_local_blocks();
+DROP FUNCTION citus_internal.restore_isolation_tester_func_skip_self_local_blocks();

--- a/src/backend/distributed/sql/udfs/citus_isolation_test_session_is_blocked_skip_self_local_blocks/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_isolation_test_session_is_blocked_skip_self_local_blocks/11.1-1.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_isolation_test_session_is_blocked_skip_self_local_blocks(pBlockedPid integer, pInterestingPids integer[])
+RETURNS boolean AS $$
+  DECLARE
+    mBlockedGlobalPid int8;
+    workerProcessId integer := current_setting('citus.isolation_test_session_remote_process_id');
+    coordinatorProcessId integer := current_setting('citus.isolation_test_session_process_id');
+  BEGIN
+    IF pg_catalog.old_pg_isolation_test_session_is_blocked(pBlockedPid, pInterestingPids) THEN
+      RETURN true;
+    END IF;
+
+    -- pg says we're not blocked locally; check whether we're blocked globally.
+    -- Note that worker process may be blocked or waiting for a lock. So we need to
+    -- get transaction number for both of them. Following IF provides the transaction
+    -- number when the worker process waiting for other session.
+    IF EXISTS (SELECT 1 FROM get_global_active_transactions()
+               WHERE process_id = workerProcessId AND pBlockedPid = coordinatorProcessId) THEN
+      SELECT global_pid INTO mBlockedGlobalPid FROM get_global_active_transactions()
+      WHERE process_id = workerProcessId AND pBlockedPid = coordinatorProcessId;
+    ELSE
+      -- Check whether transactions initiated from the coordinator get locked
+      SELECT global_pid INTO mBlockedGlobalPid
+        FROM get_all_active_transactions() WHERE process_id = pBlockedPid;
+    END IF;
+
+    RETURN EXISTS (
+      SELECT 1 FROM citus_internal_global_blocked_processes()
+        WHERE waiting_global_pid = mBlockedGlobalPid
+        AND blocking_global_pid != waiting_global_pid
+    ) OR EXISTS (
+      -- Check on the workers if any logical replication job spawned by the
+      -- current PID is blocked, by checking it's application name
+      -- Query is heavily based on: https://wiki.postgresql.org/wiki/Lock_Monitoring
+      SELECT result FROM run_command_on_workers($two$
+        SELECT blocked_activity.application_name AS blocked_application
+           FROM  pg_catalog.pg_locks         blocked_locks
+            JOIN pg_catalog.pg_stat_activity blocked_activity  ON blocked_activity.pid = blocked_locks.pid
+            JOIN pg_catalog.pg_locks         blocking_locks
+                ON blocking_locks.locktype = blocked_locks.locktype
+                AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+                AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+                AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+                AND blocking_locks.pid != blocked_locks.pid
+            JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+           WHERE NOT blocked_locks.GRANTED AND blocked_activity.application_name LIKE 'citus_shard_move_subscription_%'
+        $two$) where result='citus_shard_move_subscription_' || pBlockedPid);
+
+  END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer,integer[]) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_isolation_test_session_is_blocked_skip_self_local_blocks/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_isolation_test_session_is_blocked_skip_self_local_blocks/latest.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_isolation_test_session_is_blocked_skip_self_local_blocks(pBlockedPid integer, pInterestingPids integer[])
+RETURNS boolean AS $$
+  DECLARE
+    mBlockedGlobalPid int8;
+    workerProcessId integer := current_setting('citus.isolation_test_session_remote_process_id');
+    coordinatorProcessId integer := current_setting('citus.isolation_test_session_process_id');
+  BEGIN
+    IF pg_catalog.old_pg_isolation_test_session_is_blocked(pBlockedPid, pInterestingPids) THEN
+      RETURN true;
+    END IF;
+
+    -- pg says we're not blocked locally; check whether we're blocked globally.
+    -- Note that worker process may be blocked or waiting for a lock. So we need to
+    -- get transaction number for both of them. Following IF provides the transaction
+    -- number when the worker process waiting for other session.
+    IF EXISTS (SELECT 1 FROM get_global_active_transactions()
+               WHERE process_id = workerProcessId AND pBlockedPid = coordinatorProcessId) THEN
+      SELECT global_pid INTO mBlockedGlobalPid FROM get_global_active_transactions()
+      WHERE process_id = workerProcessId AND pBlockedPid = coordinatorProcessId;
+    ELSE
+      -- Check whether transactions initiated from the coordinator get locked
+      SELECT global_pid INTO mBlockedGlobalPid
+        FROM get_all_active_transactions() WHERE process_id = pBlockedPid;
+    END IF;
+
+    RETURN EXISTS (
+      SELECT 1 FROM citus_internal_global_blocked_processes()
+        WHERE waiting_global_pid = mBlockedGlobalPid
+        AND blocking_global_pid != waiting_global_pid
+    ) OR EXISTS (
+      -- Check on the workers if any logical replication job spawned by the
+      -- current PID is blocked, by checking it's application name
+      -- Query is heavily based on: https://wiki.postgresql.org/wiki/Lock_Monitoring
+      SELECT result FROM run_command_on_workers($two$
+        SELECT blocked_activity.application_name AS blocked_application
+           FROM  pg_catalog.pg_locks         blocked_locks
+            JOIN pg_catalog.pg_stat_activity blocked_activity  ON blocked_activity.pid = blocked_locks.pid
+            JOIN pg_catalog.pg_locks         blocking_locks
+                ON blocking_locks.locktype = blocked_locks.locktype
+                AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+                AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+                AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+                AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+                AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+                AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+                AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+                AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+                AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+                AND blocking_locks.pid != blocked_locks.pid
+            JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+           WHERE NOT blocked_locks.GRANTED AND blocked_activity.application_name LIKE 'citus_shard_move_subscription_%'
+        $two$) where result='citus_shard_move_subscription_' || pBlockedPid);
+
+  END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer,integer[]) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/replace_isolation_tester_func_skip_self_local_blocks/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/replace_isolation_tester_func_skip_self_local_blocks/11.1-1.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION citus_internal.replace_isolation_tester_func_skip_self_local_blocks()
+RETURNS void AS $$
+    BEGIN
+        ALTER FUNCTION pg_catalog.pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO old_pg_isolation_test_session_is_blocked;
+        ALTER FUNCTION pg_catalog.citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer, integer[])
+            RENAME TO pg_isolation_test_session_is_blocked;
+    END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_internal.replace_isolation_tester_func_skip_self_local_blocks() FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/replace_isolation_tester_func_skip_self_local_blocks/latest.sql
+++ b/src/backend/distributed/sql/udfs/replace_isolation_tester_func_skip_self_local_blocks/latest.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION citus_internal.replace_isolation_tester_func_skip_self_local_blocks()
+RETURNS void AS $$
+    BEGIN
+        ALTER FUNCTION pg_catalog.pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO old_pg_isolation_test_session_is_blocked;
+        ALTER FUNCTION pg_catalog.citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer, integer[])
+            RENAME TO pg_isolation_test_session_is_blocked;
+    END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_internal.replace_isolation_tester_func_skip_self_local_blocks() FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/restore_isolation_tester_func_skip_self_local_blocks/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/restore_isolation_tester_func_skip_self_local_blocks/11.1-1.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION citus_internal.restore_isolation_tester_func_skip_self_local_blocks()
+RETURNS void AS $$
+    BEGIN
+        ALTER FUNCTION pg_catalog.pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO citus_isolation_test_session_is_blocked_skip_self_local_blocks;
+        ALTER FUNCTION pg_catalog.old_pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO pg_isolation_test_session_is_blocked;
+    END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_internal.restore_isolation_tester_func_skip_self_local_blocks() FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/restore_isolation_tester_func_skip_self_local_blocks/latest.sql
+++ b/src/backend/distributed/sql/udfs/restore_isolation_tester_func_skip_self_local_blocks/latest.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION citus_internal.restore_isolation_tester_func_skip_self_local_blocks()
+RETURNS void AS $$
+    BEGIN
+        ALTER FUNCTION pg_catalog.pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO citus_isolation_test_session_is_blocked_skip_self_local_blocks;
+        ALTER FUNCTION pg_catalog.old_pg_isolation_test_session_is_blocked(integer, integer[])
+            RENAME TO pg_isolation_test_session_is_blocked;
+    END;
+$$ LANGUAGE plpgsql;
+
+REVOKE ALL ON FUNCTION citus_internal.restore_isolation_tester_func_skip_self_local_blocks() FROM PUBLIC;

--- a/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
+++ b/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
@@ -1,6 +1,11 @@
 Parsed test spec with 3 sessions
 
 starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-insert s2-start-session-level-connection s2-begin-on-worker s2-alter s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection s3-select-count
+refresh_isolation_tester_prepared_statement
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -85,13 +90,18 @@ count
     6
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
 
 
 starting permutation: s1-begin s1-index s2-start-session-level-connection s2-begin-on-worker s2-select-for-update s1-commit s2-commit-worker s2-stop-connection
+refresh_isolation_tester_prepared_statement
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-begin:
  BEGIN;
 
@@ -141,13 +151,18 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
 
 
 starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-start-session-level-connection s2-begin-on-worker s2-select-for-update s1-commit-worker s2-commit-worker s1-stop-connection s2-stop-connection
+refresh_isolation_tester_prepared_statement
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -229,13 +244,18 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
 
 
 starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
+refresh_isolation_tester_prepared_statement
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -279,7 +299,7 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -17,7 +17,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -45,7 +45,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -77,7 +77,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -112,7 +112,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -135,7 +135,7 @@ count
    11
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -158,7 +158,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -181,7 +181,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -204,7 +204,7 @@ count
     9
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -228,7 +228,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -248,7 +248,7 @@ step s1-commit: COMMIT;
 step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 ERROR:  relation "hash_copy" does not exist
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -279,7 +279,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -311,7 +311,7 @@ run_command_on_workers
 (localhost,57638,t,0)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -342,7 +342,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -373,7 +373,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -405,7 +405,7 @@ run_command_on_workers
 (localhost,57638,t,"")
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -436,7 +436,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -464,7 +464,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -487,7 +487,7 @@ count
     5
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -516,7 +516,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -547,7 +547,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -582,7 +582,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -617,7 +617,7 @@ count
     9
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -652,7 +652,7 @@ count
    20
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -687,7 +687,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -715,7 +715,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -747,7 +747,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -782,7 +782,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -805,7 +805,7 @@ count
    11
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -828,7 +828,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -851,7 +851,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -874,7 +874,7 @@ count
     9
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -898,7 +898,7 @@ count
     5
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -919,7 +919,7 @@ step s2-copy: <... completed>
 ERROR:  relation "hash_copy" does not exist
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 ERROR:  relation "hash_copy" does not exist
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -950,7 +950,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -982,7 +982,7 @@ run_command_on_workers
 (localhost,57638,t,0)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1014,7 +1014,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1046,7 +1046,7 @@ run_command_on_workers
 (localhost,57638,t,"")
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1077,7 +1077,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1105,7 +1105,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1128,7 +1128,7 @@ count
     5
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1158,7 +1158,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -1189,7 +1189,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -17,7 +17,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -45,7 +45,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -77,7 +77,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -111,7 +111,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -134,7 +134,7 @@ count
    11
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -158,7 +158,7 @@ count
    20
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -182,7 +182,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -206,7 +206,7 @@ count
     9
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -230,7 +230,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -250,7 +250,7 @@ step s1-commit: COMMIT;
 step s2-drop: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM reference_copy;
 ERROR:  relation "reference_copy" does not exist
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -281,7 +281,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -313,7 +313,7 @@ run_command_on_workers
 (localhost,57638,t,0)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -344,7 +344,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -375,7 +375,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -407,7 +407,7 @@ run_command_on_workers
 (localhost,57638,t,"")
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -438,7 +438,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -466,7 +466,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -490,7 +490,7 @@ count
     0
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -521,7 +521,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -549,7 +549,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -581,7 +581,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -615,7 +615,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -638,7 +638,7 @@ count
    11
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -662,7 +662,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -686,7 +686,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -710,7 +710,7 @@ count
     9
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -734,7 +734,7 @@ count
     5
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -755,7 +755,7 @@ step s2-copy: <... completed>
 ERROR:  relation "reference_copy" does not exist
 step s1-select-count: SELECT COUNT(*) FROM reference_copy;
 ERROR:  relation "reference_copy" does not exist
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -786,7 +786,7 @@ run_command_on_workers
 (localhost,57638,t,2)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -818,7 +818,7 @@ run_command_on_workers
 (localhost,57638,t,0)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -850,7 +850,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -882,7 +882,7 @@ run_command_on_workers
 (localhost,57638,t,"")
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -913,7 +913,7 @@ run_command_on_workers
 (localhost,57638,t,new_column)
 (2 rows)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -941,7 +941,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -965,7 +965,7 @@ count
     5
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -996,7 +996,7 @@ count
    15
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/isolation_select_vs_all_on_mx.out
+++ b/src/test/regress/expected/isolation_select_vs_all_on_mx.out
@@ -81,7 +81,7 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -176,7 +176,7 @@ count
    10
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -271,7 +271,7 @@ count
     4
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -366,7 +366,7 @@ count
     7
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -422,7 +422,7 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -509,7 +509,7 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)
@@ -568,7 +568,7 @@ stop_session_level_connection_to_node
 
 (1 row)
 
-restore_isolation_tester_func
+restore_isolation_tester_func_skip_self_local_blocks
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1034,7 +1034,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 -- Snapshot of state at 11.1-1
 ALTER EXTENSION citus UPDATE TO '11.1-1';
 SELECT * FROM multi_extension.print_extension_changes();
-                                    previous_object                                     | current_object
+                                    previous_object                                     |                                           current_object
 ---------------------------------------------------------------------
  function worker_cleanup_job_schema_cache() void                                        |
  function worker_create_schema(bigint,text) void                                        |
@@ -1044,7 +1044,10 @@ SELECT * FROM multi_extension.print_extension_changes();
  function worker_merge_files_into_table(bigint,integer,text[],text[]) void              |
  function worker_range_partition_table(bigint,integer,text,text,oid,anyarray) void      |
  function worker_repartition_cleanup(bigint) void                                       |
-(8 rows)
+                                                                                        | function citus_internal.replace_isolation_tester_func_skip_self_local_blocks() void
+                                                                                        | function citus_internal.restore_isolation_tester_func_skip_self_local_blocks() void
+                                                                                        | function citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer,integer[]) boolean
+(11 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -70,7 +70,9 @@ ORDER BY 1;
  function citus_internal.pg_dist_shard_placement_trigger_func()
  function citus_internal.refresh_isolation_tester_prepared_statement()
  function citus_internal.replace_isolation_tester_func()
+ function citus_internal.replace_isolation_tester_func_skip_self_local_blocks()
  function citus_internal.restore_isolation_tester_func()
+ function citus_internal.restore_isolation_tester_func_skip_self_local_blocks()
  function citus_internal.upgrade_columnar_storage(regclass)
  function citus_internal_add_colocation_metadata(integer,integer,integer,regtype,oid)
  function citus_internal_add_object_metadata(text,text[],text[],integer,integer,boolean)
@@ -84,6 +86,7 @@ ORDER BY 1;
  function citus_internal_update_placement_metadata(bigint,integer,integer)
  function citus_internal_update_relation_colocation(oid,integer)
  function citus_isolation_test_session_is_blocked(integer,integer[])
+ function citus_isolation_test_session_is_blocked_skip_self_local_blocks(integer,integer[])
  function citus_json_concatenate(json,json)
  function citus_json_concatenate_final(json)
  function citus_jsonb_concatenate(jsonb,jsonb)
@@ -275,5 +278,5 @@ ORDER BY 1;
  view citus_stat_statements
  view pg_dist_shard_placement
  view time_partitions
-(259 rows)
+(262 rows)
 

--- a/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
+++ b/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
@@ -5,14 +5,18 @@ setup
 	CREATE TABLE dist_table(id integer, value integer);
 	SELECT create_distributed_table('dist_table', 'id');
 	COPY dist_table FROM PROGRAM 'echo 1, 10 && echo 2, 20 && echo 3, 30 && echo 4, 40 && echo 5, 50' WITH CSV;
+
+	SELECT citus_internal.restore_isolation_tester_func();
+	SELECT citus_internal.replace_isolation_tester_func_skip_self_local_blocks();
+	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
 }
 
 // Create and use UDF to close the connection opened in the setup step. Also return the cluster
 // back to the initial state.
 teardown
 {
-        DROP TABLE IF EXISTS dist_table CASCADE;
-        SELECT citus_internal.restore_isolation_tester_func();
+	DROP TABLE IF EXISTS dist_table CASCADE;
+	SELECT citus_internal.restore_isolation_tester_func_skip_self_local_blocks();
 }
 
 session "s1"

--- a/src/test/regress/spec/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_hash_copy_vs_all.spec
@@ -5,8 +5,8 @@
 // create append distributed table to test behavior of COPY in concurrent operations
 setup
 {
-      SELECT citus_internal.replace_isolation_tester_func();
-  SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+	SELECT citus_internal.replace_isolation_tester_func_skip_self_local_blocks();
+	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE hash_copy(id integer, data text, int_data int);
 	SELECT create_distributed_table('hash_copy', 'id');
@@ -16,7 +16,7 @@ setup
 teardown
 {
 	DROP TABLE IF EXISTS hash_copy CASCADE;
- SELECT citus_internal.restore_isolation_tester_func();
+ SELECT citus_internal.restore_isolation_tester_func_skip_self_local_blocks();
 }
 
 // session 1

--- a/src/test/regress/spec/isolation_reference_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_reference_copy_vs_all.spec
@@ -5,7 +5,7 @@
 // create append distributed table to test behavior of COPY in concurrent operations
 setup
 {
-	SELECT citus_internal.replace_isolation_tester_func();
+	SELECT citus_internal.replace_isolation_tester_func_skip_self_local_blocks();
 	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE reference_copy(id integer, data text, int_data int);
@@ -16,7 +16,7 @@ setup
 teardown
 {
 	DROP TABLE IF EXISTS reference_copy CASCADE;
-	SELECT citus_internal.restore_isolation_tester_func();
+	SELECT citus_internal.restore_isolation_tester_func_skip_self_local_blocks();
 }
 
 // session 1

--- a/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
+++ b/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
@@ -2,6 +2,10 @@
 
 setup
 {
+	SELECT citus_internal.restore_isolation_tester_func();
+	SELECT citus_internal.replace_isolation_tester_func_skip_self_local_blocks();
+	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
+
 	CREATE TABLE select_table(id integer, value integer);
 	SELECT create_distributed_table('select_table', 'id');
 	COPY select_table FROM PROGRAM 'echo 1, 10 && echo 2, 20 && echo 3, 30 && echo 4, 40 && echo 5, 50' WITH CSV;
@@ -11,8 +15,8 @@ setup
 // back to the initial state.
 teardown
 {
-        DROP TABLE IF EXISTS select_table CASCADE;
-        SELECT citus_internal.restore_isolation_tester_func();
+	DROP TABLE IF EXISTS select_table CASCADE;
+	SELECT citus_internal.restore_isolation_tester_func_skip_self_local_blocks();
 }
 
 session "s1"


### PR DESCRIPTION
We have an issue #5795 that makes some of our isolation tests that contain `CREATE INDEX CONCURRENTLY` flaky. As suggested in https://github.com/citusdata/citus/pull/5910#discussion_r858416884 I created a new function to replace `pg_isolation_test_session_is_blocked` that is used in isolation test infrastructure, that attempts to filter out false positive block reports.

However I still see some flaky outputs as the proposed solution did not fully fix the underlying problem for some reason.

<details>
<summary>Here is the current flaky output on this PR</summary>

```diff
diff -dU10 -w /home/circleci/project/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out /home/circleci/project/src/test/regress/results/isolation_drop_alter_index_select_for_update_on_mx.out
--- /home/circleci/project/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out.modified	2022-05-13 01:01:39.118653039 +0000
+++ /home/circleci/project/src/test/regress/results/isolation_drop_alter_index_select_for_update_on_mx.out.modified	2022-05-13 01:01:39.130653069 +0000
@@ -275,29 +275,30 @@
 step s1-select-for-update: 
  SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id = 5 FOR UPDATE');
 
 run_commands_on_session_level_connection_to_node
 ------------------------------------------------
                                                 
 (1 row)
 
 step s2-coordinator-create-index-concurrently: 
  CREATE INDEX CONCURRENTLY dist_table_index_conc ON dist_table(id);
-
+ <waiting ...>
 step s1-commit-worker: 
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');
 
 run_commands_on_session_level_connection_to_node
 ------------------------------------------------
                                                 
 (1 row)
 
+step s2-coordinator-create-index-concurrently: <... completed>
 step s1-stop-connection: 
  SELECT stop_session_level_connection_to_node();
 
 stop_session_level_connection_to_node
 -------------------------------------
                                      
 (1 row)
 
 restore_isolation_tester_func_skip_self_local_blocks
 ----------------------------------------------------
```

</details>

