### PR TITLE
Grep logs for deterministic global_cancel test results

### DIFF
--- a/src/test/regress/expected/global_cancel.out
+++ b/src/test/regress/expected/global_cancel.out
@@ -1,6 +1,7 @@
 CREATE SCHEMA global_cancel;
 SET search_path TO global_cancel;
 SET citus.next_shard_id TO 56789000;
+SET citus.grep_remote_commands TO '%pg_cancel_backend%';
 CREATE TABLE dist_table (a INT, b INT);
 SELECT create_distributed_table ('dist_table', 'a', shard_count:=4);
  create_distributed_table
@@ -25,8 +26,6 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 ERROR:  canceling statement due to user request
 BEGIN;
 SELECT pg_cancel_backend(:coordinator_gpid) FROM dist_table WHERE a = 1;
-NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SELECT pg_cancel_backend('xxxxx'::bigint) AS pg_cancel_backend FROM global_cancel.dist_table_56789000 dist_table WHERE (a OPERATOR(pg_catalog.=) 1)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 ERROR:  canceling statement due to user request
@@ -100,13 +99,13 @@ WHERE isactive = true AND noderole = 'primary';
 SELECT citus_nodeid_for_gpid(10000000000 * 2 + 3);
  citus_nodeid_for_gpid
 ---------------------------------------------------------------------
-        2
+                     2
 (1 row)
 
 SELECT citus_pid_for_gpid(10000000000 * 2 + 3);
  citus_pid_for_gpid
 ---------------------------------------------------------------------
-        3
+                  3
 (1 row)
 
 DROP SCHEMA global_cancel CASCADE;

--- a/src/test/regress/sql/global_cancel.sql
+++ b/src/test/regress/sql/global_cancel.sql
@@ -1,6 +1,7 @@
 CREATE SCHEMA global_cancel;
 SET search_path TO global_cancel;
 SET citus.next_shard_id TO 56789000;
+SET citus.grep_remote_commands TO '%pg_cancel_backend%';
 
 CREATE TABLE dist_table (a INT, b INT);
 SELECT create_distributed_table ('dist_table', 'a', shard_count:=4);


### PR DESCRIPTION
This is a flaky test that rarely fail with a diff similar to the following

```diff
diff -dU10 -w /home/circleci/project/src/test/regress/expected/global_cancel.out /home/circleci/project/src/test/regress/results/global_cancel.out
--- /home/circleci/project/src/test/regress/expected/global_cancel.out.modified	2022-04-01 02:51:38.803652655 +0000
+++ /home/circleci/project/src/test/regress/results/global_cancel.out.modified	2022-04-01 02:51:38.811652634 +0000
@@ -22,20 +22,22 @@
 SELECT pg_cancel_backend(:coordinator_gpid) FROM dist_table WHERE a = 1;
 NOTICE:  issuing SELECT pg_cancel_backend('13700080000019081'::bigint) AS pg_cancel_backend FROM global_cancel.dist_table_56789000 dist_table WHERE (a OPERATOR(pg_catalog.=) 1)
 DETAIL:  on server postgres@localhost:57637 connectionId: 1
 ERROR:  canceling statement due to user request
 BEGIN;
 SELECT pg_cancel_backend(:coordinator_gpid) FROM dist_table WHERE a = 1;
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(0, 6145, '2022-03-31 19:51:38.619341-07');
 DETAIL:  on server postgres@localhost:57637 connectionId: 4
 NOTICE:  issuing SELECT pg_cancel_backend('13700080000019081'::bigint) AS pg_cancel_backend FROM global_cancel.dist_table_56789000 dist_table WHERE (a OPERATOR(pg_catalog.=) 1)
 DETAIL:  on server postgres@localhost:57637 connectionId: 4
+NOTICE:  issuing ROLLBACK
+DETAIL:  on server postgres@localhost:57637 connectionId: 4
 ERROR:  canceling statement due to user request
 END;
 SET citus.log_remote_commands TO OFF;
 SELECT global_pid AS maintenance_daemon_gpid
 FROM pg_stat_activity psa JOIN get_all_active_transactions() gaat ON psa.pid = gaat.process_id
 WHERE application_name = 'Citus Maintenance Daemon' \gset
 SET client_min_messages TO ERROR;
 CREATE USER global_cancel_user;
 SELECT 1 FROM run_command_on_workers('CREATE USER global_cancel_user');
  ?column? 
```