### PR TITLE
suppress notices when more dependencies are found

### DIFF
--- a/src/test/regress/expected/master_copy_shard_placement.out
+++ b/src/test/regress/expected/master_copy_shard_placement.out
@@ -112,12 +112,14 @@ SET citus.shard_replication_factor TO 1;
 -- metadata sync will succeed even if we have rep > 1 tables
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'public.articles'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'public.articles_single_shard'::regclass::oid, 0);
+SET client_min_messages TO warning;
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node
 ---------------------------------------------------------------------
 
 (1 row)
 
+RESET client_min_messages;
 CREATE TABLE mx_table(a int);
 SELECT create_distributed_table('mx_table', 'a');
  create_distributed_table

--- a/src/test/regress/sql/master_copy_shard_placement.sql
+++ b/src/test/regress/sql/master_copy_shard_placement.sql
@@ -95,7 +95,9 @@ SET citus.shard_replication_factor TO 1;
 -- metadata sync will succeed even if we have rep > 1 tables
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'public.articles'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'public.articles_single_shard'::regclass::oid, 0);
+SET client_min_messages TO warning;
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
+RESET client_min_messages;
 
 CREATE TABLE mx_table(a int);
 SELECT create_distributed_table('mx_table', 'a');


### PR DESCRIPTION
We are nearing the 100 objects being propagated in `master_copy_shard_placement` and with the extra supported objects this gets pushed over a 100 objects.

When a 100 objects are reached for propagation a notice will be shown to the user, informing them it might take a while to finish the operation.

During testing this is not important to see. Since the message contains the exact number of objects to be propagated the tests becomes very unstable when merging community into enterprsie.

This change makes that the test output stays stable.
