### PR TITLE
Add caching for functions that check the backend type

### DIFF
--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -17,6 +17,7 @@
 
 #include "catalog/pg_proc.h"
 #include "commands/defrem.h"
+#include "distributed/backend_data.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/commands.h"

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -42,6 +42,7 @@
 #include "commands/defrem.h"
 #include "commands/tablecmds.h"
 #include "distributed/adaptive_executor.h"
+#include "distributed/backend_data.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/commands.h"
 #include "distributed/commands/multi_copy.h"

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -1467,40 +1467,6 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
 
 
 /*
- * IsRebalancerInitiatedBackend returns true if we are in a backend that citus
- * rebalancer initiated.
- */
-bool
-IsRebalancerInternalBackend(void)
-{
-	return application_name && strcmp(application_name, CITUS_REBALANCER_NAME) == 0;
-}
-
-
-/*
- * IsCitusRunCommandBackend returns true if we are in a backend that one of
- * the run_command_on_* functions initiated.
- */
-bool
-IsCitusRunCommandBackend(void)
-{
-	return application_name &&
-		   strcmp(application_name, CITUS_RUN_COMMAND_APPLICATION_NAME) == 0;
-}
-
-
-/*
- * IsCitusInitiatedRemoteBackend returns true if we are in a backend that citus
- * initiated via remote connection.
- */
-bool
-IsCitusInternalBackend(void)
-{
-	return ExtractGlobalPID(application_name) != INVALID_CITUS_INTERNAL_BACKEND_GPID;
-}
-
-
-/*
  * ResetConnection preserves the given connection for later usage by
  * resetting its states.
  */

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -18,6 +18,7 @@
 #include "catalog/dependency.h"
 #include "catalog/pg_class.h"
 #include "catalog/namespace.h"
+#include "distributed/backend_data.h"
 #include "distributed/citus_custom_scan.h"
 #include "distributed/commands/multi_copy.h"
 #include "distributed/commands/utility_hook.h"

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -17,6 +17,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
+#include "distributed/backend_data.h"
 #include "distributed/metadata_utility.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/colocation_utils.h"

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2081,6 +2081,7 @@ static void
 ApplicationNameAssignHook(const char *newval, void *extra)
 {
 	ResetHideShardsDecision();
+	ResetCitusBackendType();
 	OldApplicationNameAssignHook(newval, extra);
 }
 

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -14,6 +14,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
+#include "distributed/backend_data.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/coordinator_protocol.h"
 #include "distributed/listutils.h"

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -69,6 +69,10 @@ extern LocalTransactionId GetMyProcLocalTransactionId(void);
 extern int GetExternalClientBackendCount(void);
 extern uint32 IncrementExternalClientBackendCounter(void);
 extern void DecrementExternalClientBackendCounter(void);
+extern bool IsCitusInternalBackend(void);
+extern bool IsRebalancerInternalBackend(void);
+extern bool IsCitusRunCommandBackend(void);
+extern void ResetCitusBackendType(void);
 
 #define INVALID_CITUS_INTERNAL_BACKEND_GPID 0
 #define GLOBAL_PID_NODE_ID_FOR_NODES_NOT_IN_METADATA 99999999

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -288,9 +288,6 @@ extern void FinishConnectionListEstablishment(List *multiConnectionList);
 extern void FinishConnectionEstablishment(MultiConnection *connection);
 extern void ClaimConnectionExclusively(MultiConnection *connection);
 extern void UnclaimConnection(MultiConnection *connection);
-extern bool IsCitusInternalBackend(void);
-extern bool IsRebalancerInternalBackend(void);
-extern bool IsCitusRunCommandBackend(void);
 extern void MarkConnectionConnected(MultiConnection *connection);
 
 /* waiteventset utilities */


### PR DESCRIPTION
We currently have 10 different callers of IsCitusInternalBackend(), some in fairly hot paths. It is currently a relatively expensive function that does string parsing.

This PR adds some basic caching, using the existing application_name hook to invalidate the cache when application_name changes (e.g. for run_command_on_workers in #5959).