### PR TITLE
Use blocker conditions to fix flaky iso tests

### DIFF
--- a/src/test/regress/expected/isolation_multi_shard_modify_vs_all.out
+++ b/src/test/regress/expected/isolation_multi_shard_modify_vs_all.out
@@ -182,7 +182,7 @@ user_id|value_1|value_2|value_3
 (7 rows)
 
 
-starting permutation: s1-begin s1-update_all_value_1 s2-begin s2-insert-to-table s1-commit s2-commit s2-select
+starting permutation: s1-begin s1-update_all_value_1 s2-begin s2-insert-to-table s1-commit s2-commit s2-select s1-empty
 step s1-begin:
     BEGIN;
 
@@ -203,7 +203,9 @@ step s2-commit:
 
 step s2-select:
  SELECT * FROM users_test_table ORDER BY value_2, value_3;
-
+ <waiting ...>
+step s1-empty: 
+step s2-select: <... completed>
 user_id|value_1|value_2|value_3
 ---------------------------------------------------------------------
       1|      2|      3|      4

--- a/src/test/regress/spec/isolation_multi_shard_modify_vs_all.spec
+++ b/src/test/regress/spec/isolation_multi_shard_modify_vs_all.spec
@@ -77,6 +77,8 @@ step "s1-commit"
     COMMIT;
 }
 
+step "s1-empty" { }
+
 session "s2"
 
 step "s2-begin"
@@ -144,7 +146,8 @@ permutation "s1-begin" "s1-update_value_1_of_1_or_3_to_5" "s2-begin" "s2-update_
 permutation "s1-begin" "s1-update_value_1_of_1_or_3_to_5" "s2-begin" "s2-update_value_1_of_1_or_3_to_8" "s1-commit" "s2-commit" "s2-select"
 
 // test with inserts
-permutation "s1-begin" "s1-update_all_value_1" "s2-begin" "s2-insert-to-table" "s1-commit" "s2-commit" "s2-select"
+// the next test is flaky. there is an empty step that will postpone the s2-select step output for a miniscule time
+permutation "s1-begin" "s1-update_all_value_1" "s2-begin" "s2-insert-to-table" "s1-commit" "s2-commit" "s2-select"(*) "s1-empty"
 permutation "s1-begin" "s1-update_all_value_1" "s2-begin" "s2-insert-into-select" "s1-commit" "s2-commit" "s2-select"
 
 // multi-shard update affecting the same rows

--- a/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
+++ b/src/test/regress/spec/isolation_replicate_reference_tables_to_coordinator.spec
@@ -141,7 +141,7 @@ step "add-node"
 
 // verify that locks on the placement of the reference table on the coordinator is
 // taken into account when looking for distributed deadlocks
-permutation "add-node" "s1-begin" "s2-begin" "s1-update-dist-table" "s2-lock-ref-table-placement-on-coordinator" "s1-lock-ref-table-placement-on-coordinator" "s2-update-dist-table" "deadlock-checker-call" "s1-end" "s2-end"
+permutation "add-node" "s1-begin" "s2-begin" "s1-update-dist-table" "s2-lock-ref-table-placement-on-coordinator" "s1-lock-ref-table-placement-on-coordinator"("deadlock-checker-call") "s2-update-dist-table"("s1-lock-ref-table-placement-on-coordinator", "deadlock-checker-call") "deadlock-checker-call" "s1-end" "s2-end"
 
 // verify that *_dist_stat_activity() functions return the correct result when query
 // has a task on the coordinator.


### PR DESCRIPTION
This PR aims to introduce first usages of blocker conditions in isolation tests in an attempt to make the order of outputs deterministic.

More details can be found at https://github.com/postgres/postgres/blob/5f0adec2537dab531ef63ff6e0fe640698a291d9/src/test/isolation/README#L151-L204