### PR TITLE
Alternative solution to flaky CREATE INDEX CONCURRENTLY isolation tests

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -219,20 +219,6 @@ s/^(ERROR:  child table is missing constraint "\w+)_([0-9])+"/\1_xxxxxx"/g
     }
 }
 
-# normalize for random waits for CREATE INDEX CONCURRENTLY isolation tests.
-# <waiting ...> outputs can be in separate lines, or on the same line, and hence
-# we have a slightly more complex pattern.
-# All the flaky tests use a index name that starts with `flaky` so we limit the
-# normalization using that pattern.
-/CREATE INDEX CONCURRENTLY flaky/ {
-	N; s/ <waiting ...>//
-}
-
-# Remove completion lines in isolation tests for CREATE INDEX CONCURRENTLY commands.
-# This is needed because the commands that are executed on the shards can block each other
-# for a small window of time and we may see the completion output in different lines.
-/step s2-flaky.* <... completed>/d
-
 # normalize long table shard name errors for alter_table_set_access_method and alter_distributed_table
 s/^(ERROR:  child table is missing constraint "\w+)_([0-9])+"/\1_xxxxxx"/g
 s/^(DEBUG:  the name of the shard \(abcde_01234567890123456789012345678901234567890_f7ff6612)_([0-9])+/\1_xxxxxx/g

--- a/src/test/regress/expected/isolation_ddl_vs_all.out
+++ b/src/test/regress/expected/isolation_ddl_vs_all.out
@@ -787,7 +787,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-ddl-create-index-concurrently s1-commit s1-show-indexes
+starting permutation: s1-drop s1-create-non-distributed-table s1-initialize s1-begin s1-distribute-table s2-ddl-create-index-concurrently s1-sleep s1-commit s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -804,6 +804,12 @@ create_distributed_table
 (1 row)
 
 step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY ddl_hash_index ON ddl_hash(id); <waiting ...>
+step s1-sleep: SELECT pg_sleep(.1);
+pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-commit: COMMIT;
 step s2-ddl-create-index-concurrently: <... completed>
 step s1-show-indexes: SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash\_%''');

--- a/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
+++ b/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
@@ -235,7 +235,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-coordinator-create-index-concurrently s1-commit-worker s1-sleep s1-stop-connection
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -262,11 +262,20 @@ run_commands_on_session_level_connection_to_node
 
 step s2-coordinator-create-index-concurrently:
  CREATE INDEX CONCURRENTLY dist_table_index_conc ON dist_table(id);
-
-step s1-commit-worker:
+ <waiting ...>
+step s1-commit-worker: 
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');
 
 run_commands_on_session_level_connection_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-coordinator-create-index-concurrently: <... completed>
+step s1-sleep:
+ SELECT pg_sleep(.1);
+
+pg_sleep
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
+++ b/src/test/regress/expected/isolation_drop_alter_index_select_for_update_on_mx.out
@@ -235,7 +235,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-flaky-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-select-for-update s2-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -260,8 +260,8 @@ run_commands_on_session_level_connection_to_node
 
 (1 row)
 
-step s2-flaky-coordinator-create-index-concurrently:
- CREATE INDEX CONCURRENTLY flaky_dist_table_index_conc ON dist_table(id);
+step s2-coordinator-create-index-concurrently:
+ CREATE INDEX CONCURRENTLY dist_table_index_conc ON dist_table(id);
 
 step s1-commit-worker:
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -317,7 +317,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s1-copy s2-flaky-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -326,8 +326,9 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-flaky-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY flaky_hash_copy_index ON hash_copy(id);
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); <waiting ...>
 step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_hash_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_hash_copy_vs_all.out
@@ -93,8 +93,8 @@ step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 &&
 step s1-begin: BEGIN;
 step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
 step s2-adaptive-select:
-		SET citus.enable_repartition_joins TO ON;
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+  SET citus.enable_repartition_joins TO ON;
+ SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id|data|int_data|id|data|int_data
 ---------------------------------------------------------------------
@@ -317,7 +317,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-sleep s1-select-count s1-show-indexes
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -329,6 +329,12 @@ step s1-copy: COPY hash_copy FROM PROGRAM 'echo 5, f, 5 && echo 6, g, 6 && echo 
 step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-create-index-concurrently: <... completed>
+step s1-sleep: SELECT pg_sleep(.1);
+pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-select-count: SELECT COUNT(*) FROM hash_copy;
 count
 ---------------------------------------------------------------------
@@ -560,10 +566,10 @@ create_distributed_table
 (1 row)
 
 step s1-recreate-with-replication-2:
-	DROP TABLE hash_copy;
-	SET citus.shard_replication_factor TO 2;
-	CREATE TABLE hash_copy(id integer, data text, int_data int);
-	SELECT create_distributed_table('hash_copy', 'id');
+ DROP TABLE hash_copy;
+ SET citus.shard_replication_factor TO 2;
+ CREATE TABLE hash_copy(id integer, data text, int_data int);
+ SELECT create_distributed_table('hash_copy', 'id');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -595,10 +601,10 @@ create_distributed_table
 (1 row)
 
 step s1-recreate-with-replication-2:
-	DROP TABLE hash_copy;
-	SET citus.shard_replication_factor TO 2;
-	CREATE TABLE hash_copy(id integer, data text, int_data int);
-	SELECT create_distributed_table('hash_copy', 'id');
+ DROP TABLE hash_copy;
+ SET citus.shard_replication_factor TO 2;
+ CREATE TABLE hash_copy(id integer, data text, int_data int);
+ SELECT create_distributed_table('hash_copy', 'id');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -630,10 +636,10 @@ create_distributed_table
 (1 row)
 
 step s1-recreate-with-replication-2:
-	DROP TABLE hash_copy;
-	SET citus.shard_replication_factor TO 2;
-	CREATE TABLE hash_copy(id integer, data text, int_data int);
-	SELECT create_distributed_table('hash_copy', 'id');
+ DROP TABLE hash_copy;
+ SET citus.shard_replication_factor TO 2;
+ CREATE TABLE hash_copy(id integer, data text, int_data int);
+ SELECT create_distributed_table('hash_copy', 'id');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -665,10 +671,10 @@ create_distributed_table
 (1 row)
 
 step s1-recreate-with-replication-2:
-	DROP TABLE hash_copy;
-	SET citus.shard_replication_factor TO 2;
-	CREATE TABLE hash_copy(id integer, data text, int_data int);
-	SELECT create_distributed_table('hash_copy', 'id');
+ DROP TABLE hash_copy;
+ SET citus.shard_replication_factor TO 2;
+ CREATE TABLE hash_copy(id integer, data text, int_data int);
+ SELECT create_distributed_table('hash_copy', 'id');
 
 create_distributed_table
 ---------------------------------------------------------------------
@@ -762,8 +768,8 @@ create_distributed_table
 step s1-initialize: COPY hash_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-adaptive-select:
-		SET citus.enable_repartition_joins TO ON;
-	SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
+  SET citus.enable_repartition_joins TO ON;
+ SELECT * FROM hash_copy AS t1 JOIN hash_copy AS t2 ON t1.id = t2.int_data ORDER BY 1, 2, 3, 4;
 
 id|data|int_data|id|data|int_data
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -319,7 +319,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-sleep s1-select-count s1-show-indexes
 create_reference_table
 ---------------------------------------------------------------------
 
@@ -331,6 +331,12 @@ step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5  && echo 6, g, 6 &&
 step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY reference_copy_index ON reference_copy(id); <waiting ...>
 step s1-commit: COMMIT;
 step s2-ddl-create-index-concurrently: <... completed>
+step s1-sleep: SELECT pg_sleep(.1);
+pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
 step s1-select-count: SELECT COUNT(*) FROM reference_copy;
 count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_reference_copy_vs_all.out
+++ b/src/test/regress/expected/isolation_reference_copy_vs_all.out
@@ -319,7 +319,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-initialize s1-begin s1-copy s2-flaky-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
+starting permutation: s1-initialize s1-begin s1-copy s2-ddl-create-index-concurrently s1-commit s1-select-count s1-show-indexes
 create_reference_table
 ---------------------------------------------------------------------
 
@@ -328,8 +328,9 @@ create_reference_table
 step s1-initialize: COPY reference_copy FROM PROGRAM 'echo 0, a, 0 && echo 1, b, 1 && echo 2, c, 2 && echo 3, d, 3 && echo 4, e, 4' WITH CSV;
 step s1-begin: BEGIN;
 step s1-copy: COPY reference_copy FROM PROGRAM 'echo 5, f, 5  && echo 6, g, 6 && echo 7, h, 7 && echo 8, i, 8 && echo 9, j, 9' WITH CSV;
-step s2-flaky-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY flaky_reference_copy_index ON reference_copy(id);
+step s2-ddl-create-index-concurrently: CREATE INDEX CONCURRENTLY reference_copy_index ON reference_copy(id); <waiting ...>
 step s1-commit: COMMIT;
+step s2-ddl-create-index-concurrently: <... completed>
 step s1-select-count: SELECT COUNT(*) FROM reference_copy;
 count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_select_vs_all_on_mx.out
+++ b/src/test/regress/expected/isolation_select_vs_all_on_mx.out
@@ -515,7 +515,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-disable-binary-protocol-on-worker s1-select s2-flaky-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-disable-binary-protocol-on-worker s1-select s2-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -549,8 +549,8 @@ run_commands_on_session_level_connection_to_node
 
 (1 row)
 
-step s2-flaky-coordinator-create-index-concurrently:
- CREATE INDEX CONCURRENTLY flaky_select_table_index ON select_table(id);
+step s2-coordinator-create-index-concurrently:
+ CREATE INDEX CONCURRENTLY select_table_index ON select_table(id);
 
 step s1-commit-worker:
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');

--- a/src/test/regress/expected/isolation_select_vs_all_on_mx.out
+++ b/src/test/regress/expected/isolation_select_vs_all_on_mx.out
@@ -551,8 +551,8 @@ run_commands_on_session_level_connection_to_node
 
 step s2-coordinator-create-index-concurrently:
  CREATE INDEX CONCURRENTLY select_table_index ON select_table(id);
-
-step s1-commit-worker:
+ <waiting ...>
+step s1-commit-worker: 
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');
 
 run_commands_on_session_level_connection_to_node
@@ -560,6 +560,7 @@ run_commands_on_session_level_connection_to_node
 
 (1 row)
 
+step s2-coordinator-create-index-concurrently: <... completed>
 step s1-sleep:
  SELECT pg_sleep(.1);
 

--- a/src/test/regress/expected/isolation_select_vs_all_on_mx.out
+++ b/src/test/regress/expected/isolation_select_vs_all_on_mx.out
@@ -515,7 +515,7 @@ restore_isolation_tester_func
 (1 row)
 
 
-starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-disable-binary-protocol-on-worker s1-select s2-coordinator-create-index-concurrently s1-commit-worker s1-stop-connection
+starting permutation: s1-start-session-level-connection s1-begin-on-worker s1-disable-binary-protocol-on-worker s1-select s2-coordinator-create-index-concurrently s1-commit-worker s1-sleep s1-stop-connection
 step s1-start-session-level-connection:
         SELECT start_session_level_connection_to_node('localhost', 57637);
 
@@ -556,6 +556,14 @@ step s1-commit-worker:
  SELECT run_commands_on_session_level_connection_to_node('COMMIT');
 
 run_commands_on_session_level_connection_to_node
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-sleep:
+ SELECT pg_sleep(.1);
+
+pg_sleep
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/spec/isolation_ddl_vs_all.spec
+++ b/src/test/regress/spec/isolation_ddl_vs_all.spec
@@ -85,7 +85,7 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begi
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
 // the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-ddl-create-index-concurrently"("s1-sleep") "s1-sleep" "s1-commit" "s1-show-indexes"
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-ddl-create-index-concurrently"(*, "s1-sleep") "s1-sleep" "s1-commit" "s1-show-indexes"
 
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"

--- a/src/test/regress/spec/isolation_ddl_vs_all.spec
+++ b/src/test/regress/spec/isolation_ddl_vs_all.spec
@@ -35,6 +35,7 @@ step "s1-create-non-distributed-table" { CREATE TABLE ddl_hash(id integer, data 
 step "s1-distribute-table" { SELECT create_distributed_table('ddl_hash', 'id'); }
 step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''ddl_hash\_%'''); }
 step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''ddl_hash%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-sleep" { SELECT pg_sleep(.1); }
 step "s1-commit" { COMMIT; }
 
 // session 2
@@ -83,7 +84,8 @@ permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begi
 
 permutation "s1-initialize" "s1-begin" "s1-table-size" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-master-modify-multiple-shards" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
-permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-ddl-create-index-concurrently" "s1-commit" "s1-show-indexes"
+// the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
+permutation "s1-drop" "s1-create-non-distributed-table" "s1-initialize" "s1-begin" "s1-distribute-table" "s2-ddl-create-index-concurrently"("s1-sleep") "s1-sleep" "s1-commit" "s1-show-indexes"
 
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-table-size" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s2-begin" "s1-master-modify-multiple-shards" "s2-ddl-add-column" "s1-commit" "s2-commit" "s1-show-columns"

--- a/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
+++ b/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
@@ -59,6 +59,11 @@ step "s1-stop-connection"
 	SELECT stop_session_level_connection_to_node();
 }
 
+step "s1-sleep"
+{
+	SELECT pg_sleep(.1);
+}
+
 step "s1-commit"
 {
 	COMMIT;
@@ -117,4 +122,5 @@ step "s3-select-count"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-insert" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-alter" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-select-count"
 permutation "s1-begin" "s1-index" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit" "s2-commit-worker" "s2-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"
+// the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-coordinator-create-index-concurrently"("s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"

--- a/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
+++ b/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
@@ -89,9 +89,9 @@ step "s2-select-for-update"
 	SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM dist_table WHERE id = 5 FOR UPDATE');
 }
 
-step "s2-flaky-coordinator-create-index-concurrently"
+step "s2-coordinator-create-index-concurrently"
 {
-	CREATE INDEX CONCURRENTLY flaky_dist_table_index_conc ON dist_table(id);
+	CREATE INDEX CONCURRENTLY dist_table_index_conc ON dist_table(id);
 }
 
 step "s2-commit-worker"
@@ -117,4 +117,4 @@ step "s3-select-count"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-insert" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-alter" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-select-count"
 permutation "s1-begin" "s1-index" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit" "s2-commit-worker" "s2-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-flaky-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"

--- a/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
+++ b/src/test/regress/spec/isolation_drop_alter_index_select_for_update_on_mx.spec
@@ -123,4 +123,4 @@ permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-insert"
 permutation "s1-begin" "s1-index" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit" "s2-commit-worker" "s2-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
 // the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-coordinator-create-index-concurrently"("s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select-for-update" "s2-coordinator-create-index-concurrently"(*, "s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"

--- a/src/test/regress/spec/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_hash_copy_vs_all.spec
@@ -78,7 +78,7 @@ step "s2-truncate" { TRUNCATE hash_copy; }
 step "s2-drop" { DROP TABLE hash_copy; }
 step "s2-ddl-create-index" { CREATE INDEX hash_copy_index ON hash_copy(id); }
 step "s2-ddl-drop-index" { DROP INDEX hash_copy_index; }
-step "s2-flaky-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY flaky_hash_copy_index ON hash_copy(id); }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY hash_copy_index ON hash_copy(id); }
 step "s2-ddl-add-column" { ALTER TABLE hash_copy ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE hash_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE hash_copy RENAME data TO new_column; }
@@ -102,7 +102,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-s
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-flaky-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"

--- a/src/test/regress/spec/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_hash_copy_vs_all.spec
@@ -104,7 +104,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-selec
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
 // the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently"("s1-sleep") "s1-commit" "s1-sleep" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently"(*, "s1-sleep") "s1-commit" "s1-sleep" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"

--- a/src/test/regress/spec/isolation_hash_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_hash_copy_vs_all.spec
@@ -51,6 +51,7 @@ step "s1-distribute-table" { SELECT create_distributed_table('hash_copy', 'id');
 step "s1-select-count" { SELECT COUNT(*) FROM hash_copy; }
 step "s1-show-indexes" { SELECT run_command_on_workers('SELECT COUNT(*) FROM pg_indexes WHERE tablename LIKE ''hash_copy\_%'''); }
 step "s1-show-columns" { SELECT run_command_on_workers('SELECT column_name FROM information_schema.columns WHERE table_name LIKE ''hash_copy%'' AND column_name = ''new_column'' ORDER BY 1 LIMIT 1'); }
+step "s1-sleep" { SELECT pg_sleep(.1); }
 step "s1-commit" { COMMIT; }
 step "s1-recreate-with-replication-2"
 {
@@ -102,7 +103,8 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-s
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+// the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently"("s1-sleep") "s1-commit" "s1-sleep" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"

--- a/src/test/regress/spec/isolation_reference_copy_vs_all.spec
+++ b/src/test/regress/spec/isolation_reference_copy_vs_all.spec
@@ -68,7 +68,7 @@ step "s2-truncate" { TRUNCATE reference_copy; }
 step "s2-drop" { DROP TABLE reference_copy; }
 step "s2-ddl-create-index" { CREATE INDEX reference_copy_index ON reference_copy(id); }
 step "s2-ddl-drop-index" { DROP INDEX reference_copy_index; }
-step "s2-flaky-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY flaky_reference_copy_index ON reference_copy(id); }
+step "s2-ddl-create-index-concurrently" { CREATE INDEX CONCURRENTLY reference_copy_index ON reference_copy(id); }
 step "s2-ddl-add-column" { ALTER TABLE reference_copy ADD new_column int DEFAULT 0; }
 step "s2-ddl-drop-column" { ALTER TABLE reference_copy DROP new_column; }
 step "s2-ddl-rename-column" { ALTER TABLE reference_copy RENAME data TO new_column; }
@@ -91,7 +91,7 @@ permutation "s1-initialize" "s1-begin" "s1-copy" "s2-truncate" "s1-commit" "s1-s
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-drop" "s1-commit" "s1-select-count"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-ddl-create-index" "s1-begin" "s1-copy" "s2-ddl-drop-index" "s1-commit" "s1-select-count" "s1-show-indexes"
-permutation "s1-initialize" "s1-begin" "s1-copy" "s2-flaky-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
+permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-create-index-concurrently" "s1-commit" "s1-select-count" "s1-show-indexes"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-add-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-ddl-add-column" "s1-begin" "s1-copy-additional-column" "s2-ddl-drop-column" "s1-commit" "s1-select-count" "s1-show-columns"
 permutation "s1-initialize" "s1-begin" "s1-copy" "s2-ddl-rename-column" "s1-commit" "s1-select-count" "s1-show-columns"

--- a/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
+++ b/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
@@ -49,6 +49,11 @@ step "s1-stop-connection"
 	SELECT stop_session_level_connection_to_node();
 }
 
+step "s1-sleep"
+{
+	SELECT pg_sleep(.1);
+}
+
 
 session "s2"
 
@@ -135,4 +140,5 @@ permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-copy" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-select-count"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-begin" "s2-index" "s1-commit-worker" "s2-commit" "s1-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"
+// the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-coordinator-create-index-concurrently"("s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"

--- a/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
+++ b/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
@@ -99,9 +99,9 @@ step "s2-select-for-update"
 	SELECT run_commands_on_session_level_connection_to_node('SELECT * FROM select_table WHERE id = 6 FOR UPDATE');
 }
 
-step "s2-flaky-coordinator-create-index-concurrently"
+step "s2-coordinator-create-index-concurrently"
 {
-	CREATE INDEX CONCURRENTLY flaky_select_table_index ON select_table(id);
+	CREATE INDEX CONCURRENTLY select_table_index ON select_table(id);
 }
 
 step "s2-commit-worker"
@@ -135,4 +135,4 @@ permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-copy" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection" "s3-select-count"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-begin" "s2-index" "s1-commit-worker" "s2-commit" "s1-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-flaky-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-coordinator-create-index-concurrently" "s1-commit-worker" "s1-stop-connection"

--- a/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
+++ b/src/test/regress/spec/isolation_select_vs_all_on_mx.spec
@@ -141,4 +141,4 @@ permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-begin" "s2-index" "s1-commit-worker" "s2-commit" "s1-stop-connection"
 permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-select" "s2-start-session-level-connection" "s2-begin-on-worker" "s2-select-for-update" "s1-commit-worker" "s2-commit-worker" "s1-stop-connection" "s2-stop-connection"
 // the next permutation is flaky. To have a deterministic order of outputs, we sleep in s1, and we delay completion messages of s2 until the sleep is over.
-permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-coordinator-create-index-concurrently"("s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"
+permutation "s1-start-session-level-connection" "s1-begin-on-worker" "s1-disable-binary-protocol-on-worker" "s1-select" "s2-coordinator-create-index-concurrently"(*, "s1-sleep") "s1-commit-worker" "s1-sleep" "s1-stop-connection"


### PR DESCRIPTION
This PR aims to make use of blocker conditions feature on some of the tests that are already fixed by a normalization rule.

The PR first reverts the single commit in #5910 and implements a new alternative.