### PR TITLE
Fix dropping temporary view without specifying the explicit schema name

### DIFF
--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -439,7 +439,8 @@ AlterViewOwnerCommand(Oid viewOid)
 bool
 IsViewDistributed(Oid viewOid)
 {
-	Assert(get_rel_relkind(viewOid) == RELKIND_VIEW);
+	Assert(get_rel_relkind(viewOid) == RELKIND_VIEW ||
+		   get_rel_relkind(viewOid) == RELKIND_MATVIEW);
 
 	ObjectAddress viewAddress = { 0 };
 	ObjectAddressSet(viewAddress, RelationRelationId, viewOid);

--- a/src/test/regress/expected/view_propagation.out
+++ b/src/test/regress/expected/view_propagation.out
@@ -792,6 +792,33 @@ SELECT run_command_on_workers($$SELECT count(*) FROM v_test_2$$);
  (localhost,57638,f,"ERROR:  relation ""v_test_2"" does not exist")
 (2 rows)
 
+-- create and drop temporary view
+CREATE TEMPORARY VIEW temp_view_to_drop AS SELECT 1;
+WARNING:  "view temp_view_to_drop" has dependency on unsupported object "schema pg_temp_xxx"
+DETAIL:  "view temp_view_to_drop" will be created only locally
+DROP VIEW temp_view_to_drop;
+-- drop non-existent view
+DROP VIEW IF EXISTS drop_the_nonexistent_view;
+NOTICE:  view "drop_the_nonexistent_view" does not exist, skipping
+DROP VIEW IF EXISTS non_exist_view_schema.view_to_drop;
+NOTICE:  schema "non_exist_view_schema" does not exist, skipping
+-- Check materialized view just for sanity
+CREATE MATERIALIZED VIEW materialized_view_to_test AS SELECT 1;
+DROP VIEW materialized_view_to_test;
+ERROR:  "materialized_view_to_test" is not a view
+HINT:  Use DROP MATERIALIZED VIEW to remove a materialized view.
+DROP MATERIALIZED VIEW materialized_view_to_test;
+CREATE SCHEMA axx;
+create materialized view axx.temp_view_to_drop AS SELECT 1;
+DROP VIEW axx.temp_view_to_drop;
+ERROR:  "temp_view_to_drop" is not a view
+HINT:  Use DROP MATERIALIZED VIEW to remove a materialized view.
+DROP VIEW IF EXISTS axx.temp_view_to_drop;
+ERROR:  "temp_view_to_drop" is not a view
+HINT:  Use DROP MATERIALIZED VIEW to remove a materialized view.
+DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
+DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
+NOTICE:  materialized view "temp_view_to_drop" does not exist, skipping
 SET client_min_messages TO ERROR;
 DROP SCHEMA view_prop_schema_inner CASCADE;
-DROP SCHEMA view_prop_schema CASCADE;
+DROP SCHEMA view_prop_schema, axx CASCADE;

--- a/src/test/regress/sql/view_propagation.sql
+++ b/src/test/regress/sql/view_propagation.sql
@@ -442,6 +442,26 @@ SELECT create_distributed_table('employees','employee_id');
 SELECT run_command_on_workers($$SELECT count(*) FROM v_test_1$$);
 SELECT run_command_on_workers($$SELECT count(*) FROM v_test_2$$);
 
+-- create and drop temporary view
+CREATE TEMPORARY VIEW temp_view_to_drop AS SELECT 1;
+DROP VIEW temp_view_to_drop;
+
+-- drop non-existent view
+DROP VIEW IF EXISTS drop_the_nonexistent_view;
+DROP VIEW IF EXISTS non_exist_view_schema.view_to_drop;
+
+-- Check materialized view just for sanity
+CREATE MATERIALIZED VIEW materialized_view_to_test AS SELECT 1;
+DROP VIEW materialized_view_to_test;
+DROP MATERIALIZED VIEW materialized_view_to_test;
+
+CREATE SCHEMA axx;
+create materialized view axx.temp_view_to_drop AS SELECT 1;
+DROP VIEW axx.temp_view_to_drop;
+DROP VIEW IF EXISTS axx.temp_view_to_drop;
+DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
+DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA view_prop_schema_inner CASCADE;
-DROP SCHEMA view_prop_schema CASCADE;
+DROP SCHEMA view_prop_schema, axx CASCADE;


### PR DESCRIPTION
Fix dropping temporary view without specifying the explicit schema name
