### PR TITLE
Fix bug in unqualified, non-existing DROP DOMAIN IF EXISTS

### DIFF
--- a/src/backend/distributed/deparser/qualify_domain.c
+++ b/src/backend/distributed/deparser/qualify_domain.c
@@ -205,10 +205,13 @@ QualifyTypeName(TypeName *typeName, bool missing_ok)
 		if (!schemaName)
 		{
 			Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-			Oid namespaceOid = TypeOidGetNamespaceOid(typeOid);
-			schemaName = get_namespace_name(namespaceOid);
+			if (OidIsValid(typeOid))
+			{
+				Oid namespaceOid = TypeOidGetNamespaceOid(typeOid);
+				schemaName = get_namespace_name(namespaceOid);
 
-			typeName->names = list_make2(makeString(schemaName), makeString(name));
+				typeName->names = list_make2(makeString(schemaName), makeString(name));
+			}
 		}
 	}
 }

--- a/src/test/regress/expected/distributed_domain.out
+++ b/src/test/regress/expected/distributed_domain.out
@@ -943,5 +943,7 @@ SELECT * FROM run_command_on_workers($$ SELECT '1'::distributed_domain.domain3; 
  localhost |    57638 | f       | ERROR:  type "distributed_domain.domain3" does not exist
 (2 rows)
 
+DROP DOMAIN IF EXISTS domain_does_not_exist;
+NOTICE:  type "domain_does_not_exist" does not exist, skipping
 SET client_min_messages TO warning;
 DROP SCHEMA distributed_domain, distributed_domain_moved CASCADE;

--- a/src/test/regress/sql/distributed_domain.sql
+++ b/src/test/regress/sql/distributed_domain.sql
@@ -483,5 +483,7 @@ SELECT * FROM run_command_on_workers($$ SELECT 1::distributed_domain.domain1; $$
 SELECT * FROM run_command_on_workers($$ SELECT '1'::distributed_domain.domain2; $$) ORDER BY 1,2;
 SELECT * FROM run_command_on_workers($$ SELECT '1'::distributed_domain.domain3; $$) ORDER BY 1,2;
 
+DROP DOMAIN IF EXISTS domain_does_not_exist;
+
 SET client_min_messages TO warning;
 DROP SCHEMA distributed_domain, distributed_domain_moved CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that could cause unqualified DROP DOMAIN IF EXISTS to fail

IF EXISTS implies that missing_ok is true in LookupTypeNameOid, but we do not consider the possibility of InvalidOid being returned.