### PR TITLE
Allow RENAME INDEX on tables and RENAME TABLE on indexes

### DIFF
--- a/ci/normalize_expected.sh
+++ b/ci/normalize_expected.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source ci/ci_helpers.sh
 
-for f in $(git ls-tree -r HEAD --name-only src/test/regress/expected/*.out); do
+for f in $(git ls-tree -r HEAD --name-only src/test/regress/expected/index_create*.out); do
 	sed -Ef src/test/regress/bin/normalize.sed < "$f" > "$f.modified"
 	mv "$f.modified" "$f"
 done

--- a/src/backend/distributed/commands/rename.c
+++ b/src/backend/distributed/commands/rename.c
@@ -99,6 +99,18 @@ PreprocessRenameStmt(Node *node, const char *renameCommand,
 		case OBJECT_TABCONSTRAINT:
 		case OBJECT_POLICY:
 		{
+			if (relKind == RELKIND_INDEX ||
+				relKind == RELKIND_PARTITIONED_INDEX)
+			{
+				/*
+				 * Although weird, postgres allows ALTER TABLE .. RENAME command
+				 * on indexes. We don't want to break non-distributed tables,
+				 * so allow.
+				 */
+				tableRelationId = IndexGetRelation(objectRelationId, false);
+				break;
+			}
+
 			/* the target object is our tableRelationId. */
 			tableRelationId = objectRelationId;
 			break;
@@ -106,6 +118,18 @@ PreprocessRenameStmt(Node *node, const char *renameCommand,
 
 		case OBJECT_INDEX:
 		{
+			if (relKind == RELKIND_RELATION ||
+				relKind == RELKIND_PARTITIONED_TABLE)
+			{
+				/*
+				 * Although weird, postgres allows ALTER INDEX .. RENAME command
+				 * on tables. We don't want to break non-distributed tables,
+				 * so allow.
+				 */
+				tableRelationId = objectRelationId;
+				break;
+			}
+
 			/*
 			 * here, objRelationId points to the index relation entry, and we
 			 * are interested into the entry of the table on which the index is

--- a/src/test/regress/expected/index_create.out
+++ b/src/test/regress/expected/index_create.out
@@ -38,3 +38,43 @@ ALTER INDEX idx2 ALTER COLUMN 1 SET STATISTICS 1000;
 -- test reindex
 REINDEX INDEX idx1;
 ALTER TABLE test_tbl REPLICA IDENTITY USING INDEX a_index;
+-- postgres allows ALTER INDEX rename on tables, and so Citus..
+-- and, also ALTER TABLE rename on indexes..
+CREATE TABLE alter_idx_rename_test (a INT);
+CREATE INDEX alter_idx_rename_test_idx ON alter_idx_rename_test (a);
+BEGIN;
+-- rename index/table with weird syntax
+ALTER INDEX alter_idx_rename_test RENAME TO alter_idx_rename_test_2;
+ALTER TABLE alter_idx_rename_test_idx RENAME TO alter_idx_rename_test_idx_2;
+-- also, rename index/table with proper syntax
+ALTER INDEX alter_idx_rename_test_idx_2 RENAME TO alter_idx_rename_test_idx_3;
+ALTER TABLE alter_idx_rename_test_2 RENAME TO alter_idx_rename_test_3;
+SELECT 'alter_idx_rename_test_3'::regclass, 'alter_idx_rename_test_idx_3'::regclass;
+        regclass         |          regclass
+---------------------------------------------------------------------
+ alter_idx_rename_test_3 | alter_idx_rename_test_idx_3
+(1 row)
+
+ROLLBACK;
+-- now, on distributed tables
+SELECT create_distributed_table('alter_idx_rename_test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- rename index/table with weird syntax
+ALTER INDEX alter_idx_rename_test RENAME TO alter_idx_rename_test_2;
+ALTER TABLE alter_idx_rename_test_idx RENAME TO alter_idx_rename_test_idx_2;
+-- also, rename index/table with proper syntax
+ALTER INDEX alter_idx_rename_test_idx_2 RENAME TO alter_idx_rename_test_idx_3;
+ALTER TABLE alter_idx_rename_test_2 RENAME TO alter_idx_rename_test_3;
+SELECT 'alter_idx_rename_test_3'::regclass, 'alter_idx_rename_test_idx_3'::regclass;
+        regclass         |          regclass
+---------------------------------------------------------------------
+ alter_idx_rename_test_3 | alter_idx_rename_test_idx_3
+(1 row)
+
+ALTER INDEX alter_idx_rename_test_idx_3 RENAME TO alter_idx_rename_test_idx_4;
+DROP INDEX alter_idx_rename_test_idx_4;
+DROP TABLE alter_idx_rename_test_3;

--- a/src/test/regress/sql/index_create.sql
+++ b/src/test/regress/sql/index_create.sql
@@ -39,3 +39,37 @@ ALTER INDEX idx2 ALTER COLUMN 1 SET STATISTICS 1000;
 REINDEX INDEX idx1;
 
 ALTER TABLE test_tbl REPLICA IDENTITY USING INDEX a_index;
+
+-- postgres allows ALTER INDEX rename on tables, and so Citus..
+-- and, also ALTER TABLE rename on indexes..
+CREATE TABLE alter_idx_rename_test (a INT);
+CREATE INDEX alter_idx_rename_test_idx ON alter_idx_rename_test (a);
+BEGIN;
+-- rename index/table with weird syntax
+ALTER INDEX alter_idx_rename_test RENAME TO alter_idx_rename_test_2;
+ALTER TABLE alter_idx_rename_test_idx RENAME TO alter_idx_rename_test_idx_2;
+
+-- also, rename index/table with proper syntax
+ALTER INDEX alter_idx_rename_test_idx_2 RENAME TO alter_idx_rename_test_idx_3;
+ALTER TABLE alter_idx_rename_test_2 RENAME TO alter_idx_rename_test_3;
+
+SELECT 'alter_idx_rename_test_3'::regclass, 'alter_idx_rename_test_idx_3'::regclass;
+
+ROLLBACK;
+
+-- now, on distributed tables
+SELECT create_distributed_table('alter_idx_rename_test', 'a');
+
+-- rename index/table with weird syntax
+ALTER INDEX alter_idx_rename_test RENAME TO alter_idx_rename_test_2;
+ALTER TABLE alter_idx_rename_test_idx RENAME TO alter_idx_rename_test_idx_2;
+
+-- also, rename index/table with proper syntax
+ALTER INDEX alter_idx_rename_test_idx_2 RENAME TO alter_idx_rename_test_idx_3;
+ALTER TABLE alter_idx_rename_test_2 RENAME TO alter_idx_rename_test_3;
+
+SELECT 'alter_idx_rename_test_3'::regclass, 'alter_idx_rename_test_idx_3'::regclass;
+
+ALTER INDEX alter_idx_rename_test_idx_3 RENAME TO alter_idx_rename_test_idx_4;
+DROP INDEX alter_idx_rename_test_idx_4;
+DROP TABLE alter_idx_rename_test_3;


### PR DESCRIPTION
I'm not yet fully convinced that this is the right patch or whether we have more such cases or not.

But, one alternative fix for [5337](https://github.com/citusdata/citus/issues/5337)

Postgres allows, so we should.

