### PR TITLE
Add changelog entries for 11.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 ### citus v11.0.2 (June 15, 2022) ###
 
+* Open sources enterprise features, see the rest of changelog items
+
+* Non blocking shard moves/shard rebalancer
+  (`citus.logical_replication_timeout`)
+
+* Propagation of `CREATE/DROP/ALTER ROLE` statements
+
+* Propagation of `GRANT` statements
+
+* Propagation of `CLUSTER` statements
+
+* Propagation of `ALTER DATABASE ... OWNER TO ...`
+
+* Optimization for `COPY` when loading `JSON` to avoid double parsing of
+  the `JSON` object (`citus.skip_jsonb_validation_in_copy`)
+
+* Support for row level security
+
+* Support for `pg_dist_authinfo`, which allows storing different
+  authentication options for different users, e.g. you can store
+  passwords or certificates here.
+
+* Support for `pg_dist_poolinfo`, which allows using connection poolers
+  in between coordinator and workers
+
+* Tracking distributed query execution times using
+  citus_stat_statements (`citus.stat_statements_max`,
+  `citus.stat_statements_purge_interval`,
+  `citus.stat_statements_track`). This is disabled by default.
+
+* Blocking tenant_isolation
+
+* Support for `sslkey` and `sslcert` in `citus.node_conninfo`
+
 * Introduces `citus_finish_citus_upgrade()` procedure
 
 * Introduces `synchronous` option to `citus_disable_node()` UDF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,8 @@
 
 * Turns metadata syncing on by default
 
-* Adds `citus_finalize_upgrade_to_citus11()` which is necessary to upgrade to
-  Citus 11+ from earlier versions
-
-* Introduces `citus_finish_citus_upgrade()` procedure
+* Introduces `citus_finish_citus_upgrade()` procedure which is necessary to
+  upgrade from earlier versions
 
 * Open sources non-blocking shard moves/shard rebalancer
   (`citus.logical_replication_timeout`)
@@ -39,7 +37,7 @@
   `citus.stat_statements_purge_interval`,
   `citus.stat_statements_track`). This is disabled by default.
 
-* Open sources blocking tenant_isolation
+* Open sources tenant_isolation
 
 * Open sources support for `sslkey` and `sslcert` in `citus.node_conninfo`
 
@@ -322,9 +320,6 @@
 
 * Removes support for dropping distributed and local indexes in the same
   statement
-
-* Replaces `citus.hide_shards_from_app_name_prefixes` with
-  `citus.show_shards_for_app_name_prefixes`
 
 * Replaces `citus.enable_object_propagation` GUC with
   `citus.enable_metadata_sync`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,20 @@
 
 * Converts `citus.hide_shards_from_app_name_prefixes` to `citus.show_shards_for_app_name_prefixes`
 
+* Enables distributed execution from `run_command_on_*` functions
+
+* Honors `enable_metadata_sync` in node operations
+
+* Parallelizes metadata syncing on node activate
+
 * Fixes a bug that could cause false positive distributed deadlocks due to local execution
 
 * Fixes a bug that could cause leaking files when materialized views are refreshed
 
 * Fixes a bug that could cause unqualified `DROP DOMAIN IF EXISTS` to fail
+
+* Fixes a bug that could cause wrong schema and ownership after
+  `alter_distributed_table`
 
 * Fixes a bug that prevents dropping/altering indexes
 
@@ -63,6 +72,8 @@
 * Fixes schema name qualification for `ALTER/DROP STATISTICS`
 
 * Improves nested execution checks and adds GUC `citus.allow_nested_distributed_execution`
+
+* Prevents alter table functions from dropping extensions
 
 * Refrains reading the metadata cache for all tables during upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ### citus v11.0.2 (June 15, 2022) ###
 
+* Drops support for PostgreSQL 12
+
 * Open sources enterprise features, see the rest of changelog items
+
+* Turns metadata syncing on by default
+
+* Adds `citus_finalize_upgrade_to_citus11()` which is necessary to upgrade to
+  Citus 11+ from earlier versions
+
+* Introduces `citus_finish_citus_upgrade()` procedure
 
 * Open sources non-blocking shard moves/shard rebalancer
   (`citus.logical_replication_timeout`)
@@ -34,90 +43,6 @@
 
 * Open sources support for `sslkey` and `sslcert` in `citus.node_conninfo`
 
-* Introduces `citus_finish_citus_upgrade()` procedure
-
-* Introduces `synchronous` option to `citus_disable_node()` UDF
-
-* Introduces `citus_is_coordinator` UDF to check whether a node is the
-  coordinator
-
-* Introduces `run_command_on_coordinator` UDF
-
-* Adds support for `CREATE/DROP/ALTER VIEW` commands
-
-* Adds support for `LOCK` commands on distributed tables from worker nodes
-
-* Adds support for propagating views when syncing Citus table metadata
-
-* Enables distributed execution from `run_command_on_*` functions
-
-* Honors `enable_metadata_sync` in node operations
-
-* Parallelizes metadata syncing on node activation
-
-* Replaces `citus.hide_shards_from_app_name_prefixes` with
-  `citus.show_shards_for_app_name_prefixes`
-
-* Fixes a bug that could cause false positive distributed deadlocks due to local
-  execution
-
-* Fixes a bug that could cause leaking files when materialized views are
-  refreshed
-
-* Fixes a bug that could cause unqualified `DROP DOMAIN IF EXISTS` to fail
-
-* Fixes a bug that could cause wrong schema and ownership after
-  `alter_distributed_table`
-
-* Fixes a bug that prevents dropping/altering indexes
-
-* Fixes columnar freezing/wraparound bug
-
-* Fixes `invalid read of size 1` memory error with `citus_add_node`
-
-* Fixes schema name qualification for `ALTER/DROP SEQUENCE`
-
-* Fixes schema name qualification for `ALTER/DROP STATISTICS`
-
-* Fixes schema name qualification for `CREATE STATISTICS`
-
-* Improves nested execution checks and adds GUC to control
-  (`citus.allow_nested_distributed_execution`)
-
-* Prevents alter table functions from dropping extensions
-
-* Allows `lock_table_if_exits` to be called outside of a transaction blocks
-
-* Refrains reading the metadata cache for all tables during upgrade
-
-### citus v11.0.1_beta (April 11, 2022) ###
-
-* Adds propagation of `DOMAIN` objects
-
-* Adds support for `TABLESAMPLE`
-
-* Allows adding a unique constraint with an index
-
-* Fixes a bug that could cause `EXPLAIN ANALYZE` to fail for prepared statements
-  with custom type
-
-* Fixes a bug that could cause Citus not to create function in transaction block
-  properly
-
-* Fixes a bug that could cause returning invalid JSON when running
-  `EXPLAIN ANALYZE` with subplans
-
-* Fixes a bug that prevents non-client backends from accessing shards
-
-### citus v11.0.0_beta (March 22, 2022) ###
-
-* Drops support for PostgreSQL 12
-
-* Turns metadata syncing on by default
-
-* Adds `citus_finalize_upgrade_to_citus11()` which is necessary to upgrade to
-  Citus 11+ from earlier versions
-
 * Adds `citus.max_client_connections` GUC to limit non-Citus connections
 
 * Allows locally creating objects having a dependency that cannot be distributed
@@ -144,6 +69,8 @@
 
 * Adds propagation for foreign server commands
 
+* Adds propagation of `DOMAIN` objects
+
 * Adds propagation of `TEXT SEARCH CONFIGURATION` objects
 
 * Adds propagation of `TEXT SEARCH DICTIONARY` objects
@@ -151,6 +78,8 @@
 * Adds support for `ALTER FUNCTION ... SUPPORT ...` commands
 
 * Adds support for `CREATE SCHEMA AUTHORIZATION` statements without schema name
+
+* Adds support for `CREATE/DROP/ALTER VIEW` commands
 
 * Adds support for `TRUNCATE` for foreign tables
 
@@ -171,6 +100,12 @@
 
 * Adds support for shard replication > 1 hash distributed tables on Citus MX
 
+* Adds support for `LOCK` commands on distributed tables from worker nodes
+
+* Adds support for `TABLESAMPLE`
+
+* Adds support for propagating views when syncing Citus table metadata
+
 * Improves handling of `IN`, `OUT` and `INOUT` parameters for functions
 
 * Introduces `citus_backend_gpid()` UDF to get global pid of the current backend
@@ -190,11 +125,22 @@
 
 * Introduces a new flag `force_delegation` in `create_distributed_function()`
 
+* Introduces `run_command_on_coordinator` UDF
+
+* Introduces `synchronous` option to `citus_disable_node()` UDF
+
+* Introduces `citus_is_coordinator` UDF to check whether a node is the
+  coordinator
+
+* Allows adding a unique constraint with an index
+
 * Allows `create_distributed_function()` on a function owned by an extension
 
 * Allows creating distributed tables in sequential mode
 
 * Allows disabling nodes when multiple failures happen
+
+* Allows `lock_table_if_exits` to be called outside of a transaction blocks
 
 * Adds support for pushing procedures with `OUT` arguments down to the worker
   nodes
@@ -219,6 +165,8 @@
 
 * `citus_shards_on_worker` shows all local shards regardless of `search_path`
 
+* Enables distributed execution from `run_command_on_*` functions
+
 * Deprecates inactive shard state, never marks any placement inactive
 
 * Disables distributed & reference foreign tables
@@ -240,6 +188,20 @@
 
 * Avoids unnecessary errors for `ALTER STATISTICS IF EXISTS` when the statistics
   does not exist
+
+* Fixes a bug that prevents dropping/altering indexes
+
+* Fixes a bug that prevents non-client backends from accessing shards
+
+* Fixes columnar freezing/wraparound bug
+
+* Fixes `invalid read of size 1` memory error with `citus_add_node`
+
+* Fixes schema name qualification for `ALTER/DROP SEQUENCE`
+
+* Fixes schema name qualification for `ALTER/DROP STATISTICS`
+
+* Fixes schema name qualification for `CREATE STATISTICS`
 
 * Fixes a bug that causes columnar storage pages to have zero LSN
 
@@ -267,6 +229,26 @@
   objects being not created during pg upgrades
 
 * Fixes a bug that could cause re-partition joins involving local shards to fail
+
+* Fixes a bug that could cause false positive distributed deadlocks due to local
+  execution
+
+* Fixes a bug that could cause leaking files when materialized views are
+  refreshed
+
+* Fixes a bug that could cause unqualified `DROP DOMAIN IF EXISTS` to fail
+
+* Fixes a bug that could cause wrong schema and ownership after
+  `alter_distributed_table`
+
+* Fixes a bug that could cause `EXPLAIN ANALYZE` to fail for prepared statements
+  with custom type
+
+* Fixes a bug that could cause Citus not to create function in transaction block
+  properly
+
+* Fixes a bug that could cause returning invalid JSON when running
+  `EXPLAIN ANALYZE` with subplans
 
 * Fixes a bug that limits usage of sequences in non-int columns
 
@@ -299,16 +281,27 @@
 
 * Fixes naming issues of newly created partitioned indexes
 
+* Honors `enable_metadata_sync` in node operations
+
+* Improves nested execution checks and adds GUC to control
+  (`citus.allow_nested_distributed_execution`)
+
 * Improves self-deadlock prevention for `CREATE INDEX / REINDEX CONCURRENTLY`
   commands for builds using PG14 or higher
 
 * Moves `pg_dist_object` to `pg_catalog` schema
+
+* Parallelizes metadata syncing on node activation
 
 * Partitions shards to be co-located with the parent shards
 
 * Prevents Citus table functions from being called on shards
 
 * Prevents creating distributed functions when there are out of sync nodes
+
+* Prevents alter table functions from dropping extensions
+
+* Refrains reading the metadata cache for all tables during upgrade
 
 * Provides notice message for idempotent `create_distributed_function` calls
 
@@ -329,6 +322,9 @@
 
 * Removes support for dropping distributed and local indexes in the same
   statement
+
+* Replaces `citus.hide_shards_from_app_name_prefixes` with
+  `citus.show_shards_for_app_name_prefixes`
 
 * Replaces `citus.enable_object_propagation` GUC with
   `citus.enable_metadata_sync`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,37 +2,37 @@
 
 * Open sources enterprise features, see the rest of changelog items
 
-* Non blocking shard moves/shard rebalancer
+* Open sources non-blocking shard moves/shard rebalancer
   (`citus.logical_replication_timeout`)
 
-* Propagation of `CREATE/DROP/ALTER ROLE` statements
+* Open sources propagation of `CREATE/DROP/ALTER ROLE` statements
 
-* Propagation of `GRANT` statements
+* Open sources propagation of `GRANT` statements
 
-* Propagation of `CLUSTER` statements
+* Open sources propagation of `CLUSTER` statements
 
-* Propagation of `ALTER DATABASE ... OWNER TO ...`
+* Open sources propagation of `ALTER DATABASE ... OWNER TO ...`
 
-* Optimization for `COPY` when loading `JSON` to avoid double parsing of
-  the `JSON` object (`citus.skip_jsonb_validation_in_copy`)
+* Open sources optimization for `COPY` when loading `JSON` to avoid double
+  parsing of the `JSON` object (`citus.skip_jsonb_validation_in_copy`)
 
-* Support for row level security
+* Open sources support for row level security
 
-* Support for `pg_dist_authinfo`, which allows storing different
+* Open sources support for `pg_dist_authinfo`, which allows storing different
   authentication options for different users, e.g. you can store
   passwords or certificates here.
 
-* Support for `pg_dist_poolinfo`, which allows using connection poolers
-  in between coordinator and workers
+* Open sources support for `pg_dist_poolinfo`, which allows using connection
+  poolers in between coordinator and workers
 
-* Tracking distributed query execution times using
+* Open sources tracking distributed query execution times using
   citus_stat_statements (`citus.stat_statements_max`,
   `citus.stat_statements_purge_interval`,
   `citus.stat_statements_track`). This is disabled by default.
 
-* Blocking tenant_isolation
+* Open sources blocking tenant_isolation
 
-* Support for `sslkey` and `sslcert` in `citus.node_conninfo`
+* Open sources support for `sslkey` and `sslcert` in `citus.node_conninfo`
 
 * Introduces `citus_finish_citus_upgrade()` procedure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
 
 * Introduces `synchronous` option to `citus_disable_node()` UDF
 
-* Introduces `citus_is_coordinator` UDF to check whether a node is the coordinator
+* Introduces `citus_is_coordinator` UDF to check whether a node is the
+  coordinator
 
 * Introduces `run_command_on_coordinator` UDF
 
@@ -46,7 +47,8 @@
 
 * Adds support for propagating views when syncing Citus table metadata
 
-* Converts `citus.hide_shards_from_app_name_prefixes` to `citus.show_shards_for_app_name_prefixes`
+* Converts `citus.hide_shards_from_app_name_prefixes` to
+  `citus.show_shards_for_app_name_prefixes`
 
 * Enables distributed execution from `run_command_on_*` functions
 
@@ -54,9 +56,11 @@
 
 * Parallelizes metadata syncing on node activate
 
-* Fixes a bug that could cause false positive distributed deadlocks due to local execution
+* Fixes a bug that could cause false positive distributed deadlocks due to local
+  execution
 
-* Fixes a bug that could cause leaking files when materialized views are refreshed
+* Fixes a bug that could cause leaking files when materialized views are
+  refreshed
 
 * Fixes a bug that could cause unqualified `DROP DOMAIN IF EXISTS` to fail
 
@@ -71,7 +75,8 @@
 
 * Fixes schema name qualification for `ALTER/DROP STATISTICS`
 
-* Improves nested execution checks and adds GUC `citus.allow_nested_distributed_execution`
+* Improves nested execution checks and adds GUC
+  `citus.allow_nested_distributed_execution`
 
 * Prevents alter table functions from dropping extensions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 ### citus v11.0.2 (June 15, 2022) ###
 
-* Adds `synchronous` option to `citus_disable_node()` UDF
+* Introduces `citus_finish_citus_upgrade()` procedure
 
-* Adds a `citus_is_coordinator` function to check whether a node is the coordinator
+* Introduces `synchronous` option to `citus_disable_node()` UDF
 
-* Adds a `run_command_on_coordinator` function
+* Introduces `citus_is_coordinator` UDF to check whether a node is the coordinator
 
-* Adds support for distributing `CREATE`/`DROP VIEW` commands
+* Introduces `run_command_on_coordinator` UDF
 
-* Adds support for propagating `ALTER VIEW` commands
+* Adds support for `CREATE/DROP/ALTER VIEW` commands
+
+* Adds support for propagating views when syncing Citus table metadata
 
 * Converts `citus.hide_shards_from_app_name_prefixes` to `citus.show_shards_for_app_name_prefixes`
 
-* Fixes a bug that cause false positive distributed deadlocks due to local execution
+* Fixes a bug that could cause false positive distributed deadlocks due to local execution
 
 * Fixes a bug that could cause leaking files when materialized views are refreshed
 
@@ -22,17 +24,13 @@
 
 * Fixes columnar freezing/wraparound bug
 
-* Fixes schema name qualification for `ALTER` and `DROP SEQUENCE`
+* Fixes schema name qualification for `ALTER/DROP SEQUENCE`
 
-* Fixes schema name qualification for `ALTER` and `DROP STATISTICS`
+* Fixes schema name qualification for `ALTER/DROP STATISTICS`
 
-* Improves nested execution checks and add GUC to disable
+* Improves nested execution checks and adds GUC `citus.allow_nested_distributed_execution`
 
-* Introduces a `citus_finish_citus_upgrade()` procedure
-
-* Propagates views when syncing Citus table metadata
-
-* Refrain reading the metadata cache for all tables during upgrade
+* Refrains reading the metadata cache for all tables during upgrade
 
 ### citus v11.0.1_beta (April 11, 2022) ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@
 
 * Fixes schema name qualification for `CREATE STATISTICS`
 
-* Improves nested execution checks and adds GUC
-  `citus.allow_nested_distributed_execution`
+* Improves nested execution checks and adds GUC to control
+  (`citus.allow_nested_distributed_execution`)
 
 * Prevents alter table functions from dropping extensions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 * Adds support for `CREATE/DROP/ALTER VIEW` commands
 
-* Adds support for `LOCK` commands
+* Adds support for `LOCK` commands on distributed tables from worker nodes
 
 * Adds support for propagating views when syncing Citus table metadata
 
@@ -73,6 +73,8 @@
 
 * Fixes columnar freezing/wraparound bug
 
+* Fixes `invalid read of size 1` memory error with `citus_add_node`
+
 * Fixes schema name qualification for `ALTER/DROP SEQUENCE`
 
 * Fixes schema name qualification for `ALTER/DROP STATISTICS`
@@ -83,6 +85,8 @@
   `citus.allow_nested_distributed_execution`
 
 * Prevents alter table functions from dropping extensions
+
+* Allows `lock_table_if_exits` to be called outside of a transaction blocks
 
 * Refrains reading the metadata cache for all tables during upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 * Adds support for `CREATE/DROP/ALTER VIEW` commands
 
+* Adds support for `LOCK` commands
+
 * Adds support for propagating views when syncing Citus table metadata
 
 * Enables distributed execution from `run_command_on_*` functions
@@ -74,6 +76,8 @@
 * Fixes schema name qualification for `ALTER/DROP SEQUENCE`
 
 * Fixes schema name qualification for `ALTER/DROP STATISTICS`
+
+* Fixes schema name qualification for `CREATE STATISTICS`
 
 * Improves nested execution checks and adds GUC
   `citus.allow_nested_distributed_execution`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+### citus v11.0.2 (June 15, 2022) ###
+
+* Adds `synchronous` option to `citus_disable_node()` UDF
+
+* Adds a `citus_is_coordinator` function to check whether a node is the coordinator
+
+* Adds a `run_command_on_coordinator` function
+
+* Adds support for distributing `CREATE`/`DROP VIEW` commands
+
+* Adds support for propagating `ALTER VIEW` commands
+
+* Converts `citus.hide_shards_from_app_name_prefixes` to `citus.show_shards_for_app_name_prefixes`
+
+* Fixes a bug that cause false positive distributed deadlocks due to local execution
+
+* Fixes a bug that could cause leaking files when materialized views are refreshed
+
+* Fixes a bug that could cause unqualified `DROP DOMAIN IF EXISTS` to fail
+
+* Fixes a bug that prevents dropping/altering indexes
+
+* Fixes columnar freezing/wraparound bug
+
+* Fixes schema name qualification for `ALTER` and `DROP SEQUENCE`
+
+* Fixes schema name qualification for `ALTER` and `DROP STATISTICS`
+
+* Improves nested execution checks and add GUC to disable
+
+* Introduces a `citus_finish_citus_upgrade()` procedure
+
+* Propagates views when syncing Citus table metadata
+
+* Refrain reading the metadata cache for all tables during upgrade
+
 ### citus v11.0.1_beta (April 11, 2022) ###
 
 * Adds propagation of `DOMAIN` objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 * Honors `enable_metadata_sync` in node operations
 
-* Parallelizes metadata syncing on node activate
+* Parallelizes metadata syncing on node activation
 
 * Replaces `citus.hide_shards_from_app_name_prefixes` with
   `citus.show_shards_for_app_name_prefixes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,14 @@
 
 * Adds support for propagating views when syncing Citus table metadata
 
-* Converts `citus.hide_shards_from_app_name_prefixes` to
-  `citus.show_shards_for_app_name_prefixes`
-
 * Enables distributed execution from `run_command_on_*` functions
 
 * Honors `enable_metadata_sync` in node operations
 
 * Parallelizes metadata syncing on node activate
+
+* Replaces `citus.hide_shards_from_app_name_prefixes` with
+  `citus.show_shards_for_app_name_prefixes`
 
 * Fixes a bug that could cause false positive distributed deadlocks due to local
   execution


### PR DESCRIPTION
This PR aims to add the changelog entries for all the commits on `release-11.0` branch after we bumped to `v11.0.1_beta`. As of now, the head of said branch points to 0861c80c8bddb73df37478979663e012b40952b

TODO:
- [x] Make sure that all the PRs with `needs-description` label either adds a description or removes the label.
- [x] Wait until all the changes are there on `release-11.0` branch
- [ ] Compare enterprise and community release branches for possible missing commits