### PR TITLE
Postgres Vanilla Testing Correctness with Citus Extension

### DIFF
--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -29,21 +29,5 @@
 # core dumps
 core
 
-# postgres vanilla test's outputs
-constraints.sql
-copy.sql
-create_function_0.sql
-create_function_1.sql
-create_function_2.sql
-largeobject.sql
-misc.sql
-security_label.sql
-constraints.out
-copy.out
-create_function_0.out
-create_function_1.out
-create_function_2.out
-largeobject.out
-largeobject_1.out
-misc.out
-security_label.out
+# pg_vanilla output folders
+pg_vanilla_outputs

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -34,6 +34,8 @@ arbitrary_config_check = $(citus_abs_srcdir)/citus_tests/arbitrary_configs/citus
 template_isolation_files = $(shell find $(citus_abs_srcdir)/spec/ -name '*.spec')
 generated_isolation_files = $(patsubst $(citus_abs_srcdir)/spec/%,$(citus_abs_srcdir)/build/specs/%,$(template_isolation_files))
 
+vanilla_diffs_file = $(citus_abs_srcdir)/pg_vanilla_outputs/$(MAJORVERSION)/regression.diffs
+
 # have make check actually run all tests, but keep check-full as an
 # intermediate, for muscle memory backward compatibility.
 check: check-full check-enterprise-full
@@ -183,8 +185,9 @@ check-isolation-base: all  $(isolation_test_files)
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	-- $(MULTI_REGRESS_OPTS) --inputdir=$(citus_abs_srcdir)/build --schedule=$(citus_abs_srcdir)/base_isolation_schedule $(EXTRA_TESTS)
 
+# ci takes regression.diffs output from another location, so copy diffs file at the end.
 check-vanilla:
-	$(pg_regress_multi_check) --vanillatest --vanilla-dev
+	$(pg_regress_multi_check) --vanillatest || (cp $(vanilla_diffs_file) $(citus_abs_srcdir)/regression.diffs)
 
 check-multi-mx: all
 	$(pg_regress_multi_check) --load-extension=citus \

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -60,7 +60,6 @@ my $MASTER_FOLLOWERDIR = 'master-follower';
 # Option parsing
 my $isolationtester = 0;
 my $vanillatest = 0;
-my $vanillaDev = 0;
 my $followercluster = 0;
 my $bindir = "";
 my $libdir = undef;
@@ -98,7 +97,6 @@ if ($Config{osname} eq "MSWin32")
 GetOptions(
     'isolationtester' => \$isolationtester,
     'vanillatest' => \$vanillatest,
-    'vanilla-dev' => \$vanillaDev,
     'follower-cluster' => \$followercluster,
     'bindir=s' => \$bindir,
     'libdir=s' => \$libdir,
@@ -490,15 +488,8 @@ push(@pgOptions, "citus.show_shards_for_app_name_prefixes='pg_regress'");
 # we disable slow start by default to encourage parallelism within tests
 push(@pgOptions, "citus.executor_slow_start_interval=0ms");
 
-###
 # we set some GUCs to not break postgres vanilla tests
-#
-# NOTE: we do not want to set the option right now because
-# vanilla tests currently fail. We will remove the vanillaDev flag
-# after fully supported pg vanilla tests with citus
-# extension created.
-###
-if(!$vanillaDev && $vanillatest)
+if($vanillatest)
 {
     # we enable hiding the citus dependent objects from pg meta class queries to not break postgres vanilla test behaviour
     push(@pgOptions, "citus.hide_citus_dependent_objects=true");
@@ -945,14 +936,19 @@ if (!$conninfo)
         system(catfile($bindir, "psql"),
             ('-X', '-h', $host, '-p', $port, '-U', $user, "-d", "postgres",
                 '-c', "CREATE DATABASE regression;")) == 0
-            or die "Could not create regression database on worker";
+            or die "Could not create regression database on worker port $port.";
+
+        my $firstLib = `psql -h "$host" -p "$port" -U "$user" -d regression -AXqt \\
+                        -c "SHOW shared_preload_libraries;" | cut -d ',' -f1`;
+        ($firstLib =~ m/^citus$/)
+            or die "Could not find citus as first library in shared_preload_libraries on worker $port.";
 
         for my $extension (@extensions)
         {
             system(catfile($bindir, "psql"),
                 ('-X', '-h', $host, '-p', $port, '-U', $user, "-d", "regression",
                     '-c', "CREATE EXTENSION IF NOT EXISTS $extension;")) == 0
-                or die "Could not create extension on worker";
+                or die "Could not create extension $extension on worker port $port.";
         }
 
         foreach my $function (keys %functions)
@@ -960,7 +956,7 @@ if (!$conninfo)
             system(catfile($bindir, "psql"),
                     ('-X', '-h', $host, '-p', $port, '-U', $user, "-d", "regression",
                     '-c', "CREATE FUNCTION $function RETURNS $functions{$function};")) == 0
-                or die "Could not create FUNCTION $function on worker";
+                or die "Could not create function $function on worker port $port";
         }
 
         foreach my $fdw (keys %fdws)
@@ -968,25 +964,31 @@ if (!$conninfo)
             system(catfile($bindir, "psql"),
                     ('-X', '-h', $host, '-p', $port, '-U', $user, "-d", "regression",
                     '-c', "CREATE FOREIGN DATA WRAPPER $fdw HANDLER $fdws{$fdw};")) == 0
-                or die "Could not create foreign data wrapper $fdw on worker";
+                or die "Could not create foreign data wrapper $fdw on worker port $port";
         }
     }
 }
 else
 {
+    my $citusFirstLibCount = `psql -h "$host" -p "$masterPort" -U "$user" -d "$dbname" -AXqt \\
+                                -c "SELECT run_command_on_workers('SHOW shared_preload_libraries;');" \\
+                                | cut -d ',' -f4 | grep -e '\"citus' | wc -l`;
+    ($workerCount == $citusFirstLibCount)
+        or die "Could not find citus as first library in shared_preload_libraries on workers.";
+
     for my $extension (@extensions)
     {
         system(catfile($bindir, "psql"),
                 ('-X', '-h', $host, '-p', $masterPort, '-U', $user, "-d", $dbname,
                 '-c', "SELECT run_command_on_workers('CREATE EXTENSION IF NOT EXISTS $extension;');")) == 0
-            or die "Could not create extension on worker";
+            or die "Could not create extension $extension on workers";
     }
     foreach my $function (keys %functions)
     {
         system(catfile($bindir, "psql"),
                 ('-X', '-h', $host, '-p', $masterPort, '-U', $user, "-d", $dbname,
                     '-c', "SELECT run_command_on_workers('CREATE FUNCTION $function RETURNS $functions{$function};');")) == 0
-            or die "Could not create FUNCTION $function on worker";
+            or die "Could not create function $function on workers.";
     }
 
     foreach my $fdw (keys %fdws)
@@ -994,7 +996,7 @@ else
         system(catfile($bindir, "psql"),
                 ('-X', '-h', $host, '-p', $masterPort, '-U', $user, "-d", $dbname,
                     '-c', "SELECT run_command_on_workers('CREATE FOREIGN DATA WRAPPER $fdw HANDLER $fdws{$fdw};');")) == 0
-            or die "Could not create foreign data wrapper $fdw on worker";
+            or die "Could not create foreign data wrapper $fdw on workers.";
     }
 }
 
@@ -1019,21 +1021,19 @@ my $startTime = time();
 
 my $exitcode = 0;
 
-sub PrepForVanillaTest
+sub RunVanillaTests
 {
     ###
     # We want to add is_citus_depended_object function to the default db.
-    # But without use-existing flag, pg_regress drops if exist and creates
-    # the default db. Thus, we set use-existing flag and manually create
-    # the default db, citus extension and the is_citus_depended_object
-    # function.
+    # But without use-existing flag, pg_regress recreates the default db
+    # after dropping it if exists. Thus, we set use-existing flag and
+    # manually create the default db, citus extension and is_citus_depended_object
+    # function. When use-existing flag is set, pg_regress does not drop
+    # default db.
     ###
 
-    my $dbName = shift;
-
-    # prepare tablespace folder
-    rmdir "./testtablespace";
-    mkdir "./testtablespace";
+    $ENV{VANILLATEST} = "1";
+    my $dbName = "regression";
 
     # create default db
     system(catfile($bindir, "psql"),
@@ -1046,11 +1046,6 @@ sub PrepForVanillaTest
             ('-X', '-h', $host, '-p', $masterPort, '-U', $user, "-d", $dbName,
                 '-c', "ALTER DATABASE $dbName SET lc_monetary TO 'C';")) == 0
             or die "Could not create $dbName database on master";
-
-    if ($vanillaDev)
-    {
-        return;
-    }
 
     # create extension citus
     system(catfile($bindir, "psql"),
@@ -1068,40 +1063,45 @@ sub PrepForVanillaTest
                     ('-X', '-h', $host, '-p', $masterPort, '-U', $user, "-d", $dbName,
                     '-c', $citus_depended_object_def)) == 0
                 or die "Could not create FUNCTION is_citus_depended_object on master";
+
+    my $pgregressdir="";
+    if (-f "$vanillaSchedule")
+	{
+	    $pgregressdir=catfile(dirname("$pgxsdir"), "regress");
+	}
+	else
+	{
+	    $pgregressdir=catfile("$postgresSrcdir", "src", "test", "regress");
+	}
+
+    # output dir
+    my $pgregressOutputdir = "$citusAbsSrcdir/pg_vanilla_outputs/$majorversion";
+
+    # prepare output and tablespace folder
+    system("rm", ("-rf", "$pgregressOutputdir")) == 0
+            or die "Could not remove vanilla output dir.";
+    system("mkdir", ("-p", "$pgregressOutputdir/testtablespace")) == 0
+            or die "Could not create vanilla testtablespace dir.";
+    system("mkdir", ("-p", "$pgregressOutputdir/expected")) == 0
+            or die "Could not create vanilla expected dir.";
+    system("mkdir", ("-p", "$pgregressOutputdir/sql")) == 0
+            or die "Could not create vanilla sql dir.";
+
+    $exitcode = system("$plainRegress",
+                        ("--inputdir",  $pgregressdir),
+                        ("--outputdir",  $pgregressOutputdir),
+                        ("--schedule",  catfile("$pgregressdir", "parallel_schedule")),
+                        ("--use-existing"),
+                        ("--host","$host"),
+                        ("--port","$masterPort"),
+                        ("--user","$user"),
+                        ("--dbname", "$dbName"));
 }
 
 # Finally run the tests
 if ($vanillatest)
 {
-	$ENV{VANILLATEST} = "1";
-
-    my $dbName = "regression";
-    PrepForVanillaTest($dbName);
-
-	if (-f "$vanillaSchedule")
-	{
-	    my $pgregressdir=catfile(dirname("$pgxsdir"), "regress");
-	    $exitcode = system("$plainRegress",
-                ("--inputdir",  $pgregressdir),
-                ("--schedule",  catfile("$pgregressdir", "parallel_schedule")),
-                ("--use-existing"),
-                ("--host","$host"),
-                ("--port","$masterPort"),
-                ("--user","$user"),
-                ("--dbname", "$dbName"))
-	}
-	else
-	{
-	    my $pgregressdir=catfile("$postgresSrcdir", "src", "test", "regress");
-        $exitcode = system("$plainRegress",
-                ("--inputdir",  $pgregressdir),
-                ("--schedule",  catfile("$pgregressdir", "parallel_schedule")),
-                ("--use-existing"),
-                ("--host","$host"),
-                ("--port","$masterPort"),
-                ("--user","$user"),
-                ("--dbname", "$dbName"))
-	}
+    RunVanillaTests();
 }
 elsif ($isolationtester)
 {


### PR DESCRIPTION
* We ensure citus resides on preloaded shared libraries on nodes before tests start.
* We ensure citus does not break postgres vanilla tests. There are 12 subtasks which are described in the checklist below. You can see them to look at what we have done so far to be compatible with pg tests without changing citus behaviour as much as possible.

1. #6055,
2. #6063,
3. #6056,
4. #6088 ,
5. #6081,
6. #6082,
7. #6120,
8.  #6125,
9. #6083,
10. #6131,
11. #6132,
12. #6130.