### PR TITLE
Fix matviews for citus_add_local_table_to_metadata

### DIFF
--- a/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
+++ b/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
@@ -26,6 +26,7 @@
 #include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/worker_protocol.h"
+#include "executor/spi.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -526,7 +527,11 @@ ExecuteAndLogUtilityCommandListInTableTypeConversion(List *utilityCommandList)
 	MemoryContext savedMemoryContext = CurrentMemoryContext;
 	PG_TRY();
 	{
-		ExecuteAndLogUtilityCommandList(utilityCommandList);
+		char *utilityCommand = NULL;
+		foreach_ptr(utilityCommand, utilityCommandList)
+		{
+			ExecuteQueryViaSPI(utilityCommand, SPI_OK_UTILITY);
+		}
 	}
 	PG_CATCH();
 	{

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -1053,7 +1053,9 @@ DropViewsOnTable(Oid relationId)
 		char *qualifiedViewName = quote_qualified_identifier(schemaName, viewName);
 
 		StringInfo dropCommand = makeStringInfo();
-		appendStringInfo(dropCommand, "DROP VIEW IF EXISTS %s",
+		appendStringInfo(dropCommand, "DROP %sVIEW IF EXISTS %s",
+						 get_rel_relkind(viewId) == RELKIND_MATVIEW ? "MATERIALIZED " :
+						 "",
 						 qualifiedViewName);
 
 		ExecuteAndLogUtilityCommand(dropCommand->data);


### PR DESCRIPTION
Todo list:
* Refactor `ExecuteAndLogUtilityCommandListInTableTypeConversion` and name it accordingly (uses SPI now)
* Detect circular dependencies and provide an error message
* Introduce a GUC to determine a threshold that the matviews will be recreated automatically if their sizes are below the threshold. Otherwise, the user will be asked to increase the threshold via the GUC, in order to recreate the matview after adding the table to metadata