### PR TITLE
Fixes a bug that prevents using COMPRESSION and CONSTRAINT on a column

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -377,6 +377,14 @@ pg_get_tableschemadef_string(Oid tableRelationId, IncludeSequenceDefaults
 				atttypmod);
 			appendStringInfoString(&buffer, attributeTypeName);
 
+#if PG_VERSION_NUM >= PG_VERSION_14
+			if (CompressionMethodIsValid(attributeForm->attcompression))
+			{
+				appendStringInfo(&buffer, " COMPRESSION %s",
+								 GetCompressionMethodName(attributeForm->attcompression));
+			}
+#endif
+
 			/* if this column has a default value, append the default value */
 			if (attributeForm->atthasdef)
 			{
@@ -447,14 +455,6 @@ pg_get_tableschemadef_string(Oid tableRelationId, IncludeSequenceDefaults
 			{
 				appendStringInfoString(&buffer, " NOT NULL");
 			}
-
-#if PG_VERSION_NUM >= PG_VERSION_14
-			if (CompressionMethodIsValid(attributeForm->attcompression))
-			{
-				appendStringInfo(&buffer, " COMPRESSION %s",
-								 GetCompressionMethodName(attributeForm->attcompression));
-			}
-#endif
 
 			if (attributeForm->attcollation != InvalidOid &&
 				attributeForm->attcollation != DEFAULT_COLLATION_OID)

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -1376,6 +1376,35 @@ SELECT create_distributed_table('ctlt1', 'a');
 (1 row)
 
 CREATE TABLE ctlt_all_2 (LIKE ctlt1 INCLUDING ALL);
+CREATE TABLE compression_and_defaults (
+    data text COMPRESSION lz4 DEFAULT '"{}"'::text COLLATE "C" NOT NULL PRIMARY KEY,
+    rev text
+)
+WITH (
+    autovacuum_vacuum_scale_factor='0.01',
+    fillfactor='75'
+);
+SELECT create_distributed_table('compression_and_defaults', 'data', colocate_with:='none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE compression_and_generated_col (
+    data text COMPRESSION lz4 GENERATED ALWAYS AS (rev || '{]') STORED COLLATE "C" NOT NULL,
+    rev text
+)
+WITH (
+    autovacuum_vacuum_scale_factor='0.01',
+    fillfactor='75'
+);
+SELECT create_distributed_table('compression_and_generated_col', 'rev', colocate_with:='none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP TABLE compression_and_defaults, compression_and_generated_col;
 -- cleanup
 set client_min_messages to error;
 drop extension postgres_fdw cascade;

--- a/src/test/regress/sql/pg14.sql
+++ b/src/test/regress/sql/pg14.sql
@@ -713,6 +713,30 @@ CREATE STATISTICS ctlt1_expr_stat ON (a || b) FROM ctlt1;
 CREATE TABLE ctlt_all (LIKE ctlt1 INCLUDING ALL);
 SELECT create_distributed_table('ctlt1', 'a');
 CREATE TABLE ctlt_all_2 (LIKE ctlt1 INCLUDING ALL);
+
+CREATE TABLE compression_and_defaults (
+    data text COMPRESSION lz4 DEFAULT '"{}"'::text COLLATE "C" NOT NULL PRIMARY KEY,
+    rev text
+)
+WITH (
+    autovacuum_vacuum_scale_factor='0.01',
+    fillfactor='75'
+);
+
+SELECT create_distributed_table('compression_and_defaults', 'data', colocate_with:='none');
+
+CREATE TABLE compression_and_generated_col (
+    data text COMPRESSION lz4 GENERATED ALWAYS AS (rev || '{]') STORED COLLATE "C" NOT NULL,
+    rev text
+)
+WITH (
+    autovacuum_vacuum_scale_factor='0.01',
+    fillfactor='75'
+);
+SELECT create_distributed_table('compression_and_generated_col', 'rev', colocate_with:='none');
+
+DROP TABLE compression_and_defaults, compression_and_generated_col;
+
 -- cleanup
 set client_min_messages to error;
 drop extension postgres_fdw cascade;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that prevents using COMPRESSION and CONSTRAINT on a column

Fixes https://github.com/citusdata/citus/issues/6025

Added tests with combinations from https://www.postgresql.org/docs/current/sql-createtable.html 