### PR TITLE
Bugfix for IN clause to be considered during planner phase in Columnar

### DIFF
--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -824,7 +824,8 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 		}
 	}
 
-	if (IsA(node, ScalarArrayOpExpr)) {
+	if (IsA(node, ScalarArrayOpExpr))
+	{
 		return (Expr *) node;
 	}
 

--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -1386,6 +1386,10 @@ CostColumnarScan(PlannerInfo *root, RelOptInfo *rel, Oid relationId,
 {
 	Path *path = &cpath->path;
 
+	// If EnableColumnarQualPushdown is false, we don't want to send usefulClauses
+	if (!EnableColumnarQualPushdown) {
+		usefulClauses = NIL;
+	}
 	/*List *allClauses = lsecond(cpath->custom_private); */
 	Selectivity clauseSel = clauselist_selectivity(
 		root, usefulClauses, rel->relid, JOIN_INNER, NULL);

--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -1354,6 +1354,7 @@ AddColumnarScanPath(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
 	}
 
 	int numberOfColumnsRead = bms_num_members(rte->selectedCols);
+
 	/* not sure if we want usefulClauses or allClauses */
 	int numberOfClausesPushed = list_length(allClauses);
 

--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -766,7 +766,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 			 *   WHERE id NOT IN (SELECT id FROM something).
 			 */
 			ereport(ColumnarPlannerDebugLevel,
-					(errmsg("columnar planner: cannot push down clause: "
+					(errmsg("columnar planner: cannot consider clause: "
 							"must not contain a subplan")));
 			return NULL;
 		}
@@ -785,9 +785,9 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 			else if (boolExpr->boolop == OR_EXPR)
 			{
 				ereport(ColumnarPlannerDebugLevel,
-						(errmsg("columnar planner: cannot push down clause: "
+						(errmsg("columnar planner: cannot consider clause: "
 								"all arguments of an OR expression must be "
-								"pushdownable but one of them was not, due "
+								"able to be considered but one of them was not, due "
 								"to the reason given above")));
 				return NULL;
 			}
@@ -799,8 +799,8 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 		if (npushdownableArgs == 0)
 		{
 			ereport(ColumnarPlannerDebugLevel,
-					(errmsg("columnar planner: cannot push down clause: "
-							"none of the arguments were pushdownable, "
+					(errmsg("columnar planner: cannot consider clause: "
+							"none of the arguments were able to be considered, "
 							"due to the reason(s) given above ")));
 			return NULL;
 		}
@@ -827,7 +827,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	if (!IsA(node, OpExpr) || list_length(((OpExpr *) node)->args) != 2)
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"must be binary operator expression")));
 		return NULL;
 	}
@@ -854,7 +854,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	else
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"must match 'Var <op> Expr' or 'Expr <op> Var'"),
 				 errhint("Var must only reference this rel, "
 						 "and Expr must not reference this rel")));
@@ -864,7 +864,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	if (varSide->varattno <= 0)
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"var is whole-row reference or system column")));
 		return NULL;
 	}
@@ -872,7 +872,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	if (contain_volatile_functions((Node *) exprSide))
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"expr contains volatile functions")));
 		return NULL;
 	}
@@ -887,7 +887,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 											 &varOpcInType))
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"cannot find default btree opclass and opfamily for type: %s",
 						format_type_be(varSide->vartype))));
 		return NULL;
@@ -896,7 +896,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	if (!op_in_opfamily(opExpr->opno, varOpFamily))
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"operator %d not a member of opfamily %d",
 						opExpr->opno, varOpFamily)));
 		return NULL;
@@ -914,7 +914,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 	if (!CheckVarStats(root, varSide, sortop, &absVarCorrelation))
 	{
 		ereport(ColumnarPlannerDebugLevel,
-				(errmsg("columnar planner: cannot push down clause: "
+				(errmsg("columnar planner: cannot consider clause: "
 						"absolute correlation (%.3f) of var attribute %d is "
 						"smaller than the value configured in "
 						"\"columnar.qual_pushdown_correlation_threshold\" "

--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -826,7 +826,14 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 
 	if (IsA(node, ScalarArrayOpExpr))
 	{
-		return (Expr *) node;
+		if (!contain_volatile_functions(node))
+		{
+			return (Expr *) node;
+		}
+		else
+		{
+			return NULL;
+		}
 	}
 
 	if (!IsA(node, OpExpr) || list_length(((OpExpr *) node)->args) != 2)

--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -1267,12 +1267,6 @@ GetClauseVars(List *whereClauseList, int natts)
 		Var *var = (Var *) node;
 		int idx = var->varattno - 1;
 
-		/* if the variable is a whole-row reference, varattno is 0
-		 * so idx will be out-of-bounds */
-		if (idx < 0) {
-			continue;
-		}
-
 		if (deduplicate[idx] != NULL)
 		{
 			/* if they have the same varattno, the rest should be identical */

--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -1267,6 +1267,12 @@ GetClauseVars(List *whereClauseList, int natts)
 		Var *var = (Var *) node;
 		int idx = var->varattno - 1;
 
+		/* if the variable is a whole-row reference, varattno is 0
+		 * so idx will be out-of-bounds */
+		if (idx < 0) {
+			continue;
+		}
+
 		if (deduplicate[idx] != NULL)
 		{
 			/* if they have the same varattno, the rest should be identical */

--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -1066,3 +1066,36 @@ RESET columnar.max_custom_scan_paths;
 RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
+-- https://github.com/citusdata/citus/issues/5803
+set columnar.chunk_group_row_limit = 1000;
+CREATE TABLE pushdown_test(id int, country text) using columnar;
+BEGIN;
+    INSERT INTO pushdown_test VALUES(1, 'AL');
+    INSERT INTO pushdown_test VALUES(2, 'AU');
+END;
+BEGIN;
+    INSERT INTO pushdown_test VALUES(3, 'BR');
+    INSERT INTO pushdown_test VALUES(4, 'BT');
+END;
+BEGIN;
+    INSERT INTO pushdown_test VALUES(5, 'PK');
+    INSERT INTO pushdown_test VALUES(6, 'PA');
+END;
+BEGIN;
+    INSERT INTO pushdown_test VALUES(7, 'USA');
+    INSERT INTO pushdown_test VALUES(8, 'ZW');
+END;
+EXPLAIN (analyze on, costs off, timing off, summary off)
+SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
+                                QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on pushdown_test (actual rows=3 loops=1)
+    Filter: (country = ANY ('{USA,BR,ZW}'::text[]))
+    Rows Removed by Filter: 1
+    Columnar Projected Columns: id, country
+    Columnar Chunk Group Filters: (country = ANY ('{USA,BR,ZW}'::text[]))
+    Columnar Chunk Groups Removed by Filter: 2
+(6 rows)
+
+RESET columnar.chunk_group_row_limit;
+DROP TABLE pushdown_test;

--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -1066,3 +1066,32 @@ RESET columnar.max_custom_scan_paths;
 RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
+--
+-- https://github.com/citusdata/citus/issues/5803
+--
+
+create table clause_check (id int, company_name text) using columnar;
+INSERT INTO clause_check VALUES(1, 'AAPL');
+INSERT INTO clause_check VALUES(2, 'IBM');
+INSERT INTO clause_check VALUES(3, 'TSLA');
+INSERT INTO clause_check VALUES (generate_series(4,100000), md5(random()::text));
+EXPLAIN ANALYZE SELECT * FROM clause_check WHERE company_name = 'AAPL' or company_name = 'IBM' or     company_name = 'TSLA';
+                                                            QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on clause_check  (cost=0.00..63.72 rows=1493 width=36) (actual time=0.277..70.351 rows=3 loops=1)
+   Filter: ((company_name = 'AAPL'::text) OR (company_name = 'IBM'::text) OR (company_name = 'TSLA'::text))
+   Rows Removed by Filter: 99997
+   Columnar Projected Columns: id, company_name
+   Columnar Chunk Group Filters: ((company_name = 'AAPL'::text) OR (company_name = 'IBM'::text) OR (company_name = 'TSLA'::text))
+   Columnar Chunk Groups Removed by Filter: 0
+(8 rows)
+EXPLAIN ANALYZE SELECT * FROM clause_check where company_name IN ('APPLE', 'IBM', 'TSLA');
+                                                          QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on clause_check  (cost=0.00..254.86 rows=1500 width=36) (actual time=0.324..28.994 rows=2 loops=1)
+   Filter: (company_name = ANY ('{APPLE,IBM,TSLA}'::text[]))
+   Rows Removed by Filter: 99997
+   Columnar Projected Columns: id, company_name
+   Columnar Chunk Group Filters: (company_name = ANY ('{APPLE,IBM,TSLA}'::text[]))
+   Columnar Chunk Groups Removed by Filter: 1
+(8 rows)

--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -1066,32 +1066,3 @@ RESET columnar.max_custom_scan_paths;
 RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
---
--- https://github.com/citusdata/citus/issues/5803
---
-
-create table clause_check (id int, company_name text) using columnar;
-INSERT INTO clause_check VALUES(1, 'AAPL');
-INSERT INTO clause_check VALUES(2, 'IBM');
-INSERT INTO clause_check VALUES(3, 'TSLA');
-INSERT INTO clause_check VALUES (generate_series(4,100000), md5(random()::text));
-EXPLAIN ANALYZE SELECT * FROM clause_check WHERE company_name = 'AAPL' or company_name = 'IBM' or     company_name = 'TSLA';
-                                                            QUERY PLAN
----------------------------------------------------------------------
- Custom Scan (ColumnarScan) on clause_check  (cost=0.00..63.72 rows=1493 width=36) (actual time=0.277..70.351 rows=3 loops=1)
-   Filter: ((company_name = 'AAPL'::text) OR (company_name = 'IBM'::text) OR (company_name = 'TSLA'::text))
-   Rows Removed by Filter: 99997
-   Columnar Projected Columns: id, company_name
-   Columnar Chunk Group Filters: ((company_name = 'AAPL'::text) OR (company_name = 'IBM'::text) OR (company_name = 'TSLA'::text))
-   Columnar Chunk Groups Removed by Filter: 0
-(8 rows)
-EXPLAIN ANALYZE SELECT * FROM clause_check where company_name IN ('APPLE', 'IBM', 'TSLA');
-                                                          QUERY PLAN
----------------------------------------------------------------------
- Custom Scan (ColumnarScan) on clause_check  (cost=0.00..254.86 rows=1500 width=36) (actual time=0.324..28.994 rows=2 loops=1)
-   Filter: (company_name = ANY ('{APPLE,IBM,TSLA}'::text[]))
-   Rows Removed by Filter: 99997
-   Columnar Projected Columns: id, company_name
-   Columnar Chunk Group Filters: (company_name = ANY ('{APPLE,IBM,TSLA}'::text[]))
-   Columnar Chunk Groups Removed by Filter: 1
-(8 rows)

--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -1067,7 +1067,6 @@ RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
 -- https://github.com/citusdata/citus/issues/5803
-set columnar.chunk_group_row_limit = 1000;
 CREATE TABLE pushdown_test(id int, country text) using columnar;
 BEGIN;
     INSERT INTO pushdown_test VALUES(1, 'AL');
@@ -1097,5 +1096,37 @@ SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
     Columnar Chunk Groups Removed by Filter: 2
 (6 rows)
 
-RESET columnar.chunk_group_row_limit;
+SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
+ id
+---------------------------------------------------------------------
+  3
+  7
+  8
+(3 rows)
+
+-- test for volatile functions with IN
+CREATE FUNCTION volatileFunction() returns TEXT language plpgsql AS
+$$
+BEGIN
+    return 'AL';
+END;
+$$;
+EXPLAIN (analyze on, costs off, timing off, summary off)
+SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
+                                   QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (ColumnarScan) on pushdown_test (actual rows=3 loops=1)
+   Filter: (country = ANY (ARRAY['USA'::text, 'ZW'::text, volatilefunction()]))
+   Rows Removed by Filter: 5
+   Columnar Projected Columns: id, country
+(4 rows)
+
+SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
+ id | country
+---------------------------------------------------------------------
+  1 | AL
+  7 | USA
+  8 | ZW
+(3 rows)
+
 DROP TABLE pushdown_test;

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -445,15 +445,3 @@ RESET columnar.max_custom_scan_paths;
 RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
-
---
--- https://github.com/citusdata/citus/issues/5803
---
-
-create table clause_check (id int, company_name text) using columnar;
-INSERT INTO clause_check VALUES(1, 'AAPL');
-INSERT INTO clause_check VALUES(2, 'IBM');
-INSERT INTO clause_check VALUES(3, 'TSLA');
-INSERT INTO clause_check VALUES (generate_series(4,100000), md5(random()::text));
-EXPLAIN ANALYZE SELECT * FROM clause_check WHERE company_name = 'AAPL' or company_name = 'IBM' or company_name = 'TSLA';
-EXPLAIN ANALYZE SELECT * FROM clause_check where company_name IN ('APPLE', 'IBM', 'TSLA');

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -445,3 +445,15 @@ RESET columnar.max_custom_scan_paths;
 RESET columnar.qual_pushdown_correlation_threshold;
 RESET columnar.planner_debug_level;
 DROP TABLE pushdown_test;
+
+--
+-- https://github.com/citusdata/citus/issues/5803
+--
+
+create table clause_check (id int, company_name text) using columnar;
+INSERT INTO clause_check VALUES(1, 'AAPL');
+INSERT INTO clause_check VALUES(2, 'IBM');
+INSERT INTO clause_check VALUES(3, 'TSLA');
+INSERT INTO clause_check VALUES (generate_series(4,100000), md5(random()::text));
+EXPLAIN ANALYZE SELECT * FROM clause_check WHERE company_name = 'AAPL' or company_name = 'IBM' or company_name = 'TSLA';
+EXPLAIN ANALYZE SELECT * FROM clause_check where company_name IN ('APPLE', 'IBM', 'TSLA');

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -448,8 +448,6 @@ DROP TABLE pushdown_test;
 
 -- https://github.com/citusdata/citus/issues/5803
 
-set columnar.chunk_group_row_limit = 1000;
-
 CREATE TABLE pushdown_test(id int, country text) using columnar;
 
 BEGIN;
@@ -473,5 +471,18 @@ END;
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
 
-RESET columnar.chunk_group_row_limit;
+SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
+
+-- test for volatile functions with IN
+CREATE FUNCTION volatileFunction() returns TEXT language plpgsql AS
+$$
+BEGIN
+    return 'AL';
+END;
+$$;
+EXPLAIN (analyze on, costs off, timing off, summary off)
+SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
+
+SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
+
 DROP TABLE pushdown_test;


### PR DESCRIPTION
Reported bug #5803 shows that we are currently not sending the IN clause to our planner for columnar. This PR fixes it by checking for ScalarArrayOpExpr in ExtractPushdownClause so that we do not skip it. Also added a test case for this new addition.
