### PR TITLE
Fix compilation warning on PG13 + OpenSSL 3.0

### DIFF
--- a/src/backend/distributed/utils/enable_ssl.c
+++ b/src/backend/distributed/utils/enable_ssl.c
@@ -8,6 +8,19 @@
  *-------------------------------------------------------------------------
  */
 
+
+/*
+ * Make sure that functions marked as deprecated in OpenSSL 3.0 don't trigger
+ * deprecation warnings by indicating that we're using the OpenSSL 1.0.1
+ * compatibile API. Postgres does this by already in PG14, so we should not do
+ * it otherwise we get warnings about redefining this value.
+ */
+#if PG_VERSION_NUM < PG_VERSION_14
+#ifndef OPENSSL_API_COMPAT
+#define OPENSSL_API_COMPAT 0x1000100L
+#endif
+#endif
+
 #include "postgres.h"
 
 #include "distributed/connection_management.h"


### PR DESCRIPTION
DESCRIPTION: Fix compilation warning on PG13 + OpenSSL 3.0

This removes some warnings that are present when building on Ubuntu 22.04. 
It removes warnings on PG13 + OpenSSL 3.0. OpenSSL 3.0 has marked some 
functions that we use as deprecated, but we want to continue support OpenSSL
1.0.1 for the time being too. This indicates that to OpenSSL 3.0, so it doesn't 
show warnings.
