### PR TITLE
Fix downgrade scripts from 11.0-2 to 11.0-1

### DIFF
--- a/src/backend/distributed/sql/downgrades/citus--11.0-2--11.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.0-2--11.0-1.sql
@@ -1,5 +1,6 @@
 #include "../udfs/citus_shards_on_worker/11.0-1.sql"
 #include "../udfs/citus_shard_indexes_on_worker/11.0-1.sql"
+#include "../udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql"
 
 DROP FUNCTION  pg_catalog.citus_disable_node(text, integer, bool);
 CREATE FUNCTION pg_catalog.citus_disable_node(nodename text, nodeport integer, force bool default false)
@@ -15,5 +16,4 @@ DROP FUNCTION pg_catalog.citus_is_coordinator();
 DROP FUNCTION pg_catalog.run_command_on_coordinator(text,boolean);
 
 DROP FUNCTION pg_catalog.start_metadata_sync_to_all_nodes();
-DROP FUNCTION pg_catalog.citus_finalize_upgrade_to_citus11(boolean);
 DROP PROCEDURE pg_catalog.citus_finish_citus_upgrade();

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1031,6 +1031,15 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                                                                       | view citus_stat_activity
 (41 rows)
 
+-- Test downgrade to 11.0-1 from 11.0-2
+ALTER EXTENSION citus UPDATE TO '11.0-2';
+ALTER EXTENSION citus UPDATE TO '11.0-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
 -- Snapshot of state at 11.0-2
 ALTER EXTENSION citus UPDATE TO '11.0-2';
 SELECT * FROM multi_extension.print_extension_changes();
@@ -1042,9 +1051,10 @@ SELECT * FROM multi_extension.print_extension_changes();
                  | function start_metadata_sync_to_all_nodes() boolean
 (4 rows)
 
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-1';
+-- Test downgrade to 11.0-2 from 11.0-3
+ALTER EXTENSION citus UPDATE TO '11.0-3';
 ALTER EXTENSION citus UPDATE TO '11.0-2';
+-- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
  previous_object | current_object
 ---------------------------------------------------------------------
@@ -1057,9 +1067,10 @@ SELECT * FROM multi_extension.print_extension_changes();
 ---------------------------------------------------------------------
 (0 rows)
 
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-2';
+-- Test downgrade to 11.0-3 from 11.1-1
+ALTER EXTENSION citus UPDATE TO '11.1-1';
 ALTER EXTENSION citus UPDATE TO '11.0-3';
+-- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
  previous_object | current_object
 ---------------------------------------------------------------------
@@ -1098,14 +1109,6 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                                         | view columnar.storage
                                                                                         | view columnar.stripe
 (27 rows)
-
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-3';
-ALTER EXTENSION citus UPDATE TO '11.1-1';
-SELECT * FROM multi_extension.print_extension_changes();
- previous_object | current_object
----------------------------------------------------------------------
-(0 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -459,30 +459,33 @@ SELECT * FROM multi_extension.print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '11.0-1';
 SELECT * FROM multi_extension.print_extension_changes();
 
+-- Test downgrade to 11.0-1 from 11.0-2
+ALTER EXTENSION citus UPDATE TO '11.0-2';
+ALTER EXTENSION citus UPDATE TO '11.0-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+
 -- Snapshot of state at 11.0-2
 ALTER EXTENSION citus UPDATE TO '11.0-2';
 SELECT * FROM multi_extension.print_extension_changes();
 
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-1';
+-- Test downgrade to 11.0-2 from 11.0-3
+ALTER EXTENSION citus UPDATE TO '11.0-3';
 ALTER EXTENSION citus UPDATE TO '11.0-2';
+-- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
 
 -- Snapshot of state at 11.0-3
 ALTER EXTENSION citus UPDATE TO '11.0-3';
 SELECT * FROM multi_extension.print_extension_changes();
 
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-2';
+-- Test downgrade to 11.0-3 from 11.1-1
+ALTER EXTENSION citus UPDATE TO '11.1-1';
 ALTER EXTENSION citus UPDATE TO '11.0-3';
+-- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
 
 -- Snapshot of state at 11.1-1
-ALTER EXTENSION citus UPDATE TO '11.1-1';
-SELECT * FROM multi_extension.print_extension_changes();
-
--- Test downgrade script (result should be empty)
-ALTER EXTENSION citus UPDATE TO '11.0-3';
 ALTER EXTENSION citus UPDATE TO '11.1-1';
 SELECT * FROM multi_extension.print_extension_changes();
 


### PR DESCRIPTION
We have a structure for testing downgrades in a test that occasionally finds small bugs in our code. The structure was broken for a while. I fixed the tests, and I realized that we have a slight problem in one of our downgrade scripts.

`citus_finalize_upgrade_to_citus11` UDF exists on both `11.0-2` and `11.0-1` with different definitions. When performing the downgrade, instead of redefining said UDF, we drop it. This problem got apparent after I fixed the tests.