### PR TITLE
Make DeferErrorIfCircularDependencyExists work for each object

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -204,6 +204,10 @@ ErrorIfCircularDependencyExists(const ObjectAddress *objectAddress)
  * DeferErrorIfCircularDependencyExists is a wrapper function around
  * DeferErrorIfCircularDependencyExistsOnObject, which calls that function for
  * each dependency of the given object.
+ * We do this to detect objects like A -> B -> C <-> D.
+ * For this example, A is passed to this function but we will catch the circular
+ * dependency relationship between C and D, by calling
+ * DeferErrorIfCircularDependencyExistsOnObject for C, or D.
  */
 DeferredErrorMessage *
 DeferErrorIfCircularDependencyExists(const ObjectAddress *objectAddress)

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -262,6 +262,9 @@ extern void EnsureAllObjectDependenciesExistOnAllNodes(const List *targets);
 extern DeferredErrorMessage * DeferErrorIfCircularDependencyExists(const
 																   ObjectAddress *
 																   objectAddress);
+extern DeferredErrorMessage * DeferErrorIfCircularDependencyExistsOnObject(const
+																		   ObjectAddress *
+																		   objectAddress);
 extern List * GetDistributableDependenciesForObject(const ObjectAddress *target);
 extern List * GetAllDependencyCreateDDLCommands(const List *dependencies);
 extern bool ShouldPropagate(void);


### PR DESCRIPTION
DESCRIPTION: Makes DeferErrorIfCircularDependencyExists iterate for each dependent object

This PR introduces a new function named `DeferErrorIfCircularDependencyExistsOnObject`, which does the same thing as `DeferErrorIfCircularDependencyExists` did before. With this PR, we turn `DeferErrorIfCircularDependencyExists` into a wrapper function around the newly introduced function, which calls the inner function separately for each dependent object.