### PR TITLE
change address method to return list of addresses

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1302,7 +1302,7 @@ ErrorIfUnsupportedCascadeObjects(Oid relationId)
  *
  * Extension dependency is different than the rest. If an object depends on an extension
  * dropping the object would drop the extension too.
- * So we check with IsObjectAddressOwnedByExtension function.
+ * So we check with IsAnyObjectAddressOwnedByExtension function.
  */
 static bool
 DoesCascadeDropUnsupportedObject(Oid classId, Oid objectId, HTAB *nodeMap)
@@ -1315,10 +1315,9 @@ DoesCascadeDropUnsupportedObject(Oid classId, Oid objectId, HTAB *nodeMap)
 		return false;
 	}
 
-	ObjectAddress objectAddress = { 0 };
-	ObjectAddressSet(objectAddress, classId, objectId);
-
-	if (IsObjectAddressOwnedByExtension(&objectAddress, NULL))
+	ObjectAddress *objectAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*objectAddress, classId, objectId);
+	if (IsAnyObjectAddressOwnedByExtension(list_make1(objectAddress), NULL))
 	{
 		return true;
 	}

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -307,8 +307,8 @@ CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys, bool autoConve
 		}
 	}
 
-	ObjectAddress tableAddress = { 0 };
-	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
+	ObjectAddress *tableAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*tableAddress, RelationRelationId, relationId);
 
 	/*
 	 * Ensure that the sequences used in column defaults of the table
@@ -320,7 +320,7 @@ CreateCitusLocalTable(Oid relationId, bool cascadeViaForeignKeys, bool autoConve
 	 * Ensure dependencies exist as we will create shell table on the other nodes
 	 * in the MX case.
 	 */
-	EnsureDependenciesExistOnAllNodes(&tableAddress);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(tableAddress));
 
 	/*
 	 * Make sure that existing reference tables have been replicated to all

--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -169,7 +169,7 @@ CreateCollationDDLsIdempotent(Oid collationId)
 }
 
 
-ObjectAddress
+List *
 AlterCollationOwnerObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
@@ -177,8 +177,13 @@ AlterCollationOwnerObjectAddress(Node *node, bool missing_ok)
 
 	Assert(stmt->objectType == OBJECT_COLLATION);
 
-	return get_object_address(stmt->objectType, stmt->object, &relation,
-							  AccessExclusiveLock, missing_ok);
+	ObjectAddress objectAddress = get_object_address(stmt->objectType, stmt->object,
+													 &relation, AccessExclusiveLock,
+													 missing_ok);
+
+	ObjectAddress *objectAddressCopy = palloc0(sizeof(ObjectAddress));
+	*objectAddressCopy = objectAddress;
+	return list_make1(objectAddressCopy);
 }
 
 
@@ -186,17 +191,17 @@ AlterCollationOwnerObjectAddress(Node *node, bool missing_ok)
  * RenameCollationStmtObjectAddress returns the ObjectAddress of the type that is the object
  * of the RenameStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 RenameCollationStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_COLLATION);
 
 	Oid collationOid = get_collation_oid((List *) stmt->object, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, CollationRelationId, collationOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, CollationRelationId, collationOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -209,7 +214,7 @@ RenameCollationStmtObjectAddress(Node *node, bool missing_ok)
  * new schema. Errors if missing_ok is false and the type cannot be found in either of the
  * schemas.
  */
-ObjectAddress
+List *
 AlterCollationSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -232,9 +237,9 @@ AlterCollationSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, CollationRelationId, collationOid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, CollationRelationId, collationOid);
+	return list_make1(address);
 }
 
 
@@ -291,15 +296,15 @@ GenerateBackupNameForCollationCollision(const ObjectAddress *address)
 }
 
 
-ObjectAddress
+List *
 DefineCollationStmtObjectAddress(Node *node, bool missing_ok)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 	Assert(stmt->kind == OBJECT_COLLATION);
 
 	Oid collOid = get_collation_oid(stmt->defnames, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, CollationRelationId, collOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, CollationRelationId, collOid);
 
-	return address;
+	return list_make1(address);
 }

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -442,10 +442,9 @@ CreateDistributedTable(Oid relationId, char *distributionColumnName,
 	 * via their own connection and committed immediately so they become visible to all
 	 * sessions creating shards.
 	 */
-	ObjectAddress tableAddress = { 0 };
-	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
-
-	EnsureDependenciesExistOnAllNodes(&tableAddress);
+	ObjectAddress *tableAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*tableAddress, RelationRelationId, relationId);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(tableAddress));
 
 	char replicationModel = DecideReplicationModel(distributionMethod,
 												   colocateWithTableName,

--- a/src/backend/distributed/commands/database.c
+++ b/src/backend/distributed/commands/database.c
@@ -40,17 +40,17 @@ bool EnableAlterDatabaseOwner = true;
  * AlterDatabaseOwnerObjectAddress returns the ObjectAddress of the database that is the
  * object of the AlterOwnerStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 AlterDatabaseOwnerObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Assert(stmt->objectType == OBJECT_DATABASE);
 
 	Oid databaseOid = get_database_oid(strVal((String *) stmt->object), missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, DatabaseRelationId, databaseOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, DatabaseRelationId, databaseOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/domain.c
+++ b/src/backend/distributed/commands/domain.c
@@ -37,7 +37,7 @@
 
 
 static CollateClause * MakeCollateClauseFromOid(Oid collationOid);
-static ObjectAddress GetDomainAddressByName(TypeName *domainName, bool missing_ok);
+static List * GetDomainAddressByName(TypeName *domainName, bool missing_ok);
 
 /*
  * GetDomainAddressByName returns the ObjectAddress of the domain identified by
@@ -45,13 +45,13 @@ static ObjectAddress GetDomainAddressByName(TypeName *domainName, bool missing_o
  * InvalidOid. When missing_ok is false this function will raise an error instead when the
  * domain can't be found.
  */
-static ObjectAddress
+static List *
 GetDomainAddressByName(TypeName *domainName, bool missing_ok)
 {
-	ObjectAddress address = { 0 };
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	Oid domainOid = LookupTypeNameOid(NULL, domainName, missing_ok);
-	ObjectAddressSet(address, TypeRelationId, domainOid);
-	return address;
+	ObjectAddressSet(*address, TypeRelationId, domainOid);
+	return list_make1(address);
 }
 
 
@@ -229,17 +229,17 @@ MakeCollateClauseFromOid(Oid collationOid)
  * created by the statement. When missing_ok is false the function will raise an error if
  * the domain cannot be found in the local catalog.
  */
-ObjectAddress
+List *
 CreateDomainStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CreateDomainStmt *stmt = castNode(CreateDomainStmt, node);
 
 	TypeName *typeName = makeTypeNameFromNameList(stmt->domainname);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -248,7 +248,7 @@ CreateDomainStmtObjectAddress(Node *node, bool missing_ok)
  * When missing_ok is false this function will raise an error when the domain is not
  * found.
  */
-ObjectAddress
+List *
 AlterDomainStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterDomainStmt *stmt = castNode(AlterDomainStmt, node);
@@ -263,7 +263,7 @@ AlterDomainStmtObjectAddress(Node *node, bool missing_ok)
  * which the constraint is being renamed. When missing_ok this function will raise an
  * error if the domain cannot be found.
  */
-ObjectAddress
+List *
 DomainRenameConstraintStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -278,7 +278,7 @@ DomainRenameConstraintStmtObjectAddress(Node *node, bool missing_ok)
  * being changed. When missing_ok is false this function will raise an error if the domain
  * cannot be found.
  */
-ObjectAddress
+List *
 AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
@@ -294,7 +294,7 @@ AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok)
  * When missing_ok is false this function will raise an error when the domain cannot be
  * found.
  */
-ObjectAddress
+List *
 RenameDomainStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -1128,7 +1128,7 @@ GetDependentFDWsToExtension(Oid extensionId)
  * AlterExtensionSchemaStmtObjectAddress returns the ObjectAddress of the extension that is
  * the subject of the AlterObjectSchemaStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -1145,10 +1145,10 @@ AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok)
 							   extensionName)));
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, ExtensionRelationId, extensionOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, ExtensionRelationId, extensionOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -1156,7 +1156,7 @@ AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * AlterExtensionUpdateStmtObjectAddress returns the ObjectAddress of the extension that is
  * the subject of the AlterExtensionStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 AlterExtensionUpdateStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterExtensionStmt *stmt = castNode(AlterExtensionStmt, node);
@@ -1171,10 +1171,10 @@ AlterExtensionUpdateStmtObjectAddress(Node *node, bool missing_ok)
 							   extensionName)));
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, ExtensionRelationId, extensionOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, ExtensionRelationId, extensionOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/foreign_data_wrapper.c
+++ b/src/backend/distributed/commands/foreign_data_wrapper.c
@@ -64,6 +64,7 @@ PreprocessGrantOnFDWStmt(Node *node, const char *queryString,
 
 	EnsureCoordinator();
 
+	/*  the code-path only supports a single object */
 	Assert(list_length(stmt->objects) == 1);
 
 	char *sql = DeparseTreeNode((Node *) stmt);
@@ -87,12 +88,15 @@ NameListHasFDWOwnedByDistributedExtension(List *FDWNames)
 	foreach_ptr(FDWValue, FDWNames)
 	{
 		/* captures the extension address during lookup */
-		ObjectAddress extensionAddress = { 0 };
+		ObjectAddress *extensionAddress = palloc0(sizeof(ObjectAddress));
 		ObjectAddress FDWAddress = GetObjectAddressByFDWName(strVal(FDWValue), false);
 
-		if (IsObjectAddressOwnedByExtension(&FDWAddress, &extensionAddress))
+		ObjectAddress *copyFDWAddress = palloc0(sizeof(ObjectAddress));
+		*copyFDWAddress = FDWAddress;
+		if (IsAnyObjectAddressOwnedByExtension(list_make1(copyFDWAddress),
+											   extensionAddress))
 		{
-			if (IsObjectDistributed(&extensionAddress))
+			if (IsAnyObjectDistributed(list_make1(extensionAddress)))
 			{
 				return true;
 			}

--- a/src/backend/distributed/commands/foreign_server.c
+++ b/src/backend/distributed/commands/foreign_server.c
@@ -102,6 +102,7 @@ PreprocessGrantOnForeignServerStmt(Node *node, const char *queryString,
 
 	EnsureCoordinator();
 
+	/*  the code-path only supports a single object */
 	Assert(list_length(stmt->objects) == 1);
 
 	char *sql = DeparseTreeNode((Node *) stmt);
@@ -247,15 +248,14 @@ NameListHasDistributedServer(List *serverNames)
 	foreach_ptr(serverValue, serverNames)
 	{
 		List *addresses = GetObjectAddressByServerName(strVal(serverValue), false);
-		if (list_length(addresses) > 1)
-		{
-			ereport(ERROR, errmsg(
-						"citus does not support multiple object addresses in NameListHasDistributedServer"));
-		}
 
+		/*  the code-path only supports a single object */
+		Assert(list_length(addresses) == 1);
+
+		/* We have already asserted that we have exactly 1 address in the addresses. */
 		ObjectAddress *address = linitial(addresses);
 
-		if (IsObjectDistributed(address))
+		if (IsAnyObjectDistributed(list_make1(address)))
 		{
 			return true;
 		}

--- a/src/backend/distributed/commands/foreign_server.c
+++ b/src/backend/distributed/commands/foreign_server.c
@@ -16,6 +16,7 @@
 #include "distributed/commands.h"
 #include "distributed/deparser.h"
 #include "distributed/listutils.h"
+#include "distributed/log_utils.h"
 #include "distributed/metadata/distobject.h"
 #include "distributed/metadata_sync.h"
 #include "distributed/multi_executor.h"
@@ -29,7 +30,7 @@
 static char * GetForeignServerAlterOwnerCommand(Oid serverId);
 static Node * RecreateForeignServerStmt(Oid serverId);
 static bool NameListHasDistributedServer(List *serverNames);
-static ObjectAddress GetObjectAddressByServerName(char *serverName, bool missing_ok);
+static List * GetObjectAddressByServerName(char *serverName, bool missing_ok);
 
 
 /*
@@ -40,7 +41,7 @@ static ObjectAddress GetObjectAddressByServerName(char *serverName, bool missing
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CreateForeignServerStmt *stmt = castNode(CreateForeignServerStmt, node);
@@ -57,7 +58,7 @@ CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok)
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 AlterForeignServerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterForeignServerStmt *stmt = castNode(AlterForeignServerStmt, node);
@@ -121,7 +122,7 @@ PreprocessGrantOnForeignServerStmt(Node *node, const char *queryString,
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -139,7 +140,7 @@ RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok)
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 AlterForeignServerOwnerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
@@ -245,9 +246,16 @@ NameListHasDistributedServer(List *serverNames)
 	String *serverValue = NULL;
 	foreach_ptr(serverValue, serverNames)
 	{
-		ObjectAddress address = GetObjectAddressByServerName(strVal(serverValue), false);
+		List *addresses = GetObjectAddressByServerName(strVal(serverValue), false);
+		if (list_length(addresses) > 1)
+		{
+			ereport(ERROR, errmsg(
+						"citus does not support multiple object addresses in NameListHasDistributedServer"));
+		}
 
-		if (IsObjectDistributed(&address))
+		ObjectAddress *address = linitial(addresses);
+
+		if (IsObjectDistributed(address))
 		{
 			return true;
 		}
@@ -257,13 +265,13 @@ NameListHasDistributedServer(List *serverNames)
 }
 
 
-static ObjectAddress
+static List *
 GetObjectAddressByServerName(char *serverName, bool missing_ok)
 {
 	ForeignServer *server = GetForeignServerByName(serverName, missing_ok);
 	Oid serverOid = server->serverid;
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, ForeignServerRelationId, serverOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, ForeignServerRelationId, serverOid);
 
-	return address;
+	return list_make1(address);
 }

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -128,7 +128,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 	text *colocateWithText = NULL; /* optional */
 
 	StringInfoData ddlCommand = { 0 };
-	ObjectAddress functionAddress = { 0 };
+	ObjectAddress *functionAddress = palloc0(sizeof(ObjectAddress));
 
 	Oid distributionArgumentOid = InvalidOid;
 	bool colocatedWithReferenceTable = false;
@@ -203,9 +203,9 @@ create_distributed_function(PG_FUNCTION_ARGS)
 	EnsureCoordinator();
 	EnsureFunctionOwner(funcOid);
 
-	ObjectAddressSet(functionAddress, ProcedureRelationId, funcOid);
+	ObjectAddressSet(*functionAddress, ProcedureRelationId, funcOid);
 
-	if (RecreateSameNonColocatedFunction(functionAddress,
+	if (RecreateSameNonColocatedFunction(*functionAddress,
 										 distributionArgumentName,
 										 colocateWithTableNameDefault,
 										 forceDelegationAddress))
@@ -224,9 +224,10 @@ create_distributed_function(PG_FUNCTION_ARGS)
 	 * pg_dist_object, and not propagate the CREATE FUNCTION. Function
 	 * will be created by the virtue of the extension creation.
 	 */
-	if (IsObjectAddressOwnedByExtension(&functionAddress, &extensionAddress))
+	if (IsAnyObjectAddressOwnedByExtension(list_make1(functionAddress),
+										   &extensionAddress))
 	{
-		EnsureExtensionFunctionCanBeDistributed(functionAddress, extensionAddress,
+		EnsureExtensionFunctionCanBeDistributed(*functionAddress, extensionAddress,
 												distributionArgumentName);
 	}
 	else
@@ -237,7 +238,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 		 */
 		EnsureSequentialMode(OBJECT_FUNCTION);
 
-		EnsureDependenciesExistOnAllNodes(&functionAddress);
+		EnsureAllObjectDependenciesExistOnAllNodes(list_make1(functionAddress));
 
 		const char *createFunctionSQL = GetFunctionDDLCommand(funcOid, true);
 		const char *alterFunctionOwnerSQL = GetFunctionAlterOwnerCommand(funcOid);
@@ -257,7 +258,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 								   ddlCommand.data);
 	}
 
-	MarkObjectDistributed(&functionAddress);
+	MarkObjectDistributed(functionAddress);
 
 	if (distributionArgumentName != NULL)
 	{
@@ -272,12 +273,12 @@ create_distributed_function(PG_FUNCTION_ARGS)
 												   distributionArgumentOid,
 												   colocateWithTableName,
 												   forceDelegationAddress,
-												   &functionAddress);
+												   functionAddress);
 	}
 	else if (!colocatedWithReferenceTable)
 	{
 		DistributeFunctionColocatedWithDistributedTable(funcOid, colocateWithTableName,
-														&functionAddress);
+														functionAddress);
 	}
 	else if (colocatedWithReferenceTable)
 	{
@@ -288,7 +289,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 		 */
 		ErrorIfAnyNodeDoesNotHaveMetadata();
 
-		DistributeFunctionColocatedWithReferenceTable(&functionAddress);
+		DistributeFunctionColocatedWithReferenceTable(functionAddress);
 	}
 
 	PG_RETURN_VOID();
@@ -1308,7 +1309,7 @@ ShouldPropagateAlterFunction(const ObjectAddress *address)
 		return false;
 	}
 
-	if (!IsObjectDistributed(address))
+	if (!IsAnyObjectDistributed(list_make1((ObjectAddress *) address)))
 	{
 		/* do not propagate alter function for non-distributed functions */
 		return false;
@@ -1373,15 +1374,19 @@ PostprocessCreateFunctionStmt(Node *node, const char *queryString)
 		return NIL;
 	}
 
-	ObjectAddress functionAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
+	List *functionAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
 
-	if (IsObjectAddressOwnedByExtension(&functionAddress, NULL))
+	/*  the code-path only supports a single object */
+	Assert(list_length(functionAddresses) == 1);
+
+	if (IsAnyObjectAddressOwnedByExtension(functionAddresses, NULL))
 	{
 		return NIL;
 	}
 
 	/* If the function has any unsupported dependency, create it locally */
-	DeferredErrorMessage *errMsg = DeferErrorIfHasUnsupportedDependency(&functionAddress);
+	DeferredErrorMessage *errMsg = DeferErrorIfAnyObjectHasUnsupportedDependency(
+		functionAddresses);
 
 	if (errMsg != NULL)
 	{
@@ -1389,11 +1394,14 @@ PostprocessCreateFunctionStmt(Node *node, const char *queryString)
 		return NIL;
 	}
 
-	EnsureDependenciesExistOnAllNodes(&functionAddress);
+	EnsureAllObjectDependenciesExistOnAllNodes(functionAddresses);
+
+	/* We have already asserted that we have exactly 1 address in the addresses. */
+	ObjectAddress *functionAddress = linitial(functionAddresses);
 
 	List *commands = list_make1(DISABLE_DDL_PROPAGATION);
 	commands = list_concat(commands, CreateFunctionDDLCommandsIdempotent(
-							   &functionAddress));
+							   functionAddress));
 	commands = list_concat(commands, list_make1(ENABLE_DDL_PROPAGATION));
 
 	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);
@@ -1494,8 +1502,15 @@ PreprocessAlterFunctionStmt(Node *node, const char *queryString,
 	AlterFunctionStmt *stmt = castNode(AlterFunctionStmt, node);
 	AssertObjectTypeIsFunctional(stmt->objtype);
 
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt, false);
-	if (!ShouldPropagateAlterFunction(&address))
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
+
+	/* We have already asserted that we have exactly 1 address in the addresses. */
+	ObjectAddress *address = linitial(addresses);
+
+	if (!ShouldPropagateAlterFunction(address))
 	{
 		return NIL;
 	}
@@ -1549,20 +1564,26 @@ PreprocessAlterFunctionDependsStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt, true);
-	if (!IsObjectDistributed(&address))
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
+
+	if (!IsAnyObjectDistributed(addresses))
 	{
 		return NIL;
 	}
+
+	/* We have already asserted that we have exactly 1 address in the addresses. */
+	ObjectAddress *address = linitial(addresses);
 
 	/*
 	 * Distributed objects should not start depending on an extension, this will break
 	 * the dependency resolving mechanism we use to replicate distributed objects to new
 	 * workers
 	 */
-
 	const char *functionName =
-		getObjectIdentity_compat(&address, /* missingOk: */ false);
+		getObjectIdentity_compat(address, /* missingOk: */ false);
 	ereport(ERROR, (errmsg("distrtibuted functions are not allowed to depend on an "
 						   "extension"),
 					errdetail("Function \"%s\" is already distributed. Functions from "
@@ -1920,7 +1941,7 @@ EnsureExtensionFunctionCanBeDistributed(const ObjectAddress functionAddress,
 	/*
 	 * Ensure corresponding extension is in pg_dist_object.
 	 * Functions owned by an extension are depending internally on that extension,
-	 * hence EnsureDependenciesExistOnAllNodes() creates the extension, which in
+	 * hence EnsureAllObjectDependenciesExistOnAllNodes() creates the extension, which in
 	 * turn creates the function, and thus we don't have to create it ourself like
 	 * we do for non-extension functions.
 	 */
@@ -1930,7 +1951,9 @@ EnsureExtensionFunctionCanBeDistributed(const ObjectAddress functionAddress,
 							get_extension_name(extensionAddress.objectId),
 							get_func_name(functionAddress.objectId))));
 
-	EnsureDependenciesExistOnAllNodes(&functionAddress);
+	ObjectAddress *copyFunctionAddress = palloc0(sizeof(ObjectAddress));
+	*copyFunctionAddress = functionAddress;
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(copyFunctionAddress));
 }
 
 
@@ -2004,7 +2027,7 @@ PostprocessGrantOnFunctionStmt(Node *node, const char *queryString)
 	ObjectAddress *functionAddress = NULL;
 	foreach_ptr(functionAddress, distributedFunctions)
 	{
-		EnsureDependenciesExistOnAllNodes(functionAddress);
+		EnsureAllObjectDependenciesExistOnAllNodes(list_make1(functionAddress));
 	}
 	return NIL;
 }
@@ -2083,7 +2106,7 @@ FilterDistributedFunctions(GrantStmt *grantStmt)
 			 * if this function from GRANT .. ON FUNCTION .. is a distributed
 			 * function, add it to the list
 			 */
-			if (IsObjectDistributed(functionAddress))
+			if (IsAnyObjectDistributed(list_make1(functionAddress)))
 			{
 				grantFunctionList = lappend(grantFunctionList, functionAddress);
 			}

--- a/src/backend/distributed/commands/grant.c
+++ b/src/backend/distributed/commands/grant.c
@@ -238,9 +238,9 @@ CollectGrantTableIdList(GrantStmt *grantStmt)
 			}
 
 			/* check for distributed sequences included in GRANT ON TABLE statement */
-			ObjectAddress sequenceAddress = { 0 };
-			ObjectAddressSet(sequenceAddress, RelationRelationId, relationId);
-			if (IsObjectDistributed(&sequenceAddress))
+			ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+			ObjectAddressSet(*sequenceAddress, RelationRelationId, relationId);
+			if (IsAnyObjectDistributed(list_make1(sequenceAddress)))
 			{
 				grantTableList = lappend_oid(grantTableList, relationId);
 			}

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -761,9 +761,9 @@ PostprocessIndexStmt(Node *node, const char *queryString)
 	Oid indexRelationId = get_relname_relid(indexStmt->idxname, schemaId);
 
 	/* ensure dependencies of index exist on all nodes */
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, RelationRelationId, indexRelationId);
-	EnsureDependenciesExistOnAllNodes(&address);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, RelationRelationId, indexRelationId);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(address));
 
 	/* furtheron we are only processing CONCURRENT index statements */
 	if (!indexStmt->concurrent)
@@ -772,7 +772,7 @@ PostprocessIndexStmt(Node *node, const char *queryString)
 	}
 
 	/*
-	 * EnsureDependenciesExistOnAllNodes could have distributed objects that are required
+	 * EnsureAllObjectDependenciesExistOnAllNodes could have distributed objects that are required
 	 * by this index. During the propagation process an active snapshout might be left as
 	 * a side effect of inserting the local tuples via SPI. To not leak a snapshot like
 	 * that we will pop any snapshot if we have any right before we commit.

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -40,7 +40,7 @@
 #include "utils/relcache.h"
 
 
-static ObjectAddress GetObjectAddressBySchemaName(char *schemaName, bool missing_ok);
+static List * GetObjectAddressBySchemaName(char *schemaName, bool missing_ok);
 static List * FilterDistributedSchemas(List *schemas);
 static bool SchemaHasDistributedTableWithFKey(char *schemaName);
 static bool ShouldPropagateCreateSchemaStmt(void);
@@ -183,7 +183,7 @@ PreprocessGrantOnSchemaStmt(Node *node, const char *queryString,
  * CreateSchemaStmtObjectAddress returns the ObjectAddress of the schema that is
  * the object of the CreateSchemaStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 CreateSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CreateSchemaStmt *stmt = castNode(CreateSchemaStmt, node);
@@ -213,7 +213,7 @@ CreateSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * AlterSchemaRenameStmtObjectAddress returns the ObjectAddress of the schema that is
  * the object of the RenameStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -227,15 +227,15 @@ AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok)
  * GetObjectAddressBySchemaName returns the ObjectAddress of the schema with the
  * given name. Errors out if schema is not found and missing_ok is false.
  */
-ObjectAddress
+List *
 GetObjectAddressBySchemaName(char *schemaName, bool missing_ok)
 {
 	Oid schemaOid = get_namespace_oid(schemaName, missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, NamespaceRelationId, schemaOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, NamespaceRelationId, schemaOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -259,10 +259,9 @@ FilterDistributedSchemas(List *schemas)
 			continue;
 		}
 
-		ObjectAddress address = { 0 };
-		ObjectAddressSet(address, NamespaceRelationId, schemaOid);
-
-		if (!IsObjectDistributed(&address))
+		ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+		ObjectAddressSet(*address, NamespaceRelationId, schemaOid);
+		if (!IsAnyObjectDistributed(list_make1(address)))
 		{
 			continue;
 		}

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -268,18 +268,16 @@ PreprocessDropSequenceStmt(Node *node, const char *queryString,
 
 		Oid seqOid = RangeVarGetRelid(seq, NoLock, stmt->missing_ok);
 
-		ObjectAddress sequenceAddress = { 0 };
-		ObjectAddressSet(sequenceAddress, RelationRelationId, seqOid);
-
-		if (!IsObjectDistributed(&sequenceAddress))
+		ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+		ObjectAddressSet(*sequenceAddress, RelationRelationId, seqOid);
+		if (!IsAnyObjectDistributed(list_make1(sequenceAddress)))
 		{
 			continue;
 		}
 
 		/* collect information for all distributed sequences */
-		ObjectAddress *addressp = palloc(sizeof(ObjectAddress));
-		*addressp = sequenceAddress;
-		distributedSequenceAddresses = lappend(distributedSequenceAddresses, addressp);
+		distributedSequenceAddresses = lappend(distributedSequenceAddresses,
+											   sequenceAddress);
 		distributedSequencesList = lappend(distributedSequencesList, objectNameList);
 	}
 
@@ -334,10 +332,13 @@ PreprocessRenameSequenceStmt(Node *node, const char *queryString, ProcessUtility
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_SEQUENCE);
 
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt,
-														  stmt->missing_ok);
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
+														stmt->missing_ok);
 
-	if (!ShouldPropagateObject(&address))
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
+
+	if (!ShouldPropagateAnyObject(addresses))
 	{
 		return NIL;
 	}
@@ -395,21 +396,27 @@ PreprocessAlterSequenceStmt(Node *node, const char *queryString,
 {
 	AlterSeqStmt *stmt = castNode(AlterSeqStmt, node);
 
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt,
-														  stmt->missing_ok);
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
+														stmt->missing_ok);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
 
 	/* error out if the sequence is distributed */
-	if (IsObjectDistributed(&address))
+	if (IsAnyObjectDistributed(addresses))
 	{
 		ereport(ERROR, (errmsg(
 							"Altering a distributed sequence is currently not supported.")));
 	}
 
+	/* We have already asserted that we have exactly 1 address in the addresses. */
+	ObjectAddress *address = linitial(addresses);
+
 	/*
 	 * error out if the sequence is used in a distributed table
 	 * and this is an ALTER SEQUENCE .. AS .. statement
 	 */
-	Oid citusTableId = SequenceUsedInDistributedTable(&address);
+	Oid citusTableId = SequenceUsedInDistributedTable(address);
 	if (citusTableId != InvalidOid)
 	{
 		List *options = stmt->options;
@@ -463,6 +470,7 @@ SequenceUsedInDistributedTable(const ObjectAddress *sequenceAddress)
 			}
 		}
 	}
+
 	return InvalidOid;
 }
 
@@ -498,9 +506,13 @@ PreprocessAlterSequenceSchemaStmt(Node *node, const char *queryString,
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_SEQUENCE);
 
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt,
-														  stmt->missing_ok);
-	if (!ShouldPropagateObject(&address))
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
+														stmt->missing_ok);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
+
+	if (!ShouldPropagateAnyObject(addresses))
 	{
 		return NIL;
 	}
@@ -572,16 +584,19 @@ PostprocessAlterSequenceSchemaStmt(Node *node, const char *queryString)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_SEQUENCE);
-	ObjectAddress address = GetObjectAddressFromParseTree((Node *) stmt,
-														  stmt->missing_ok);
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
+														stmt->missing_ok);
 
-	if (!ShouldPropagateObject(&address))
+	/*  the code-path only supports a single object */
+	Assert(list_length(addresses) == 1);
+
+	if (!ShouldPropagateAnyObject(addresses))
 	{
 		return NIL;
 	}
 
 	/* dependencies have changed (schema) let's ensure they exist */
-	EnsureDependenciesExistOnAllNodes(&address);
+	EnsureAllObjectDependenciesExistOnAllNodes(addresses);
 
 	return NIL;
 }
@@ -601,8 +616,12 @@ PreprocessAlterSequenceOwnerStmt(Node *node, const char *queryString,
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_SEQUENCE);
 
-	ObjectAddress sequenceAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
-	if (!ShouldPropagateObject(&sequenceAddress))
+	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(sequenceAddresses) == 1);
+
+	if (!ShouldPropagateAnyObject(sequenceAddresses))
 	{
 		return NIL;
 	}
@@ -649,14 +668,18 @@ PostprocessAlterSequenceOwnerStmt(Node *node, const char *queryString)
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_SEQUENCE);
 
-	ObjectAddress sequenceAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
-	if (!ShouldPropagateObject(&sequenceAddress))
+	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(sequenceAddresses) == 1);
+
+	if (!ShouldPropagateAnyObject(sequenceAddresses))
 	{
 		return NIL;
 	}
 
 	/* dependencies have changed (owner) let's ensure they exist */
-	EnsureDependenciesExistOnAllNodes(&sequenceAddress);
+	EnsureAllObjectDependenciesExistOnAllNodes(sequenceAddresses);
 
 	return NIL;
 }
@@ -744,10 +767,10 @@ PostprocessGrantOnSequenceStmt(Node *node, const char *queryString)
 	RangeVar *sequence = NULL;
 	foreach_ptr(sequence, distributedSequences)
 	{
-		ObjectAddress sequenceAddress = { 0 };
+		ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
 		Oid sequenceOid = RangeVarGetRelid(sequence, NoLock, false);
-		ObjectAddressSet(sequenceAddress, RelationRelationId, sequenceOid);
-		EnsureDependenciesExistOnAllNodes(&sequenceAddress);
+		ObjectAddressSet(*sequenceAddress, RelationRelationId, sequenceOid);
+		EnsureAllObjectDependenciesExistOnAllNodes(list_make1(sequenceAddress));
 	}
 	return NIL;
 }
@@ -866,15 +889,15 @@ FilterDistributedSequences(GrantStmt *stmt)
 		RangeVar *sequenceRangeVar = NULL;
 		foreach_ptr(sequenceRangeVar, stmt->objects)
 		{
-			ObjectAddress sequenceAddress = { 0 };
 			Oid sequenceOid = RangeVarGetRelid(sequenceRangeVar, NoLock, missing_ok);
-			ObjectAddressSet(sequenceAddress, RelationRelationId, sequenceOid);
+			ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+			ObjectAddressSet(*sequenceAddress, RelationRelationId, sequenceOid);
 
 			/*
 			 * if this sequence from GRANT .. ON SEQUENCE .. is a distributed
 			 * sequence, add it to the list
 			 */
-			if (IsObjectDistributed(&sequenceAddress))
+			if (IsAnyObjectDistributed(list_make1(sequenceAddress)))
 			{
 				grantSequenceList = lappend(grantSequenceList, sequenceRangeVar);
 			}

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -358,7 +358,7 @@ PreprocessRenameSequenceStmt(Node *node, const char *queryString, ProcessUtility
  * RenameSequenceStmtObjectAddress returns the ObjectAddress of the sequence that is the
  * subject of the RenameStmt.
  */
-ObjectAddress
+List *
 RenameSequenceStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -366,10 +366,10 @@ RenameSequenceStmtObjectAddress(Node *node, bool missing_ok)
 
 	RangeVar *sequence = stmt->relation;
 	Oid seqOid = RangeVarGetRelid(sequence, NoLock, missing_ok);
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, RelationRelationId, seqOid);
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, RelationRelationId, seqOid);
 
-	return sequenceAddress;
+	return list_make1(sequenceAddress);
 }
 
 
@@ -471,17 +471,17 @@ SequenceUsedInDistributedTable(const ObjectAddress *sequenceAddress)
  * AlterSequenceStmtObjectAddress returns the ObjectAddress of the sequence that is the
  * subject of the AlterSeqStmt.
  */
-ObjectAddress
+List *
 AlterSequenceStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterSeqStmt *stmt = castNode(AlterSeqStmt, node);
 
 	RangeVar *sequence = stmt->sequence;
 	Oid seqOid = RangeVarGetRelid(sequence, NoLock, stmt->missing_ok);
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, RelationRelationId, seqOid);
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, RelationRelationId, seqOid);
 
-	return sequenceAddress;
+	return list_make1(sequenceAddress);
 }
 
 
@@ -521,7 +521,7 @@ PreprocessAlterSequenceSchemaStmt(Node *node, const char *queryString,
  * AlterSequenceSchemaStmtObjectAddress returns the ObjectAddress of the sequence that is
  * the subject of the AlterObjectSchemaStmt.
  */
-ObjectAddress
+List *
 AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -555,10 +555,10 @@ AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, RelationRelationId, seqOid);
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, RelationRelationId, seqOid);
 
-	return sequenceAddress;
+	return list_make1(sequenceAddress);
 }
 
 
@@ -623,7 +623,7 @@ PreprocessAlterSequenceOwnerStmt(Node *node, const char *queryString,
  * AlterSequenceOwnerStmtObjectAddress returns the ObjectAddress of the sequence that is the
  * subject of the AlterOwnerStmt.
  */
-ObjectAddress
+List *
 AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
@@ -631,10 +631,10 @@ AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok)
 
 	RangeVar *sequence = stmt->relation;
 	Oid seqOid = RangeVarGetRelid(sequence, NoLock, missing_ok);
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, RelationRelationId, seqOid);
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, RelationRelationId, seqOid);
 
-	return sequenceAddress;
+	return list_make1(sequenceAddress);
 }
 
 

--- a/src/backend/distributed/commands/statistics.c
+++ b/src/backend/distributed/commands/statistics.c
@@ -138,16 +138,16 @@ PostprocessCreateStatisticsStmt(Node *node, const char *queryString)
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 CreateStatisticsStmtObjectAddress(Node *node, bool missingOk)
 {
 	CreateStatsStmt *stmt = castNode(CreateStatsStmt, node);
 
-	ObjectAddress address = { 0 };
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	Oid statsOid = get_statistics_object_oid(stmt->defnames, missingOk);
-	ObjectAddressSet(address, StatisticExtRelationId, statsOid);
+	ObjectAddressSet(*address, StatisticExtRelationId, statsOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -322,18 +322,18 @@ PostprocessAlterStatisticsSchemaStmt(Node *node, const char *queryString)
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 AlterStatisticsSchemaStmtObjectAddress(Node *node, bool missingOk)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 
-	ObjectAddress address = { 0 };
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	String *statName = llast((List *) stmt->object);
 	Oid statsOid = get_statistics_object_oid(list_make2(makeString(stmt->newschema),
 														statName), missingOk);
-	ObjectAddressSet(address, StatisticExtRelationId, statsOid);
+	ObjectAddressSet(*address, StatisticExtRelationId, statsOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/statistics.c
+++ b/src/backend/distributed/commands/statistics.c
@@ -122,9 +122,12 @@ PostprocessCreateStatisticsStmt(Node *node, const char *queryString)
 	}
 
 	bool missingOk = false;
-	ObjectAddress objectAddress = GetObjectAddressFromParseTree((Node *) stmt, missingOk);
+	List *objectAddresses = GetObjectAddressListFromParseTree((Node *) stmt, missingOk);
 
-	EnsureDependenciesExistOnAllNodes(&objectAddress);
+	/*  the code-path only supports a single object */
+	Assert(list_length(objectAddresses) == 1);
+
+	EnsureAllObjectDependenciesExistOnAllNodes(objectAddresses);
 
 	return NIL;
 }
@@ -306,9 +309,12 @@ PostprocessAlterStatisticsSchemaStmt(Node *node, const char *queryString)
 	}
 
 	bool missingOk = false;
-	ObjectAddress objectAddress = GetObjectAddressFromParseTree((Node *) stmt, missingOk);
+	List *objectAddresses = GetObjectAddressListFromParseTree((Node *) stmt, missingOk);
 
-	EnsureDependenciesExistOnAllNodes(&objectAddress);
+	/*  the code-path only supports a single object */
+	Assert(list_length(objectAddresses) == 1);
+
+	EnsureAllObjectDependenciesExistOnAllNodes(objectAddresses);
 
 	return NIL;
 }
@@ -449,10 +455,9 @@ PostprocessAlterStatisticsOwnerStmt(Node *node, const char *queryString)
 		return NIL;
 	}
 
-	ObjectAddress statisticsAddress = { 0 };
-	ObjectAddressSet(statisticsAddress, StatisticExtRelationId, statsOid);
-
-	EnsureDependenciesExistOnAllNodes(&statisticsAddress);
+	ObjectAddress *statisticsAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*statisticsAddress, StatisticExtRelationId, statsOid);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(statisticsAddress));
 
 	return NIL;
 }

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -3353,7 +3353,7 @@ ErrorIfUnsupportedAlterAddConstraintStmt(AlterTableStmt *alterTableStatement)
  * will look in the new schema. Errors if missing_ok is false and the table cannot
  * be found in either of the schemas.
  */
-ObjectAddress
+List *
 AlterTableSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -3389,10 +3389,10 @@ AlterTableSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, RelationRelationId, tableOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, RelationRelationId, tableOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/text_search.c
+++ b/src/backend/distributed/commands/text_search.c
@@ -569,7 +569,7 @@ get_ts_parser_namelist(Oid tsparserOid)
  * being created. If missing_pk is false the function will error, explaining to the user
  * the text search configuration described in the statement doesn't exist.
  */
-ObjectAddress
+List *
 CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
@@ -577,9 +577,9 @@ CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_config_oid(stmt->defnames, missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSConfigRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSConfigRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -588,7 +588,7 @@ CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok)
  * being created. If missing_pk is false the function will error, explaining to the user
  * the text search dictionary described in the statement doesn't exist.
  */
-ObjectAddress
+List *
 CreateTextSearchDictObjectAddress(Node *node, bool missing_ok)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
@@ -596,9 +596,9 @@ CreateTextSearchDictObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_dict_oid(stmt->defnames, missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSDictionaryRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSDictionaryRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -607,7 +607,7 @@ CreateTextSearchDictObjectAddress(Node *node, bool missing_ok)
  * SEARCH CONFIGURATION being renamed. Optionally errors if the configuration does not
  * exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -615,9 +615,9 @@ RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_config_oid(castNode(List, stmt->object), missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSConfigRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSConfigRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -626,7 +626,7 @@ RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
  * SEARCH DICTIONARY being renamed. Optionally errors if the dictionary does not
  * exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -634,9 +634,9 @@ RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_dict_oid(castNode(List, stmt->object), missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSDictionaryRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSDictionaryRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -645,16 +645,16 @@ RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
  * SEARCH CONFIGURATION being altered. Optionally errors if the configuration does not
  * exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 AlterTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterTSConfigurationStmt *stmt = castNode(AlterTSConfigurationStmt, node);
 
 	Oid objid = get_ts_config_oid(stmt->cfgname, missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSConfigRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSConfigRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -663,16 +663,16 @@ AlterTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
  * SEARCH CONFIGURATION being altered. Optionally errors if the configuration does not
  * exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 AlterTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterTSDictionaryStmt *stmt = castNode(AlterTSDictionaryStmt, node);
 
 	Oid objid = get_ts_dict_oid(stmt->dictname, missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSDictionaryRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSDictionaryRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -685,7 +685,7 @@ AlterTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
  * the triple checking before the error might be thrown. Errors for non-existing schema's
  * in edgecases will be raised by postgres while executing the move.
  */
-ObjectAddress
+List *
 AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -723,9 +723,9 @@ AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, TSConfigRelationId, objid);
-	return sequenceAddress;
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, TSConfigRelationId, objid);
+	return list_make1(sequenceAddress);
 }
 
 
@@ -738,7 +738,7 @@ AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * the triple checking before the error might be thrown. Errors for non-existing schema's
  * in edgecases will be raised by postgres while executing the move.
  */
-ObjectAddress
+List *
 AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -776,9 +776,9 @@ AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, TSDictionaryRelationId, objid);
-	return sequenceAddress;
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, TSDictionaryRelationId, objid);
+	return list_make1(sequenceAddress);
 }
 
 
@@ -787,7 +787,7 @@ AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok)
  * SEARCH CONFIGURATION on which the comment is placed. Optionally errors if the
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok)
 {
 	CommentStmt *stmt = castNode(CommentStmt, node);
@@ -795,9 +795,9 @@ TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_config_oid(castNode(List, stmt->object), missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSConfigRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSConfigRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -806,7 +806,7 @@ TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok)
  * DICTIONARY on which the comment is placed. Optionally errors if the dictionary does not
  * exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 TextSearchDictCommentObjectAddress(Node *node, bool missing_ok)
 {
 	CommentStmt *stmt = castNode(CommentStmt, node);
@@ -814,9 +814,9 @@ TextSearchDictCommentObjectAddress(Node *node, bool missing_ok)
 
 	Oid objid = get_ts_dict_oid(castNode(List, stmt->object), missing_ok);
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TSDictionaryRelationId, objid);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TSDictionaryRelationId, objid);
+	return list_make1(address);
 }
 
 
@@ -825,7 +825,7 @@ TextSearchDictCommentObjectAddress(Node *node, bool missing_ok)
  * SEARCH CONFIGURATION for which the owner is changed. Optionally errors if the
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
@@ -833,8 +833,14 @@ AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok)
 
 	Assert(stmt->objectType == OBJECT_TSCONFIGURATION);
 
-	return get_object_address(stmt->objectType, stmt->object, &relation, AccessShareLock,
-							  missing_ok);
+	ObjectAddress objectAddress = get_object_address(stmt->objectType, stmt->object,
+													 &relation, AccessShareLock,
+													 missing_ok);
+
+	ObjectAddress *objectAddressCopy = palloc0(sizeof(ObjectAddress));
+	*objectAddressCopy = objectAddress;
+
+	return list_make1(objectAddressCopy);
 }
 
 
@@ -843,16 +849,20 @@ AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok)
  * SEARCH DICTIONARY for which the owner is changed. Optionally errors if the
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
-ObjectAddress
+List *
 AlterTextSearchDictOwnerObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Relation relation = NULL;
 
 	Assert(stmt->objectType == OBJECT_TSDICTIONARY);
+	ObjectAddress objectAddress = get_object_address(stmt->objectType, stmt->object,
+													 &relation, AccessShareLock,
+													 missing_ok);
+	ObjectAddress *objectAddressCopy = palloc0(sizeof(ObjectAddress));
+	*objectAddressCopy = objectAddress;
 
-	return get_object_address(stmt->objectType, stmt->object, &relation, AccessShareLock,
-							  missing_ok);
+	return list_make1(objectAddressCopy);
 }
 
 

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -224,8 +224,12 @@ PostprocessCreateTriggerStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 	ErrorOutForTriggerIfNotSupported(relationId);
 
-	ObjectAddress objectAddress = GetObjectAddressFromParseTree(node, missingOk);
-	EnsureDependenciesExistOnAllNodes(&objectAddress);
+	List *objectAddresses = GetObjectAddressListFromParseTree(node, missingOk);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(objectAddresses) == 1);
+
+	EnsureAllObjectDependenciesExistOnAllNodes(objectAddresses);
 
 	char *triggerName = createTriggerStmt->trigname;
 	return CitusCreateTriggerCommandDDLJob(relationId, triggerName,

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -241,7 +241,7 @@ PostprocessCreateTriggerStmt(Node *node, const char *queryString)
  * Never returns NULL, but the objid in the address can be invalid if missingOk
  * was set to true.
  */
-ObjectAddress
+List *
 CreateTriggerStmtObjectAddress(Node *node, bool missingOk)
 {
 	CreateTrigStmt *createTriggerStmt = castNode(CreateTrigStmt, node);
@@ -260,9 +260,9 @@ CreateTriggerStmtObjectAddress(Node *node, bool missingOk)
 							   triggerName, relationName)));
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TriggerRelationId, triggerId);
-	return address;
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TriggerRelationId, triggerId);
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -117,8 +117,12 @@ PreprocessRenameTypeAttributeStmt(Node *node, const char *queryString,
 	Assert(stmt->renameType == OBJECT_ATTRIBUTE);
 	Assert(stmt->relationType == OBJECT_TYPE);
 
-	ObjectAddress typeAddress = GetObjectAddressFromParseTree((Node *) stmt, false);
-	if (!ShouldPropagateObject(&typeAddress))
+	List *typeAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+
+	/*  the code-path only supports a single object */
+	Assert(list_length(objectAddresses) == 1);
+
+	if (!ShouldPropagateAnyObject(typeAddresses))
 	{
 		return NIL;
 	}

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -300,16 +300,16 @@ EnumValsList(Oid typeOid)
  * Never returns NULL, but the objid in the address could be invalid if missing_ok was set
  * to true.
  */
-ObjectAddress
+List *
 CompositeTypeStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CompositeTypeStmt *stmt = castNode(CompositeTypeStmt, node);
 	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->typevar);
 	Oid typeOid = LookupNonAssociatedArrayTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -321,16 +321,16 @@ CompositeTypeStmtObjectAddress(Node *node, bool missing_ok)
  * Never returns NULL, but the objid in the address could be invalid if missing_ok was set
  * to true.
  */
-ObjectAddress
+List *
 CreateEnumStmtObjectAddress(Node *node, bool missing_ok)
 {
 	CreateEnumStmt *stmt = castNode(CreateEnumStmt, node);
 	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
 	Oid typeOid = LookupNonAssociatedArrayTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -342,7 +342,7 @@ CreateEnumStmtObjectAddress(Node *node, bool missing_ok)
  * Never returns NULL, but the objid in the address could be invalid if missing_ok was set
  * to true.
  */
-ObjectAddress
+List *
 AlterTypeStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
@@ -350,10 +350,10 @@ AlterTypeStmtObjectAddress(Node *node, bool missing_ok)
 
 	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->relation);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -361,16 +361,16 @@ AlterTypeStmtObjectAddress(Node *node, bool missing_ok)
  * AlterEnumStmtObjectAddress return the ObjectAddress of the enum type that is the
  * object of the AlterEnumStmt. Errors is missing_ok is false.
  */
-ObjectAddress
+List *
 AlterEnumStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterEnumStmt *stmt = castNode(AlterEnumStmt, node);
 	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -378,7 +378,7 @@ AlterEnumStmtObjectAddress(Node *node, bool missing_ok)
  * RenameTypeStmtObjectAddress returns the ObjectAddress of the type that is the object
  * of the RenameStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 RenameTypeStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -386,10 +386,10 @@ RenameTypeStmtObjectAddress(Node *node, bool missing_ok)
 
 	TypeName *typeName = makeTypeNameFromNameList((List *) stmt->object);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -402,7 +402,7 @@ RenameTypeStmtObjectAddress(Node *node, bool missing_ok)
  * new schema. Errors if missing_ok is false and the type cannot be found in either of the
  * schemas.
  */
-ObjectAddress
+List *
 AlterTypeSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -447,10 +447,10 @@ AlterTypeSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -462,7 +462,7 @@ AlterTypeSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * changed as Attributes are not distributed on their own but as a side effect of the
  * whole type distribution.
  */
-ObjectAddress
+List *
 RenameTypeAttributeStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
@@ -471,10 +471,10 @@ RenameTypeAttributeStmtObjectAddress(Node *node, bool missing_ok)
 
 	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->relation);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 
@@ -482,7 +482,7 @@ RenameTypeAttributeStmtObjectAddress(Node *node, bool missing_ok)
  * AlterTypeOwnerObjectAddress returns the ObjectAddress of the type that is the object
  * of the AlterOwnerStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 AlterTypeOwnerObjectAddress(Node *node, bool missing_ok)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
@@ -490,10 +490,10 @@ AlterTypeOwnerObjectAddress(Node *node, bool missing_ok)
 
 	TypeName *typeName = makeTypeNameFromNameList((List *) stmt->object);
 	Oid typeOid = LookupTypeNameOid(NULL, typeName, missing_ok);
-	ObjectAddress address = { 0 };
-	ObjectAddressSet(address, TypeRelationId, typeOid);
+	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*address, TypeRelationId, typeOid);
 
-	return address;
+	return list_make1(address);
 }
 
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -853,8 +853,12 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		 */
 		if (ops && ops->markDistributed)
 		{
-			ObjectAddress address = GetObjectAddressFromParseTree(parsetree, false);
-			MarkObjectDistributed(&address);
+			List *addresses = GetObjectAddressListFromParseTree(parsetree, false);
+			ObjectAddress *address = NULL;
+			foreach_ptr(address, addresses)
+			{
+				MarkObjectDistributed(address);
+			}
 		}
 	}
 

--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -152,17 +152,17 @@ PostprocessViewStmt(Node *node, const char *queryString)
  * ViewStmtObjectAddress returns the ObjectAddress for the subject of the
  * CREATE [OR REPLACE] VIEW statement.
  */
-ObjectAddress
+List *
 ViewStmtObjectAddress(Node *node, bool missing_ok)
 {
 	ViewStmt *stmt = castNode(ViewStmt, node);
 
 	Oid viewOid = RangeVarGetRelid(stmt->view, NoLock, missing_ok);
 
-	ObjectAddress viewAddress = { 0 };
-	ObjectAddressSet(viewAddress, RelationRelationId, viewOid);
+	ObjectAddress *viewAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*viewAddress, RelationRelationId, viewOid);
 
-	return viewAddress;
+	return list_make1(viewAddress);
 }
 
 
@@ -520,16 +520,16 @@ PostprocessAlterViewStmt(Node *node, const char *queryString)
  * AlterViewStmtObjectAddress returns the ObjectAddress for the subject of the
  * ALTER VIEW statement.
  */
-ObjectAddress
+List *
 AlterViewStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Oid viewOid = RangeVarGetRelid(stmt->relation, NoLock, missing_ok);
 
-	ObjectAddress viewAddress = { 0 };
-	ObjectAddressSet(viewAddress, RelationRelationId, viewOid);
+	ObjectAddress *viewAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*viewAddress, RelationRelationId, viewOid);
 
-	return viewAddress;
+	return list_make1(viewAddress);
 }
 
 
@@ -572,17 +572,17 @@ PreprocessRenameViewStmt(Node *node, const char *queryString,
  * RenameViewStmtObjectAddress returns the ObjectAddress of the view that is the object
  * of the RenameStmt. Errors if missing_ok is false.
  */
-ObjectAddress
+List *
 RenameViewStmtObjectAddress(Node *node, bool missing_ok)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 
 	Oid viewOid = RangeVarGetRelid(stmt->relation, NoLock, missing_ok);
 
-	ObjectAddress viewAddress = { 0 };
-	ObjectAddressSet(viewAddress, RelationRelationId, viewOid);
+	ObjectAddress *viewAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*viewAddress, RelationRelationId, viewOid);
 
-	return viewAddress;
+	return list_make1(viewAddress);
 }
 
 
@@ -648,7 +648,7 @@ PostprocessAlterViewSchemaStmt(Node *node, const char *queryString)
  * AlterViewSchemaStmtObjectAddress returns the ObjectAddress of the view that is the object
  * of the alter schema statement.
  */
-ObjectAddress
+List *
 AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
@@ -676,10 +676,10 @@ AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	ObjectAddress viewAddress = { 0 };
-	ObjectAddressSet(viewAddress, RelationRelationId, viewOid);
+	ObjectAddress *viewAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*viewAddress, RelationRelationId, viewOid);
 
-	return viewAddress;
+	return list_make1(viewAddress);
 }
 
 

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -20,11 +20,11 @@
 
 
 /*
- * GetObjectAddressFromParseTree returns the ObjectAddress of the main target of the parse
+ * GetObjectAddressListFromParseTree returns the list of ObjectAddress of the main target of the parse
  * tree.
  */
-ObjectAddress
-GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok)
+List *
+GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok)
 {
 	const DistributeObjectOps *ops = GetDistributeObjectOps(parseTree);
 
@@ -33,19 +33,7 @@ GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok)
 		ereport(ERROR, (errmsg("unsupported statement to get object address for")));
 	}
 
-	List *objectAddresses = ops->address(parseTree, missing_ok);
-
-	if (list_length(objectAddresses) > 1)
-	{
-		ereport(ERROR, (errmsg(
-							"citus does not support multiple object addresses in GetObjectAddressFromParseTree")));
-	}
-
-	Assert(list_length(objectAddresses) == 1);
-
-	ObjectAddress *objectAddress = linitial(objectAddresses);
-
-	return *objectAddress;
+	return ops->address(parseTree, missing_ok);
 }
 
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -356,10 +356,9 @@ CreateDependingViewsOnWorkers(Oid relationId)
 			continue;
 		}
 
-		ObjectAddress viewAddress = { 0 };
-		ObjectAddressSet(viewAddress, RelationRelationId, viewOid);
-
-		EnsureDependenciesExistOnAllNodes(&viewAddress);
+		ObjectAddress *viewAddress = palloc0(sizeof(ObjectAddress));
+		ObjectAddressSet(*viewAddress, RelationRelationId, viewOid);
+		EnsureAllObjectDependenciesExistOnAllNodes(list_make1(viewAddress));
 
 		char *createViewCommand = CreateViewDDLCommand(viewOid);
 		char *alterViewOwnerCommand = AlterViewOwnerCommand(viewOid);
@@ -367,7 +366,7 @@ CreateDependingViewsOnWorkers(Oid relationId)
 		SendCommandToWorkersWithMetadata(createViewCommand);
 		SendCommandToWorkersWithMetadata(alterViewOwnerCommand);
 
-		MarkObjectDistributed(&viewAddress);
+		MarkObjectDistributed(viewAddress);
 	}
 
 	SendCommandToWorkersWithMetadata(ENABLE_DDL_PROPAGATION);
@@ -603,10 +602,10 @@ ShouldSyncSequenceMetadata(Oid relationId)
 		return false;
 	}
 
-	ObjectAddress sequenceAddress = { 0 };
-	ObjectAddressSet(sequenceAddress, RelationRelationId, relationId);
+	ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*sequenceAddress, RelationRelationId, relationId);
 
-	return IsObjectDistributed(&sequenceAddress);
+	return IsAnyObjectDistributed(list_make1(sequenceAddress));
 }
 
 

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -70,7 +70,6 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	text *tableNameText = PG_GETARG_TEXT_P(0);
 	int32 shardCount = PG_GETARG_INT32(1);
 	int32 replicationFactor = PG_GETARG_INT32(2);
-	ObjectAddress tableAddress = { 0 };
 
 	Oid distributedTableId = ResolveRelationId(tableNameText, false);
 
@@ -83,8 +82,9 @@ master_create_worker_shards(PG_FUNCTION_ARGS)
 	 * via their own connection and committed immediately so they become visible to all
 	 * sessions creating shards.
 	 */
-	ObjectAddressSet(tableAddress, RelationRelationId, distributedTableId);
-	EnsureDependenciesExistOnAllNodes(&tableAddress);
+	ObjectAddress *tableAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*tableAddress, RelationRelationId, distributedTableId);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(tableAddress));
 
 	EnsureReferenceTablesExistOnAllNodes();
 

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -96,7 +96,7 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	text *relationNameText = PG_GETARG_TEXT_P(0);
 	char *relationName = text_to_cstring(relationNameText);
 	uint32 attemptableNodeCount = 0;
-	ObjectAddress tableAddress = { 0 };
+	ObjectAddress *tableAddress = palloc0(sizeof(ObjectAddress));
 
 	uint32 candidateNodeIndex = 0;
 	List *candidateNodeList = NIL;
@@ -115,8 +115,8 @@ master_create_empty_shard(PG_FUNCTION_ARGS)
 	 * via their own connection and committed immediately so they become visible to all
 	 * sessions creating shards.
 	 */
-	ObjectAddressSet(tableAddress, RelationRelationId, relationId);
-	EnsureDependenciesExistOnAllNodes(&tableAddress);
+	ObjectAddressSet(*tableAddress, RelationRelationId, relationId);
+	EnsureAllObjectDependenciesExistOnAllNodes(list_make1(tableAddress));
 	EnsureReferenceTablesExistOnAllNodes();
 
 	/* don't allow the table to be dropped */

--- a/src/backend/distributed/worker/worker_create_or_replace.c
+++ b/src/backend/distributed/worker/worker_create_or_replace.c
@@ -181,8 +181,13 @@ WorkerCreateOrReplaceObject(List *sqlStatements)
 	 * same subject.
 	 */
 	Node *parseTree = ParseTreeNode(linitial(sqlStatements));
-	ObjectAddress address = GetObjectAddressFromParseTree(parseTree, true);
-	if (ObjectExists(&address))
+	List *addresses = GetObjectAddressListFromParseTree(parseTree, true);
+	Assert(list_length(viewAddresses) == 1);
+
+	/* We have already asserted that we have exactly 1 address in the addresses. */
+	ObjectAddress *address = linitial(addresses);
+
+	if (ObjectExists(address))
 	{
 		/*
 		 * Object with name from statement is already found locally, check if states are
@@ -195,7 +200,7 @@ WorkerCreateOrReplaceObject(List *sqlStatements)
 		 * recreate our version of the object. This we can compare to what the coordinator
 		 * sent us. If they match we don't do anything.
 		 */
-		List *localSqlStatements = CreateStmtListByObjectAddress(&address);
+		List *localSqlStatements = CreateStmtListByObjectAddress(address);
 		if (CompareStringList(sqlStatements, localSqlStatements))
 		{
 			/*
@@ -208,9 +213,9 @@ WorkerCreateOrReplaceObject(List *sqlStatements)
 			return false;
 		}
 
-		char *newName = GenerateBackupNameForCollision(&address);
+		char *newName = GenerateBackupNameForCollision(address);
 
-		RenameStmt *renameStmt = CreateRenameStatement(&address, newName);
+		RenameStmt *renameStmt = CreateRenameStatement(address, newName);
 		const char *sqlRenameStmt = DeparseTreeNode((Node *) renameStmt);
 		ProcessUtilityParseTree((Node *) renameStmt, sqlRenameStmt,
 								PROCESS_UTILITY_QUERY,

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -63,7 +63,7 @@ typedef struct DistributeObjectOps
 	void (*qualify)(Node *);
 	List * (*preprocess)(Node *, const char *, ProcessUtilityContext);
 	List * (*postprocess)(Node *, const char *);
-	ObjectAddress (*address)(Node *, bool);
+	List * (*address)(Node *, bool);
 	bool markDistributed;
 
 	/* fields used by common implementations, omitted for specialized implementations */
@@ -159,24 +159,24 @@ extern bool CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *d
 /* collation.c - forward declarations */
 extern char * CreateCollationDDL(Oid collationId);
 extern List * CreateCollationDDLsIdempotent(Oid collationId);
-extern ObjectAddress AlterCollationOwnerObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress RenameCollationStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress AlterCollationSchemaStmtObjectAddress(Node *stmt,
-														   bool missing_ok);
+extern List * AlterCollationOwnerObjectAddress(Node *stmt, bool missing_ok);
+extern List * RenameCollationStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * AlterCollationSchemaStmtObjectAddress(Node *stmt,
+													bool missing_ok);
 extern char * GenerateBackupNameForCollationCollision(const ObjectAddress *address);
-extern ObjectAddress DefineCollationStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * DefineCollationStmtObjectAddress(Node *stmt, bool missing_ok);
 
 /* database.c - forward declarations */
-extern ObjectAddress AlterDatabaseOwnerObjectAddress(Node *node, bool missing_ok);
+extern List * AlterDatabaseOwnerObjectAddress(Node *node, bool missing_ok);
 extern List * DatabaseOwnerDDLCommands(const ObjectAddress *address);
 
 /* domain.c - forward declarations */
-extern ObjectAddress CreateDomainStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterDomainStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress DomainRenameConstraintStmtObjectAddress(Node *node,
-															 bool missing_ok);
-extern ObjectAddress AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress RenameDomainStmtObjectAddress(Node *node, bool missing_ok);
+extern List * CreateDomainStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterDomainStmtObjectAddress(Node *node, bool missing_ok);
+extern List * DomainRenameConstraintStmtObjectAddress(Node *node,
+													  bool missing_ok);
+extern List * AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok);
+extern List * RenameDomainStmtObjectAddress(Node *node, bool missing_ok);
 extern CreateDomainStmt * RecreateDomainStmt(Oid domainOid);
 extern Oid get_constraint_typid(Oid conoid);
 
@@ -208,10 +208,10 @@ extern List * PreprocessAlterExtensionContentsStmt(Node *node,
 												   ProcessUtilityContext
 												   processUtilityContext);
 extern List * CreateExtensionDDLCommand(const ObjectAddress *extensionAddress);
-extern ObjectAddress AlterExtensionSchemaStmtObjectAddress(Node *stmt,
-														   bool missing_ok);
-extern ObjectAddress AlterExtensionUpdateStmtObjectAddress(Node *stmt,
-														   bool missing_ok);
+extern List * AlterExtensionSchemaStmtObjectAddress(Node *stmt,
+													bool missing_ok);
+extern List * AlterExtensionUpdateStmtObjectAddress(Node *stmt,
+													bool missing_ok);
 extern void CreateExtensionWithVersion(char *extname, char *extVersion);
 extern void AlterExtensionUpdateStmt(char *extname, char *extVersion);
 extern int GetExtensionVersionNumber(char *extVersion);
@@ -263,11 +263,11 @@ extern Acl * GetPrivilegesForFDW(Oid FDWOid);
 extern List * PreprocessGrantOnForeignServerStmt(Node *node, const char *queryString,
 												 ProcessUtilityContext
 												 processUtilityContext);
-extern ObjectAddress CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterForeignServerStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterForeignServerOwnerStmtObjectAddress(Node *node, bool
-															  missing_ok);
+extern List * CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterForeignServerStmtObjectAddress(Node *node, bool missing_ok);
+extern List * RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterForeignServerOwnerStmtObjectAddress(Node *node, bool
+													   missing_ok);
 extern List * GetForeignServerCreateDDLCommand(Oid serverId);
 
 
@@ -282,26 +282,26 @@ extern List * PreprocessCreateFunctionStmt(Node *stmt, const char *queryString,
 										   ProcessUtilityContext processUtilityContext);
 extern List * PostprocessCreateFunctionStmt(Node *stmt,
 											const char *queryString);
-extern ObjectAddress CreateFunctionStmtObjectAddress(Node *stmt,
-													 bool missing_ok);
-extern ObjectAddress DefineAggregateStmtObjectAddress(Node *stmt,
-													  bool missing_ok);
+extern List * CreateFunctionStmtObjectAddress(Node *stmt,
+											  bool missing_ok);
+extern List * DefineAggregateStmtObjectAddress(Node *stmt,
+											   bool missing_ok);
 extern List * PreprocessAlterFunctionStmt(Node *stmt, const char *queryString,
 										  ProcessUtilityContext processUtilityContext);
-extern ObjectAddress AlterFunctionStmtObjectAddress(Node *stmt,
-													bool missing_ok);
-extern ObjectAddress RenameFunctionStmtObjectAddress(Node *stmt,
-													 bool missing_ok);
-extern ObjectAddress AlterFunctionOwnerObjectAddress(Node *stmt,
-													 bool missing_ok);
-extern ObjectAddress AlterFunctionSchemaStmtObjectAddress(Node *stmt,
-														  bool missing_ok);
+extern List * AlterFunctionStmtObjectAddress(Node *stmt,
+											 bool missing_ok);
+extern List * RenameFunctionStmtObjectAddress(Node *stmt,
+											  bool missing_ok);
+extern List * AlterFunctionOwnerObjectAddress(Node *stmt,
+											  bool missing_ok);
+extern List * AlterFunctionSchemaStmtObjectAddress(Node *stmt,
+												   bool missing_ok);
 extern List * PreprocessAlterFunctionDependsStmt(Node *stmt,
 												 const char *queryString,
 												 ProcessUtilityContext
 												 processUtilityContext);
-extern ObjectAddress AlterFunctionDependsStmtObjectAddress(Node *stmt,
-														   bool missing_ok);
+extern List * AlterFunctionDependsStmtObjectAddress(Node *stmt,
+													bool missing_ok);
 extern List * PreprocessGrantOnFunctionStmt(Node *node, const char *queryString,
 											ProcessUtilityContext processUtilityContext);
 extern List * PostprocessGrantOnFunctionStmt(Node *node, const char *queryString);
@@ -340,7 +340,7 @@ extern List * ExecuteFunctionOnEachTableIndex(Oid relationId, PGIndexProcessor
 extern bool IsReindexWithParam_compat(ReindexStmt *stmt, char *paramName);
 
 /* objectaddress.c - forward declarations */
-extern ObjectAddress CreateExtensionStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * CreateExtensionStmtObjectAddress(Node *stmt, bool missing_ok);
 
 
 /* policy.c -  forward declarations */
@@ -376,10 +376,10 @@ extern List * PostprocessAlterRoleStmt(Node *stmt, const char *queryString);
 extern List * PreprocessAlterRoleSetStmt(Node *stmt, const char *queryString,
 										 ProcessUtilityContext processUtilityContext);
 extern List * GenerateAlterRoleSetCommandForRole(Oid roleid);
-extern ObjectAddress AlterRoleStmtObjectAddress(Node *node,
-												bool missing_ok);
-extern ObjectAddress AlterRoleSetStmtObjectAddress(Node *node,
-												   bool missing_ok);
+extern List * AlterRoleStmtObjectAddress(Node *node,
+										 bool missing_ok);
+extern List * AlterRoleSetStmtObjectAddress(Node *node,
+											bool missing_ok);
 extern List * PreprocessCreateRoleStmt(Node *stmt, const char *queryString,
 									   ProcessUtilityContext processUtilityContext);
 extern List * PreprocessDropRoleStmt(Node *stmt, const char *queryString,
@@ -388,7 +388,7 @@ extern List * PreprocessGrantRoleStmt(Node *stmt, const char *queryString,
 									  ProcessUtilityContext processUtilityContext);
 extern List * PostprocessGrantRoleStmt(Node *stmt, const char *queryString);
 extern List * GenerateCreateOrAlterRoleCommand(Oid roleOid);
-ObjectAddress CreateRoleStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * CreateRoleStmtObjectAddress(Node *stmt, bool missing_ok);
 extern void UnmarkRolesDistributed(List *roles);
 extern List * FilterDistributedRoles(List *roles);
 
@@ -402,8 +402,8 @@ extern List * PreprocessAlterObjectSchemaStmt(Node *alterObjectSchemaStmt,
 											  const char *alterObjectSchemaCommand);
 extern List * PreprocessGrantOnSchemaStmt(Node *node, const char *queryString,
 										  ProcessUtilityContext processUtilityContext);
-extern ObjectAddress CreateSchemaStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok);
+extern List * CreateSchemaStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok);
 
 /* sequence.c - forward declarations */
 extern List * PreprocessAlterSequenceStmt(Node *node, const char *queryString,
@@ -422,10 +422,10 @@ extern List * PreprocessRenameSequenceStmt(Node *node, const char *queryString,
 extern List * PreprocessGrantOnSequenceStmt(Node *node, const char *queryString,
 											ProcessUtilityContext processUtilityContext);
 extern List * PostprocessGrantOnSequenceStmt(Node *node, const char *queryString);
-extern ObjectAddress AlterSequenceStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress RenameSequenceStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterSequenceStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok);
+extern List * RenameSequenceStmtObjectAddress(Node *node, bool missing_ok);
 extern void ErrorIfUnsupportedSeqStmt(CreateSeqStmt *createSeqStmt);
 extern void ErrorIfDistributedAlterSeqOwnedBy(AlterSeqStmt *alterSeqStmt);
 extern char * GenerateBackupNameForSequenceCollision(const ObjectAddress *address);
@@ -436,7 +436,7 @@ extern void RenameExistingSequenceWithDifferentTypeIfExists(RangeVar *sequence,
 extern List * PreprocessCreateStatisticsStmt(Node *node, const char *queryString,
 											 ProcessUtilityContext processUtilityContext);
 extern List * PostprocessCreateStatisticsStmt(Node *node, const char *queryString);
-extern ObjectAddress CreateStatisticsStmtObjectAddress(Node *node, bool missingOk);
+extern List * CreateStatisticsStmtObjectAddress(Node *node, bool missingOk);
 extern List * PreprocessDropStatisticsStmt(Node *node, const char *queryString,
 										   ProcessUtilityContext processUtilityContext);
 extern List * PreprocessAlterStatisticsRenameStmt(Node *node, const char *queryString,
@@ -446,7 +446,7 @@ extern List * PreprocessAlterStatisticsSchemaStmt(Node *node, const char *queryS
 												  ProcessUtilityContext
 												  processUtilityContext);
 extern List * PostprocessAlterStatisticsSchemaStmt(Node *node, const char *queryString);
-extern ObjectAddress AlterStatisticsSchemaStmtObjectAddress(Node *node, bool missingOk);
+extern List * AlterStatisticsSchemaStmtObjectAddress(Node *node, bool missingOk);
 extern List * PreprocessAlterStatisticsStmt(Node *node, const char *queryString,
 											ProcessUtilityContext processUtilityContext);
 extern List * PreprocessAlterStatisticsOwnerStmt(Node *node, const char *queryString,
@@ -487,8 +487,8 @@ extern void ErrorUnsupportedAlterTableAddColumn(Oid relationId, AlterTableCmd *c
 extern void ErrorIfUnsupportedConstraint(Relation relation, char distributionMethod,
 										 char referencingReplicationModel,
 										 Var *distributionColumn, uint32 colocationId);
-extern ObjectAddress AlterTableSchemaStmtObjectAddress(Node *stmt,
-													   bool missing_ok);
+extern List * AlterTableSchemaStmtObjectAddress(Node *stmt,
+												bool missing_ok);
 extern List * MakeNameListFromRangeVar(const RangeVar *rel);
 extern Oid GetSequenceOid(Oid relationId, AttrNumber attnum);
 extern bool ConstrTypeUsesIndex(ConstrType constrType);
@@ -499,30 +499,30 @@ extern List * GetCreateTextSearchConfigStatements(const ObjectAddress *address);
 extern List * GetCreateTextSearchDictionaryStatements(const ObjectAddress *address);
 extern List * CreateTextSearchConfigDDLCommandsIdempotent(const ObjectAddress *address);
 extern List * CreateTextSearchDictDDLCommandsIdempotent(const ObjectAddress *address);
-extern ObjectAddress CreateTextSearchConfigurationObjectAddress(Node *node,
-																bool missing_ok);
-extern ObjectAddress CreateTextSearchDictObjectAddress(Node *node,
-													   bool missing_ok);
-extern ObjectAddress RenameTextSearchConfigurationStmtObjectAddress(Node *node,
-																	bool missing_ok);
-extern ObjectAddress RenameTextSearchDictionaryStmtObjectAddress(Node *node,
-																 bool missing_ok);
-extern ObjectAddress AlterTextSearchConfigurationStmtObjectAddress(Node *node,
-																   bool missing_ok);
-extern ObjectAddress AlterTextSearchDictionaryStmtObjectAddress(Node *node,
-																bool missing_ok);
-extern ObjectAddress AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node,
-																		 bool missing_ok);
-extern ObjectAddress AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node,
-																	  bool missing_ok);
-extern ObjectAddress TextSearchConfigurationCommentObjectAddress(Node *node,
-																 bool missing_ok);
-extern ObjectAddress TextSearchDictCommentObjectAddress(Node *node,
-														bool missing_ok);
-extern ObjectAddress AlterTextSearchConfigurationOwnerObjectAddress(Node *node,
-																	bool missing_ok);
-extern ObjectAddress AlterTextSearchDictOwnerObjectAddress(Node *node,
-														   bool missing_ok);
+extern List * CreateTextSearchConfigurationObjectAddress(Node *node,
+														 bool missing_ok);
+extern List * CreateTextSearchDictObjectAddress(Node *node,
+												bool missing_ok);
+extern List * RenameTextSearchConfigurationStmtObjectAddress(Node *node,
+															 bool missing_ok);
+extern List * RenameTextSearchDictionaryStmtObjectAddress(Node *node,
+														  bool missing_ok);
+extern List * AlterTextSearchConfigurationStmtObjectAddress(Node *node,
+															bool missing_ok);
+extern List * AlterTextSearchDictionaryStmtObjectAddress(Node *node,
+														 bool missing_ok);
+extern List * AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node,
+																  bool missing_ok);
+extern List * AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node,
+															   bool missing_ok);
+extern List * TextSearchConfigurationCommentObjectAddress(Node *node,
+														  bool missing_ok);
+extern List * TextSearchDictCommentObjectAddress(Node *node,
+												 bool missing_ok);
+extern List * AlterTextSearchConfigurationOwnerObjectAddress(Node *node,
+															 bool missing_ok);
+extern List * AlterTextSearchDictOwnerObjectAddress(Node *node,
+													bool missing_ok);
 extern char * GenerateBackupNameForTextSearchConfiguration(const ObjectAddress *address);
 extern char * GenerateBackupNameForTextSearchDict(const ObjectAddress *address);
 extern List * get_ts_config_namelist(Oid tsconfigOid);
@@ -535,16 +535,16 @@ extern List * PreprocessRenameTypeAttributeStmt(Node *stmt, const char *queryStr
 												ProcessUtilityContext
 												processUtilityContext);
 extern Node * CreateTypeStmtByObjectAddress(const ObjectAddress *address);
-extern ObjectAddress CompositeTypeStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress CreateEnumStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress AlterTypeStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress AlterEnumStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress RenameTypeStmtObjectAddress(Node *stmt, bool missing_ok);
-extern ObjectAddress AlterTypeSchemaStmtObjectAddress(Node *stmt,
-													  bool missing_ok);
-extern ObjectAddress RenameTypeAttributeStmtObjectAddress(Node *stmt,
-														  bool missing_ok);
-extern ObjectAddress AlterTypeOwnerObjectAddress(Node *stmt, bool missing_ok);
+extern List * CompositeTypeStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * CreateEnumStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * AlterTypeStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * AlterEnumStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * RenameTypeStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * AlterTypeSchemaStmtObjectAddress(Node *stmt,
+											   bool missing_ok);
+extern List * RenameTypeAttributeStmtObjectAddress(Node *stmt,
+												   bool missing_ok);
+extern List * AlterTypeOwnerObjectAddress(Node *stmt, bool missing_ok);
 extern List * CreateTypeDDLCommandsIdempotent(const ObjectAddress *typeAddress);
 extern char * GenerateBackupNameForTypeCollision(const ObjectAddress *address);
 
@@ -565,8 +565,8 @@ extern List * PostprocessVacuumStmt(Node *node, const char *vacuumCommand);
 extern List * PreprocessViewStmt(Node *node, const char *queryString,
 								 ProcessUtilityContext processUtilityContext);
 extern List * PostprocessViewStmt(Node *node, const char *queryString);
-extern ObjectAddress ViewStmtObjectAddress(Node *node, bool missing_ok);
-extern ObjectAddress AlterViewStmtObjectAddress(Node *node, bool missing_ok);
+extern List * ViewStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterViewStmtObjectAddress(Node *node, bool missing_ok);
 extern List * PreprocessDropViewStmt(Node *node, const char *queryString,
 									 ProcessUtilityContext processUtilityContext);
 extern char * CreateViewDDLCommand(Oid viewOid);
@@ -582,11 +582,11 @@ extern List * PreprocessAlterViewStmt(Node *node, const char *queryString,
 extern List * PostprocessAlterViewStmt(Node *node, const char *queryString);
 extern List * PreprocessRenameViewStmt(Node *node, const char *queryString,
 									   ProcessUtilityContext processUtilityContext);
-extern ObjectAddress RenameViewStmtObjectAddress(Node *node, bool missing_ok);
+extern List * RenameViewStmtObjectAddress(Node *node, bool missing_ok);
 extern List * PreprocessAlterViewSchemaStmt(Node *node, const char *queryString,
 											ProcessUtilityContext processUtilityContext);
 extern List * PostprocessAlterViewSchemaStmt(Node *node, const char *queryString);
-extern ObjectAddress AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok);
+extern List * AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok);
 extern bool IsViewRenameStmt(RenameStmt *renameStmt);
 
 /* trigger.c - forward declarations */
@@ -594,7 +594,7 @@ extern List * GetExplicitTriggerCommandList(Oid relationId);
 extern HeapTuple GetTriggerTupleById(Oid triggerId, bool missingOk);
 extern List * GetExplicitTriggerIdList(Oid relationId);
 extern List * PostprocessCreateTriggerStmt(Node *node, const char *queryString);
-extern ObjectAddress CreateTriggerStmtObjectAddress(Node *node, bool missingOk);
+extern List * CreateTriggerStmtObjectAddress(Node *node, bool missingOk);
 extern void CreateTriggerEventExtendNames(CreateTrigStmt *createTriggerStmt,
 										  char *schemaName, uint64 shardId);
 extern List * PostprocessAlterTriggerRenameStmt(Node *node, const char *queryString);

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -149,7 +149,7 @@ extern char * GetTypeNamespaceNameByNameList(List *names);
 extern Oid TypeOidGetNamespaceOid(Oid typeOid);
 
 extern ObjectAddress GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok);
-extern ObjectAddress RenameAttributeStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * RenameAttributeStmtObjectAddress(Node *stmt, bool missing_ok);
 
 /* forward declarations for deparse_view_stmts.c */
 extern void QualifyDropViewStmt(Node *node);

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -148,7 +148,7 @@ extern void QualifyAlterTypeOwnerStmt(Node *stmt);
 extern char * GetTypeNamespaceNameByNameList(List *names);
 extern Oid TypeOidGetNamespaceOid(Oid typeOid);
 
-extern ObjectAddress GetObjectAddressFromParseTree(Node *parseTree, bool missing_ok);
+extern List * GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok);
 extern List * RenameAttributeStmtObjectAddress(Node *stmt, bool missing_ok);
 
 /* forward declarations for deparse_view_stmts.c */

--- a/src/include/distributed/metadata/dependency.h
+++ b/src/include/distributed/metadata/dependency.h
@@ -23,10 +23,9 @@ extern List * GetUniqueDependenciesList(List *objectAddressesList);
 extern List * GetDependenciesForObject(const ObjectAddress *target);
 extern List * GetAllSupportedDependenciesForObject(const ObjectAddress *target);
 extern List * GetAllDependenciesForObject(const ObjectAddress *target);
-extern bool ErrorOrWarnIfObjectHasUnsupportedDependency(ObjectAddress *objectAddress);
-extern DeferredErrorMessage * DeferErrorIfHasUnsupportedDependency(const
-																   ObjectAddress *
-																   objectAddress);
+extern bool ErrorOrWarnIfAnyObjectHasUnsupportedDependency(List *objectAddresses);
+extern DeferredErrorMessage * DeferErrorIfAnyObjectHasUnsupportedDependency(const List *
+																			objectAddresses);
 extern List * OrderObjectAddressListInDependencyOrder(List *objectAddressList);
 extern bool SupportedDependencyByCitus(const ObjectAddress *address);
 extern List * GetPgDependTuplesForDependingObjects(Oid targetObjectClassId,

--- a/src/include/distributed/metadata/distobject.h
+++ b/src/include/distributed/metadata/distobject.h
@@ -20,15 +20,15 @@
 
 extern bool ObjectExists(const ObjectAddress *address);
 extern bool CitusExtensionObject(const ObjectAddress *objectAddress);
-extern bool IsObjectDistributed(const ObjectAddress *address);
+extern bool IsAnyObjectDistributed(const List *addresses);
 extern bool ClusterHasDistributedFunctionWithDistArgument(void);
 extern void MarkObjectDistributed(const ObjectAddress *distAddress);
 extern void MarkObjectDistributedViaSuperUser(const ObjectAddress *distAddress);
 extern void MarkObjectDistributedLocally(const ObjectAddress *distAddress);
 extern void UnmarkObjectDistributed(const ObjectAddress *address);
 extern bool IsTableOwnedByExtension(Oid relationId);
-extern bool IsObjectAddressOwnedByExtension(const ObjectAddress *target,
-											ObjectAddress *extensionAddress);
+extern bool IsAnyObjectAddressOwnedByExtension(const List *targets,
+											   ObjectAddress *extensionAddress);
 extern ObjectAddress PgGetObjectAddress(char *ttype, ArrayType *namearr,
 										ArrayType *argsarr);
 extern List * GetDistributedObjectAddressList(void);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -258,15 +258,15 @@ extern void CreateDistributedTable(Oid relationId, char *distributionColumnName,
 extern void CreateTruncateTrigger(Oid relationId);
 extern TableConversionReturn * UndistributeTable(TableConversionParameters *params);
 
-extern void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
+extern void EnsureAllObjectDependenciesExistOnAllNodes(const List *targets);
 extern DeferredErrorMessage * DeferErrorIfCircularDependencyExists(const
 																   ObjectAddress *
 																   objectAddress);
 extern List * GetDistributableDependenciesForObject(const ObjectAddress *target);
-extern List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
+extern List * GetAllDependencyCreateDDLCommands(const List *dependencies);
 extern bool ShouldPropagate(void);
 extern bool ShouldPropagateCreateInCoordinatedTransction(void);
-extern bool ShouldPropagateObject(const ObjectAddress *address);
+extern bool ShouldPropagateAnyObject(List *addresses);
 extern List * ReplicateAllObjectsToNodeCommandList(const char *nodeName, int nodePort);
 
 /* Remaining metadata utility functions  */


### PR DESCRIPTION
We change address method's return value for distributed objects. It returns list of object adresses instead of single address because some of the statements accepts more than 1 object. 