### PR TITLE
Replace isolation tester func only once on enterprise tests

### DIFF
--- a/src/test/regress/enterprise_isolation_logicalrep_1_schedule
+++ b/src/test/regress/enterprise_isolation_logicalrep_1_schedule
@@ -1,3 +1,5 @@
+test: isolation_setup
+
 # tests that change node metadata should precede
 # isolation_cluster_management such that tests
 # that come later can be parallelized

--- a/src/test/regress/enterprise_isolation_logicalrep_3_schedule
+++ b/src/test/regress/enterprise_isolation_logicalrep_3_schedule
@@ -1,3 +1,5 @@
+test: isolation_setup
+
 # tests that change node metadata should precede
 # isolation_cluster_management such that tests
 # that come later can be parallelized

--- a/src/test/regress/enterprise_isolation_schedule
+++ b/src/test/regress/enterprise_isolation_schedule
@@ -1,3 +1,5 @@
+test: isolation_setup
+
 # tests that change node metadata should precede
 # isolation_cluster_management such that tests
 # that come later can be parallelized

--- a/src/test/regress/expected/isolation_ref2ref_foreign_keys_enterprise.out
+++ b/src/test/regress/expected/isolation_ref2ref_foreign_keys_enterprise.out
@@ -63,11 +63,6 @@ id|value
 11|   11
 (5 rows)
 
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
-
 
 starting permutation: s1-insert-table-1 s3-acquire-advisory-lock s2-begin s2-move-shards s1-update-table-1 s3-release-advisory-lock s2-commit s1-select-table-1 s1-select-dist-table
 step s1-insert-table-1:
@@ -134,11 +129,6 @@ id|value
 11|   11
 (6 rows)
 
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
-
 
 starting permutation: s3-acquire-advisory-lock s2-begin s2-move-shards s1-insert-table-1 s3-release-advisory-lock s2-commit s1-select-table-1 s1-select-dist-table
 step s3-acquire-advisory-lock:
@@ -202,11 +192,6 @@ id|value
 11|   11
 (6 rows)
 
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
-
 
 starting permutation: s1-insert-table-1 s3-acquire-advisory-lock s2-begin s2-move-shards s1-select-table-1 s3-release-advisory-lock s2-commit
 step s1-insert-table-1:
@@ -256,11 +241,6 @@ master_move_shard_placement
 
 step s2-commit:
     COMMIT;
-
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
 
 
 starting permutation: s1-insert-table-1 s2-begin s1-begin s1-delete-table-1 s2-move-shards s1-commit s2-commit s1-select-table-1 s1-select-dist-table
@@ -315,11 +295,6 @@ id|value
  9|    9
 11|   11
 (5 rows)
-
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
 
 
 starting permutation: s1-insert-table-1 s2-begin s1-begin s1-update-table-1 s2-move-shards s1-commit s2-commit s1-select-table-1 s1-select-dist-table
@@ -377,11 +352,6 @@ id|value
 11|   11
 (6 rows)
 
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
-
 
 starting permutation: s2-begin s1-begin s1-insert-table-1 s2-move-shards s1-commit s2-commit s1-select-table-1 s1-select-dist-table
 step s2-begin:
@@ -434,9 +404,4 @@ id|value
  9|    9
 11|   11
 (6 rows)
-
-restore_isolation_tester_func
----------------------------------------------------------------------
-
-(1 row)
 

--- a/src/test/regress/spec/isolation_logical_replication_multi_shard_commands.spec
+++ b/src/test/regress/spec/isolation_logical_replication_multi_shard_commands.spec
@@ -3,9 +3,6 @@
 
 setup
 {
-  SELECT citus_internal.replace_isolation_tester_func();
-  SELECT citus_internal.refresh_isolation_tester_prepared_statement();
-
   SET citus.shard_count TO 8;
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE logical_replicate_placement (x int PRIMARY KEY, y int);
@@ -17,8 +14,6 @@ setup
 
 teardown
 {
-  SELECT citus_internal.restore_isolation_tester_func();
-
   DROP TABLE selected_shard;
 	DROP TABLE logical_replicate_placement;
 }

--- a/src/test/regress/spec/isolation_logical_replication_single_shard_commands.spec
+++ b/src/test/regress/spec/isolation_logical_replication_single_shard_commands.spec
@@ -2,9 +2,6 @@
 // so setting the corresponding shard here is useful
 setup
 {
-  SELECT citus_internal.replace_isolation_tester_func();
-  SELECT citus_internal.refresh_isolation_tester_prepared_statement();
-
 	SET citus.shard_count TO 8;
 	SET citus.shard_replication_factor TO 1;
 	CREATE TABLE logical_replicate_placement (x int PRIMARY KEY, y int);
@@ -15,8 +12,6 @@ setup
 
 teardown
 {
-  SELECT citus_internal.restore_isolation_tester_func();
-
   DROP TABLE selected_shard;
 	DROP TABLE logical_replicate_placement;
 }

--- a/src/test/regress/spec/isolation_ref2ref_foreign_keys_enterprise.spec
+++ b/src/test/regress/spec/isolation_ref2ref_foreign_keys_enterprise.spec
@@ -2,8 +2,6 @@ setup
 {
     SET citus.shard_count TO 2;
 	SET citus.shard_replication_factor TO 1;
-	SELECT citus_internal.replace_isolation_tester_func();
-	SELECT citus_internal.refresh_isolation_tester_prepared_statement();
 
     CREATE TABLE ref_table_1(id int PRIMARY KEY, value int);
 	SELECT create_reference_table('ref_table_1');
@@ -24,7 +22,6 @@ setup
 teardown
 {
 	DROP TABLE ref_table_1, ref_table_2, dist_table, selected_shard_for_dist_table;
-	SELECT citus_internal.restore_isolation_tester_func();
 }
 
 session "s1"


### PR DESCRIPTION
This is a continuation of a refactor (with commit sha
2b7cf0c09771a49a47f4438dfe71b07898723e04) that aimed to use Citus helper
UDFs by default in iso tests.

PostgreSQL isolation test infrastructure uses some UDFs to detect
whether concurrent sessions block each other. Citus implements
alternatives to that UDF so that we are able to detect and report
distributed transactions that get blocked on the worker nodes as well.

We needed to explicitly replace PG helper functions with Citus
implementations in each isolation file. Now we replace them by default.

Sister PR: #5964 
