### PR TITLE
allow ./configure to pass without checking the postgres version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           name: 'Configure'
           command: |
             chown -R circleci .
-            gosu circleci ./configure
+            gosu circleci ./configure --without-pg-version-check
       - run:
           name: 'Enable core dumps'
           command: |
@@ -209,7 +209,7 @@ jobs:
           name: 'Configure'
           command: |
             chown -R circleci .
-            gosu circleci ./configure
+            gosu circleci ./configure --without-pg-version-check
       - run:
           name: 'Enable core dumps'
           command: |
@@ -283,7 +283,7 @@ jobs:
           name: 'Configure'
           command: |
             chown -R circleci .
-            gosu circleci ./configure
+            gosu circleci ./configure --without-pg-version-check
       - run:
           name: 'Enable core dumps'
           command: |
@@ -371,7 +371,7 @@ jobs:
           name: 'Configure'
           command: |
             chown -R circleci .
-            gosu circleci ./configure
+            gosu circleci ./configure --without-pg-version-check
       - run:
           name: 'Enable core dumps'
           command: |
@@ -448,7 +448,7 @@ jobs:
           name: 'Configure'
           command: |
             chown -R circleci .
-            gosu circleci ./configure
+            gosu circleci ./configure --without-pg-version-check
       - run:
           name: 'Enable core dumps'
           command: |

--- a/configure
+++ b/configure
@@ -644,6 +644,7 @@ LDFLAGS
 CFLAGS
 CC
 vpath_build
+with_pg_version_check
 PATH
 PG_CONFIG
 FLEX
@@ -692,6 +693,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_extra_version
+with_pg_version_check
 enable_coverage
 with_libcurl
 with_reports_hostname
@@ -1337,6 +1339,8 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-extra-version=STRING
                           append STRING to version
+  --without-pg-version-check
+                          do not check postgres version during configure
   --without-libcurl       do not use libcurl for anonymous statistics
                           collection
   --with-reports-hostname=HOSTNAME
@@ -2555,7 +2559,36 @@ if test -z "$version_num"; then
   as_fn_error $? "Could not detect PostgreSQL version from pg_config." "$LINENO" 5
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14'; then
+
+
+
+# Check whether --with-pg-version-check was given.
+if test "${with_pg_version_check+set}" = set; then :
+  withval=$with_pg_version_check;
+  case $withval in
+    yes)
+      :
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --with-pg-version-check option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  with_pg_version_check=yes
+
+fi
+
+
+
+
+if test "$with_pg_version_check" = no; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num (skipped compatibility check)" >&5
+$as_echo "$as_me: building against PostgreSQL $version_num (skipped compatibility check)" >&6;}
+elif test "$version_num" != '13' -a "$version_num" != '14'; then
    as_fn_error $? "Citus is not compatible with the detected PostgreSQL version ${version_num}." "$LINENO" 5
 else
    { $as_echo "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,13 @@ if test -z "$version_num"; then
   AC_MSG_ERROR([Could not detect PostgreSQL version from pg_config.])
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14'; then
+PGAC_ARG_BOOL(with, pg-version-check, yes,
+              [do not check postgres version during configure])
+AC_SUBST(with_pg_version_check)
+
+if test "$with_pg_version_check" = no; then
+    AC_MSG_NOTICE([building against PostgreSQL $version_num (skipped compatibility check)])
+elif test "$version_num" != '13' -a "$version_num" != '14'; then
    AC_MSG_ERROR([Citus is not compatible with the detected PostgreSQL version ${version_num}.])
 else
    AC_MSG_NOTICE([building against PostgreSQL $version_num])


### PR DESCRIPTION
For working on initial changes to postgres beta versions make the version check in `./configure` default, but optional.

Normal users will still get the postgres version check error when building on other postgres versions, however, advanced users can use this flag to force configure to pass and find the compilation errors Citus would run into.

Use of the flag is not advised for users not understanding what this does.