### PR TITLE
Check the PGPROC's validity properly

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -647,6 +647,7 @@ CitusCleanupConnectionsAtExit(int code, Datum arg)
 
 	/* we don't want any monitoring view/udf to show already exited backends */
 	UnSetGlobalPID();
+	SetActiveMyBackend(false);
 }
 
 

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -42,6 +42,7 @@ typedef struct BackendData
 	uint64 globalPID;
 	bool distributedCommandOriginator;
 	DistributedTransactionId transactionId;
+	bool activeBackend; /* set to false when backend exists */
 } BackendData;
 
 
@@ -54,6 +55,7 @@ extern void LockBackendSharedMemory(LWLockMode lockMode);
 extern void UnlockBackendSharedMemory(void);
 extern void UnSetDistributedTransactionId(void);
 extern void UnSetGlobalPID(void);
+extern void SetActiveMyBackend(bool value);
 extern void AssignDistributedTransactionId(void);
 extern void AssignGlobalPID(void);
 extern uint64 GetGlobalPID(void);

--- a/src/test/regress/expected/isolation_get_all_active_transactions.out
+++ b/src/test/regress/expected/isolation_get_all_active_transactions.out
@@ -1,4 +1,4 @@
-Parsed test spec with 3 sessions
+Parsed test spec with 5 sessions
 
 starting permutation: s1-grant s1-begin-insert s2-begin-insert s3-as-admin s3-as-user-1 s3-as-readonly s3-as-monitor s1-commit s2-commit
 step s1-grant:
@@ -92,4 +92,35 @@ step s1-commit:
 
 step s2-commit:
 	COMMIT;
+
+
+starting permutation: s4-record-pid s3-show-activity s5-kill s3-show-activity
+step s4-record-pid:
+	SELECT pg_backend_pid() INTO selected_pid;
+
+step s3-show-activity:
+	SET ROLE postgres;
+	select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
+
+count
+---------------------------------------------------------------------
+    1
+(1 row)
+
+step s5-kill:
+	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
+
+pg_terminate_backend
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s3-show-activity:
+	SET ROLE postgres;
+	select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
+
+count
+---------------------------------------------------------------------
+    0
+(1 row)
 

--- a/src/test/regress/spec/isolation_get_all_active_transactions.spec
+++ b/src/test/regress/spec/isolation_get_all_active_transactions.spec
@@ -21,6 +21,7 @@ teardown
 {
 	DROP TABLE test_table;
 	DROP USER test_user_1, test_user_2, test_readonly, test_monitor;
+	DROP TABLE IF EXISTS selected_pid;
 }
 
 session "s1"
@@ -100,4 +101,26 @@ step "s3-as-monitor"
 	SELECT count(*) FROM get_global_active_transactions() WHERE transaction_number != 0;
 }
 
+step "s3-show-activity"
+{
+	SET ROLE postgres;
+	select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
+}
+
+session "s4"
+
+step "s4-record-pid"
+{
+	SELECT pg_backend_pid() INTO selected_pid;
+}
+
+session "s5"
+
+step "s5-kill"
+{
+	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
+}
+
+
 permutation "s1-grant" "s1-begin-insert" "s2-begin-insert" "s3-as-admin" "s3-as-user-1" "s3-as-readonly" "s3-as-monitor" "s1-commit" "s2-commit"
+permutation "s4-record-pid" "s3-show-activity" "s5-kill" "s3-show-activity"


### PR DESCRIPTION
We used to only check whether the PID is valid
or not. However, Postgres does not necessarily
set the PID of the backend to 0 when it exists.

Instead, we need to be able to check it from procArray.
IsBackendPid() is what pg_stat_activity also relies
on for a similar purpose.

Fixes https://github.com/citusdata/citus/issues/6074