### PR TITLE
Bump to latest PG minors in CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: '14.4'
   upgrade_pg_versions:
     type: string
-    default: '13.7-14.4'
+    default: '13.7-14.4-15beta2'
 jobs:
   build:
     description: Build the citus extension

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
       image_tag:
         description: 'docker image tag to use'
         type: string
-        default: 12-13
     docker:
       - image: '<< parameters.image >>:<< parameters.image_tag >><< pipeline.parameters.image_suffix >>'
     working_directory: /home/circleci/project
@@ -192,7 +191,6 @@ jobs:
       image_tag:
         description: 'docker image tag to use'
         type: string
-        default: 12-13
     docker:
       - image: '<< parameters.image >>:<< parameters.image_tag >><< pipeline.parameters.image_suffix >>'
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,16 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-b07a192'
+    default: '-dev-a983dbe'
   pg13_version:
     type: string
-    default: '13.4'
+    default: '13.7'
   pg14_version:
     type: string
-    default: '14.0'
+    default: '14.4'
   upgrade_pg_versions:
     type: string
-    default: '13.4-14.0'
+    default: '13.7-14.4'
 jobs:
   build:
     description: Build the citus extension

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -108,6 +108,7 @@ s/(ERROR: |WARNING: |error:) server closed the connection unexpectedly/\1 connec
 /^\s*before or while processing the request.$/d
 /^\s*connection not open$/d
 /^\s*invalid socket$/d
+s/invalid socket/connection not open/g
 
 # intermediate_results
 s/(ERROR.*)pgsql_job_cache\/([0-9]+_[0-9]+_[0-9]+)\/(.*).data/\1pgsql_job_cache\/xx_x_xxx\/\3.data/g

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -107,6 +107,7 @@ s/(ERROR: |WARNING: |error:) server closed the connection unexpectedly/\1 connec
 /^\s*This probably means the server terminated abnormally$/d
 /^\s*before or while processing the request.$/d
 /^\s*connection not open$/d
+/^\s*invalid socket$/d
 
 # intermediate_results
 s/(ERROR.*)pgsql_job_cache\/([0-9]+_[0-9]+_[0-9]+)\/(.*).data/\1pgsql_job_cache\/xx_x_xxx\/\3.data/g


### PR DESCRIPTION
This PR aims to capture the changes in our test suite to use the latest PG minor versions for 13 and 14.



Blocked on #6075 as we need to have matching libpq and PG minor versions in images here.