### PR TITLE
enable propagation warnings before postgres vanilla tests

### DIFF
--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -39,9 +39,12 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 
 	if (clusterStmt->relation == NULL)
 	{
-		ereport(WARNING, (errmsg("not propagating CLUSTER command to worker nodes"),
-						  errhint("Provide a specific table in order to CLUSTER "
-								  "distributed tables.")));
+		if (EnableUnsupportedFeatureMessages)
+		{
+			ereport(WARNING, (errmsg("not propagating CLUSTER command to worker nodes"),
+							  errhint("Provide a specific table in order to CLUSTER "
+									  "distributed tables.")));
+		}
 
 		return NIL;
 	}

--- a/src/backend/distributed/commands/common.c
+++ b/src/backend/distributed/commands/common.c
@@ -74,7 +74,11 @@ PostprocessCreateDistributedObjectFromCatalogStmt(Node *stmt, const char *queryS
 		addresses);
 	if (depError != NULL)
 	{
-		RaiseDeferredError(depError, WARNING);
+		if (EnableUnsupportedFeatureMessages)
+		{
+			RaiseDeferredError(depError, WARNING);
+		}
+
 		return NIL;
 	}
 

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1387,7 +1387,11 @@ PostprocessCreateFunctionStmt(Node *node, const char *queryString)
 
 	if (errMsg != NULL)
 	{
-		RaiseDeferredError(errMsg, WARNING);
+		if (EnableUnsupportedFeatureMessages)
+		{
+			RaiseDeferredError(errMsg, WARNING);
+		}
+
 		return NIL;
 	}
 

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1754,10 +1754,13 @@ List *
 PreprocessAlterTableMoveAllStmt(Node *node, const char *queryString,
 								ProcessUtilityContext processUtilityContext)
 {
-	ereport(WARNING, (errmsg("not propagating ALTER TABLE ALL IN TABLESPACE "
-							 "commands to worker nodes"),
-					  errhint("Connect to worker nodes directly to manually "
-							  "move all tables.")));
+	if (EnableUnsupportedFeatureMessages)
+	{
+		ereport(WARNING, (errmsg("not propagating ALTER TABLE ALL IN TABLESPACE "
+								 "commands to worker nodes"),
+						  errhint("Connect to worker nodes directly to manually "
+								  "move all tables.")));
+	}
 
 	return NIL;
 }

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -734,10 +734,14 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		if (IsA(parsetree, RenameStmt) && ((RenameStmt *) parsetree)->renameType ==
 			OBJECT_ROLE && EnableAlterRolePropagation)
 		{
-			ereport(NOTICE, (errmsg("not propagating ALTER ROLE ... RENAME TO commands "
-									"to worker nodes"),
-							 errhint("Connect to worker nodes directly to manually "
-									 "rename the role")));
+			if (EnableUnsupportedFeatureMessages)
+			{
+				ereport(NOTICE, (errmsg(
+									 "not propagating ALTER ROLE ... RENAME TO commands "
+									 "to worker nodes"),
+								 errhint("Connect to worker nodes directly to manually "
+										 "rename the role")));
+			}
 		}
 	}
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -48,6 +48,7 @@
 #include "distributed/local_executor.h"
 #include "distributed/local_distributed_join_planner.h"
 #include "distributed/locally_reserved_shared_connections.h"
+#include "distributed/log_utils.h"
 #include "distributed/maintenanced.h"
 #include "distributed/shard_cleaner.h"
 #include "distributed/metadata_utility.h"
@@ -1151,6 +1152,17 @@ RegisterCitusConfigVariables(void)
 		false,
 		PGC_USERSET,
 		GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
+		"citus.enable_unsupported_feature_messages",
+		gettext_noop("Controls showing of some citus related messages. It is intended to "
+					 "be used before vanilla tests to stop unwanted citus messages."),
+		NULL,
+		&EnableUnsupportedFeatureMessages,
+		true,
+		PGC_SUSET,
+		GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(

--- a/src/backend/distributed/utils/log_utils.c
+++ b/src/backend/distributed/utils/log_utils.c
@@ -24,6 +24,12 @@
 
 
 /*
+ * GUC controls showing of some of the unwanted citus messages, it is intended to be set false
+ * before vanilla tests to not break postgres test logs.
+ */
+bool EnableUnsupportedFeatureMessages = true;
+
+/*
  * IsLoggableLevel returns true if either of client or server log guc is configured to
  * log the given log level.
  * In postgres, log can be configured differently for clients and servers.

--- a/src/include/distributed/log_utils.h
+++ b/src/include/distributed/log_utils.h
@@ -16,6 +16,8 @@
 #define CITUS_LOG_LEVEL_OFF 0
 
 
+extern bool EnableUnsupportedFeatureMessages;
+
 extern bool IsLoggableLevel(int logLevel);
 extern char * HashLogMessage(const char *text);
 

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -500,6 +500,9 @@ if(!$vanillaDev && $vanillatest)
 {
     # we enable hiding the citus dependent objects from pg meta class queries to not break postgres vanilla test behaviour
     push(@pgOptions, "citus.hide_citus_dependent_objects=true");
+
+    # we disable citus related unwanted messages to not break postgres vanilla test behaviour.
+    push(@pgOptions, "citus.enable_unsupported_feature_messages=false");
 }
 
 if ($useMitmproxy)


### PR DESCRIPTION
DESCRIPTION: Adds the GUC enable_unsupported_feature_messages to control some of the citus related messages.

This PR adds the GUC to stop some of the citus messages that causes some of the postgres tests to fail. It is a subtask for the main PR #6018. It is intended to be set false only before postgres vanilla tests to prevent some of the tests from failing.