### PR TITLE
We supress notice log during looking up function oid to not break pg vanilla tests.

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -32,6 +32,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/extension.h"
+#include "distributed/citus_depended_object.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/citus_safe_lib.h"
 #include "distributed/colocation_utils.h"
@@ -1438,7 +1439,17 @@ CreateFunctionStmtObjectAddress(Node *node, bool missing_ok)
 		}
 	}
 
-	return FunctionToObjectAddress(objectType, objectWithArgs, missing_ok);
+	int OldClientMinMessage = client_min_messages;
+
+	/* suppress NOTICE if running under pg vanilla tests */
+	SetLocalClientMinMessagesIfRunningPGTests(WARNING);
+
+	List *funcAddresses = FunctionToObjectAddress(objectType, objectWithArgs, missing_ok);
+
+	/* set it back */
+	SetLocalClientMinMessagesIfRunningPGTests(OldClientMinMessage);
+
+	return funcAddresses;
 }
 
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -596,6 +596,21 @@ StartupCitusBackend(void)
 
 
 /*
+ * GetCurrentClientMinMessageLevelName returns the name of the
+ * the GUC client_min_messages for its specified value.
+ */
+const char *
+GetClientMinMessageLevelNameForValue(int minMessageLevel)
+{
+	struct config_enum record = { 0 };
+	record.options = log_level_options;
+	const char *clientMinMessageLevelName = config_enum_lookup_by_value(&record,
+																		minMessageLevel);
+	return clientMinMessageLevelName;
+}
+
+
+/*
  * RegisterConnectionCleanup cleans up any resources left at the end of the
  * session. We prefer to cleanup before shared memory exit to make sure that
  * this session properly releases anything hold in the shared memory.

--- a/src/backend/distributed/utils/citus_depended_object.c
+++ b/src/backend/distributed/utils/citus_depended_object.c
@@ -33,6 +33,8 @@
 #include "distributed/citus_depended_object.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/listutils.h"
+#include "distributed/log_utils.h"
+#include "distributed/shared_library_init.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/parsenodes.h"
@@ -71,6 +73,27 @@ SetLocalHideCitusDependentObjectsDisabledWhenAlreadyEnabled(void)
 	}
 
 	set_config_option("citus.hide_citus_dependent_objects", "false",
+					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
+					  GUC_ACTION_LOCAL, true, 0, false);
+}
+
+
+/*
+ * SetLocalClientMinMessagesIfRunningPGTests sets client_min_message locally to the given value
+ * if EnableUnsupportedFeatureMessages is set to false.
+ */
+void
+SetLocalClientMinMessagesIfRunningPGTests(int clientMinMessageLevel)
+{
+	if (EnableUnsupportedFeatureMessages)
+	{
+		return;
+	}
+
+	const char *clientMinMessageLevelName = GetClientMinMessageLevelNameForValue(
+		clientMinMessageLevel);
+
+	set_config_option("client_min_messages", clientMinMessageLevelName,
 					  (superuser() ? PGC_SUSET : PGC_USERSET), PGC_S_SESSION,
 					  GUC_ACTION_LOCAL, true, 0, false);
 }

--- a/src/include/distributed/citus_depended_object.h
+++ b/src/include/distributed/citus_depended_object.h
@@ -17,6 +17,8 @@
 
 extern bool HideCitusDependentObjects;
 
+extern void SetLocalClientMinMessagesIfRunningPGTests(int
+													  clientMinMessageLevel);
 extern void SetLocalHideCitusDependentObjectsDisabledWhenAlreadyEnabled(void);
 extern bool HideCitusDependentObjectsOnQueriesOfPgMetaTables(Node *node, void *context);
 extern bool IsPgLocksTable(RangeTblEntry *rte);

--- a/src/include/distributed/shared_library_init.h
+++ b/src/include/distributed/shared_library_init.h
@@ -23,5 +23,6 @@ extern IsColumnarTableAmTable_type extern_IsColumnarTableAmTable;
 extern ReadColumnarOptions_type extern_ReadColumnarOptions;
 
 extern void StartupCitusBackend(void);
+extern const char * GetClientMinMessageLevelNameForValue(int minMessageLevel);
 
 #endif /* SHARED_LIBRARY_INIT_H */


### PR DESCRIPTION
We supress notice log during looking up function oid to not break pg
 vanilla tests. That PR is a sub task for the main PR #6018.
