### PR TITLE
stop distributing views with no distributed dependency if GUC Distrib…

### DIFF
--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -843,7 +843,10 @@ ErrorOrWarnIfObjectHasUnsupportedDependency(const ObjectAddress *objectAddress)
 		}
 		else
 		{
-			RaiseDeferredError(errMsg, WARNING);
+			if (EnableUnsupportedFeatureMessages)
+			{
+				RaiseDeferredError(errMsg, WARNING);
+			}
 		}
 
 		return true;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1204,6 +1204,17 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.enforce_object_restrictions_for_local_objects",
+		gettext_noop(
+			"Controls some restrictions for local objects."),
+		NULL,
+		&EnforceLocalObjectRestrictions,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
 	DefineCustomIntVariable(
 		"citus.executor_slow_start_interval",
 		gettext_noop("Time to wait between opening connections to the same worker node"),

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -31,6 +31,8 @@ extern bool EnableUnsafeTriggers;
 
 extern int MaxMatViewSizeToAutoRecreate;
 
+extern bool EnforceLocalObjectRestrictions;
+
 extern void SwitchToSequentialAndLocalExecutionIfRelationNameTooLong(Oid relationId,
 																	 char *
 																	 finalRelationName);

--- a/src/test/regress/expected/view_propagation.out
+++ b/src/test/regress/expected/view_propagation.out
@@ -855,6 +855,85 @@ HINT:  Use DROP MATERIALIZED VIEW to remove a materialized view.
 DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
 DROP MATERIALIZED VIEW IF EXISTS axx.temp_view_to_drop;
 NOTICE:  materialized view "temp_view_to_drop" does not exist, skipping
+-- Test the GUC citus.enforce_object_restrictions_for_local_objects
+SET search_path to view_prop_schema;
+CREATE TABLE local_t (a int);
+-- tests when citus.enforce_object_restrictions_for_local_objects=true
+SET citus.enforce_object_restrictions_for_local_objects TO true;
+-- views will be created locally with warnings
+CREATE VIEW vv1 as SELECT * FROM local_t;
+WARNING:  "view vv1" has dependency to "table local_t" that is not in Citus' metadata
+DETAIL:  "view vv1" will be created only locally
+HINT:  Distribute "table local_t" first to distribute "view vv1"
+CREATE OR REPLACE VIEW vv2 as SELECT * FROM vv1;
+WARNING:  "view vv2" has dependency to "table local_t" that is not in Citus' metadata
+DETAIL:  "view vv2" will be created only locally
+HINT:  Distribute "table local_t" first to distribute "view vv2"
+-- view will fail due to local circular dependency
+CREATE OR REPLACE VIEW vv1 as SELECT * FROM vv2;
+ERROR:  Citus can not handle circular dependencies between distributed objects
+DETAIL:  "view vv1" circularly depends itself, resolve circular dependency first
+-- local view with no citus relation dependency will be distributed
+CREATE VIEW v_dist AS SELECT 1;
+-- show that the view is in pg_dist_object
+SELECT COUNT(*) FROM pg_dist_object WHERE objid = 'v_dist'::regclass;
+ count
+---------------------------------------------------------------------
+    1
+(1 row)
+
+-- tests when citus.enforce_object_restrictions_for_local_objects=false
+SET citus.enforce_object_restrictions_for_local_objects TO false;
+SET citus.enable_unsupported_feature_messages TO false;
+-- views will be created locally without errors OR warnings
+CREATE VIEW vv3 as SELECT * FROM local_t;
+CREATE OR REPLACE VIEW vv4 as SELECT * FROM vv3;
+CREATE OR REPLACE VIEW vv3 as SELECT * FROM vv4;
+-- show that views are NOT in pg_dist_object
+SELECT COUNT(*) FROM pg_dist_object WHERE objid IN ('vv3'::regclass, 'vv4'::regclass);
+ count
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- local view with no citus relation dependency will NOT be distributed
+CREATE VIEW v_local_only AS SELECT 1;
+-- show that the view is NOT in pg_dist_object
+SELECT COUNT(*) FROM pg_dist_object WHERE objid = 'v_local_only'::regclass;
+ count
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- distribute the local table and check the distribution of dependent views
+SELECT create_distributed_table('local_t', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- show that views with no circular dependency are in pg_dist_object
+SELECT COUNT(*) FROM pg_dist_object WHERE objid IN ('vv1'::regclass, 'vv2'::regclass);
+ count
+---------------------------------------------------------------------
+    2
+(1 row)
+
+-- show that views with circular dependency are NOT in pg_dist_object
+SELECT COUNT(*) FROM pg_dist_object WHERE objid IN ('vv3'::regclass, 'vv4'::regclass);
+ count
+---------------------------------------------------------------------
+    0
+(1 row)
+
+-- show that we cannot re-create the circular views ever
+CREATE OR REPLACE VIEW vv3 as SELECT * FROM local_t;
+CREATE OR REPLACE VIEW vv4 as SELECT * FROM vv3;
+CREATE OR REPLACE VIEW vv3 as SELECT * FROM vv4;
+ERROR:  Citus can not handle circular dependencies between distributed objects
+DETAIL:  "view vv3" circularly depends itself, resolve circular dependency first
+RESET citus.enable_unsupported_feature_messages;
+RESET citus.enforce_object_restrictions_for_local_objects;
 SET client_min_messages TO ERROR;
 DROP SCHEMA view_prop_schema_inner CASCADE;
 DROP SCHEMA view_prop_schema, axx CASCADE;

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -503,6 +503,9 @@ if(!$vanillaDev && $vanillatest)
 
     # we disable citus related unwanted messages to not break postgres vanilla test behaviour.
     push(@pgOptions, "citus.enable_unsupported_feature_messages=false");
+
+    # we disable some restrictions for local objects like local views to not break postgres vanilla test behaviour.
+    push(@pgOptions, "citus.enforce_object_restrictions_for_local_objects=false");
 }
 
 if ($useMitmproxy)


### PR DESCRIPTION
Stop distributing views with no distributed relation dependency if GUC EnforceLocalObjectRestrictions is disabled. we need that to prevent postgres vanilla tests from failing because of dependency related logs. That PR is a subtask for the main PR #6018.
