### PR TITLE
Reduce memory consumption of index name fix for partitioned tables

### DIFF
--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -161,12 +161,30 @@ GeneratePositiveIntSequenceList(int upTo)
 /*
  * StringJoin gets a list of char * and then simply
  * returns a newly allocated char * joined with the
- * given delimiter.
+ * given delimiter. It uses ';' as the delimiter by
+ * default.
  */
 char *
 StringJoin(List *stringList, char delimiter)
 {
+	return StringJoinParams(stringList, delimiter, NULL, NULL);
+}
+
+
+/*
+ * StringJoin gets a list of char * and then simply
+ * returns a newly allocated char * joined with the
+ * given delimiter, prefix and postfix.
+ */
+char *
+StringJoinParams(List *stringList, char delimiter, char *prefix, char *postfix)
+{
 	StringInfo joinedString = makeStringInfo();
+
+	if (prefix != NULL)
+	{
+		appendStringInfoString(joinedString, prefix);
+	}
 
 	const char *command = NULL;
 	int curIndex = 0;
@@ -178,6 +196,11 @@ StringJoin(List *stringList, char delimiter)
 		}
 		appendStringInfoString(joinedString, command);
 		curIndex++;
+	}
+
+	if (postfix != NULL)
+	{
+		appendStringInfoString(joinedString, postfix);
 	}
 
 	return joinedString->data;

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -205,6 +205,13 @@ fix_partition_shard_index_names(PG_FUNCTION_ARGS)
 
 	FixPartitionShardIndexNames(relationId, parentIndexOid);
 
+	/*
+	 * This UDF is called from fix_all_partition_shard_index_names() which iterates
+	 * over all the partitioned tables. There is no need to hold all the distributed
+	 * table metadata until the end of the transaction for the input table.
+	 */
+	CitusTableCacheFlushInvalidatedEntries();
+
 	PG_RETURN_VOID();
 }
 

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -569,13 +569,11 @@ CreateFixPartitionShardIndexNames(Oid parentRelationId, Oid partitionRelationId,
 			task->taskId = taskId++;
 			task->taskType = DDL_TASK;
 
+			char *prefix = "SELECT pg_catalog.citus_run_local_command($$";
+			char *postfix = "$$)";
+			char *string = StringJoinParams(queryStringList, ';', prefix, postfix);
 
-			char *string = StringJoin(queryStringList, ';');
-			StringInfo commandToRun = makeStringInfo();
-
-			appendStringInfo(commandToRun,
-							 "SELECT pg_catalog.citus_run_local_command($$%s$$)", string);
-			SetTaskQueryString(task, commandToRun->data);
+			SetTaskQueryString(task, string);
 
 
 			task->dependentTaskList = NULL;

--- a/src/include/distributed/listutils.h
+++ b/src/include/distributed/listutils.h
@@ -166,6 +166,8 @@ extern List * SortList(List *pointerList,
 extern void ** PointerArrayFromList(List *pointerList);
 extern HTAB * ListToHashSet(List *pointerList, Size keySize, bool isStringList);
 extern char * StringJoin(List *stringList, char delimiter);
+extern char * StringJoinParams(List *stringList, char delimiter,
+							   char *prefix, char *postfix);
 extern List * ListTake(List *pointerList, int size);
 extern void * safe_list_nth(const List *list, int index);
 extern List * GeneratePositiveIntSequenceList(int upTo);


### PR DESCRIPTION
Previously, CreateFixPartitionShardIndexNames() created all
the relevant query strings for all the shards, and executed
the large query string. And, in terms of the memory consumption,
this huge command (and its ExprContext generated while running
the command) is the main bottleneck/

With this change, we are reducing the total amount of memory
usage to almost 1/shard_count.

On my local machine, a distributed partitioned table with 120 partitions,
each 32 shards, the total memory consumption reduced from ~3GB
to ~0.1GB. And, the total execution time increased from ~28 seconds
to ~30 seconds. This seems like a good trade-off.

DESCRIPTION: Reduces memory consumption of index name fix for partitioned tables
