### PR TITLE
use address method to decide if we should run preprocess and postproc…

### DIFF
--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -170,7 +170,7 @@ CreateCollationDDLsIdempotent(Oid collationId)
 
 
 List *
-AlterCollationOwnerObjectAddress(Node *node, bool missing_ok)
+AlterCollationOwnerObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Relation relation;
@@ -192,7 +192,7 @@ AlterCollationOwnerObjectAddress(Node *node, bool missing_ok)
  * of the RenameStmt. Errors if missing_ok is false.
  */
 List *
-RenameCollationStmtObjectAddress(Node *node, bool missing_ok)
+RenameCollationStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_COLLATION);
@@ -215,7 +215,7 @@ RenameCollationStmtObjectAddress(Node *node, bool missing_ok)
  * schemas.
  */
 List *
-AlterCollationSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterCollationSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_COLLATION);
@@ -297,7 +297,7 @@ GenerateBackupNameForCollationCollision(const ObjectAddress *address)
 
 
 List *
-DefineCollationStmtObjectAddress(Node *node, bool missing_ok)
+DefineCollationStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 	Assert(stmt->kind == OBJECT_COLLATION);

--- a/src/backend/distributed/commands/common.c
+++ b/src/backend/distributed/commands/common.c
@@ -63,7 +63,7 @@ PostprocessCreateDistributedObjectFromCatalogStmt(Node *stmt, const char *queryS
 		return NIL;
 	}
 
-	List *addresses = GetObjectAddressListFromParseTree(stmt, false);
+	List *addresses = GetObjectAddressListFromParseTree(stmt, false, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -121,7 +121,7 @@ PreprocessAlterDistributedObjectStmt(Node *stmt, const char *queryString,
 	const DistributeObjectOps *ops = GetDistributeObjectOps(stmt);
 	Assert(ops != NULL);
 
-	List *addresses = GetObjectAddressListFromParseTree(stmt, false);
+	List *addresses = GetObjectAddressListFromParseTree(stmt, false, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -170,7 +170,7 @@ PostprocessAlterDistributedObjectStmt(Node *stmt, const char *queryString)
 	const DistributeObjectOps *ops = GetDistributeObjectOps(stmt);
 	Assert(ops != NULL);
 
-	List *addresses = GetObjectAddressListFromParseTree(stmt, false);
+	List *addresses = GetObjectAddressListFromParseTree(stmt, false, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -296,7 +296,7 @@ PreprocessDropDistributedObjectStmt(Node *node, const char *queryString,
  * the drop tsdict statement.
  */
 List *
-DropTextSearchDictObjectAddress(Node *node, bool missing_ok)
+DropTextSearchDictObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	DropStmt *stmt = castNode(DropStmt, node);
 
@@ -321,7 +321,7 @@ DropTextSearchDictObjectAddress(Node *node, bool missing_ok)
  * the drop tsconfig statement.
  */
 List *
-DropTextSearchConfigObjectAddress(Node *node, bool missing_ok)
+DropTextSearchConfigObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	DropStmt *stmt = castNode(DropStmt, node);
 

--- a/src/backend/distributed/commands/database.c
+++ b/src/backend/distributed/commands/database.c
@@ -41,7 +41,7 @@ bool EnableAlterDatabaseOwner = true;
  * object of the AlterOwnerStmt. Errors if missing_ok is false.
  */
 List *
-AlterDatabaseOwnerObjectAddress(Node *node, bool missing_ok)
+AlterDatabaseOwnerObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Assert(stmt->objectType == OBJECT_DATABASE);

--- a/src/backend/distributed/commands/distribute_object_ops.c
+++ b/src/backend/distributed/commands/distribute_object_ops.c
@@ -23,6 +23,7 @@ static DistributeObjectOps NoDistributeOps = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_NONE,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -32,6 +33,7 @@ static DistributeObjectOps Aggregate_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -41,6 +43,7 @@ static DistributeObjectOps Aggregate_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -50,6 +53,7 @@ static DistributeObjectOps Aggregate_Define = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_AGGREGATE,
+	.operationType = DIST_OPS_CREATE,
 	.address = DefineAggregateStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -58,6 +62,7 @@ static DistributeObjectOps Aggregate_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -67,6 +72,7 @@ static DistributeObjectOps Aggregate_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameFunctionStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -76,6 +82,7 @@ static DistributeObjectOps Any_AlterEnum = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterEnumStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -84,6 +91,7 @@ static DistributeObjectOps Any_AlterExtension = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterExtensionUpdateStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterExtensionUpdateStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -92,6 +100,7 @@ static DistributeObjectOps Any_AlterExtensionContents = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterExtensionContentsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -101,6 +110,7 @@ static DistributeObjectOps Any_AlterForeignServer = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FOREIGN_SERVER,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterForeignServerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -109,6 +119,7 @@ static DistributeObjectOps Any_AlterFunction = {
 	.qualify = QualifyAlterFunctionStmt,
 	.preprocess = PreprocessAlterFunctionStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -117,6 +128,7 @@ static DistributeObjectOps Any_AlterPolicy = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterPolicyStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -125,6 +137,7 @@ static DistributeObjectOps Any_AlterRole = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessAlterRoleStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterRoleStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -133,6 +146,7 @@ static DistributeObjectOps Any_AlterRoleSet = {
 	.qualify = QualifyAlterRoleSetStmt,
 	.preprocess = PreprocessAlterRoleSetStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterRoleSetStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -141,6 +155,7 @@ static DistributeObjectOps Any_AlterTableMoveAll = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterTableMoveAllStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -149,6 +164,7 @@ static DistributeObjectOps Any_Cluster = {
 	.qualify = NULL,
 	.preprocess = PreprocessClusterStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_NONE,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -158,6 +174,7 @@ static DistributeObjectOps Any_CompositeType = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_CREATE,
 	.featureFlag = &EnableCreateTypePropagation,
 	.address = CompositeTypeStmtObjectAddress,
 	.markDistributed = true,
@@ -168,6 +185,7 @@ static DistributeObjectOps Any_CreateDomain = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateDomainStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -177,6 +195,7 @@ static DistributeObjectOps Any_CreateEnum = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_CREATE,
 	.featureFlag = &EnableCreateTypePropagation,
 	.address = CreateEnumStmtObjectAddress,
 	.markDistributed = true,
@@ -186,6 +205,7 @@ static DistributeObjectOps Any_CreateExtension = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateExtensionStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateExtensionStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -194,6 +214,7 @@ static DistributeObjectOps Any_CreateFunction = {
 	.qualify = NULL,
 	.preprocess = PreprocessCreateFunctionStmt,
 	.postprocess = PostprocessCreateFunctionStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateFunctionStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -202,6 +223,7 @@ static DistributeObjectOps Any_View = {
 	.qualify = NULL,
 	.preprocess = PreprocessViewStmt,
 	.postprocess = PostprocessViewStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = ViewStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -210,6 +232,7 @@ static DistributeObjectOps Any_CreatePolicy = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessCreatePolicyStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -218,6 +241,7 @@ static DistributeObjectOps Any_CreateRole = {
 	.qualify = NULL,
 	.preprocess = PreprocessCreateRoleStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateRoleStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -226,6 +250,7 @@ static DistributeObjectOps Any_DropRole = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropRoleStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -235,6 +260,7 @@ static DistributeObjectOps Any_CreateForeignServer = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_FOREIGN_SERVER,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateForeignServerStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -243,6 +269,7 @@ static DistributeObjectOps Any_CreateSchema = {
 	.qualify = NULL,
 	.preprocess = PreprocessCreateSchemaStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateSchemaStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -251,6 +278,7 @@ static DistributeObjectOps Any_CreateStatistics = {
 	.qualify = QualifyCreateStatisticsStmt,
 	.preprocess = PreprocessCreateStatisticsStmt,
 	.postprocess = PostprocessCreateStatisticsStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateStatisticsStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -259,6 +287,7 @@ static DistributeObjectOps Any_CreateTrigger = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateTriggerStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateTriggerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -267,6 +296,7 @@ static DistributeObjectOps Any_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -275,6 +305,7 @@ static DistributeObjectOps Any_GrantRole = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantRoleStmt,
 	.postprocess = PostprocessGrantRoleStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -283,6 +314,7 @@ static DistributeObjectOps Any_Index = {
 	.qualify = NULL,
 	.preprocess = PreprocessIndexStmt,
 	.postprocess = PostprocessIndexStmt,
+	.operationType = DIST_OPS_CREATE,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -291,6 +323,7 @@ static DistributeObjectOps Any_Reindex = {
 	.qualify = NULL,
 	.preprocess = PreprocessReindexStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_NONE,
 	.address = ReindexStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -299,6 +332,7 @@ static DistributeObjectOps Any_Rename = {
 	.qualify = NULL,
 	.preprocess = PreprocessRenameStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -307,6 +341,7 @@ static DistributeObjectOps Attribute_Rename = {
 	.qualify = QualifyRenameAttributeStmt,
 	.preprocess = PreprocessRenameAttributeStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameAttributeStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -316,6 +351,7 @@ static DistributeObjectOps Collation_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_COLLATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterCollationSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -325,6 +361,7 @@ static DistributeObjectOps Collation_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_COLLATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterCollationOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -334,6 +371,7 @@ static DistributeObjectOps Collation_Define = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_COLLATION,
+	.operationType = DIST_OPS_CREATE,
 	.address = DefineCollationStmtObjectAddress,
 	.markDistributed = true,
 };
@@ -342,6 +380,7 @@ static DistributeObjectOps Collation_Drop = {
 	.qualify = QualifyDropCollationStmt,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -351,6 +390,7 @@ static DistributeObjectOps Collation_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_COLLATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameCollationStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -360,6 +400,7 @@ static DistributeObjectOps Database_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_DATABASE,
+	.operationType = DIST_OPS_ALTER,
 	.featureFlag = &EnableAlterDatabaseOwner,
 	.address = AlterDatabaseOwnerObjectAddress,
 	.markDistributed = false,
@@ -370,6 +411,7 @@ static DistributeObjectOps Domain_Alter = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterDomainStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -379,6 +421,7 @@ static DistributeObjectOps Domain_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTypeSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -388,6 +431,7 @@ static DistributeObjectOps Domain_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterDomainOwnerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -396,6 +440,7 @@ static DistributeObjectOps Domain_Drop = {
 	.qualify = QualifyDropDomainStmt,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -405,6 +450,7 @@ static DistributeObjectOps Domain_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameDomainStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -415,6 +461,7 @@ static DistributeObjectOps Domain_RenameConstraint = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_DOMAIN,
+	.operationType = DIST_OPS_ALTER,
 	.address = DomainRenameConstraintStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -423,6 +470,7 @@ static DistributeObjectOps Extension_AlterObjectSchema = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterExtensionSchemaStmt,
 	.postprocess = PostprocessAlterExtensionSchemaStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterExtensionSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -431,6 +479,7 @@ static DistributeObjectOps Extension_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropExtensionStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -439,6 +488,7 @@ static DistributeObjectOps FDW_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnFDWStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -447,6 +497,7 @@ static DistributeObjectOps ForeignServer_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -455,6 +506,7 @@ static DistributeObjectOps ForeignServer_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnForeignServerStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -464,6 +516,7 @@ static DistributeObjectOps ForeignServer_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FOREIGN_SERVER,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameForeignServerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -473,6 +526,7 @@ static DistributeObjectOps ForeignServer_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FOREIGN_SERVER,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterForeignServerOwnerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -481,6 +535,7 @@ static DistributeObjectOps ForeignTable_AlterTable = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterTableStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -489,6 +544,7 @@ static DistributeObjectOps Function_AlterObjectDepends = {
 	.qualify = QualifyAlterFunctionDependsStmt,
 	.preprocess = PreprocessAlterFunctionDependsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionDependsStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -498,6 +554,7 @@ static DistributeObjectOps Function_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -507,6 +564,7 @@ static DistributeObjectOps Function_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -515,6 +573,7 @@ static DistributeObjectOps Function_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -523,6 +582,7 @@ static DistributeObjectOps Function_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnFunctionStmt,
 	.postprocess = PostprocessGrantOnFunctionStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -531,6 +591,7 @@ static DistributeObjectOps View_Drop = {
 	.qualify = QualifyDropViewStmt,
 	.preprocess = PreprocessDropViewStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = DropViewStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -540,6 +601,7 @@ static DistributeObjectOps Function_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameFunctionStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -548,6 +610,7 @@ static DistributeObjectOps Index_AlterTable = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterTableStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -556,6 +619,7 @@ static DistributeObjectOps Index_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropIndexStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -564,6 +628,7 @@ static DistributeObjectOps Policy_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropPolicyStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -572,6 +637,7 @@ static DistributeObjectOps Procedure_AlterObjectDepends = {
 	.qualify = QualifyAlterFunctionDependsStmt,
 	.preprocess = PreprocessAlterFunctionDependsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionDependsStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -581,6 +647,7 @@ static DistributeObjectOps Procedure_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -590,6 +657,7 @@ static DistributeObjectOps Procedure_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -598,6 +666,7 @@ static DistributeObjectOps Procedure_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -606,6 +675,7 @@ static DistributeObjectOps Procedure_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnFunctionStmt,
 	.postprocess = PostprocessGrantOnFunctionStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -615,6 +685,7 @@ static DistributeObjectOps Procedure_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameFunctionStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -623,6 +694,7 @@ static DistributeObjectOps Routine_AlterObjectDepends = {
 	.qualify = QualifyAlterFunctionDependsStmt,
 	.preprocess = PreprocessAlterFunctionDependsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionDependsStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -631,6 +703,7 @@ static DistributeObjectOps Sequence_Alter = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterSequenceStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterSequenceStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -639,6 +712,7 @@ static DistributeObjectOps Sequence_AlterObjectSchema = {
 	.qualify = QualifyAlterSequenceSchemaStmt,
 	.preprocess = PreprocessAlterSequenceSchemaStmt,
 	.postprocess = PostprocessAlterSequenceSchemaStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterSequenceSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -647,6 +721,7 @@ static DistributeObjectOps Sequence_AlterOwner = {
 	.qualify = QualifyAlterSequenceOwnerStmt,
 	.preprocess = PreprocessAlterSequenceOwnerStmt,
 	.postprocess = PostprocessAlterSequenceOwnerStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterSequenceOwnerStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -655,6 +730,7 @@ static DistributeObjectOps Sequence_Drop = {
 	.qualify = QualifyDropSequenceStmt,
 	.preprocess = PreprocessDropSequenceStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = SequenceDropStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -663,6 +739,7 @@ static DistributeObjectOps Sequence_Grant = {
 	.qualify = QualifyGrantOnSequenceStmt,
 	.preprocess = PreprocessGrantOnSequenceStmt,
 	.postprocess = PostprocessGrantOnSequenceStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -671,6 +748,7 @@ static DistributeObjectOps Sequence_Rename = {
 	.qualify = QualifyRenameSequenceStmt,
 	.preprocess = PreprocessRenameSequenceStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameSequenceStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -680,6 +758,7 @@ static DistributeObjectOps TextSearchConfig_Alter = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchConfigurationStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -689,6 +768,7 @@ static DistributeObjectOps TextSearchConfig_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchConfigurationSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -698,6 +778,7 @@ static DistributeObjectOps TextSearchConfig_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchConfigurationOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -707,6 +788,7 @@ static DistributeObjectOps TextSearchConfig_Comment = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = TextSearchConfigurationCommentObjectAddress,
 	.markDistributed = false,
 };
@@ -716,6 +798,7 @@ static DistributeObjectOps TextSearchConfig_Define = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateTextSearchConfigurationObjectAddress,
 	.markDistributed = true,
 };
@@ -724,6 +807,7 @@ static DistributeObjectOps TextSearchConfig_Drop = {
 	.qualify = QualifyDropTextSearchConfigurationStmt,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = DropTextSearchConfigObjectAddress,
 	.markDistributed = false,
 };
@@ -733,6 +817,7 @@ static DistributeObjectOps TextSearchConfig_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSCONFIGURATION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameTextSearchConfigurationStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -742,6 +827,7 @@ static DistributeObjectOps TextSearchDict_Alter = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchDictionaryStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -751,6 +837,7 @@ static DistributeObjectOps TextSearchDict_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchDictionarySchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -760,6 +847,7 @@ static DistributeObjectOps TextSearchDict_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTextSearchDictOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -769,6 +857,7 @@ static DistributeObjectOps TextSearchDict_Comment = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_ALTER,
 	.address = TextSearchDictCommentObjectAddress,
 	.markDistributed = false,
 };
@@ -778,6 +867,7 @@ static DistributeObjectOps TextSearchDict_Define = {
 	.preprocess = NULL,
 	.postprocess = PostprocessCreateDistributedObjectFromCatalogStmt,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_CREATE,
 	.address = CreateTextSearchDictObjectAddress,
 	.markDistributed = true,
 };
@@ -786,6 +876,7 @@ static DistributeObjectOps TextSearchDict_Drop = {
 	.qualify = QualifyDropTextSearchDictionaryStmt,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = DropTextSearchDictObjectAddress,
 	.markDistributed = false,
 };
@@ -795,6 +886,7 @@ static DistributeObjectOps TextSearchDict_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TSDICTIONARY,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameTextSearchDictionaryStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -803,6 +895,7 @@ static DistributeObjectOps Trigger_AlterObjectDepends = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterTriggerDependsStmt,
 	.postprocess = PostprocessAlterTriggerDependsStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -812,6 +905,7 @@ static DistributeObjectOps Routine_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -821,6 +915,7 @@ static DistributeObjectOps Routine_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterFunctionOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -829,6 +924,7 @@ static DistributeObjectOps Routine_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -837,6 +933,7 @@ static DistributeObjectOps Routine_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnFunctionStmt,
 	.postprocess = PostprocessGrantOnFunctionStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -846,6 +943,7 @@ static DistributeObjectOps Routine_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_FUNCTION,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameFunctionStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -854,6 +952,7 @@ static DistributeObjectOps Schema_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropSchemaStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -862,6 +961,7 @@ static DistributeObjectOps Schema_Grant = {
 	.qualify = NULL,
 	.preprocess = PreprocessGrantOnSchemaStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -871,6 +971,7 @@ static DistributeObjectOps Schema_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_SCHEMA,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterSchemaRenameStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -879,6 +980,7 @@ static DistributeObjectOps Statistics_Alter = {
 	.qualify = QualifyAlterStatisticsStmt,
 	.preprocess = PreprocessAlterStatisticsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -887,6 +989,7 @@ static DistributeObjectOps Statistics_AlterObjectSchema = {
 	.qualify = QualifyAlterStatisticsSchemaStmt,
 	.preprocess = PreprocessAlterStatisticsSchemaStmt,
 	.postprocess = PostprocessAlterStatisticsSchemaStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterStatisticsSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -894,6 +997,7 @@ static DistributeObjectOps Statistics_AlterOwner = {
 	.deparse = DeparseAlterStatisticsOwnerStmt,
 	.qualify = QualifyAlterStatisticsOwnerStmt,
 	.preprocess = PreprocessAlterStatisticsOwnerStmt,
+	.operationType = DIST_OPS_ALTER,
 	.postprocess = PostprocessAlterStatisticsOwnerStmt,
 	.address = NULL,
 	.markDistributed = false,
@@ -903,6 +1007,7 @@ static DistributeObjectOps Statistics_Drop = {
 	.qualify = QualifyDropStatisticsStmt,
 	.preprocess = PreprocessDropStatisticsStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = DropStatisticsObjectAddress,
 	.markDistributed = false,
 };
@@ -911,6 +1016,7 @@ static DistributeObjectOps Statistics_Rename = {
 	.qualify = QualifyAlterStatisticsRenameStmt,
 	.preprocess = PreprocessAlterStatisticsRenameStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -919,6 +1025,7 @@ static DistributeObjectOps Table_AlterTable = {
 	.qualify = NULL,
 	.preprocess = PreprocessAlterTableStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -927,6 +1034,7 @@ static DistributeObjectOps Table_AlterObjectSchema = {
 	.qualify = QualifyAlterTableSchemaStmt,
 	.preprocess = PreprocessAlterTableSchemaStmt,
 	.postprocess = PostprocessAlterTableSchemaStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTableSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -935,6 +1043,7 @@ static DistributeObjectOps Table_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropTableStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -944,6 +1053,7 @@ static DistributeObjectOps Type_AlterObjectSchema = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTypeSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -960,6 +1070,7 @@ static DistributeObjectOps View_AlterObjectSchema = {
 	.qualify = QualifyAlterViewSchemaStmt,
 	.preprocess = PreprocessAlterViewSchemaStmt,
 	.postprocess = PostprocessAlterViewSchemaStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterViewSchemaStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -969,6 +1080,7 @@ static DistributeObjectOps Type_AlterOwner = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = PostprocessAlterDistributedObjectStmt,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTypeOwnerObjectAddress,
 	.markDistributed = false,
 };
@@ -978,6 +1090,7 @@ static DistributeObjectOps Type_AlterTable = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterTypeStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -994,6 +1107,7 @@ static DistributeObjectOps View_AlterView = {
 	.qualify = QualifyAlterViewStmt,
 	.preprocess = PreprocessAlterViewStmt,
 	.postprocess = PostprocessAlterViewStmt,
+	.operationType = DIST_OPS_ALTER,
 	.address = AlterViewStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -1002,6 +1116,7 @@ static DistributeObjectOps Type_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropDistributedObjectStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -1010,6 +1125,7 @@ static DistributeObjectOps Trigger_Drop = {
 	.qualify = NULL,
 	.preprocess = PreprocessDropTriggerStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_DROP,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -1019,6 +1135,7 @@ static DistributeObjectOps Type_Rename = {
 	.preprocess = PreprocessAlterDistributedObjectStmt,
 	.postprocess = NULL,
 	.objectType = OBJECT_TYPE,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameTypeStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -1027,6 +1144,7 @@ static DistributeObjectOps Vacuum_Analyze = {
 	.qualify = NULL,
 	.preprocess = NULL,
 	.postprocess = PostprocessVacuumStmt,
+	.operationType = DIST_OPS_NONE,
 	.address = NULL,
 	.markDistributed = false,
 };
@@ -1042,6 +1160,7 @@ static DistributeObjectOps View_Rename = {
 	.qualify = QualifyRenameViewStmt,
 	.preprocess = PreprocessRenameViewStmt,
 	.postprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.address = RenameViewStmtObjectAddress,
 	.markDistributed = false,
 };
@@ -1049,6 +1168,7 @@ static DistributeObjectOps Trigger_Rename = {
 	.deparse = NULL,
 	.qualify = NULL,
 	.preprocess = NULL,
+	.operationType = DIST_OPS_ALTER,
 	.postprocess = PostprocessAlterTriggerRenameStmt,
 	.address = NULL,
 	.markDistributed = false,

--- a/src/backend/distributed/commands/domain.c
+++ b/src/backend/distributed/commands/domain.c
@@ -230,7 +230,7 @@ MakeCollateClauseFromOid(Oid collationOid)
  * the domain cannot be found in the local catalog.
  */
 List *
-CreateDomainStmtObjectAddress(Node *node, bool missing_ok)
+CreateDomainStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateDomainStmt *stmt = castNode(CreateDomainStmt, node);
 
@@ -249,7 +249,7 @@ CreateDomainStmtObjectAddress(Node *node, bool missing_ok)
  * found.
  */
 List *
-AlterDomainStmtObjectAddress(Node *node, bool missing_ok)
+AlterDomainStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterDomainStmt *stmt = castNode(AlterDomainStmt, node);
 
@@ -264,7 +264,7 @@ AlterDomainStmtObjectAddress(Node *node, bool missing_ok)
  * error if the domain cannot be found.
  */
 List *
-DomainRenameConstraintStmtObjectAddress(Node *node, bool missing_ok)
+DomainRenameConstraintStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 
@@ -279,7 +279,7 @@ DomainRenameConstraintStmtObjectAddress(Node *node, bool missing_ok)
  * cannot be found.
  */
 List *
-AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok)
+AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Assert(stmt->objectType == OBJECT_DOMAIN);
@@ -295,7 +295,7 @@ AlterDomainOwnerStmtObjectAddress(Node *node, bool missing_ok)
  * found.
  */
 List *
-RenameDomainStmtObjectAddress(Node *node, bool missing_ok)
+RenameDomainStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_DOMAIN);

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -181,7 +181,7 @@ PostprocessCreateExtensionStmt(Node *node, const char *queryString)
 								(void *) createExtensionStmtSql,
 								ENABLE_DDL_PROPAGATION);
 
-	List *extensionAddresses = GetObjectAddressListFromParseTree(node, false);
+	List *extensionAddresses = GetObjectAddressListFromParseTree(node, false, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(extensionAddresses) == 1);
@@ -413,7 +413,7 @@ PreprocessAlterExtensionSchemaStmt(Node *node, const char *queryString,
 List *
 PostprocessAlterExtensionSchemaStmt(Node *node, const char *queryString)
 {
-	List *extensionAddresses = GetObjectAddressListFromParseTree(node, false);
+	List *extensionAddresses = GetObjectAddressListFromParseTree(node, false, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(extensionAddresses) == 1);
@@ -1134,7 +1134,7 @@ GetDependentFDWsToExtension(Oid extensionId)
  * the subject of the AlterObjectSchemaStmt. Errors if missing_ok is false.
  */
 List *
-AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_EXTENSION);
@@ -1162,7 +1162,7 @@ AlterExtensionSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * the subject of the AlterExtensionStmt. Errors if missing_ok is false.
  */
 List *
-AlterExtensionUpdateStmtObjectAddress(Node *node, bool missing_ok)
+AlterExtensionUpdateStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterExtensionStmt *stmt = castNode(AlterExtensionStmt, node);
 	const char *extensionName = stmt->extname;

--- a/src/backend/distributed/commands/foreign_server.c
+++ b/src/backend/distributed/commands/foreign_server.c
@@ -42,7 +42,7 @@ static List * GetObjectAddressByServerName(char *serverName, bool missing_ok);
  * was set to true.
  */
 List *
-CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok)
+CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateForeignServerStmt *stmt = castNode(CreateForeignServerStmt, node);
 
@@ -59,7 +59,7 @@ CreateForeignServerStmtObjectAddress(Node *node, bool missing_ok)
  * was set to true.
  */
 List *
-AlterForeignServerStmtObjectAddress(Node *node, bool missing_ok)
+AlterForeignServerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterForeignServerStmt *stmt = castNode(AlterForeignServerStmt, node);
 
@@ -124,7 +124,7 @@ PreprocessGrantOnForeignServerStmt(Node *node, const char *queryString,
  * was set to true.
  */
 List *
-RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok)
+RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_FOREIGN_SERVER);
@@ -142,7 +142,7 @@ RenameForeignServerStmtObjectAddress(Node *node, bool missing_ok)
  * was set to true.
  */
 List *
-AlterForeignServerOwnerStmtObjectAddress(Node *node, bool missing_ok)
+AlterForeignServerOwnerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	char *serverName = strVal(stmt->object);

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -1372,7 +1372,8 @@ PostprocessCreateFunctionStmt(Node *node, const char *queryString)
 		return NIL;
 	}
 
-	List *functionAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *functionAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false,
+																true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(functionAddresses) == 1);
@@ -1416,7 +1417,7 @@ PostprocessCreateFunctionStmt(Node *node, const char *queryString)
  * normal postgres error for unfound functions.
  */
 List *
-CreateFunctionStmtObjectAddress(Node *node, bool missing_ok)
+CreateFunctionStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateFunctionStmt *stmt = castNode(CreateFunctionStmt, node);
 	ObjectType objectType = OBJECT_FUNCTION;
@@ -1461,7 +1462,7 @@ CreateFunctionStmtObjectAddress(Node *node, bool missing_ok)
  * objectId in the address can be invalid if missing_ok was set to true.
  */
 List *
-DefineAggregateStmtObjectAddress(Node *node, bool missing_ok)
+DefineAggregateStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 
@@ -1514,7 +1515,7 @@ PreprocessAlterFunctionStmt(Node *node, const char *queryString,
 	AlterFunctionStmt *stmt = castNode(AlterFunctionStmt, node);
 	AssertObjectTypeIsFunctional(stmt->objtype);
 
-	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, false, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -1576,7 +1577,7 @@ PreprocessAlterFunctionDependsStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt, true, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -1610,7 +1611,7 @@ PreprocessAlterFunctionDependsStmt(Node *node, const char *queryString,
  * missing_ok is set to false the lookup will raise an error.
  */
 List *
-AlterFunctionDependsStmtObjectAddress(Node *node, bool missing_ok)
+AlterFunctionDependsStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectDependsStmt *stmt = castNode(AlterObjectDependsStmt, node);
 	AssertObjectTypeIsFunctional(stmt->objectType);
@@ -1626,7 +1627,7 @@ AlterFunctionDependsStmtObjectAddress(Node *node, bool missing_ok)
  * was unable to find the function/procedure that was the target of the statement.
  */
 List *
-AlterFunctionStmtObjectAddress(Node *node, bool missing_ok)
+AlterFunctionStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterFunctionStmt *stmt = castNode(AlterFunctionStmt, node);
 	return FunctionToObjectAddress(stmt->objtype, stmt->func, missing_ok);
@@ -1638,7 +1639,7 @@ AlterFunctionStmtObjectAddress(Node *node, bool missing_ok)
  * subject of the RenameStmt. Errors if missing_ok is false.
  */
 List *
-RenameFunctionStmtObjectAddress(Node *node, bool missing_ok)
+RenameFunctionStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	return FunctionToObjectAddress(stmt->renameType,
@@ -1651,7 +1652,7 @@ RenameFunctionStmtObjectAddress(Node *node, bool missing_ok)
  * subject of the AlterOwnerStmt. Errors if missing_ok is false.
  */
 List *
-AlterFunctionOwnerObjectAddress(Node *node, bool missing_ok)
+AlterFunctionOwnerObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	return FunctionToObjectAddress(stmt->objectType,
@@ -1669,7 +1670,7 @@ AlterFunctionOwnerObjectAddress(Node *node, bool missing_ok)
  * the schemas.
  */
 List *
-AlterFunctionSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterFunctionSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	AssertObjectTypeIsFunctional(stmt->objectType);

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -658,7 +658,7 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand,
  * else, we add invalid address.
  */
 List *
-ReindexStmtObjectAddress(Node *stmt, bool missing_ok)
+ReindexStmtObjectAddress(Node *stmt, bool missing_ok, bool isPostprocess)
 {
 	ReindexStmt *reindexStatement = castNode(ReindexStmt, stmt);
 

--- a/src/backend/distributed/commands/role.c
+++ b/src/backend/distributed/commands/role.c
@@ -124,6 +124,13 @@ RoleSpecToObjectAddress(RoleSpec *role, bool missing_ok)
 		Oid roleOid = get_rolespec_oid(role, missing_ok);
 		ObjectAddressSet(*address, AuthIdRelationId, roleOid);
 	}
+	else
+	{
+		/*
+		 * If rolespec is null, role can be 'ALL'. We should be returning a pseudo-valid oid.
+		 */
+		ObjectAddressSet(*address, AuthIdRelationId, OID_MAX);
+	}
 
 	return list_make1(address);
 }

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -184,7 +184,7 @@ PreprocessGrantOnSchemaStmt(Node *node, const char *queryString,
  * the object of the CreateSchemaStmt. Errors if missing_ok is false.
  */
 List *
-CreateSchemaStmtObjectAddress(Node *node, bool missing_ok)
+CreateSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateSchemaStmt *stmt = castNode(CreateSchemaStmt, node);
 
@@ -214,7 +214,7 @@ CreateSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * the object of the RenameStmt. Errors if missing_ok is false.
  */
 List *
-AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok)
+AlterSchemaRenameStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_SCHEMA);

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -318,7 +318,7 @@ PreprocessDropSequenceStmt(Node *node, const char *queryString,
  * statement.
  */
 List *
-SequenceDropStmtObjectAddress(Node *stmt, bool missing_ok)
+SequenceDropStmtObjectAddress(Node *stmt, bool missing_ok, bool isPostprocess)
 {
 	DropStmt *dropSeqStmt = castNode(DropStmt, stmt);
 
@@ -357,7 +357,7 @@ PreprocessRenameSequenceStmt(Node *node, const char *queryString, ProcessUtility
 	Assert(stmt->renameType == OBJECT_SEQUENCE);
 
 	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
-														stmt->missing_ok);
+														stmt->missing_ok, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -384,7 +384,7 @@ PreprocessRenameSequenceStmt(Node *node, const char *queryString, ProcessUtility
  * subject of the RenameStmt.
  */
 List *
-RenameSequenceStmtObjectAddress(Node *node, bool missing_ok)
+RenameSequenceStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_SEQUENCE);
@@ -421,7 +421,7 @@ PreprocessAlterSequenceStmt(Node *node, const char *queryString,
 	AlterSeqStmt *stmt = castNode(AlterSeqStmt, node);
 
 	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
-														stmt->missing_ok);
+														stmt->missing_ok, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -504,7 +504,7 @@ SequenceUsedInDistributedTable(const ObjectAddress *sequenceAddress)
  * subject of the AlterSeqStmt.
  */
 List *
-AlterSequenceStmtObjectAddress(Node *node, bool missing_ok)
+AlterSequenceStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterSeqStmt *stmt = castNode(AlterSeqStmt, node);
 
@@ -531,7 +531,7 @@ PreprocessAlterSequenceSchemaStmt(Node *node, const char *queryString,
 	Assert(stmt->objectType == OBJECT_SEQUENCE);
 
 	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
-														stmt->missing_ok);
+														stmt->missing_ok, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -558,7 +558,7 @@ PreprocessAlterSequenceSchemaStmt(Node *node, const char *queryString,
  * the subject of the AlterObjectSchemaStmt.
  */
 List *
-AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterSequenceSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_SEQUENCE);
@@ -609,7 +609,7 @@ PostprocessAlterSequenceSchemaStmt(Node *node, const char *queryString)
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_SEQUENCE);
 	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
-														stmt->missing_ok);
+														stmt->missing_ok, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -640,7 +640,8 @@ PreprocessAlterSequenceOwnerStmt(Node *node, const char *queryString,
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_SEQUENCE);
 
-	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false,
+																false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(sequenceAddresses) == 1);
@@ -667,7 +668,7 @@ PreprocessAlterSequenceOwnerStmt(Node *node, const char *queryString,
  * subject of the AlterOwnerStmt.
  */
 List *
-AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok)
+AlterSequenceOwnerStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_SEQUENCE);
@@ -692,7 +693,8 @@ PostprocessAlterSequenceOwnerStmt(Node *node, const char *queryString)
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_SEQUENCE);
 
-	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *sequenceAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false,
+																true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(sequenceAddresses) == 1);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -649,7 +649,7 @@ PostprocessAlterTableSchemaStmt(Node *node, const char *queryString)
 	/*
 	 * We will let Postgres deal with missing_ok
 	 */
-	List *tableAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *tableAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(tableAddresses) == 1);
@@ -1786,7 +1786,7 @@ PreprocessAlterTableSchemaStmt(Node *node, const char *queryString,
 	}
 
 	List *addresses = GetObjectAddressListFromParseTree((Node *) stmt,
-														stmt->missing_ok);
+														stmt->missing_ok, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(addresses) == 1);
@@ -3369,7 +3369,7 @@ ErrorIfUnsupportedAlterAddConstraintStmt(AlterTableStmt *alterTableStatement)
  * be found in either of the schemas.
  */
 List *
-AlterTableSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterTableSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_TABLE || stmt->objectType == OBJECT_FOREIGN_TABLE);

--- a/src/backend/distributed/commands/text_search.c
+++ b/src/backend/distributed/commands/text_search.c
@@ -570,7 +570,8 @@ get_ts_parser_namelist(Oid tsparserOid)
  * the text search configuration described in the statement doesn't exist.
  */
 List *
-CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok)
+CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok, bool
+										   isPostprocess)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 	Assert(stmt->kind == OBJECT_TSCONFIGURATION);
@@ -589,7 +590,7 @@ CreateTextSearchConfigurationObjectAddress(Node *node, bool missing_ok)
  * the text search dictionary described in the statement doesn't exist.
  */
 List *
-CreateTextSearchDictObjectAddress(Node *node, bool missing_ok)
+CreateTextSearchDictObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	DefineStmt *stmt = castNode(DefineStmt, node);
 	Assert(stmt->kind == OBJECT_TSDICTIONARY);
@@ -608,7 +609,8 @@ CreateTextSearchDictObjectAddress(Node *node, bool missing_ok)
  * exist based on the missing_ok flag passed in by the caller.
  */
 List *
-RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
+RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok, bool
+											   isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_TSCONFIGURATION);
@@ -627,7 +629,8 @@ RenameTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
  * exist based on the missing_ok flag passed in by the caller.
  */
 List *
-RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
+RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok, bool
+											isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_TSDICTIONARY);
@@ -646,7 +649,8 @@ RenameTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
  * exist based on the missing_ok flag passed in by the caller.
  */
 List *
-AlterTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok, bool
+											  isPostprocess)
 {
 	AlterTSConfigurationStmt *stmt = castNode(AlterTSConfigurationStmt, node);
 
@@ -664,7 +668,8 @@ AlterTextSearchConfigurationStmtObjectAddress(Node *node, bool missing_ok)
  * exist based on the missing_ok flag passed in by the caller.
  */
 List *
-AlterTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok, bool
+										   isPostprocess)
 {
 	AlterTSDictionaryStmt *stmt = castNode(AlterTSDictionaryStmt, node);
 
@@ -686,7 +691,8 @@ AlterTextSearchDictionaryStmtObjectAddress(Node *node, bool missing_ok)
  * in edgecases will be raised by postgres while executing the move.
  */
 List *
-AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok, bool
+													isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_TSCONFIGURATION);
@@ -739,7 +745,8 @@ AlterTextSearchConfigurationSchemaStmtObjectAddress(Node *node, bool missing_ok)
  * in edgecases will be raised by postgres while executing the move.
  */
 List *
-AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok, bool
+												 isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_TSDICTIONARY);
@@ -788,7 +795,8 @@ AlterTextSearchDictionarySchemaStmtObjectAddress(Node *node, bool missing_ok)
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
 List *
-TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok)
+TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok, bool
+											isPostprocess)
 {
 	CommentStmt *stmt = castNode(CommentStmt, node);
 	Assert(stmt->objtype == OBJECT_TSCONFIGURATION);
@@ -807,7 +815,7 @@ TextSearchConfigurationCommentObjectAddress(Node *node, bool missing_ok)
  * exist based on the missing_ok flag passed in by the caller.
  */
 List *
-TextSearchDictCommentObjectAddress(Node *node, bool missing_ok)
+TextSearchDictCommentObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CommentStmt *stmt = castNode(CommentStmt, node);
 	Assert(stmt->objtype == OBJECT_TSDICTIONARY);
@@ -826,7 +834,8 @@ TextSearchDictCommentObjectAddress(Node *node, bool missing_ok)
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
 List *
-AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok, bool
+											   isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Relation relation = NULL;
@@ -850,7 +859,7 @@ AlterTextSearchConfigurationOwnerObjectAddress(Node *node, bool missing_ok)
  * configuration does not exist based on the missing_ok flag passed in by the caller.
  */
 List *
-AlterTextSearchDictOwnerObjectAddress(Node *node, bool missing_ok)
+AlterTextSearchDictOwnerObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Relation relation = NULL;

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -224,7 +224,7 @@ PostprocessCreateTriggerStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 	ErrorOutForTriggerIfNotSupported(relationId);
 
-	List *objectAddresses = GetObjectAddressListFromParseTree(node, missingOk);
+	List *objectAddresses = GetObjectAddressListFromParseTree(node, missingOk, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(objectAddresses) == 1);
@@ -246,7 +246,7 @@ PostprocessCreateTriggerStmt(Node *node, const char *queryString)
  * was set to true.
  */
 List *
-CreateTriggerStmtObjectAddress(Node *node, bool missingOk)
+CreateTriggerStmtObjectAddress(Node *node, bool missingOk, bool isPostprocess)
 {
 	CreateTrigStmt *createTriggerStmt = castNode(CreateTrigStmt, node);
 

--- a/src/backend/distributed/commands/type.c
+++ b/src/backend/distributed/commands/type.c
@@ -117,7 +117,7 @@ PreprocessRenameTypeAttributeStmt(Node *node, const char *queryString,
 	Assert(stmt->renameType == OBJECT_ATTRIBUTE);
 	Assert(stmt->relationType == OBJECT_TYPE);
 
-	List *typeAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *typeAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(typeAddresses) == 1);
@@ -305,7 +305,7 @@ EnumValsList(Oid typeOid)
  * to true.
  */
 List *
-CompositeTypeStmtObjectAddress(Node *node, bool missing_ok)
+CompositeTypeStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CompositeTypeStmt *stmt = castNode(CompositeTypeStmt, node);
 	TypeName *typeName = MakeTypeNameFromRangeVar(stmt->typevar);
@@ -326,7 +326,7 @@ CompositeTypeStmtObjectAddress(Node *node, bool missing_ok)
  * to true.
  */
 List *
-CreateEnumStmtObjectAddress(Node *node, bool missing_ok)
+CreateEnumStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateEnumStmt *stmt = castNode(CreateEnumStmt, node);
 	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
@@ -347,7 +347,7 @@ CreateEnumStmtObjectAddress(Node *node, bool missing_ok)
  * to true.
  */
 List *
-AlterTypeStmtObjectAddress(Node *node, bool missing_ok)
+AlterTypeStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_TYPE);
@@ -366,7 +366,7 @@ AlterTypeStmtObjectAddress(Node *node, bool missing_ok)
  * object of the AlterEnumStmt. Errors is missing_ok is false.
  */
 List *
-AlterEnumStmtObjectAddress(Node *node, bool missing_ok)
+AlterEnumStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterEnumStmt *stmt = castNode(AlterEnumStmt, node);
 	TypeName *typeName = makeTypeNameFromNameList(stmt->typeName);
@@ -383,7 +383,7 @@ AlterEnumStmtObjectAddress(Node *node, bool missing_ok)
  * of the RenameStmt. Errors if missing_ok is false.
  */
 List *
-RenameTypeStmtObjectAddress(Node *node, bool missing_ok)
+RenameTypeStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_TYPE);
@@ -407,7 +407,7 @@ RenameTypeStmtObjectAddress(Node *node, bool missing_ok)
  * schemas.
  */
 List *
-AlterTypeSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterTypeSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 	Assert(stmt->objectType == OBJECT_TYPE || stmt->objectType == OBJECT_DOMAIN);
@@ -487,7 +487,7 @@ RenameTypeAttributeStmtObjectAddress(Node *node, bool missing_ok)
  * of the AlterOwnerStmt. Errors if missing_ok is false.
  */
 List *
-AlterTypeOwnerObjectAddress(Node *node, bool missing_ok)
+AlterTypeOwnerObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, node);
 	Assert(stmt->objectType == OBJECT_TYPE);

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -552,8 +552,8 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		 * prevent before-mentioned citus related messages. PG will complain about the
 		 * invalid address, so we are safe to not execute qualify and preprocess. Also
 		 * note that we should not guard any step after standardProcess_Utility with
-		 * the flag distOpsHasInvalidObject because PG would have already failed the 
-		 * transaction.  
+		 * the flag distOpsHasInvalidObject because PG would have already failed the
+		 * transaction.
 		 */
 		distOpsHasInvalidObject = DistOpsHasInvalidObject(parsetree, ops);
 
@@ -872,7 +872,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		 */
 		if (ops && ops->markDistributed)
 		{
-			List *addresses = GetObjectAddressListFromParseTree(parsetree, false);
+			List *addresses = GetObjectAddressListFromParseTree(parsetree, false, true);
 			ObjectAddress *address = NULL;
 			foreach_ptr(address, addresses)
 			{

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -550,7 +550,10 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		 * Therefore, we first check if all addresses in the given statement are valid.
 		 * Then, we do not execute qualify and preprocess if any address is invalid to
 		 * prevent before-mentioned citus related messages. PG will complain about the
-		 * invalid address, so we are safe to not execute qualify and preprocess.
+		 * invalid address, so we are safe to not execute qualify and preprocess. Also
+		 * note that we should not guard any step after standardProcess_Utility with
+		 * the flag distOpsHasInvalidObject because PG would have already failed the 
+		 * transaction.  
 		 */
 		distOpsHasInvalidObject = DistOpsHasInvalidObject(parsetree, ops);
 

--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -94,7 +94,7 @@ PostprocessViewStmt(Node *node, const char *queryString)
 		return NIL;
 	}
 
-	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false);
+	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, false, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -158,7 +158,7 @@ PostprocessViewStmt(Node *node, const char *queryString)
  * CREATE [OR REPLACE] VIEW statement.
  */
 List *
-ViewStmtObjectAddress(Node *node, bool missing_ok)
+ViewStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	ViewStmt *stmt = castNode(ViewStmt, node);
 
@@ -226,7 +226,7 @@ PreprocessDropViewStmt(Node *node, const char *queryString, ProcessUtilityContex
  * statement.
  */
 List *
-DropViewStmtObjectAddress(Node *stmt, bool missing_ok)
+DropViewStmtObjectAddress(Node *stmt, bool missing_ok, bool isPostprocess)
 {
 	DropStmt *dropStmt = castNode(DropStmt, stmt);
 
@@ -489,7 +489,7 @@ PreprocessAlterViewStmt(Node *node, const char *queryString, ProcessUtilityConte
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 
-	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -531,7 +531,7 @@ PostprocessAlterViewStmt(Node *node, const char *queryString)
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Assert(AlterTableStmtObjType_compat(stmt) == OBJECT_VIEW);
 
-	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -563,7 +563,7 @@ PostprocessAlterViewStmt(Node *node, const char *queryString)
  * ALTER VIEW statement.
  */
 List *
-AlterViewStmtObjectAddress(Node *node, bool missing_ok)
+AlterViewStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterTableStmt *stmt = castNode(AlterTableStmt, node);
 	Oid viewOid = RangeVarGetRelid(stmt->relation, NoLock, missing_ok);
@@ -583,7 +583,7 @@ List *
 PreprocessRenameViewStmt(Node *node, const char *queryString,
 						 ProcessUtilityContext processUtilityContext)
 {
-	List *viewAddresses = GetObjectAddressListFromParseTree(node, true);
+	List *viewAddresses = GetObjectAddressListFromParseTree(node, true, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -622,7 +622,7 @@ PreprocessRenameViewStmt(Node *node, const char *queryString,
  * of the RenameStmt. Errors if missing_ok is false.
  */
 List *
-RenameViewStmtObjectAddress(Node *node, bool missing_ok)
+RenameViewStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 
@@ -645,7 +645,7 @@ PreprocessAlterViewSchemaStmt(Node *node, const char *queryString,
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 
-	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true, false);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -687,7 +687,7 @@ PostprocessAlterViewSchemaStmt(Node *node, const char *queryString)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 
-	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true);
+	List *viewAddresses = GetObjectAddressListFromParseTree((Node *) stmt, true, true);
 
 	/*  the code-path only supports a single object */
 	Assert(list_length(viewAddresses) == 1);
@@ -709,7 +709,7 @@ PostprocessAlterViewSchemaStmt(Node *node, const char *queryString)
  * of the alter schema statement.
  */
 List *
-AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok)
+AlterViewSchemaStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, node);
 

--- a/src/backend/distributed/deparser/objectaddress.c
+++ b/src/backend/distributed/deparser/objectaddress.c
@@ -24,7 +24,7 @@
  * tree.
  */
 List *
-GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok)
+GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok, bool isPostprocess)
 {
 	const DistributeObjectOps *ops = GetDistributeObjectOps(parseTree);
 
@@ -33,12 +33,12 @@ GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok)
 		ereport(ERROR, (errmsg("unsupported statement to get object address for")));
 	}
 
-	return ops->address(parseTree, missing_ok);
+	return ops->address(parseTree, missing_ok, isPostprocess);
 }
 
 
 List *
-RenameAttributeStmtObjectAddress(Node *node, bool missing_ok)
+RenameAttributeStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	RenameStmt *stmt = castNode(RenameStmt, node);
 	Assert(stmt->renameType == OBJECT_ATTRIBUTE);
@@ -68,7 +68,7 @@ RenameAttributeStmtObjectAddress(Node *node, bool missing_ok)
  * to true.
  */
 List *
-CreateExtensionStmtObjectAddress(Node *node, bool missing_ok)
+CreateExtensionStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 {
 	CreateExtensionStmt *stmt = castNode(CreateExtensionStmt, node);
 	ObjectAddress *address = palloc0(sizeof(ObjectAddress));

--- a/src/backend/distributed/utils/citus_depended_object.c
+++ b/src/backend/distributed/utils/citus_depended_object.c
@@ -308,3 +308,35 @@ GetCitusDependedObjectArgs(int pgMetaTableVarno, int pgMetaTableOid)
 
 	return list_make2((Node *) metaTableOidConst, (Node *) oidVar);
 }
+
+
+/*
+ * DistOpsHasInvalidObject returns true if any address in the given node
+ * is invalid; otherwise, returns false. If ops is null or it has no
+ * implemented address method, we return false.
+ *
+ * If EnableUnsupportedFeatureMessages is active, then we return false.
+ */
+bool
+DistOpsHasInvalidObject(Node *node, const DistributeObjectOps *ops)
+{
+	if (EnableUnsupportedFeatureMessages)
+	{
+		return false;
+	}
+
+	if (ops && ops->address)
+	{
+		List *objectAddresses = ops->address(node, true);
+		ObjectAddress *objectAddress = NULL;
+		foreach_ptr(objectAddress, objectAddresses)
+		{
+			if (!OidIsValid(objectAddress->objectId))
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/src/backend/distributed/utils/citus_depended_object.c
+++ b/src/backend/distributed/utils/citus_depended_object.c
@@ -32,6 +32,7 @@
 #include "catalog/pg_type.h"
 #include "distributed/citus_depended_object.h"
 #include "distributed/metadata_cache.h"
+#include "distributed/commands.h"
 #include "distributed/listutils.h"
 #include "distributed/log_utils.h"
 #include "distributed/shared_library_init.h"
@@ -48,6 +49,8 @@ bool HideCitusDependentObjects = false;
 
 static Node * CreateCitusDependentObjectExpr(int pgMetaTableVarno, int pgMetaTableOid);
 static List * GetCitusDependedObjectArgs(int pgMetaTableVarno, int pgMetaTableOid);
+static bool StatementContainsIfExist(Node *node);
+static bool AlterRoleSetStatementContainsAll(Node *node);
 
 /*
  * IsPgLocksTable returns true if RTE is pg_locks table.
@@ -315,12 +318,26 @@ GetCitusDependedObjectArgs(int pgMetaTableVarno, int pgMetaTableOid)
  * is invalid; otherwise, returns false. If ops is null or it has no
  * implemented address method, we return false.
  *
- * If EnableUnsupportedFeatureMessages is active, then we return false.
+ * We have some dist ops for which we should not validate.
+ * 1) We should not validate CREATE statements because no address exists
+ * here yet.
+ * 2) We should not validate '[DROP|ALTER] IF EXISTS' statements because it is ok
+ * by the semantics even if any object is invalid.
+ * 3) We should not validate 'ALTER ROLE ALL [SET|UNSET] because for the role ALL
+ * AlterRoleSetStmtObjectAddress returns an invalid address even though it should not.
  */
 bool
 DistOpsHasInvalidObject(Node *node, const DistributeObjectOps *ops)
 {
-	if (EnableUnsupportedFeatureMessages)
+	if (ops && ops->operationType == DIST_OPS_CREATE)
+	{
+		return false;
+	}
+	else if (StatementContainsIfExist(node))
+	{
+		return false;
+	}
+	else if (AlterRoleSetStatementContainsAll(node))
 	{
 		return false;
 	}
@@ -336,6 +353,134 @@ DistOpsHasInvalidObject(Node *node, const DistributeObjectOps *ops)
 				return true;
 			}
 		}
+	}
+
+	return false;
+}
+
+
+/*
+ * StatementContainsIfExist returns true if the statement contains
+ * IF EXIST syntax.
+ */
+static bool
+StatementContainsIfExist(Node *node)
+{
+	if (node == NULL)
+	{
+		return false;
+	}
+
+	switch (nodeTag(node))
+	{
+		case T_DropStmt:
+		{
+			DropStmt *dropStmt = castNode(DropStmt, node);
+			return dropStmt->missing_ok;
+		}
+
+		case T_DropRoleStmt:
+		{
+			DropRoleStmt *dropRoleStmt = castNode(DropRoleStmt, node);
+			return dropRoleStmt->missing_ok;
+		}
+
+		case T_DropdbStmt:
+		{
+			DropdbStmt *dropdbStmt = castNode(DropdbStmt, node);
+			return dropdbStmt->missing_ok;
+		}
+
+		case T_DropTableSpaceStmt:
+		{
+			DropTableSpaceStmt *dropTableSpaceStmt = castNode(DropTableSpaceStmt, node);
+			return dropTableSpaceStmt->missing_ok;
+		}
+
+		case T_DropUserMappingStmt:
+		{
+			DropUserMappingStmt *dropUserMappingStmt = castNode(DropUserMappingStmt,
+																node);
+			return dropUserMappingStmt->missing_ok;
+		}
+
+		case T_DropSubscriptionStmt:
+		{
+			DropSubscriptionStmt *dropSubscriptionStmt = castNode(DropSubscriptionStmt,
+																  node);
+			return dropSubscriptionStmt->missing_ok;
+		}
+
+		case T_AlterTableStmt:
+		{
+			AlterTableStmt *alterTableStmt = castNode(AlterTableStmt, node);
+			return alterTableStmt->missing_ok;
+		}
+
+		case T_AlterDomainStmt:
+		{
+			AlterDomainStmt *alterDomainStmt = castNode(AlterDomainStmt, node);
+			return alterDomainStmt->missing_ok;
+		}
+
+		case T_AlterSeqStmt:
+		{
+			AlterSeqStmt *alterSeqStmt = castNode(AlterSeqStmt, node);
+			return alterSeqStmt->missing_ok;
+		}
+
+		case T_AlterStatsStmt:
+		{
+			AlterStatsStmt *alterStatsStmt = castNode(AlterStatsStmt, node);
+			return alterStatsStmt->missing_ok;
+		}
+
+		case T_RenameStmt:
+		{
+			RenameStmt *renameStmt = castNode(RenameStmt, node);
+			return renameStmt->missing_ok;
+		}
+
+		case T_AlterObjectSchemaStmt:
+		{
+			AlterObjectSchemaStmt *alterObjectSchemaStmt = castNode(AlterObjectSchemaStmt,
+																	node);
+			return alterObjectSchemaStmt->missing_ok;
+		}
+
+		case T_AlterTSConfigurationStmt:
+		{
+			AlterTSConfigurationStmt *alterTSConfigurationStmt = castNode(
+				AlterTSConfigurationStmt, node);
+			return alterTSConfigurationStmt->missing_ok;
+		}
+
+		default:
+		{
+			return false;
+		}
+	}
+}
+
+
+/*
+ * AlterRoleSetStatementContainsAll returns true if the statement is a
+ * ALTER ROLE ALL (SET / RESET).
+ */
+static bool
+AlterRoleSetStatementContainsAll(Node *node)
+{
+	if (node == NULL)
+	{
+		return false;
+	}
+
+	if (nodeTag(node) == T_AlterRoleSetStmt)
+	{
+		/* rolespec is null for the role 'ALL' */
+		AlterRoleSetStmt *alterRoleSetStmt = castNode(AlterRoleSetStmt, node);
+
+		return alterRoleSetStmt->role == NULL;
 	}
 
 	return false;

--- a/src/backend/distributed/worker/worker_create_or_replace.c
+++ b/src/backend/distributed/worker/worker_create_or_replace.c
@@ -181,7 +181,7 @@ WorkerCreateOrReplaceObject(List *sqlStatements)
 	 * same subject.
 	 */
 	Node *parseTree = ParseTreeNode(linitial(sqlStatements));
-	List *addresses = GetObjectAddressListFromParseTree(parseTree, true);
+	List *addresses = GetObjectAddressListFromParseTree(parseTree, true, false);
 	Assert(list_length(addresses) == 1);
 
 	/* We have already asserted that we have exactly 1 address in the addresses. */

--- a/src/include/distributed/citus_depended_object.h
+++ b/src/include/distributed/citus_depended_object.h
@@ -12,6 +12,7 @@
 #ifndef CITUS_DEPENDED_OBJECT_H
 #define CITUS_DEPENDED_OBJECT_H
 
+#include "distributed/commands.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 
@@ -22,5 +23,6 @@ extern void SetLocalClientMinMessagesIfRunningPGTests(int
 extern void SetLocalHideCitusDependentObjectsDisabledWhenAlreadyEnabled(void);
 extern bool HideCitusDependentObjectsOnQueriesOfPgMetaTables(Node *node, void *context);
 extern bool IsPgLocksTable(RangeTblEntry *rte);
+extern bool DistOpsHasInvalidObject(Node *node, const DistributeObjectOps *ops);
 
 #endif /* CITUS_DEPENDED_OBJECT_H */

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -39,6 +39,14 @@ extern void SwitchToSequentialAndLocalExecutionIfPartitionNameTooLong(Oid
 																	  Oid
 																	  partitionRelationId);
 
+typedef enum DistOpsOperationType
+{
+	DIST_OPS_NONE,
+	DIST_OPS_CREATE,
+	DIST_OPS_ALTER,
+	DIST_OPS_DROP,
+} DistOpsOperationType;
+
 
 /*
  * DistributeObjectOps specifies handlers for node/object type pairs.
@@ -74,6 +82,9 @@ typedef struct DistributeObjectOps
 	 * common propagation functions will not propagate the creation of the object.
 	 */
 	bool *featureFlag;
+
+	/* specifies the type of the operation */
+	DistOpsOperationType operationType;
 } DistributeObjectOps;
 
 #define CITUS_TRUNCATE_TRIGGER_NAME "citus_truncate_trigger"

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -148,8 +148,10 @@ extern void QualifyAlterTypeOwnerStmt(Node *stmt);
 extern char * GetTypeNamespaceNameByNameList(List *names);
 extern Oid TypeOidGetNamespaceOid(Oid typeOid);
 
-extern List * GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok);
-extern List * RenameAttributeStmtObjectAddress(Node *stmt, bool missing_ok);
+extern List * GetObjectAddressListFromParseTree(Node *parseTree, bool missing_ok, bool
+												isPostprocess);
+extern List * RenameAttributeStmtObjectAddress(Node *stmt, bool missing_ok, bool
+											   isPostprocess);
 
 /* forward declarations for deparse_view_stmts.c */
 extern void QualifyDropViewStmt(Node *node);


### PR DESCRIPTION
1-) We use address method to validate if the returned object addresses are all valid. In that way, we can prevent preprocess and qualify steps to execute if any object address is invalid. That PR is a sub task for the PR #6018. 

2-) We added operationType for dist ops objects to differentiate if the ops type is CREATE, DROP or ALTER. We did this to not validate CREATE ops because there will be no object address to return yet.

3-) We changed address method for dist ops by adding a parameter named isPostprocess. We did this because some statements change schema. The address method for them should search the object in the old schema for preprocess step whereas in the new schema for postprocess step.


