### PR TITLE
Small fix in CreateCollationDDL logic

### DIFF
--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -106,7 +106,7 @@ CreateCollationDDLInternal(Oid collationId, Oid *collowner, char **quotedCollati
 					 "CREATE COLLATION %s (provider = '%s'",
 					 *quotedCollationName, providerString);
 
-	if (strcmp(collcollate, collctype))
+	if (strcmp(collcollate, collctype) == 0)
 	{
 		appendStringInfo(&collationNameDef,
 						 ", locale = %s",

--- a/src/test/regress/expected/distributed_collations_conflict.out
+++ b/src/test/regress/expected/distributed_collations_conflict.out
@@ -74,13 +74,13 @@ ORDER BY 1,2,3;
 \c - - - :master_port
 SET search_path TO collation_conflict;
 -- now test worker_create_or_replace_object directly
-SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', lc_collate = 'und-u-ks-level2', lc_ctype = 'und-u-ks-level2')$$);
+SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', locale = 'und-u-ks-level2')$$);
  worker_create_or_replace_object
 ---------------------------------------------------------------------
  f
 (1 row)
 
-SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', lc_collate = 'und-u-ks-level2', lc_ctype = 'und-u-ks-level2')$$);
+SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', locale = 'und-u-ks-level2')$$);
  worker_create_or_replace_object
 ---------------------------------------------------------------------
  f

--- a/src/test/regress/sql/distributed_collations_conflict.sql
+++ b/src/test/regress/sql/distributed_collations_conflict.sql
@@ -67,8 +67,8 @@ ORDER BY 1,2,3;
 SET search_path TO collation_conflict;
 
 -- now test worker_create_or_replace_object directly
-SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', lc_collate = 'und-u-ks-level2', lc_ctype = 'und-u-ks-level2')$$);
-SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', lc_collate = 'und-u-ks-level2', lc_ctype = 'und-u-ks-level2')$$);
+SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', locale = 'und-u-ks-level2')$$);
+SELECT worker_create_or_replace_object($$CREATE COLLATION collation_conflict.caseinsensitive (provider = 'icu', locale = 'und-u-ks-level2')$$);
 
 -- hide cascades
 SET client_min_messages TO error;


### PR DESCRIPTION
We should swap the commands based on string comparison of `collcollate` (`lc_collate`) and `collctype` (`lc_ctype`).

In `CREATE COLLATION` command, when `lc_collate` and `lc_ctype` parameters are the same, the practice is to only specify the `locale` parameter. The below two commands _generate identical objects_, and the common practice is to use the first one:
``` SQL
# first command: specify locale
CREATE COLLATION caseinsensitive (provider = 'icu', locale = 'und-u-ks-level2');
# second command: specify same lc_collate and lc_ctype
CREATE COLLATION caseinsensitive (provider = 'icu', lc_collate = 'und-u-ks-level2', lc_ctype = 'und-u-ks-level2');
```
However, `worker_create_or_replace_object` decides on identical objects if the objects' creation command strings are identical. Given that the first command above is the common practice, I changed the test to that.

Note: the test so far was passing because of the mistake in the code. It would generate the second command above for the collation, even though `lc_collate` and `lc_ctype` were the same.


