### PR TITLE
Remove useless PG version compats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,9 +26,6 @@ configure				-whitespace
 
 # except these exceptions...
 src/backend/distributed/utils/citus_outfuncs.c -citus-style
-src/backend/distributed/utils/pg11_snprintf.c -citus-style
-src/backend/distributed/deparser/ruleutils_11.c -citus-style
-src/backend/distributed/deparser/ruleutils_12.c -citus-style
 src/backend/distributed/deparser/ruleutils_13.c -citus-style
 src/backend/distributed/deparser/ruleutils_14.c -citus-style
 src/backend/distributed/commands/index_pg_source.c -citus-style

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -122,7 +122,7 @@ static void ColumnarProcessUtility(PlannedStmt *pstmt,
 								   ParamListInfo params,
 								   struct QueryEnvironment *queryEnv,
 								   DestReceiver *dest,
-								   QueryCompletionCompat *completionTag);
+								   QueryCompletion *completionTag);
 static bool ConditionalLockRelationWithTimeout(Relation rel, LOCKMODE lockMode,
 											   int timeout, int retryInterval);
 static List * NeededColumnsList(TupleDesc tupdesc, Bitmapset *attr_needed);
@@ -2239,7 +2239,7 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 					   ParamListInfo params,
 					   struct QueryEnvironment *queryEnv,
 					   DestReceiver *dest,
-					   QueryCompletionCompat *completionTag)
+					   QueryCompletion *completionTag)
 {
 #if PG_VERSION_NUM >= PG_VERSION_14
 	if (readOnlyTree)
@@ -2956,7 +2956,7 @@ AvailableExtensionVersionColumnar(void)
 	/* pg_available_extensions returns result set containing all available extensions */
 	(*pg_available_extensions)(fcinfo);
 
-	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(
 		extensionsResultSet->setDesc,
 		&TTSOpsMinimalTuple);
 	bool hasTuple = tuplestore_gettupleslot(extensionsResultSet->setResult, goForward,

--- a/src/backend/distributed/commands/call.c
+++ b/src/backend/distributed/commands/call.c
@@ -168,8 +168,8 @@ CallDistributedProcedureRemotely(CallStmt *callStmt, DestReceiver *dest)
 	{
 		Tuplestorestate *tupleStore = tuplestore_begin_heap(true, false, work_mem);
 		TupleDesc tupleDesc = CallStmtResultDesc(callStmt);
-		TupleTableSlot *slot = MakeSingleTupleTableSlotCompat(tupleDesc,
-															  &TTSOpsMinimalTuple);
+		TupleTableSlot *slot = MakeSingleTupleTableSlot(tupleDesc,
+														&TTSOpsMinimalTuple);
 		bool expectResults = true;
 		Task *task = CitusMakeNode(Task);
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1654,7 +1654,7 @@ CopyLocalDataIntoShards(Oid distributedRelationId)
 
 	/* get the table columns */
 	TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
-	TupleTableSlot *slot = CreateTableSlotForRel(distributedRelation);
+	TupleTableSlot *slot = table_slot_create(distributedRelation, NULL);
 	List *columnNameList = TupleDescColumnNameList(tupleDescriptor);
 
 	int partitionColumnIndex = INVALID_PARTITION_COLUMN_INDEX;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -245,7 +245,7 @@ typedef enum LocalCopyStatus
 
 /* Local functions forward declarations */
 static void CopyToExistingShards(CopyStmt *copyStatement,
-								 QueryCompletionCompat *completionTag);
+								 QueryCompletion *completionTag);
 static bool IsCopyInBinaryFormat(CopyStmt *copyStatement);
 static List * FindJsonbInputColumns(TupleDesc tupleDescriptor,
 									List *inputColumnNameList);
@@ -274,7 +274,7 @@ static FmgrInfo * TypeOutputFunctions(uint32 columnCount, Oid *typeIdArray,
 static List * CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist);
 #endif
 static bool CopyStatementHasFormat(CopyStmt *copyStatement, char *formatName);
-static void CitusCopyFrom(CopyStmt *copyStatement, QueryCompletionCompat *completionTag);
+static void CitusCopyFrom(CopyStmt *copyStatement, QueryCompletion *completionTag);
 static void EnsureCopyCanRunOnRelation(Oid relationId);
 static HTAB * CreateConnectionStateHash(MemoryContext memoryContext);
 static HTAB * CreateShardStateHash(MemoryContext memoryContext);
@@ -308,7 +308,7 @@ static void UnclaimCopyConnections(List *connectionStateList);
 static void ShutdownCopyConnectionState(CopyConnectionState *connectionState,
 										CitusCopyDestReceiver *copyDest);
 static SelectStmt * CitusCopySelect(CopyStmt *copyStatement);
-static void CitusCopyTo(CopyStmt *copyStatement, QueryCompletionCompat *completionTag);
+static void CitusCopyTo(CopyStmt *copyStatement, QueryCompletion *completionTag);
 static int64 ForwardCopyDataFromConnection(CopyOutState copyOutState,
 										   MultiConnection *connection);
 
@@ -345,7 +345,7 @@ static bool CitusCopyDestReceiverReceive(TupleTableSlot *slot,
 static void CitusCopyDestReceiverShutdown(DestReceiver *destReceiver);
 static void CitusCopyDestReceiverDestroy(DestReceiver *destReceiver);
 static bool ContainsLocalPlacement(int64 shardId);
-static void CompleteCopyQueryTagCompat(QueryCompletionCompat *completionTag, uint64
+static void CompleteCopyQueryTagCompat(QueryCompletion *completionTag, uint64
 									   processedRowCount);
 static void FinishLocalCopy(CitusCopyDestReceiver *copyDest);
 static void CreateLocalColocatedIntermediateFile(CitusCopyDestReceiver *copyDest,
@@ -368,7 +368,7 @@ PG_FUNCTION_INFO_V1(citus_text_send_as_jsonb);
  * and the partition method of the distributed table.
  */
 static void
-CitusCopyFrom(CopyStmt *copyStatement, QueryCompletionCompat *completionTag)
+CitusCopyFrom(CopyStmt *copyStatement, QueryCompletion *completionTag)
 {
 	UseCoordinatedTransaction();
 
@@ -450,7 +450,7 @@ EnsureCopyCanRunOnRelation(Oid relationId)
  * rows.
  */
 static void
-CopyToExistingShards(CopyStmt *copyStatement, QueryCompletionCompat *completionTag)
+CopyToExistingShards(CopyStmt *copyStatement, QueryCompletion *completionTag)
 {
 	Oid tableId = RangeVarGetRelid(copyStatement->relation, NoLock, false);
 
@@ -471,8 +471,8 @@ CopyToExistingShards(CopyStmt *copyStatement, QueryCompletionCompat *completionT
 	bool *columnNulls = palloc0(columnCount * sizeof(bool));
 
 	/* set up a virtual tuple table slot */
-	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(tupleDescriptor,
-																	&TTSOpsVirtual);
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(tupleDescriptor,
+															  &TTSOpsVirtual);
 	tupleTableSlot->tts_nvalid = columnCount;
 	tupleTableSlot->tts_values = columnValues;
 	tupleTableSlot->tts_isnull = columnNulls;
@@ -639,8 +639,8 @@ CopyToExistingShards(CopyStmt *copyStatement, QueryCompletionCompat *completionT
 		MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
 
 		/* parse a row from the input */
-		bool nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
-											   columnValues, columnNulls);
+		bool nextRowFound = NextCopyFrom(copyState, executorExpressionContext,
+										 columnValues, columnNulls);
 
 		if (!nextRowFound)
 		{
@@ -760,7 +760,7 @@ FindJsonbInputColumns(TupleDesc tupleDescriptor, List *inputColumnNameList)
 
 
 static void
-CompleteCopyQueryTagCompat(QueryCompletionCompat *completionTag, uint64 processedRowCount)
+CompleteCopyQueryTagCompat(QueryCompletion *completionTag, uint64 processedRowCount)
 {
 	SetQueryCompletion(completionTag, CMDTAG_COPY, processedRowCount);
 }
@@ -780,7 +780,7 @@ RemoveOptionFromList(List *optionList, char *optionName)
 
 		if (strncmp(option->defname, optionName, NAMEDATALEN) == 0)
 		{
-			return list_delete_cell_compat(optionList, optionCell, previousCell);
+			return list_delete_cell(optionList, optionCell);
 		}
 	}
 
@@ -1387,7 +1387,7 @@ ColumnCoercionPaths(TupleDesc destTupleDescriptor, TupleDesc inputTupleDescripto
 		ConversionPathForTypes(inputTupleType, destTupleType,
 							   &coercePaths[columnIndex]);
 
-		currentColumnName = lnext_compat(columnNameList, currentColumnName);
+		currentColumnName = lnext(columnNameList, currentColumnName);
 
 		if (currentColumnName == NULL)
 		{
@@ -2864,7 +2864,7 @@ CopyStatementHasFormat(CopyStmt *copyStatement, char *formatName)
  * further processing is needed.
  */
 Node *
-ProcessCopyStmt(CopyStmt *copyStatement, QueryCompletionCompat *completionTag, const
+ProcessCopyStmt(CopyStmt *copyStatement, QueryCompletion *completionTag, const
 				char *queryString)
 {
 	/*
@@ -3016,7 +3016,7 @@ CitusCopySelect(CopyStmt *copyStatement)
  * table dump.
  */
 static void
-CitusCopyTo(CopyStmt *copyStatement, QueryCompletionCompat *completionTag)
+CitusCopyTo(CopyStmt *copyStatement, QueryCompletion *completionTag)
 {
 	ListCell *shardIntervalCell = NULL;
 	int64 tuplesSent = 0;
@@ -3481,7 +3481,7 @@ InitializeCopyShardState(CopyShardState *shardState,
 	bool hasRemoteCopy = false;
 
 	MemoryContext localContext =
-		AllocSetContextCreateExtended(CurrentMemoryContext,
+		AllocSetContextCreateInternal(CurrentMemoryContext,
 									  "InitializeCopyShardState",
 									  ALLOCSET_DEFAULT_MINSIZE,
 									  ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/distributed/commands/policy.c
+++ b/src/backend/distributed/commands/policy.c
@@ -362,7 +362,7 @@ PreprocessAlterPolicyStmt(Node *node, const char *queryString,
 
 			appendStringInfoString(&ddlString, RoleSpecString(roleSpec, true));
 
-			if (lnext_compat(stmt->roles, roleCell) != NULL)
+			if (lnext(stmt->roles, roleCell) != NULL)
 			{
 				appendStringInfoString(&ddlString, ", ");
 			}

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -191,7 +191,7 @@ ExtractDefaultColumnsAndOwnedSequences(Oid relationId, List **columnNameList,
 		*columnNameList = lappend(*columnNameList, columnName);
 
 		List *columnOwnedSequences =
-			GetSequencesOwnedByColumn(relationId, attributeIndex + 1);
+			getOwnedSequences_internal(relationId, attributeIndex + 1, 0);
 
 		Oid ownedSequenceId = InvalidOid;
 		if (list_length(columnOwnedSequences) != 0)

--- a/src/backend/distributed/commands/subscription.c
+++ b/src/backend/distributed/commands/subscription.c
@@ -45,9 +45,8 @@ ProcessCreateSubscriptionStmt(CreateSubscriptionStmt *createSubStmt)
 		{
 			useAuthinfo = defGetBoolean(defElem);
 
-			createSubStmt->options = list_delete_cell_compat(createSubStmt->options,
-															 currCell,
-															 prevCell);
+			createSubStmt->options = list_delete_cell(createSubStmt->options,
+													  currCell);
 
 			break;
 		}

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -104,7 +104,7 @@ static void ProcessUtilityInternal(PlannedStmt *pstmt,
 								   ParamListInfo params,
 								   struct QueryEnvironment *queryEnv,
 								   DestReceiver *dest,
-								   QueryCompletionCompat *completionTag);
+								   QueryCompletion *completionTag);
 #if PG_VERSION_NUM >= 140000
 static void set_indexsafe_procflags(void);
 #endif
@@ -128,7 +128,7 @@ void
 ProcessUtilityParseTree(Node *node, const char *queryString, ProcessUtilityContext
 						context,
 						ParamListInfo params, DestReceiver *dest,
-						QueryCompletionCompat *completionTag)
+						QueryCompletion *completionTag)
 {
 	PlannedStmt *plannedStmt = makeNode(PlannedStmt);
 	plannedStmt->commandType = CMD_UTILITY;
@@ -158,7 +158,7 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 					 ParamListInfo params,
 					 struct QueryEnvironment *queryEnv,
 					 DestReceiver *dest,
-					 QueryCompletionCompat *completionTag)
+					 QueryCompletion *completionTag)
 {
 	Node *parsetree;
 
@@ -372,7 +372,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 					   ParamListInfo params,
 					   struct QueryEnvironment *queryEnv,
 					   DestReceiver *dest,
-					   QueryCompletionCompat *completionTag)
+					   QueryCompletion *completionTag)
 {
 	Node *parsetree = pstmt->utilityStmt;
 	List *ddlJobs = NIL;

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -105,7 +105,7 @@ InitializeConnectionManagement(void)
 	 * management. Doing so, instead of allocating in TopMemoryContext, makes
 	 * it easier to associate used memory.
 	 */
-	ConnectionContext = AllocSetContextCreateExtended(TopMemoryContext,
+	ConnectionContext = AllocSetContextCreateInternal(TopMemoryContext,
 													  "Connection Context",
 													  ALLOCSET_DEFAULT_MINSIZE,
 													  ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -339,7 +339,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 			 * implemented. So, let planner to call distributed_planner() which
 			 * eventually calls standard_planner().
 			 */
-			localPlan = planner_compat(shardQuery, cursorOptions, paramListInfo);
+			localPlan = planner(shardQuery, NULL, cursorOptions, paramListInfo);
 		}
 
 		char *shardQueryString = NULL;
@@ -382,8 +382,8 @@ LocallyPlanAndExecuteMultipleQueries(List *queryStrings, TupleDestination *tuple
 											 0);
 		int cursorOptions = 0;
 		ParamListInfo paramListInfo = NULL;
-		PlannedStmt *localPlan = planner_compat(shardQuery, cursorOptions,
-												paramListInfo);
+		PlannedStmt *localPlan = planner(shardQuery, NULL, cursorOptions,
+										 paramListInfo);
 		totalProcessedRows += LocallyExecuteTaskPlan(localPlan, queryString,
 													 tupleDest, task,
 													 paramListInfo);

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -459,8 +459,8 @@ ReadFileIntoTupleStore(char *fileName, char *copyFormat, TupleDesc tupleDescript
 		ResetPerTupleExprContext(executorState);
 		MemoryContext oldContext = MemoryContextSwitchTo(executorTupleContext);
 
-		bool nextRowFound = NextCopyFromCompat(copyState, executorExpressionContext,
-											   columnValues, columnNulls);
+		bool nextRowFound = NextCopyFrom(copyState, executorExpressionContext,
+										 columnValues, columnNulls);
 		if (!nextRowFound)
 		{
 			MemoryContextSwitchTo(oldContext);
@@ -554,8 +554,8 @@ SortTupleStore(CitusScanState *scanState)
 	/* iterate over all the sorted tuples, add them to original tuplestore */
 	while (true)
 	{
-		TupleTableSlot *newSlot = MakeSingleTupleTableSlotCompat(tupleDescriptor,
-																 &TTSOpsMinimalTuple);
+		TupleTableSlot *newSlot = MakeSingleTupleTableSlot(tupleDescriptor,
+														   &TTSOpsMinimalTuple);
 		bool found = tuplesort_gettupleslot(tuplesortstate, true, false, newSlot, NULL);
 
 		if (!found)
@@ -660,7 +660,7 @@ ExecuteQueryIntoDestReceiver(Query *query, ParamListInfo params, DestReceiver *d
 	}
 
 	/* plan the subquery, this may be another distributed query */
-	PlannedStmt *queryPlan = pg_plan_query_compat(query, NULL, cursorOptions, params);
+	PlannedStmt *queryPlan = pg_plan_query(query, NULL, cursorOptions, params);
 
 	ExecutePlanIntoDestReceiver(queryPlan, params, dest);
 }
@@ -686,7 +686,7 @@ ExecutePlanIntoDestReceiver(PlannedStmt *queryPlan, ParamListInfo params,
 	PortalDefineQuery(portal,
 					  NULL,
 					  "",
-					  CMDTAG_SELECT_COMPAT,
+					  CMDTAG_SELECT,
 					  list_make1(queryPlan),
 					  NULL);
 

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -286,14 +286,14 @@ StartPortalForQueryExecution(const char *queryString)
 	Query *query = ParseQueryString(queryString, NULL, 0);
 
 	int cursorOptions = CURSOR_OPT_PARALLEL_OK;
-	PlannedStmt *queryPlan = pg_plan_query_compat(query, NULL, cursorOptions, NULL);
+	PlannedStmt *queryPlan = pg_plan_query(query, NULL, cursorOptions, NULL);
 
 	Portal portal = CreateNewPortal();
 
 	/* don't display the portal in pg_cursors, it is for internal use only */
 	portal->visible = false;
 
-	PortalDefineQuery(portal, NULL, queryString, CMDTAG_SELECT_COMPAT,
+	PortalDefineQuery(portal, NULL, queryString, CMDTAG_SELECT,
 					  list_make1(queryPlan), NULL);
 	int eflags = 0;
 	PortalStart(portal, NULL, eflags, GetActiveSnapshot());

--- a/src/backend/distributed/executor/query_stats.c
+++ b/src/backend/distributed/executor/query_stats.c
@@ -868,7 +868,7 @@ BuildExistingQueryIdHash(void)
 		fmgrPGStatStatements->fn_addr,
 		pgStatStatementsOid,
 		commandTypeDatum);
-	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(
 		statStatementsReturnSet->setDesc,
 		&TTSOpsMinimalTuple);
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -2209,7 +2209,7 @@ AvailableExtensionVersion(void)
 	/* pg_available_extensions returns result set containing all available extensions */
 	(*pg_available_extensions)(fcinfo);
 
-	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(
 		extensionsResultSet->setDesc,
 		&TTSOpsMinimalTuple);
 	bool hasTuple = tuplestore_gettupleslot(extensionsResultSet->setResult, goForward,
@@ -2700,10 +2700,10 @@ CitusCopyFormatTypeId(void)
 	if (MetadataCache.copyFormatTypeId == InvalidOid)
 	{
 		char *typeName = "citus_copy_format";
-		MetadataCache.copyFormatTypeId = GetSysCacheOid2Compat(TYPENAMENSP,
-															   Anum_pg_enum_oid,
-															   PointerGetDatum(typeName),
-															   PG_CATALOG_NAMESPACE);
+		MetadataCache.copyFormatTypeId = GetSysCacheOid2(TYPENAMENSP,
+														 Anum_pg_enum_oid,
+														 PointerGetDatum(typeName),
+														 PG_CATALOG_NAMESPACE);
 	}
 
 	return MetadataCache.copyFormatTypeId;

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -170,7 +170,7 @@ master_get_table_ddl_events(PG_FUNCTION_ARGS)
 		Assert(CitusIsA(ddlStatement, TableDDLCommand));
 		text *ddlStatementText = cstring_to_text(GetTableDDLCommand(ddlStatement));
 
-		wrapper->listCell = lnext_compat(wrapper->list, wrapper->listCell);
+		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
 		SRF_RETURN_NEXT(functionContext, PointerGetDatum(ddlStatementText));
 	}

--- a/src/backend/distributed/planner/combine_query_planner.c
+++ b/src/backend/distributed/planner/combine_query_planner.c
@@ -295,7 +295,7 @@ BuildSelectStatementViaStdPlanner(Query *combineQuery, List *remoteScanTargetLis
 		ReplaceCitusExtraDataContainer = true;
 		ReplaceCitusExtraDataContainerWithCustomScan = remoteScan;
 
-		standardStmt = standard_planner_compat(combineQuery, 0, NULL);
+		standardStmt = standard_planner(combineQuery, NULL, 0, NULL);
 
 		ReplaceCitusExtraDataContainer = false;
 		ReplaceCitusExtraDataContainerWithCustomScan = NULL;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -239,9 +239,9 @@ distributed_planner(Query *parse,
 			 * restriction information per table and parse tree transformations made by
 			 * postgres' planner.
 			 */
-			planContext.plan = standard_planner_compat(planContext.query,
-													   planContext.cursorOptions,
-													   planContext.boundParams);
+			planContext.plan = standard_planner(planContext.query, NULL,
+												planContext.cursorOptions,
+												planContext.boundParams);
 			if (needsDistributedPlanning)
 			{
 				result = PlanDistributedStmt(&planContext, rteIdCounter);
@@ -1024,7 +1024,7 @@ CreateDistributedPlan(uint64 planId, Query *originalQuery, Query *query, ParamLi
 		 * being contiguous.
 		 */
 
-		standard_planner_compat(newQuery, 0, boundParams);
+		standard_planner(newQuery, NULL, 0, boundParams);
 
 		/* overwrite the old transformed query with the new transformed query */
 		*query = *newQuery;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -987,7 +987,7 @@ ReorderInsertSelectTargetLists(Query *originalQuery, RangeTblEntry *insertRte,
 											   oldInsertTargetEntry->resname);
 
 		/* see transformInsertRow() for the details */
-		if (IsA(oldInsertTargetEntry->expr, ArrayRef) ||
+		if (IsA(oldInsertTargetEntry->expr, SubscriptingRef) ||
 			IsA(oldInsertTargetEntry->expr, FieldStore))
 		{
 			ereport(ERROR, (errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -1515,8 +1515,8 @@ CreateNonPushableInsertSelectPlan(uint64 planId, Query *parse, ParamListInfo bou
 
 	/* plan the subquery, this may be another distributed query */
 	int cursorOptions = CURSOR_OPT_PARALLEL_OK;
-	PlannedStmt *selectPlan = pg_plan_query_compat(selectQueryCopy, NULL, cursorOptions,
-												   boundParams);
+	PlannedStmt *selectPlan = pg_plan_query(selectQueryCopy, NULL, cursorOptions,
+											boundParams);
 
 	bool repartitioned = IsRedistributablePlan(selectPlan->planTree) &&
 						 IsSupportedRedistributionTarget(targetRelationId);

--- a/src/backend/distributed/planner/intermediate_result_pruning.c
+++ b/src/backend/distributed/planner/intermediate_result_pruning.c
@@ -376,7 +376,7 @@ RemoveLocalNodeFromWorkerList(List *workerNodeList)
 		WorkerNode *workerNode = (WorkerNode *) lfirst(workerNodeCell);
 		if (workerNode->groupId == localGroupId)
 		{
-			return list_delete_cell_compat(workerNodeList, workerNodeCell, prev);
+			return list_delete_cell(workerNodeList, workerNodeCell);
 		}
 	}
 

--- a/src/backend/distributed/planner/local_plan_cache.c
+++ b/src/backend/distributed/planner/local_plan_cache.c
@@ -88,7 +88,7 @@ CacheLocalPlanForShardQuery(Task *task, DistributedPlan *originalDistributedPlan
 	LockRelationOid(rangeTableEntry->relid, lockMode);
 
 	LocalPlannedStatement *localPlannedStatement = CitusMakeNode(LocalPlannedStatement);
-	localPlan = planner_compat(localShardQuery, 0, NULL);
+	localPlan = planner(localShardQuery, NULL, 0, NULL);
 	localPlannedStatement->localPlan = localPlan;
 	localPlannedStatement->shardId = task->anchorShardId;
 	localPlannedStatement->localGroupId = GetLocalGroupId();

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -358,8 +358,8 @@ ExplainSubPlans(DistributedPlan *distributedPlan, ExplainState *es)
 
 		ExplainOpenGroup("PlannedStmt", "PlannedStmt", false, es);
 
-		ExplainOnePlanCompat(plan, into, es, queryString, params, NULL, &planduration,
-							 (es->buffers ? &bufusage : NULL));
+		ExplainOnePlan(plan, into, es, queryString, params, NULL, &planduration,
+					   (es->buffers ? &bufusage : NULL));
 
 		ExplainCloseGroup("PlannedStmt", "PlannedStmt", false, es);
 		ExplainCloseGroup("Subplan", NULL, true, es);
@@ -1079,7 +1079,7 @@ worker_save_query_explain_analyze(PG_FUNCTION_ARGS)
 
 	INSTR_TIME_SET_CURRENT(planStart);
 
-	PlannedStmt *plan = pg_plan_query_compat(query, NULL, CURSOR_OPT_PARALLEL_OK, NULL);
+	PlannedStmt *plan = pg_plan_query(query, NULL, CURSOR_OPT_PARALLEL_OK, NULL);
 
 	INSTR_TIME_SET_CURRENT(planDuration);
 	INSTR_TIME_SUBTRACT(planDuration, planStart);
@@ -1201,7 +1201,7 @@ CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
 	SetLocalHideCitusDependentObjectsDisabledWhenAlreadyEnabled();
 
 	/* plan the query */
-	PlannedStmt *plan = pg_plan_query_compat(query, NULL, cursorOptions, params);
+	PlannedStmt *plan = pg_plan_query(query, NULL, cursorOptions, params);
 	INSTR_TIME_SET_CURRENT(planduration);
 	INSTR_TIME_SUBTRACT(planduration, planstart);
 
@@ -1213,8 +1213,8 @@ CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
 	}
 
 	/* run it (if needed) and produce output */
-	ExplainOnePlanCompat(plan, into, es, queryString, params, queryEnv,
-						 &planduration, (es->buffers ? &bufusage : NULL));
+	ExplainOnePlan(plan, into, es, queryString, params, queryEnv,
+				   &planduration, (es->buffers ? &bufusage : NULL));
 }
 
 
@@ -1632,7 +1632,7 @@ ExplainOneQuery(Query *query, int cursorOptions,
 		INSTR_TIME_SET_CURRENT(planstart);
 
 		/* plan the query */
-		PlannedStmt *plan = pg_plan_query_compat(query, NULL, cursorOptions, params);
+		PlannedStmt *plan = pg_plan_query(query, NULL, cursorOptions, params);
 
 		INSTR_TIME_SET_CURRENT(planduration);
 		INSTR_TIME_SUBTRACT(planduration, planstart);
@@ -1645,7 +1645,7 @@ ExplainOneQuery(Query *query, int cursorOptions,
 		}
 
 		/* run it (if needed) and produce output */
-		ExplainOnePlanCompat(plan, into, es, queryString, params, queryEnv,
+		ExplainOnePlan(plan, into, es, queryString, params, queryEnv,
 					   &planduration, (es->buffers ? &bufusage : NULL));
 	}
 }

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -543,7 +543,7 @@ OrSelectClauseList(List *selectClauseList)
 	Node *selectClause = NULL;
 	foreach_ptr(selectClause, selectClauseList)
 	{
-		bool orClause = or_clause(selectClause);
+		bool orClause = is_orclause(selectClause);
 		if (orClause)
 		{
 			orSelectClauseList = lappend(orSelectClauseList, selectClause);
@@ -3674,9 +3674,9 @@ CoordCombineAggOid()
 static Oid
 TypeOid(Oid schemaId, const char *typeName)
 {
-	Oid typeOid = GetSysCacheOid2Compat(TYPENAMENSP, Anum_pg_type_oid,
-										PointerGetDatum(typeName),
-										ObjectIdGetDatum(schemaId));
+	Oid typeOid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
+								  PointerGetDatum(typeName),
+								  ObjectIdGetDatum(schemaId));
 
 	return typeOid;
 }

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1236,7 +1236,7 @@ DeferErrorIfUnsupportedClause(List *clauseList)
 	{
 		Node *clause = (Node *) lfirst(clauseCell);
 
-		if (!(IsSelectClause(clause) || IsJoinClause(clause) || or_clause(clause)))
+		if (!(IsSelectClause(clause) || IsJoinClause(clause) || is_orclause(clause)))
 		{
 			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 								 "unsupported clause type", NULL, NULL);

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -1214,7 +1214,7 @@ CreateDistributedSubPlan(uint32 subPlanId, Query *subPlanQuery)
 	}
 
 	DistributedSubPlan *subPlan = CitusMakeNode(DistributedSubPlan);
-	subPlan->plan = planner_compat(subPlanQuery, cursorOptions, NULL);
+	subPlan->plan = planner(subPlanQuery, NULL, cursorOptions, NULL);
 	subPlan->subPlanId = subPlanId;
 
 	return subPlan;

--- a/src/backend/distributed/progress/multi_progress.c
+++ b/src/backend/distributed/progress/multi_progress.c
@@ -165,7 +165,7 @@ ProgressMonitorList(uint64 commandTypeMagicNumber, List **attachedDSMSegments)
 		getProgressInfoFunctionOid,
 		commandTypeDatum);
 
-	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlotCompat(
+	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(
 		progressResultSet->setDesc,
 		&TTSOpsMinimalTuple);
 

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -1646,7 +1646,7 @@ WaitForRelationSubscriptionsBecomeReady(MultiConnection *targetConnection,
 	 * and reset it on every iteration to make sure we don't slowly build up
 	 * a lot of memory.
 	 */
-	MemoryContext loopContext = AllocSetContextCreateExtended(CurrentMemoryContext,
+	MemoryContext loopContext = AllocSetContextCreateInternal(CurrentMemoryContext,
 															  "WaitForRelationSubscriptionsBecomeReady",
 															  ALLOCSET_DEFAULT_MINSIZE,
 															  ALLOCSET_DEFAULT_INITSIZE,
@@ -1928,7 +1928,7 @@ WaitForShardMoveSubscription(MultiConnection *targetConnection, XLogRecPtr sourc
 	 * and reset it on every iteration to make sure we don't slowly build up
 	 * a lot of memory.
 	 */
-	MemoryContext loopContext = AllocSetContextCreateExtended(CurrentMemoryContext,
+	MemoryContext loopContext = AllocSetContextCreateInternal(CurrentMemoryContext,
 															  "WaitForShardMoveSubscription",
 															  ALLOCSET_DEFAULT_MINSIZE,
 															  ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -51,10 +51,10 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	bool binaryFormat = PG_GETARG_BOOL(3);
 
 	Query *parsedQuery = ParseQueryString(queryString, NULL, 0);
-	PlannedStmt *queryPlan = pg_plan_query_compat(parsedQuery,
-												  queryString,
-												  CURSOR_OPT_PARALLEL_OK,
-												  NULL);
+	PlannedStmt *queryPlan = pg_plan_query(parsedQuery,
+										   queryString,
+										   CURSOR_OPT_PARALLEL_OK,
+										   NULL);
 	if (!IsCitusCustomScan(queryPlan->planTree))
 	{
 		ereport(ERROR, (errmsg("query must be distributed and shouldn't require "
@@ -122,10 +122,10 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 	bool binaryFormat = PG_GETARG_BOOL(3);
 
 	Query *parsedQuery = ParseQueryString(queryString, NULL, 0);
-	PlannedStmt *queryPlan = pg_plan_query_compat(parsedQuery,
-												  queryString,
-												  CURSOR_OPT_PARALLEL_OK,
-												  NULL);
+	PlannedStmt *queryPlan = pg_plan_query(parsedQuery,
+										   queryString,
+										   CURSOR_OPT_PARALLEL_OK,
+										   NULL);
 	if (!IsCitusCustomScan(queryPlan->planTree))
 	{
 		ereport(ERROR, (errmsg("query must be distributed and shouldn't require "

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -117,7 +117,7 @@ get_referencing_relation_id_list(PG_FUNCTION_ARGS)
 	{
 		Oid refId = lfirst_oid(wrapper->listCell);
 
-		wrapper->listCell = lnext_compat(wrapper->list, wrapper->listCell);
+		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
 		SRF_RETURN_NEXT(functionContext, PointerGetDatum(refId));
 	}
@@ -176,7 +176,7 @@ get_referenced_relation_id_list(PG_FUNCTION_ARGS)
 	{
 		Oid refId = lfirst_oid(wrapper->listCell);
 
-		wrapper->listCell = lnext_compat(wrapper->list, wrapper->listCell);
+		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
 		SRF_RETURN_NEXT(functionContext, PointerGetDatum(refId));
 	}

--- a/src/backend/distributed/test/foreign_key_to_reference_table_rebalance.c
+++ b/src/backend/distributed/test/foreign_key_to_reference_table_rebalance.c
@@ -76,7 +76,7 @@ get_foreign_key_to_reference_table_commands(PG_FUNCTION_ARGS)
 		char *command = (char *) lfirst(wrapper->listCell);
 		text *commandText = cstring_to_text(command);
 
-		wrapper->listCell = lnext_compat(wrapper->list, wrapper->listCell);
+		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
 		SRF_RETURN_NEXT(functionContext, PointerGetDatum(commandText));
 	}

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -155,7 +155,7 @@ AllocateRelationAccessHash(void)
 	 * management. Doing so, instead of allocating in TopMemoryContext, makes
 	 * it easier to associate used memory.
 	 */
-	RelationAcessContext = AllocSetContextCreateExtended(TopMemoryContext,
+	RelationAcessContext = AllocSetContextCreateInternal(TopMemoryContext,
 														 "Relation Access Context",
 														 ALLOCSET_DEFAULT_MINSIZE,
 														 ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -244,7 +244,7 @@ InitializeTransactionManagement(void)
 	AdjustMaxPreparedTransactions();
 
 	/* set aside 8kb of memory for use in CoordinatedTransactionCallback */
-	CommitContext = AllocSetContextCreateExtended(TopMemoryContext,
+	CommitContext = AllocSetContextCreateInternal(TopMemoryContext,
 												  "CommitContext",
 												  8 * 1024,
 												  8 * 1024,

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -165,7 +165,7 @@ RecoverWorkerTransactions(WorkerNode *workerNode)
 		return 0;
 	}
 
-	MemoryContext localContext = AllocSetContextCreateExtended(CurrentMemoryContext,
+	MemoryContext localContext = AllocSetContextCreateInternal(CurrentMemoryContext,
 															   "RecoverWorkerTransactions",
 															   ALLOCSET_DEFAULT_MINSIZE,
 															   ALLOCSET_DEFAULT_INITSIZE,

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -324,7 +324,7 @@ CreateForeignConstraintRelationshipGraph()
 
 	ClearForeignConstraintRelationshipGraphContext();
 
-	MemoryContext fConstraintRelationshipMemoryContext = AllocSetContextCreateExtended(
+	MemoryContext fConstraintRelationshipMemoryContext = AllocSetContextCreateInternal(
 		CacheMemoryContext,
 		"Forign Constraint Relationship Graph Context",
 		ALLOCSET_DEFAULT_MINSIZE,

--- a/src/include/distributed/commands/multi_copy.h
+++ b/src/include/distributed/commands/multi_copy.h
@@ -176,7 +176,7 @@ extern void AppendCopyBinaryFooters(CopyOutState footerOutputState);
 extern void EndRemoteCopy(int64 shardId, List *connectionList);
 extern List * CreateRangeTable(Relation rel, AclMode requiredAccess);
 extern Node * ProcessCopyStmt(CopyStmt *copyStatement,
-							  QueryCompletionCompat *completionTag,
+							  QueryCompletion *completionTag,
 							  const char *queryString);
 extern void CheckCopyPermissions(CopyStmt *copyStatement);
 extern bool IsCopyResultStmt(CopyStmt *copyStatement);

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -84,13 +84,13 @@ extern void multi_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 #endif
 								 ProcessUtilityContext context, ParamListInfo params,
 								 struct QueryEnvironment *queryEnv, DestReceiver *dest,
-								 QueryCompletionCompat *completionTag
+								 QueryCompletion *completionTag
 								 );
 extern void ProcessUtilityParseTree(Node *node, const char *queryString,
 									ProcessUtilityContext context, ParamListInfo
 									params,
 									DestReceiver *dest,
-									QueryCompletionCompat *completionTag
+									QueryCompletion *completionTag
 									);
 extern void MarkInvalidateForeignKeyGraph(void);
 extern void InvalidateForeignKeyGraphForDDL(void);

--- a/src/include/distributed/listutils.h
+++ b/src/include/distributed/listutils.h
@@ -52,7 +52,7 @@ typedef struct ListCellAndListWrapper
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst(var ## CellDoNotUse)) || true); \
-		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
+		 var ## CellDoNotUse = lnext(l, var ## CellDoNotUse))
 
 
 /*
@@ -65,7 +65,7 @@ typedef struct ListCellAndListWrapper
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_int(var ## CellDoNotUse)) || true); \
-		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
+		 var ## CellDoNotUse = lnext(l, var ## CellDoNotUse))
 
 
 /*
@@ -78,7 +78,7 @@ typedef struct ListCellAndListWrapper
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_oid(var ## CellDoNotUse)) || true); \
-		 var ## CellDoNotUse = lnext_compat(l, var ## CellDoNotUse))
+		 var ## CellDoNotUse = lnext(l, var ## CellDoNotUse))
 
 /*
  * forboth_ptr -
@@ -93,8 +93,8 @@ typedef struct ListCellAndListWrapper
 		 (var2 ## CellDoNotUse) != NULL && \
 		 (((var1) = lfirst(var1 ## CellDoNotUse)) || true) && \
 		 (((var2) = lfirst(var2 ## CellDoNotUse)) || true); \
-		 var1 ## CellDoNotUse = lnext_compat(l1, var1 ## CellDoNotUse), \
-		 var2 ## CellDoNotUse = lnext_compat(l2, var2 ## CellDoNotUse) \
+		 var1 ## CellDoNotUse = lnext(l1, var1 ## CellDoNotUse), \
+		 var2 ## CellDoNotUse = lnext(l2, var2 ## CellDoNotUse) \
 		 )
 
 /*
@@ -111,8 +111,8 @@ typedef struct ListCellAndListWrapper
 		 (var2 ## CellDoNotUse) != NULL && \
 		 (((var1) = lfirst(var1 ## CellDoNotUse)) || true) && \
 		 (((var2) = lfirst_oid(var2 ## CellDoNotUse)) || true); \
-		 var1 ## CellDoNotUse = lnext_compat(l1, var1 ## CellDoNotUse), \
-		 var2 ## CellDoNotUse = lnext_compat(l2, var2 ## CellDoNotUse) \
+		 var1 ## CellDoNotUse = lnext(l1, var1 ## CellDoNotUse), \
+		 var2 ## CellDoNotUse = lnext(l2, var2 ## CellDoNotUse) \
 		 )
 
 /*
@@ -129,8 +129,8 @@ typedef struct ListCellAndListWrapper
 		 (var2 ## CellDoNotUse) != NULL && \
 		 (((var1) = lfirst_int(var1 ## CellDoNotUse)) || true) && \
 		 (((var2) = lfirst_oid(var2 ## CellDoNotUse)) || true); \
-		 var1 ## CellDoNotUse = lnext_compat(l1, var1 ## CellDoNotUse), \
-		 var2 ## CellDoNotUse = lnext_compat(l2, var2 ## CellDoNotUse) \
+		 var1 ## CellDoNotUse = lnext(l1, var1 ## CellDoNotUse), \
+		 var2 ## CellDoNotUse = lnext(l2, var2 ## CellDoNotUse) \
 		 )
 
 /*

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -123,37 +123,12 @@ RelationGetSmgr(Relation rel)
 #define ROLE_PG_READ_ALL_STATS DEFAULT_ROLE_READ_ALL_STATS
 #endif
 
-#define lnext_compat(l, r) lnext(l, r)
-#define list_delete_cell_compat(l, c, p) list_delete_cell(l, c)
-#define pg_plan_query_compat(p, q, c, b) pg_plan_query(p, q, c, b)
-#define planner_compat(p, c, b) planner(p, NULL, c, b)
-#define standard_planner_compat(a, c, d) standard_planner(a, NULL, c, d)
-#define GetSequencesOwnedByRelation(a) getOwnedSequences(a)
-#define GetSequencesOwnedByColumn(a, b) getOwnedSequences_internal(a, b, 0)
-#define CMDTAG_SELECT_COMPAT CMDTAG_SELECT
-#define ExplainOnePlanCompat(a, b, c, d, e, f, g, h) \
-	ExplainOnePlan(a, b, c, d, e, f, g, h)
 #define SetListCellPtr(a, b) ((a)->ptr_value = (b))
 #define RangeTableEntryFromNSItem(a) ((a)->p_rte)
-#define QueryCompletionCompat QueryCompletion
-
-#define CreateTableSlotForRel(rel) table_slot_create(rel, NULL)
-#define MakeSingleTupleTableSlotCompat MakeSingleTupleTableSlot
-#define AllocSetContextCreateExtended AllocSetContextCreateInternal
-#define NextCopyFromCompat NextCopyFrom
-#define ArrayRef SubscriptingRef
-#define T_ArrayRef T_SubscriptingRef
-#define or_clause is_orclause
-#define GetSysCacheOid1Compat GetSysCacheOid1
-#define GetSysCacheOid2Compat GetSysCacheOid2
-#define GetSysCacheOid3Compat GetSysCacheOid3
-#define GetSysCacheOid4Compat GetSysCacheOid4
-
 #define fcGetArgValue(fc, n) ((fc)->args[n].value)
 #define fcGetArgNull(fc, n) ((fc)->args[n].isnull)
 #define fcSetArgExt(fc, n, val, is_null) \
 	(((fc)->args[n].isnull = (is_null)), ((fc)->args[n].value = (val)))
-
 #define fcSetArg(fc, n, value) fcSetArgExt(fc, n, value, false)
 #define fcSetArgNull(fc, n) fcSetArgExt(fc, n, (Datum) 0, true)
 


### PR DESCRIPTION
Lets get this before PG 15 changes to simplify compats

[Remove useless version compats](https://github.com/citusdata/citus/commit/7df6130e2bae4706a6f3c984156443fde9fea96c): While dropping old functions, we never cleaned up old compats

Also [Remove unusued gitattributes](https://github.com/citusdata/citus/commit/42c6d03dc6bca286ac8bb339368ea4c1341939e7)

Addresses https://github.com/citusdata/citus/pull/6040#discussion_r925598863