### PR TITLE
Fix get_current_transaction_id() UDF

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -215,7 +215,7 @@ get_current_transaction_id(PG_FUNCTION_ARGS)
 	values[3] = UInt64GetDatum(distributedTransctionId->transactionNumber);
 
 	/* provide a better output */
-	if (distributedTransctionId->initiatorNodeIdentifier != 0)
+	if (distributedTransctionId->transactionNumber != 0)
 	{
 		values[4] = TimestampTzGetDatum(distributedTransctionId->timestamp);
 	}


### PR DESCRIPTION
get_current_transaction_id() UDF is not printing the timestamp of the… current transaction on the coordinator even when non-null

DESCRIPTION: Fixes the transaction timestamp column of the get_current_transaction_id() on coordinator.
