### PR TITLE
null check for server in GetObjectAddressByServerName

### DIFF
--- a/src/backend/distributed/commands/foreign_server.c
+++ b/src/backend/distributed/commands/foreign_server.c
@@ -269,7 +269,7 @@ static List *
 GetObjectAddressByServerName(char *serverName, bool missing_ok)
 {
 	ForeignServer *server = GetForeignServerByName(serverName, missing_ok);
-	Oid serverOid = server->serverid;
+	Oid serverOid = (server) ? server->serverid : InvalidOid;
 	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, ForeignServerRelationId, serverOid);
 


### PR DESCRIPTION
The address method used for foreign server statements has a bug which does not null-check server object.

