### PR TITLE
Reindex object address should return invalid addresses for object types other than table or index in reindex stmt

### DIFF
--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -654,14 +654,21 @@ PreprocessReindexStmt(Node *node, const char *reindexCommand,
 
 /*
  * ReindexStmtObjectAddress returns list of object addresses in the reindex
- * statement.
+ * statement. We add the address if the object is either index or table;
+ * else, we add invalid address.
  */
 List *
 ReindexStmtObjectAddress(Node *stmt, bool missing_ok)
 {
 	ReindexStmt *reindexStatement = castNode(ReindexStmt, stmt);
 
-	Oid relationId = ReindexStmtFindRelationOid(reindexStatement, missing_ok);
+	Oid relationId = InvalidOid;
+	if (reindexStatement->relation != NULL)
+	{
+		/* we currently only support reindex commands on tables */
+		relationId = ReindexStmtFindRelationOid(reindexStatement, missing_ok);
+	}
+
 	ObjectAddress *objectAddress = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*objectAddress, RelationRelationId, relationId);
 


### PR DESCRIPTION
Reindex object address should return invalid addresses for object types other than table or index in reindex stmt.
We return NIL if object type is different than table or index in preprocess step for reindex statements. Address method should also return invalidobjectaddress for the types other than table or index. 
