### PR TITLE
Use CommitContext for subxact mgmt and reduce memory usage in CommitContext

### DIFF
--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -283,7 +283,8 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			 *   postgres already creates a TransactionAbortContext which performs this
 			 *   trick, so there's no need for us to do it again.
 			 */
-			MemoryContext previousContext = MemoryContextSwitchTo(CitusXactCallbackContext);
+			MemoryContext previousContext =
+				MemoryContextSwitchTo(CitusXactCallbackContext);
 
 			if (CurrentCoordinatedTransactionState == COORD_TRANS_PREPARED)
 			{
@@ -379,6 +380,9 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 
 			ResetGlobalVariables();
 			ResetRelationAccessHash();
+
+			/* empty the CitusXactCallbackContext to ensure we're not leaking memory */
+			MemoryContextReset(CitusXactCallbackContext);
 
 			/*
 			 * Clear MetadataCache table if we're aborting from a CREATE EXTENSION Citus
@@ -629,7 +633,8 @@ CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 		 */
 		case SUBXACT_EVENT_START_SUB:
 		{
-			MemoryContext previousContext = MemoryContextSwitchTo(CitusXactCallbackContext);
+			MemoryContext previousContext =
+				MemoryContextSwitchTo(CitusXactCallbackContext);
 
 			PushSubXact(subId);
 			if (InCoordinatedTransaction())
@@ -644,7 +649,8 @@ CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 
 		case SUBXACT_EVENT_COMMIT_SUB:
 		{
-			MemoryContext previousContext = MemoryContextSwitchTo(CitusXactCallbackContext);
+			MemoryContext previousContext =
+				MemoryContextSwitchTo(CitusXactCallbackContext);
 
 			if (InCoordinatedTransaction())
 			{
@@ -666,7 +672,8 @@ CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 
 		case SUBXACT_EVENT_ABORT_SUB:
 		{
-			MemoryContext previousContext = MemoryContextSwitchTo(CitusXactCallbackContext);
+			MemoryContext previousContext =
+				MemoryContextSwitchTo(CitusXactCallbackContext);
 
 			/*
 			 * Stop showing message for now, will re-enable when executing


### PR DESCRIPTION
(Hopefully) Fixes #5000.

If memory allocation done for `SubXactContext *state` in `PushSubXact()`
fails, then `PopSubXact()` might segfault, for example, when grabbing the
topmost `SubXactContext` from `activeSubXactContexts` if this is the first
ever subxact within the current xact, with the following stack trace:
```c
citus.so!list_nth_cell(const List * list, int n) (\opt\pgenv\pgsql-14.3\include\server\nodes\pg_list.h:260)
citus.so!PopSubXact(SubTransactionId subId) (\home\onurctirtir\citus\src\backend\distributed\transaction\transaction_management.c:761)
citus.so!CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId, SubTransactionId parentSubid, void * arg) (\home\onurctirtir\citus\src\backend\distributed\transaction\transaction_management.c:673)
CallSubXactCallbacks(SubXactEvent event, SubTransactionId mySubid, SubTransactionId parentSubid) (\opt\pgenv\src\postgresql-14.3\src\backend\access\transam\xact.c:3644)
AbortSubTransaction() (\opt\pgenv\src\postgresql-14.3\src\backend\access\transam\xact.c:5058)
AbortCurrentTransaction() (\opt\pgenv\src\postgresql-14.3\src\backend\access\transam\xact.c:3366)
PostgresMain(int argc, char ** argv, const char * dbname, const char * username) (\opt\pgenv\src\postgresql-14.3\src\backend\tcop\postgres.c:4250)
BackendRun(Port * port) (\opt\pgenv\src\postgresql-14.3\src\backend\postmaster\postmaster.c:4530)
BackendStartup(Port * port) (\opt\pgenv\src\postgresql-14.3\src\backend\postmaster\postmaster.c:4252)
ServerLoop() (\opt\pgenv\src\postgresql-14.3\src\backend\postmaster\postmaster.c:1745)
PostmasterMain(int argc, char ** argv) (\opt\pgenv\src\postgresql-14.3\src\backend\postmaster\postmaster.c:1417)
main(int argc, char ** argv) (\opt\pgenv\src\postgresql-14.3\src\backend\main\main.c:209)
```

For this reason, to be more defensive against memory-allocation errors
that could happen at `PushSubXact()`, now we use our pre-allocated memory 
context for the objects created in `PushSubXact()`.

This commit also attempts reducing the memory allocations done under
CommitContext to reduce the chances of consuming all the memory available
to CommitContext.

Note that it's problematic to encounter with such a memory-allocation
error for other objects created in `PushSubXact()` as well, so above is
an **example** scenario that might result in a segfault.

DESCRIPTION: Fixes a bug that might cause segfaults when handling deeply nested subtransactions