### PR TITLE
Removed USE_PGXS snippet in Columnar Makefile

### DIFF
--- a/src/backend/columnar/Makefile
+++ b/src/backend/columnar/Makefile
@@ -17,13 +17,7 @@ DATA = $(columnar_sql_files) \
 
 PG_CPPFLAGS += -I$(libpq_srcdir) -I$(safestringlib_srcdir)/include
 
-ifdef USE_PGXS
-PG_CONFIG = pg_config
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)
-else
 include $(citus_top_builddir)/Makefile.global
 
 .PHONY: install-all
 install-all: install
-endif


### PR DESCRIPTION
Code snippet in Makefile was blocking Citus build when USE_PGXS flag was set. This was included for port to FSPG but is not needed for Citus engine and can be safely removed.
