### PR TITLE
Fixes a crash that can happen due to catalog read in shmem_exit

### DIFF
--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -420,7 +420,7 @@ IncrementSharedConnectionCounter(const char *hostname, int port)
 {
 	SharedConnStatsHashKey connKey;
 
-	if (GetMaxSharedPoolSize() == DISABLE_CONNECTION_THROTTLING)
+	if (MaxSharedPoolSize == DISABLE_CONNECTION_THROTTLING)
 	{
 		/* connection throttling disabled */
 		return;
@@ -484,7 +484,11 @@ DecrementSharedConnectionCounter(const char *hostname, int port)
 {
 	SharedConnStatsHashKey connKey;
 
-	if (GetMaxSharedPoolSize() == DISABLE_CONNECTION_THROTTLING)
+	/*
+	 * Do not call GetMaxSharedPoolSize() here, since it may read from
+	 * the catalog and we may be in the process exit handler.
+	 */
+	if (MaxSharedPoolSize == DISABLE_CONNECTION_THROTTLING)
 	{
 		/* connection throttling disabled */
 		return;


### PR DESCRIPTION
DESCRIPTION: Fixes a crash that can happen due to catalog read in shmem_exit

DecrementSharedConnectionCounter can be called when the process exits. It calls GetMaxSharedPoolSize(), which might call GetMaxClientConnections(), which might call superuser(), which reads from the catalog, which can crash.

However, we are only interested in the MaxSharedPoolSize to check whether it's disabled, not to get the actual value. Change to using the GUC directly.