### PR TITLE
Removes leftover PG version_above_11 checks from tests

### DIFF
--- a/src/test/regress/expected/multi_drop_extension.out
+++ b/src/test/regress/expected/multi_drop_extension.out
@@ -60,14 +60,10 @@ SELECT create_reference_table('ref');
 
 CREATE INDEX CONCURRENTLY ref_concurrent_idx_x ON ref(x);
 CREATE INDEX CONCURRENTLY ref_concurrent_idx_y ON ref(x);
-SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
-\gset
-\if :server_version_above_eleven
 REINDEX INDEX CONCURRENTLY ref_concurrent_idx_x;
 REINDEX INDEX CONCURRENTLY ref_concurrent_idx_y;
 REINDEX TABLE CONCURRENTLY ref;
 REINDEX SCHEMA CONCURRENTLY test_schema;
-\endif
 SET search_path TO public;
 \set VERBOSITY TERSE
 DROP SCHEMA test_schema CASCADE;

--- a/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
+++ b/src/test/regress/expected/replicate_reference_tables_to_coordinator.out
@@ -19,11 +19,7 @@ SELECT create_reference_table('squares');
 INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
 NOTICE:  executing the copy locally for shard xxxxx
 CREATE INDEX CONCURRENTLY squares_a_idx ON squares (a);
-SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
-\gset
-\if :server_version_above_eleven
 REINDEX INDEX CONCURRENTLY squares_a_idx;
-\endif
 DROP INDEX CONCURRENTLY squares_a_idx;
 -- should be executed locally
 SELECT count(*) FROM squares;

--- a/src/test/regress/expected/undistribute_table_cascade.out
+++ b/src/test/regress/expected/undistribute_table_cascade.out
@@ -347,18 +347,7 @@ ERROR:  relation "non_existent_table" does not exist at character 27
 CREATE TABLE local_table(a int);
 SELECT undistribute_table('local_table', cascade_via_foreign_keys=>true);
 ERROR:  cannot undistribute table because the table is not distributed
--- as pg < 12 doesn't support foreign keys between partitioned tables,
--- define below foreign key conditionally instead of adding another
--- test output
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_15 FOREIGN KEY (col_1) REFERENCES partitioned_table_1(col_1);
-  $$;
-END IF;
-END$proc$;
+ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_15 FOREIGN KEY (col_1) REFERENCES partitioned_table_1(col_1);
 BEGIN;
   SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
  undistribute_table
@@ -481,18 +470,7 @@ BEGIN;
   SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
 ERROR:  cannot cascade operation via foreign keys as partition table undistribute_table_cascade.partitioned_table_2_100_200 involved in a foreign key relationship that is not inherited from it's parent table
 ROLLBACK;
--- as pg < 12 doesn't support foreign keys between partitioned tables,
--- define below foreign key conditionally instead of adding another
--- test output
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES partitioned_table_2(col_1);
-  $$;
-END IF;
-END$proc$;
+ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES partitioned_table_2(col_1);
 BEGIN;
   -- For pg versions 11, 12 & 13, partitioned_table_1 references to reference_table_3
   -- and partitioned_table_2 references to reference_table_3.

--- a/src/test/regress/expected/undistribute_table_cascade_mx.out
+++ b/src/test/regress/expected/undistribute_table_cascade_mx.out
@@ -185,16 +185,12 @@ SELECT alter_distributed_table ('users', shard_count=>10);
 -- first drop the column that has a foreign key since
 -- alter_table_set_access_method doesn't support foreign keys
 ALTER TABLE users DROP country_id;
--- set access method to columnar if pg version > 11
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  SELECT alter_table_set_access_method('users', 'columnar');
-  $$;
-END IF;
-END$proc$;
+SELECT alter_table_set_access_method('users', 'columnar');
+ alter_table_set_access_method
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT COUNT(*)
 FROM pg_class s
   JOIN pg_depend d ON d.objid=s.oid AND d.classid='pg_class'::regclass AND d.refclassid='pg_class'::regclass

--- a/src/test/regress/sql/multi_drop_extension.sql
+++ b/src/test/regress/sql/multi_drop_extension.sql
@@ -52,14 +52,10 @@ SELECT create_reference_table('ref');
 CREATE INDEX CONCURRENTLY ref_concurrent_idx_x ON ref(x);
 CREATE INDEX CONCURRENTLY ref_concurrent_idx_y ON ref(x);
 
-SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
-\gset
-\if :server_version_above_eleven
 REINDEX INDEX CONCURRENTLY ref_concurrent_idx_x;
 REINDEX INDEX CONCURRENTLY ref_concurrent_idx_y;
 REINDEX TABLE CONCURRENTLY ref;
 REINDEX SCHEMA CONCURRENTLY test_schema;
-\endif
 
 SET search_path TO public;
 \set VERBOSITY TERSE

--- a/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
+++ b/src/test/regress/sql/replicate_reference_tables_to_coordinator.sql
@@ -17,11 +17,7 @@ SELECT create_reference_table('squares');
 INSERT INTO squares SELECT i, i * i FROM generate_series(1, 10) i;
 
 CREATE INDEX CONCURRENTLY squares_a_idx ON squares (a);
-SELECT substring(current_Setting('server_version'), '\d+')::int > 11 AS server_version_above_eleven
-\gset
-\if :server_version_above_eleven
 REINDEX INDEX CONCURRENTLY squares_a_idx;
-\endif
 DROP INDEX CONCURRENTLY squares_a_idx;
 
 -- should be executed locally

--- a/src/test/regress/sql/undistribute_table_cascade.sql
+++ b/src/test/regress/sql/undistribute_table_cascade.sql
@@ -200,18 +200,7 @@ SELECT undistribute_table('non_existent_table', cascade_via_foreign_keys=>true);
 CREATE TABLE local_table(a int);
 SELECT undistribute_table('local_table', cascade_via_foreign_keys=>true);
 
--- as pg < 12 doesn't support foreign keys between partitioned tables,
--- define below foreign key conditionally instead of adding another
--- test output
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_15 FOREIGN KEY (col_1) REFERENCES partitioned_table_1(col_1);
-  $$;
-END IF;
-END$proc$;
+ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_15 FOREIGN KEY (col_1) REFERENCES partitioned_table_1(col_1);
 
 BEGIN;
   SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
@@ -318,18 +307,7 @@ BEGIN;
   SELECT undistribute_table('partitioned_table_1', cascade_via_foreign_keys=>true);
 ROLLBACK;
 
--- as pg < 12 doesn't support foreign keys between partitioned tables,
--- define below foreign key conditionally instead of adding another
--- test output
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES partitioned_table_2(col_1);
-  $$;
-END IF;
-END$proc$;
+ALTER TABLE partitioned_table_1 ADD CONSTRAINT fkey_13 FOREIGN KEY (col_1) REFERENCES partitioned_table_2(col_1);
 
 BEGIN;
   -- For pg versions 11, 12 & 13, partitioned_table_1 references to reference_table_3

--- a/src/test/regress/sql/undistribute_table_cascade_mx.sql
+++ b/src/test/regress/sql/undistribute_table_cascade_mx.sql
@@ -112,16 +112,7 @@ SELECT alter_distributed_table ('users', shard_count=>10);
 -- alter_table_set_access_method doesn't support foreign keys
 ALTER TABLE users DROP country_id;
 
--- set access method to columnar if pg version > 11
-DO $proc$
-BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
-  EXECUTE
-  $$
-  SELECT alter_table_set_access_method('users', 'columnar');
-  $$;
-END IF;
-END$proc$;
+SELECT alter_table_set_access_method('users', 'columnar');
 
 SELECT COUNT(*)
 FROM pg_class s


### PR DESCRIPTION
Completes https://github.com/citusdata/citus/pull/4799