### PR TITLE
RoleSpecToObjectAddress should return a valid address for the role ALL

### DIFF
--- a/src/backend/distributed/commands/role.c
+++ b/src/backend/distributed/commands/role.c
@@ -124,6 +124,13 @@ RoleSpecToObjectAddress(RoleSpec *role, bool missing_ok)
 		Oid roleOid = get_rolespec_oid(role, missing_ok);
 		ObjectAddressSet(*address, AuthIdRelationId, roleOid);
 	}
+	else
+	{
+		/*
+		 * If rolespec is null, role can be 'ALL'. We should return a pseudo-valid oid.
+		 */
+		ObjectAddressSet(*address, AuthIdRelationId, OID_MAX);
+	}
 
 	return list_make1(address);
 }


### PR DESCRIPTION
This PR is required by the PR #6088. We use address method to validate distributed object. Role statement should return a valid object address for the role ALL.
