### PR TITLE
Add missing ifdef for PG 15 for testing & development purposes

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_14.c
+++ b/src/backend/distributed/deparser/ruleutils_14.c
@@ -18,7 +18,8 @@
 
 #include "pg_config.h"
 
-#if (PG_VERSION_NUM >= PG_VERSION_14) && (PG_VERSION_NUM < PG_VERSION_15)
+/* We should drop PG 15 support from this file, this is only for testing purposes until #6085 is merged. */
+#if (PG_VERSION_NUM >= PG_VERSION_14) && (PG_VERSION_NUM <= PG_VERSION_15)
 
 #include "postgres.h"
 


### PR DESCRIPTION
This is a PR that we should revert before #6085.

This patch allows Citus to work with PG 15 -- for testing&development purposes. 

You should configure:
```
./configure --without-pg-version-check
```

This would use PG 14's ruleutiles file, which is by and large correct, but for full set of features, as noted above, we need #6085.