### PR TITLE
Fix flakyness in isolation_data_migration.spec

### DIFF
--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -26,7 +26,8 @@ test: isolation_citus_dist_activity
 test: isolation_insert_select_repartition
 test: isolation_dml_vs_repair isolation_copy_placement_vs_copy_placement
 
-test: isolation_concurrent_dml isolation_data_migration
+test: isolation_concurrent_dml
+test: isolation_data_migration
 test: isolation_drop_shards isolation_copy_placement_vs_modification
 test: isolation_insert_vs_vacuum isolation_transaction_recovery isolation_vacuum_skip_locked
 test: isolation_progress_monitoring


### PR DESCRIPTION
The tests isolation_concurrent_dml and isolation_data_migration tests
were being run in parallel, but they were interfering with each others
output. Sometimes queries from isolation_concurrent_dml were blocking
create_distributed_table in isolation_data_migration:

1. https://app.circleci.com/pipelines/github/citusdata/citus/25562/workflows/f9d0a6ff-bb7a-4b71-9fcf-1a3e46d54425/jobs/713270
2. https://app.circleci.com/pipelines/github/citusdata/citus/25562/workflows/1e22454c-1623-48a7-97fb-c6803c7959c7/jobs/713223
3. https://app.circleci.com/pipelines/github/citusdata/citus/25562/workflows/618c419e-eefb-4582-9482-322dbb9ac96d/jobs/713110

This fixes it changing the schedule to not run these tests in parallel.
