### PR TITLE
we validate constraint as well if the statement is alter domain drop constraint

### DIFF
--- a/src/include/distributed/citus_depended_object.h
+++ b/src/include/distributed/citus_depended_object.h
@@ -18,11 +18,20 @@
 
 extern bool HideCitusDependentObjects;
 
+/* DistOpsValidationState to be used to determine validity of dist ops */
+typedef enum DistOpsValidationState
+{
+	HasAtLeastOneValidObject,
+	HasNoneValidObject,
+	NoAddressResolutionRequired
+} DistOpsValidationState;
+
 extern void SetLocalClientMinMessagesIfRunningPGTests(int
 													  clientMinMessageLevel);
 extern void SetLocalHideCitusDependentObjectsDisabledWhenAlreadyEnabled(void);
 extern bool HideCitusDependentObjectsOnQueriesOfPgMetaTables(Node *node, void *context);
 extern bool IsPgLocksTable(RangeTblEntry *rte);
-extern bool DistOpsHasInvalidObject(Node *node, const DistributeObjectOps *ops);
+extern DistOpsValidationState DistOpsValidityState(Node *node, const
+												   DistributeObjectOps *ops);
 
 #endif /* CITUS_DEPENDED_OBJECT_H */

--- a/src/test/regress/expected/distributed_domain.out
+++ b/src/test/regress/expected/distributed_domain.out
@@ -636,7 +636,7 @@ SELECT * FROM run_command_on_workers($$ SELECT null::distributed_domain.alter_ad
 (2 rows)
 
 ALTER DOMAIN alter_add_constraint DROP CONSTRAINT IF EXISTS check_distinct;
-NOTICE:  constraint "check_distinct" of domain "distributed_domain.alter_add_constraint" does not exist, skipping
+NOTICE:  constraint "check_distinct" of domain "alter_add_constraint" does not exist, skipping
 ALTER DOMAIN alter_add_constraint ADD CONSTRAINT check_distinct CHECK (sql_is_distinct_from(value, null));
 ALTER DOMAIN alter_add_constraint RENAME CONSTRAINT check_distinct TO check_distinct_renamed;
 ALTER DOMAIN alter_add_constraint DROP CONSTRAINT check_distinct_renamed;


### PR DESCRIPTION
 That PR is a subtask for #6018.  

1) We also validate the constraint if the statement is alter domain drop constraint. We do that to prevent error log which differs from pg log due to a qualified domain name. 

2) We should execute preprocess step if any object which is returned by address method is valid.