### PR TITLE
Add another expr to ORDER BY clause for consistency

### DIFF
--- a/src/test/regress/input/hyperscale_tutorial.source
+++ b/src/test/regress/input/hyperscale_tutorial.source
@@ -99,7 +99,7 @@ SELECT a.campaign_id,
    AND i.ad_id      = a.id
  WHERE a.company_id = 5
 GROUP BY a.campaign_id, a.id
-ORDER BY a.campaign_id, n_impressions desc
+ORDER BY a.campaign_id, n_impressions desc, a.id
 LIMIT 10;
 
 DROP TABLE companies, campaigns, ads, clicks, impressions;
@@ -197,7 +197,7 @@ SELECT a.campaign_id,
    AND i.ad_id      = a.id
  WHERE a.company_id = 8
 GROUP BY a.campaign_id, a.id
-ORDER BY a.campaign_id, n_impressions desc
+ORDER BY a.campaign_id, n_impressions desc, a.id
 LIMIT 10;
 
 DROP TABLE companies, campaigns, ads, clicks, impressions;

--- a/src/test/regress/output/hyperscale_tutorial.source
+++ b/src/test/regress/output/hyperscale_tutorial.source
@@ -120,7 +120,7 @@ SELECT a.campaign_id,
    AND i.ad_id      = a.id
  WHERE a.company_id = 5
 GROUP BY a.campaign_id, a.id
-ORDER BY a.campaign_id, n_impressions desc
+ORDER BY a.campaign_id, n_impressions desc, a.id
 LIMIT 10;
  campaign_id | rank | n_impressions | id  
 -------------+------+---------------+-----
@@ -264,7 +264,7 @@ SELECT a.campaign_id,
    AND i.ad_id      = a.id
  WHERE a.company_id = 8
 GROUP BY a.campaign_id, a.id
-ORDER BY a.campaign_id, n_impressions desc
+ORDER BY a.campaign_id, n_impressions desc, a.id
 LIMIT 10;
  campaign_id | rank | n_impressions | id  
 -------------+------+---------------+-----


### PR DESCRIPTION
In test outputs with PG15, order of the following two tuples is swapped. Hence I added another ORDER BY clause.
Useful for https://github.com/citusdata/citus/pull/6085
``` SQL
 campaign_id | rank | n_impressions | id  
-------------+------+---------------+-----
                  .
                  .
                  .
          59 |    4 |            52 | 474
          59 |    4 |            52 | 480
                  .
                  .
                  .
```
