### PR TITLE
Reimplement tenant isolation on top of blocking shard split

### DIFF
--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -575,6 +575,9 @@ BlockingShardSplit(SplitOperation splitOperation,
 	}
 	PG_CATCH();
 	{
+		/* end ongoing transactions to enable us to clean up */
+		ShutdownAllConnections();
+
 		/* Do a best effort cleanup of shards created on workers in the above block */
 		TryDropSplitShardsOnFailure(mapOfShardToPlacementCreatedByWorkflow);
 
@@ -1447,6 +1450,9 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 	}
 	PG_CATCH();
 	{
+		/* end ongoing transactions to enable us to clean up */
+		ShutdownAllConnections();
+
 		/* Do a best effort cleanup of shards created on workers in the above block */
 		TryDropSplitShardsOnFailure(mapOfShardToPlacementCreatedByWorkflow);
 

--- a/src/test/regress/expected/failure_tenant_isolation.out
+++ b/src/test/regress/expected/failure_tenant_isolation.out
@@ -10,6 +10,7 @@ SET SEARCH_PATH = tenant_isolation;
 SET citus.shard_count TO 2;
 SET citus.next_shard_id TO 300;
 SET citus.shard_replication_factor TO 1;
+SET citus.max_adaptive_executor_pool_size TO 1;
 SELECT pg_backend_pid() as pid \gset
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
@@ -59,7 +60,7 @@ SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
 ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
 -- cancellation on colocated table creation
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_2").after(1).cancel(' || :pid || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_2").cancel(' || :pid || ')');
  mitmproxy
 ---------------------------------------------------------------------
 
@@ -68,17 +69,16 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
 ERROR:  canceling statement due to user request
 -- failure on colocated table population
-SELECT citus.mitmproxy('conn.onQuery(query="INSERT INTO tenant_isolation.table_2").after(2).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="worker_split_copy\(302").kill()');
  mitmproxy
 ---------------------------------------------------------------------
 
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
-ERROR:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- cancellation on colocated table population
-SELECT citus.mitmproxy('conn.onQuery(query="INSERT INTO tenant_isolation.table_2").cancel(' || :pid || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="worker_split_copy\(302").cancel(' || :pid || ')');
  mitmproxy
 ---------------------------------------------------------------------
 
@@ -94,8 +94,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="ALTER TABLE tenant_isolation.table_2
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
-ERROR:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- cancellation on colocated table constraints
 SELECT citus.mitmproxy('conn.onQuery(query="ALTER TABLE tenant_isolation.table_2 ADD CONSTRAINT").after(2).cancel(' || :pid || ')');
  mitmproxy
@@ -116,7 +115,7 @@ SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
 ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
 -- cancellation on table creation
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_1").after(1).cancel(' || :pid || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_1").cancel(' || :pid || ')');
  mitmproxy
 ---------------------------------------------------------------------
 
@@ -125,17 +124,16 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE TABLE tenant_isolation.table_
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
 ERROR:  canceling statement due to user request
 -- failure on table population
-SELECT citus.mitmproxy('conn.onQuery(query="INSERT INTO tenant_isolation.table_1").after(2).kill()');
+SELECT citus.mitmproxy('conn.onQuery(query="worker_split_copy\(300").kill()');
  mitmproxy
 ---------------------------------------------------------------------
 
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
-ERROR:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- cancellation on table population
-SELECT citus.mitmproxy('conn.onQuery(query="INSERT INTO tenant_isolation.table_1").cancel(' || :pid || ')');
+SELECT citus.mitmproxy('conn.onQuery(query="worker_split_copy\(300").cancel(' || :pid || ')');
  mitmproxy
 ---------------------------------------------------------------------
 
@@ -151,8 +149,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="ALTER TABLE tenant_isolation.table_1
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
-ERROR:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- cancellation on table constraints
 SELECT citus.mitmproxy('conn.onQuery(query="ALTER TABLE tenant_isolation.table_1 ADD CONSTRAINT").after(2).cancel(' || :pid || ')');
  mitmproxy
@@ -323,8 +320,8 @@ DO LANGUAGE plpgsql
 $$
 BEGIN
 	SELECT isolate_tenant_to_new_shard('table_1', 5, 'CASCADE');
- 	 EXCEPTION WHEN OTHERS THEN
-        RAISE 'Command failed to execute';
+	EXCEPTION WHEN OTHERS THEN
+	RAISE 'Command failed to execute';
 END;
 $$;
 ERROR:  Command failed to execute

--- a/src/test/regress/expected/isolation_tenant_isolation.out
+++ b/src/test/regress/expected/isolation_tenant_isolation.out
@@ -7,10 +7,10 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -19,7 +19,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -27,10 +27,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -38,26 +38,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-update:
-	UPDATE isolation_table SET value = 5 WHERE id = 5;
+ UPDATE isolation_table SET value = 5 WHERE id = 5;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-update: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -80,10 +80,10 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -92,7 +92,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -100,10 +100,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -111,26 +111,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-delete:
-	DELETE FROM isolation_table WHERE id = 5;
+ DELETE FROM isolation_table WHERE id = 5;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-delete: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -153,7 +153,7 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-begin:
     BEGIN;
@@ -162,7 +162,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -170,10 +170,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -181,26 +181,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-insert: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -222,7 +222,7 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-begin:
     BEGIN;
@@ -231,7 +231,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -239,10 +239,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -250,26 +250,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-copy:
-	COPY isolation_table FROM PROGRAM 'echo "1,1\n2,2\n3,3\n4,4\n5,5"' WITH CSV;
+ COPY isolation_table FROM PROGRAM 'echo "1,1\n2,2\n3,3\n4,4\n5,5"' WITH CSV;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-copy: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -291,7 +291,7 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-begin:
     BEGIN;
@@ -300,7 +300,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -308,10 +308,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -319,25 +319,25 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-ddl:
-	CREATE INDEX test_table_index ON isolation_table(id);
+ CREATE INDEX test_table_index ON isolation_table(id);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-ddl: <... completed>
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -352,12 +352,12 @@ id|value
 (0 rows)
 
 step s2-print-index-count:
-	SELECT
-		nodeport, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
-	ORDER BY
-		nodeport;
+ SELECT
+  nodeport, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+ ORDER BY
+  nodeport;
 
 nodeport|success|result
 ---------------------------------------------------------------------
@@ -375,7 +375,7 @@ create_distributed_table
 (1 row)
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -384,7 +384,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -392,10 +392,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -403,26 +403,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-update:
-	UPDATE isolation_table SET value = 5 WHERE id = 5;
+ UPDATE isolation_table SET value = 5 WHERE id = 5;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-update: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -445,7 +445,7 @@ create_distributed_table
 (1 row)
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -454,7 +454,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -462,10 +462,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -473,26 +473,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-delete:
-	DELETE FROM isolation_table WHERE id = 5;
+ DELETE FROM isolation_table WHERE id = 5;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-delete: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -521,7 +521,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -529,10 +529,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -540,26 +540,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-insert: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -587,7 +587,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -595,10 +595,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -606,26 +606,26 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-copy:
-	COPY isolation_table FROM PROGRAM 'echo "1,1\n2,2\n3,3\n4,4\n5,5"' WITH CSV;
+ COPY isolation_table FROM PROGRAM 'echo "1,1\n2,2\n3,3\n4,4\n5,5"' WITH CSV;
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-copy: <... completed>
 ERROR:  could not find valid entry for shard xxxxx
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -653,7 +653,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-select:
-	SELECT count(*) FROM isolation_table WHERE id = 5;
+ SELECT count(*) FROM isolation_table WHERE id = 5;
 
 count
 ---------------------------------------------------------------------
@@ -661,10 +661,10 @@ count
 (1 row)
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -672,25 +672,25 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s1-ddl:
-	CREATE INDEX test_table_index ON isolation_table(id);
+ CREATE INDEX test_table_index ON isolation_table(id);
  <waiting ...>
 step s2-commit: 
-	COMMIT;
+ COMMIT;
 
 step s1-ddl: <... completed>
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
@@ -705,12 +705,12 @@ id|value
 (0 rows)
 
 step s2-print-index-count:
-	SELECT
-		nodeport, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
-	ORDER BY
-		nodeport;
+ SELECT
+  nodeport, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from pg_indexes WHERE tablename = ''%s''')
+ ORDER BY
+  nodeport;
 
 nodeport|success|result
 ---------------------------------------------------------------------
@@ -728,10 +728,10 @@ create_distributed_table
 (1 row)
 
 step s1-load-cache:
-	TRUNCATE isolation_table;
+ TRUNCATE isolation_table;
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -740,7 +740,7 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 2);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 2);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
@@ -748,37 +748,30 @@ isolate_tenant_to_new_shard
 (1 row)
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
- <waiting ...>
-step s1-commit: 
-	COMMIT;
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
-step s2-isolate-tenant: <... completed>
-isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                    1500067
-(1 row)
+ERROR:  could not acquire the lock required to split public.isolation_table
+step s1-commit:
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
-   57637|1500066|t      |     0
-   57637|1500067|t      |     1
-   57637|1500068|t      |     0
+   57637|1500061|t      |     1
    57638|1500063|t      |     0
    57638|1500064|t      |     0
    57638|1500065|t      |     0
-(6 rows)
+(4 rows)
 
 id|value
 ---------------------------------------------------------------------
@@ -793,7 +786,7 @@ create_distributed_table
 (1 row)
 
 step s1-insert:
-	INSERT INTO isolation_table VALUES (5, 10);
+ INSERT INTO isolation_table VALUES (5, 10);
 
 step s1-begin:
     BEGIN;
@@ -802,45 +795,38 @@ step s1-begin:
     SET citus.select_opens_transaction_block TO false;
 
 step s1-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 2);
+ SELECT isolate_tenant_to_new_shard('isolation_table', 2);
 
 isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
-                    1500073
+                    1500070
 (1 row)
 
 step s2-isolate-tenant:
-	SELECT isolate_tenant_to_new_shard('isolation_table', 5);
- <waiting ...>
-step s1-commit: 
-	COMMIT;
+ SELECT isolate_tenant_to_new_shard('isolation_table', 5);
 
-step s2-isolate-tenant: <... completed>
-isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                    1500076
-(1 row)
+ERROR:  could not acquire the lock required to split public.isolation_table
+step s1-commit:
+ COMMIT;
 
 step s2-print-cluster:
-	-- row count per shard
-	SELECT
-		nodeport, shardid, success, result
-	FROM
-		run_command_on_placements('isolation_table', 'select count(*) from %s')
-	ORDER BY
-		nodeport, shardid;
-	-- rows
-	SELECT id, value FROM isolation_table ORDER BY id, value;
+ -- row count per shard
+ SELECT
+  nodeport, shardid, success, result
+ FROM
+  run_command_on_placements('isolation_table', 'select count(*) from %s')
+ ORDER BY
+  nodeport, shardid;
+ -- rows
+ SELECT id, value FROM isolation_table ORDER BY id, value;
 
 nodeport|shardid|success|result
 ---------------------------------------------------------------------
-   57637|1500075|t      |     0
-   57637|1500076|t      |     1
-   57637|1500077|t      |     0
-   57638|1500072|t      |     0
-   57638|1500073|t      |     0
-   57638|1500074|t      |     0
-(6 rows)
+   57637|1500067|t      |     1
+   57638|1500069|t      |     0
+   57638|1500070|t      |     0
+   57638|1500071|t      |     0
+(4 rows)
 
 id|value
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_create_table.out
+++ b/src/test/regress/expected/multi_create_table.out
@@ -392,6 +392,7 @@ SELECT count(*) FROM pg_dist_colocation WHERE shardcount = 9;
 (1 row)
 
 SET citus.shard_count TO 9;
+SET citus.shard_replication_factor TO 1;
 CREATE TABLE shard_split_table (a int, b int);
 SELECT create_distributed_table ('shard_split_table', 'a');
  create_distributed_table

--- a/src/test/regress/expected/multi_multiuser_master_protocol.out
+++ b/src/test/regress/expected/multi_multiuser_master_protocol.out
@@ -309,6 +309,7 @@ DROP TABLE stage_postgres;
 CREATE SCHEMA multiuser_schema;
 CREATE TABLE multiuser_schema.hash_table(a int, b int);
 CREATE TABLE multiuser_schema.reference_table(a int, b int);
+SET citus.shard_replication_factor TO 1;
 SELECT create_distributed_table('multiuser_schema.hash_table', 'a', colocate_with => 'none');
  create_distributed_table
 ---------------------------------------------------------------------
@@ -323,14 +324,10 @@ ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109090 | t       | f
- localhost |    57637 |  109091 | t       | f
  localhost |    57637 |  109092 | t       | f
- localhost |    57637 |  109093 | t       | f
- localhost |    57638 |  109090 | t       | f
  localhost |    57638 |  109091 | t       | f
- localhost |    57638 |  109092 | t       | f
  localhost |    57638 |  109093 | t       | f
-(8 rows)
+(4 rows)
 
 -- grant select
 GRANT SELECT ON ALL TABLES IN SCHEMA multiuser_schema TO read_access;
@@ -340,14 +337,10 @@ ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109090 | t       | t
- localhost |    57637 |  109091 | t       | t
  localhost |    57637 |  109092 | t       | t
- localhost |    57637 |  109093 | t       | t
- localhost |    57638 |  109090 | t       | t
  localhost |    57638 |  109091 | t       | t
- localhost |    57638 |  109092 | t       | t
  localhost |    57638 |  109093 | t       | t
-(8 rows)
+(4 rows)
 
 -- distribute the second table
 SELECT create_reference_table('multiuser_schema.reference_table');
@@ -378,14 +371,10 @@ ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109095 | t       | f
- localhost |    57637 |  109096 | t       | f
  localhost |    57637 |  109097 | t       | f
- localhost |    57637 |  109098 | t       | f
- localhost |    57638 |  109095 | t       | f
  localhost |    57638 |  109096 | t       | f
- localhost |    57638 |  109097 | t       | f
  localhost |    57638 |  109098 | t       | f
-(8 rows)
+(4 rows)
 
 -- grant select again, verify it is granted
 GRANT SELECT ON ALL TABLES IN SCHEMA multiuser_schema TO read_access;
@@ -394,14 +383,10 @@ ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109095 | t       | t
- localhost |    57637 |  109096 | t       | t
  localhost |    57637 |  109097 | t       | t
- localhost |    57637 |  109098 | t       | t
- localhost |    57638 |  109095 | t       | t
  localhost |    57638 |  109096 | t       | t
- localhost |    57638 |  109097 | t       | t
  localhost |    57638 |  109098 | t       | t
-(8 rows)
+(4 rows)
 
 -- verify isolate tenant carries grants
 SELECT isolate_tenant_to_new_shard('multiuser_schema.hash_table', 5);
@@ -414,19 +399,13 @@ SELECT * FROM run_command_on_placements('multiuser_schema.hash_table', $$ select
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
- localhost |    57637 |  109091 | t       | t
  localhost |    57637 |  109092 | t       | t
- localhost |    57637 |  109093 | t       | t
  localhost |    57637 |  109099 | t       | t
  localhost |    57637 |  109100 | t       | t
  localhost |    57637 |  109101 | t       | t
  localhost |    57638 |  109091 | t       | t
- localhost |    57638 |  109092 | t       | t
  localhost |    57638 |  109093 | t       | t
- localhost |    57638 |  109099 | t       | t
- localhost |    57638 |  109100 | t       | t
- localhost |    57638 |  109101 | t       | t
-(12 rows)
+(6 rows)
 
 -- revoke select
 REVOKE SELECT ON ALL TABLES IN SCHEMA multiuser_schema FROM read_access;
@@ -434,19 +413,13 @@ SELECT * FROM run_command_on_placements('multiuser_schema.hash_table', $$ select
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
- localhost |    57637 |  109091 | t       | f
  localhost |    57637 |  109092 | t       | f
- localhost |    57637 |  109093 | t       | f
  localhost |    57637 |  109099 | t       | f
  localhost |    57637 |  109100 | t       | f
  localhost |    57637 |  109101 | t       | f
  localhost |    57638 |  109091 | t       | f
- localhost |    57638 |  109092 | t       | f
  localhost |    57638 |  109093 | t       | f
- localhost |    57638 |  109099 | t       | f
- localhost |    57638 |  109100 | t       | f
- localhost |    57638 |  109101 | t       | f
-(12 rows)
+(6 rows)
 
 -- test multi-schema grants
 CREATE SCHEMA multiuser_second_schema;
@@ -462,33 +435,23 @@ SELECT * FROM run_command_on_placements('multiuser_schema.hash_table', $$ select
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
- localhost |    57637 |  109091 | t       | t
  localhost |    57637 |  109092 | t       | t
- localhost |    57637 |  109093 | t       | t
  localhost |    57637 |  109099 | t       | t
  localhost |    57637 |  109100 | t       | t
  localhost |    57637 |  109101 | t       | t
  localhost |    57638 |  109091 | t       | t
- localhost |    57638 |  109092 | t       | t
  localhost |    57638 |  109093 | t       | t
- localhost |    57638 |  109099 | t       | t
- localhost |    57638 |  109100 | t       | t
- localhost |    57638 |  109101 | t       | t
-(12 rows)
+(6 rows)
 
 SELECT * FROM run_command_on_placements('multiuser_second_schema.hash_table', $$ select has_table_privilege('read_access', '%s', 'select') $$)
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109102 | t       | t
- localhost |    57637 |  109103 | t       | t
  localhost |    57637 |  109104 | t       | t
- localhost |    57637 |  109105 | t       | t
- localhost |    57638 |  109102 | t       | t
  localhost |    57638 |  109103 | t       | t
- localhost |    57638 |  109104 | t       | t
  localhost |    57638 |  109105 | t       | t
-(8 rows)
+(4 rows)
 
 -- revoke from multiple schemas, verify result
 REVOKE SELECT ON ALL TABLES IN SCHEMA multiuser_schema, multiuser_second_schema FROM read_access;
@@ -496,33 +459,23 @@ SELECT * FROM run_command_on_placements('multiuser_schema.hash_table', $$ select
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
- localhost |    57637 |  109091 | t       | f
  localhost |    57637 |  109092 | t       | f
- localhost |    57637 |  109093 | t       | f
  localhost |    57637 |  109099 | t       | f
  localhost |    57637 |  109100 | t       | f
  localhost |    57637 |  109101 | t       | f
  localhost |    57638 |  109091 | t       | f
- localhost |    57638 |  109092 | t       | f
  localhost |    57638 |  109093 | t       | f
- localhost |    57638 |  109099 | t       | f
- localhost |    57638 |  109100 | t       | f
- localhost |    57638 |  109101 | t       | f
-(12 rows)
+(6 rows)
 
 SELECT * FROM run_command_on_placements('multiuser_second_schema.hash_table', $$ select has_table_privilege('read_access', '%s', 'select') $$)
 ORDER BY nodename, nodeport, shardid;
  nodename  | nodeport | shardid | success | result
 ---------------------------------------------------------------------
  localhost |    57637 |  109102 | t       | f
- localhost |    57637 |  109103 | t       | f
  localhost |    57637 |  109104 | t       | f
- localhost |    57637 |  109105 | t       | f
- localhost |    57638 |  109102 | t       | f
  localhost |    57638 |  109103 | t       | f
- localhost |    57638 |  109104 | t       | f
  localhost |    57638 |  109105 | t       | f
-(8 rows)
+(4 rows)
 
 DROP SCHEMA multiuser_schema CASCADE;
 NOTICE:  drop cascades to 3 other objects

--- a/src/test/regress/expected/multi_tenant_isolation.out
+++ b/src/test/regress/expected/multi_tenant_isolation.out
@@ -228,7 +228,7 @@ SELECT isolate_tenant_to_new_shard('orders_streaming', 102, 'CASCADE');
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('lineitem_streaming', 102, 'CASCADE');
-ERROR:  table "lineitem_streaming" has already been isolated for the given value
+ERROR:  table lineitem_streaming has already been isolated for the given value
 COMMIT;
 -- test a rollback transaction block
 BEGIN;
@@ -239,42 +239,38 @@ SELECT isolate_tenant_to_new_shard('orders_streaming', 102, 'CASCADE');
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('orders_streaming', 103, 'CASCADE');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230032
-(1 row)
-
+ERROR:  cannot isolate tenant after other modifications in the same transaction.
 ROLLBACK;
 -- test a succesfull transaction block
 BEGIN;
 SELECT isolate_tenant_to_new_shard('orders_streaming', 102, 'CASCADE');
  isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
-                     1230038
-(1 row)
-
-SELECT isolate_tenant_to_new_shard('orders_streaming', 103, 'CASCADE');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230044
+                     1230032
 (1 row)
 
 COMMIT;
+SELECT isolate_tenant_to_new_shard('orders_streaming', 103, 'CASCADE');
+ isolate_tenant_to_new_shard
+---------------------------------------------------------------------
+                     1230038
+(1 row)
+
 SELECT isolate_tenant_to_new_shard('lineitem_streaming', 100, 'CASCADE');
-ERROR:  table "lineitem_streaming" has already been isolated for the given value
+ERROR:  table lineitem_streaming has already been isolated for the given value
 SELECT isolate_tenant_to_new_shard('orders_streaming', 101, 'CASCADE');
-ERROR:  table "orders_streaming" has already been isolated for the given value
+ERROR:  table orders_streaming has already been isolated for the given value
 -- test corner cases: hash(-1995148554) = -2147483648 and hash(-1686493264) = 2147483647
 SELECT isolate_tenant_to_new_shard('lineitem_streaming', -1995148554, 'CASCADE');
  isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
-                     1230046
+                     1230040
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('orders_streaming', -1686493264, 'CASCADE');
  isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
-                     1230053
+                     1230047
 (1 row)
 
 SELECT count(*) FROM orders_streaming WHERE o_orderkey = -1995148554;
@@ -393,14 +389,14 @@ SELECT * FROM pg_dist_shard
 	ORDER BY shardminvalue::BIGINT, logicalrelid;
     logicalrelid    | shardid | shardstorage | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- lineitem_streaming | 1230046 | t            | -2147483648   | -2147483648
- orders_streaming   | 1230048 | t            | -2147483648   | -2147483648
- lineitem_streaming | 1230047 | t            | -2147483647   | -136164586
- orders_streaming   | 1230049 | t            | -2147483647   | -136164586
- lineitem_streaming | 1230041 | t            | -136164585    | -136164585
- orders_streaming   | 1230044 | t            | -136164585    | -136164585
- lineitem_streaming | 1230042 | t            | -136164584    | -85071815
- orders_streaming   | 1230045 | t            | -136164584    | -85071815
+ lineitem_streaming | 1230040 | t            | -2147483648   | -2147483648
+ orders_streaming   | 1230042 | t            | -2147483648   | -2147483648
+ lineitem_streaming | 1230041 | t            | -2147483647   | -136164586
+ orders_streaming   | 1230043 | t            | -2147483647   | -136164586
+ lineitem_streaming | 1230035 | t            | -136164585    | -136164585
+ orders_streaming   | 1230038 | t            | -136164585    | -136164585
+ lineitem_streaming | 1230036 | t            | -136164584    | -85071815
+ orders_streaming   | 1230039 | t            | -136164584    | -85071815
  lineitem_streaming | 1230011 | t            | -85071814     | -85071814
  orders_streaming   | 1230014 | t            | -85071814     | -85071814
  lineitem_streaming | 1230012 | t            | -85071813     | -1
@@ -409,14 +405,14 @@ SELECT * FROM pg_dist_shard
  orders_streaming   | 1230007 | t            | 0             | 108199380
  lineitem_streaming | 1230005 | t            | 108199381     | 108199381
  orders_streaming   | 1230008 | t            | 108199381     | 108199381
- lineitem_streaming | 1230034 | t            | 108199382     | 412880111
- orders_streaming   | 1230037 | t            | 108199382     | 412880111
- lineitem_streaming | 1230035 | t            | 412880112     | 412880112
- orders_streaming   | 1230038 | t            | 412880112     | 412880112
- lineitem_streaming | 1230050 | t            | 412880113     | 2147483646
- orders_streaming   | 1230052 | t            | 412880113     | 2147483646
- lineitem_streaming | 1230051 | t            | 2147483647    | 2147483647
- orders_streaming   | 1230053 | t            | 2147483647    | 2147483647
+ lineitem_streaming | 1230028 | t            | 108199382     | 412880111
+ orders_streaming   | 1230031 | t            | 108199382     | 412880111
+ lineitem_streaming | 1230029 | t            | 412880112     | 412880112
+ orders_streaming   | 1230032 | t            | 412880112     | 412880112
+ lineitem_streaming | 1230044 | t            | 412880113     | 2147483646
+ orders_streaming   | 1230046 | t            | 412880113     | 2147483646
+ lineitem_streaming | 1230045 | t            | 2147483647    | 2147483647
+ orders_streaming   | 1230047 | t            | 2147483647    | 2147483647
 (24 rows)
 
 SELECT * FROM pg_dist_shard_placement WHERE shardid >= 1230000 ORDER BY nodeport, shardid;
@@ -426,32 +422,32 @@ SELECT * FROM pg_dist_shard_placement WHERE shardid >= 1230000 ORDER BY nodeport
  1230012 |          1 |           0 | localhost |    57637 |      100012
  1230014 |          1 |           0 | localhost |    57637 |      100014
  1230015 |          1 |           0 | localhost |    57637 |      100015
+ 1230035 |          1 |           0 | localhost |    57637 |      100035
+ 1230036 |          1 |           0 | localhost |    57637 |      100036
+ 1230038 |          1 |           0 | localhost |    57637 |      100038
+ 1230039 |          1 |           0 | localhost |    57637 |      100039
+ 1230040 |          1 |           0 | localhost |    57637 |      100040
  1230041 |          1 |           0 | localhost |    57637 |      100041
  1230042 |          1 |           0 | localhost |    57637 |      100042
- 1230044 |          1 |           0 | localhost |    57637 |      100044
- 1230045 |          1 |           0 | localhost |    57637 |      100045
- 1230046 |          1 |           0 | localhost |    57637 |      100046
- 1230047 |          1 |           0 | localhost |    57637 |      100047
- 1230048 |          1 |           0 | localhost |    57637 |      100048
- 1230049 |          1 |           0 | localhost |    57637 |      100049
+ 1230043 |          1 |           0 | localhost |    57637 |      100043
  1230004 |          1 |           0 | localhost |    57638 |      100004
  1230005 |          1 |           0 | localhost |    57638 |      100005
  1230007 |          1 |           0 | localhost |    57638 |      100007
  1230008 |          1 |           0 | localhost |    57638 |      100008
- 1230034 |          1 |           0 | localhost |    57638 |      100034
- 1230035 |          1 |           0 | localhost |    57638 |      100035
- 1230037 |          1 |           0 | localhost |    57638 |      100037
- 1230038 |          1 |           0 | localhost |    57638 |      100038
- 1230050 |          1 |           0 | localhost |    57638 |      100050
- 1230051 |          1 |           0 | localhost |    57638 |      100051
- 1230052 |          1 |           0 | localhost |    57638 |      100052
- 1230053 |          1 |           0 | localhost |    57638 |      100053
+ 1230028 |          1 |           0 | localhost |    57638 |      100028
+ 1230029 |          1 |           0 | localhost |    57638 |      100029
+ 1230031 |          1 |           0 | localhost |    57638 |      100031
+ 1230032 |          1 |           0 | localhost |    57638 |      100032
+ 1230044 |          1 |           0 | localhost |    57638 |      100044
+ 1230045 |          1 |           0 | localhost |    57638 |      100045
+ 1230046 |          1 |           0 | localhost |    57638 |      100046
+ 1230047 |          1 |           0 | localhost |    57638 |      100047
 (24 rows)
 
 -- test failing foreign constraints after multiple tenant isolation
 \COPY lineitem_streaming FROM STDIN WITH DELIMITER '|'
-ERROR:  insert or update on table "lineitem_streaming_1230050" violates foreign key constraint "test_constraint_1230050"
-DETAIL:  Key (l_orderkey)=(128) is not present in table "orders_streaming_1230052".
+ERROR:  insert or update on table "lineitem_streaming_1230044" violates foreign key constraint "test_constraint_1230044"
+DETAIL:  Key (l_orderkey)=(128) is not present in table "orders_streaming_1230046".
 -- connect to the worker node with metadata
 \c - mx_isolation_role_ent - :worker_1_port
 SET search_path to "Tenant Isolation";
@@ -503,28 +499,22 @@ SET citus.override_table_visibility TO false;
  Tenant Isolation | lineitem_streaming         | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230011 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230012 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230028 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230029 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230030 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230035 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230036 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230040 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230041 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230042 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230046 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230047 | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming           | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230014   | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230015   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230031   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230032   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230033   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230044   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230045   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230048   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230049   | table | mx_isolation_role_ent
-(20 rows)
+ Tenant Isolation | orders_streaming_1230038   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230039   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230042   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230043   | table | mx_isolation_role_ent
+(14 rows)
 
 \c - postgres - :worker_1_port
 SET search_path to "Tenant Isolation";
-SELECT "Column", "Type", "Modifiers" FROM public.table_desc WHERE relid='orders_streaming_1230045'::regclass;
+SELECT "Column", "Type", "Modifiers" FROM public.table_desc WHERE relid='orders_streaming_1230039'::regclass;
      Column      |         Type          | Modifiers
 ---------------------------------------------------------------------
  o_orderkey      | bigint                | not null
@@ -546,14 +536,14 @@ SELECT * FROM pg_dist_shard
 	ORDER BY shardminvalue::BIGINT, logicalrelid;
     logicalrelid    | shardid | shardstorage | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- lineitem_streaming | 1230046 | t            | -2147483648   | -2147483648
- orders_streaming   | 1230048 | t            | -2147483648   | -2147483648
- lineitem_streaming | 1230047 | t            | -2147483647   | -136164586
- orders_streaming   | 1230049 | t            | -2147483647   | -136164586
- lineitem_streaming | 1230041 | t            | -136164585    | -136164585
- orders_streaming   | 1230044 | t            | -136164585    | -136164585
- lineitem_streaming | 1230042 | t            | -136164584    | -85071815
- orders_streaming   | 1230045 | t            | -136164584    | -85071815
+ lineitem_streaming | 1230040 | t            | -2147483648   | -2147483648
+ orders_streaming   | 1230042 | t            | -2147483648   | -2147483648
+ lineitem_streaming | 1230041 | t            | -2147483647   | -136164586
+ orders_streaming   | 1230043 | t            | -2147483647   | -136164586
+ lineitem_streaming | 1230035 | t            | -136164585    | -136164585
+ orders_streaming   | 1230038 | t            | -136164585    | -136164585
+ lineitem_streaming | 1230036 | t            | -136164584    | -85071815
+ orders_streaming   | 1230039 | t            | -136164584    | -85071815
  lineitem_streaming | 1230011 | t            | -85071814     | -85071814
  orders_streaming   | 1230014 | t            | -85071814     | -85071814
  lineitem_streaming | 1230012 | t            | -85071813     | -1
@@ -562,14 +552,14 @@ SELECT * FROM pg_dist_shard
  orders_streaming   | 1230007 | t            | 0             | 108199380
  lineitem_streaming | 1230005 | t            | 108199381     | 108199381
  orders_streaming   | 1230008 | t            | 108199381     | 108199381
- lineitem_streaming | 1230034 | t            | 108199382     | 412880111
- orders_streaming   | 1230037 | t            | 108199382     | 412880111
- lineitem_streaming | 1230035 | t            | 412880112     | 412880112
- orders_streaming   | 1230038 | t            | 412880112     | 412880112
- lineitem_streaming | 1230050 | t            | 412880113     | 2147483646
- orders_streaming   | 1230052 | t            | 412880113     | 2147483646
- lineitem_streaming | 1230051 | t            | 2147483647    | 2147483647
- orders_streaming   | 1230053 | t            | 2147483647    | 2147483647
+ lineitem_streaming | 1230028 | t            | 108199382     | 412880111
+ orders_streaming   | 1230031 | t            | 108199382     | 412880111
+ lineitem_streaming | 1230029 | t            | 412880112     | 412880112
+ orders_streaming   | 1230032 | t            | 412880112     | 412880112
+ lineitem_streaming | 1230044 | t            | 412880113     | 2147483646
+ orders_streaming   | 1230046 | t            | 412880113     | 2147483646
+ lineitem_streaming | 1230045 | t            | 2147483647    | 2147483647
+ orders_streaming   | 1230047 | t            | 2147483647    | 2147483647
 (24 rows)
 
 -- return to master node
@@ -633,23 +623,11 @@ SELECT count(*) FROM lineitem_date WHERE l_shipdate = '1997-08-08';
 (1 row)
 
 SELECT isolate_tenant_to_new_shard('lineitem_date', '1998-05-26');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230057
-(1 row)
-
+ERROR:  cannot isolate tenants when using shard replication
 SELECT isolate_tenant_to_new_shard('lineitem_date', '1997-07-30');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230060
-(1 row)
-
+ERROR:  cannot isolate tenants when using shard replication
 SELECT isolate_tenant_to_new_shard('lineitem_date', '1998-01-15');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230063
-(1 row)
-
+ERROR:  cannot isolate tenants when using shard replication
 SELECT count(*) FROM lineitem_date;
  count
 ---------------------------------------------------------------------
@@ -685,7 +663,7 @@ SELECT count(*) FROM lineitem_date WHERE l_shipdate = '1997-08-08';
 SET search_path to "Tenant Isolation";
 UPDATE pg_dist_shard_placement SET shardstate = 3 WHERE nodeport = :worker_1_port;
 SELECT isolate_tenant_to_new_shard('lineitem_date', '1997-08-08');
-ERROR:  cannot isolate tenant because relation "lineitem_date" has an inactive shard placement for the shard xxxxx
+ERROR:  cannot split shard because relation "lineitem_date" has an inactive shard placement for the shard xxxxx
 HINT:  Use master_copy_shard_placement UDF to repair the inactive shard placement.
 UPDATE pg_dist_shard_placement SET shardstate = 1 WHERE nodeport = :worker_1_port;
 \c - mx_isolation_role_ent - :master_port
@@ -709,14 +687,14 @@ SELECT * FROM pg_dist_shard
 	ORDER BY shardminvalue::BIGINT, logicalrelid;
     logicalrelid    | shardid | shardstorage | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- lineitem_streaming | 1230046 | t            | -2147483648   | -2147483648
- orders_streaming   | 1230048 | t            | -2147483648   | -2147483648
- lineitem_streaming | 1230047 | t            | -2147483647   | -136164586
- orders_streaming   | 1230049 | t            | -2147483647   | -136164586
- lineitem_streaming | 1230041 | t            | -136164585    | -136164585
- orders_streaming   | 1230044 | t            | -136164585    | -136164585
- lineitem_streaming | 1230042 | t            | -136164584    | -85071815
- orders_streaming   | 1230045 | t            | -136164584    | -85071815
+ lineitem_streaming | 1230040 | t            | -2147483648   | -2147483648
+ orders_streaming   | 1230042 | t            | -2147483648   | -2147483648
+ lineitem_streaming | 1230041 | t            | -2147483647   | -136164586
+ orders_streaming   | 1230043 | t            | -2147483647   | -136164586
+ lineitem_streaming | 1230035 | t            | -136164585    | -136164585
+ orders_streaming   | 1230038 | t            | -136164585    | -136164585
+ lineitem_streaming | 1230036 | t            | -136164584    | -85071815
+ orders_streaming   | 1230039 | t            | -136164584    | -85071815
  lineitem_streaming | 1230011 | t            | -85071814     | -85071814
  orders_streaming   | 1230014 | t            | -85071814     | -85071814
  lineitem_streaming | 1230012 | t            | -85071813     | -1
@@ -725,14 +703,14 @@ SELECT * FROM pg_dist_shard
  orders_streaming   | 1230007 | t            | 0             | 108199380
  lineitem_streaming | 1230005 | t            | 108199381     | 108199381
  orders_streaming   | 1230008 | t            | 108199381     | 108199381
- lineitem_streaming | 1230034 | t            | 108199382     | 412880111
- orders_streaming   | 1230037 | t            | 108199382     | 412880111
- lineitem_streaming | 1230035 | t            | 412880112     | 412880112
- orders_streaming   | 1230038 | t            | 412880112     | 412880112
- lineitem_streaming | 1230050 | t            | 412880113     | 2147483646
- orders_streaming   | 1230052 | t            | 412880113     | 2147483646
- lineitem_streaming | 1230051 | t            | 2147483647    | 2147483647
- orders_streaming   | 1230053 | t            | 2147483647    | 2147483647
+ lineitem_streaming | 1230028 | t            | 108199382     | 412880111
+ orders_streaming   | 1230031 | t            | 108199382     | 412880111
+ lineitem_streaming | 1230029 | t            | 412880112     | 412880112
+ orders_streaming   | 1230032 | t            | 412880112     | 412880112
+ lineitem_streaming | 1230044 | t            | 412880113     | 2147483646
+ orders_streaming   | 1230046 | t            | 412880113     | 2147483646
+ lineitem_streaming | 1230045 | t            | 2147483647    | 2147483647
+ orders_streaming   | 1230047 | t            | 2147483647    | 2147483647
 (24 rows)
 
 -- test failure scenarios with triggers on workers
@@ -758,24 +736,18 @@ SET citus.override_table_visibility TO false;
  Tenant Isolation | lineitem_streaming         | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230011 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230012 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230028 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230029 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230030 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230035 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230036 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230040 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230041 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230042 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230046 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230047 | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming           | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230014   | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230015   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230031   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230032   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230033   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230044   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230045   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230048   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230049   | table | mx_isolation_role_ent
-(20 rows)
+ Tenant Isolation | orders_streaming_1230038   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230039   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230042   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230043   | table | mx_isolation_role_ent
+(14 rows)
 
 \c - mx_isolation_role_ent - :master_port
 SET search_path to "Tenant Isolation";
@@ -793,24 +765,18 @@ SET citus.override_table_visibility TO false;
  Tenant Isolation | lineitem_streaming         | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230011 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230012 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230028 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230029 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230030 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230035 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230036 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230040 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230041 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230042 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230046 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230047 | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming           | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230014   | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230015   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230031   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230032   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230033   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230044   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230045   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230048   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230049   | table | mx_isolation_role_ent
-(20 rows)
+ Tenant Isolation | orders_streaming_1230038   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230039   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230042   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230043   | table | mx_isolation_role_ent
+(14 rows)
 
 DROP EVENT TRIGGER abort_ddl;
 -- create a trigger for drops
@@ -830,6 +796,12 @@ CREATE EVENT TRIGGER abort_drop ON sql_drop
 SET search_path to "Tenant Isolation";
 \set VERBOSITY terse
 SELECT isolate_tenant_to_new_shard('orders_streaming', 104, 'CASCADE');
+WARNING:  command DROP TABLE is disabled
+WARNING:  command DROP TABLE is disabled
+WARNING:  command DROP TABLE is disabled
+WARNING:  command DROP TABLE is disabled
+WARNING:  command DROP TABLE is disabled
+WARNING:  command DROP TABLE is disabled
 ERROR:  command DROP TABLE is disabled
 \set VERBOSITY default
 -- check if metadata is changed
@@ -838,14 +810,14 @@ SELECT * FROM pg_dist_shard
 	ORDER BY shardminvalue::BIGINT, logicalrelid;
     logicalrelid    | shardid | shardstorage | shardminvalue | shardmaxvalue
 ---------------------------------------------------------------------
- lineitem_streaming | 1230046 | t            | -2147483648   | -2147483648
- orders_streaming   | 1230048 | t            | -2147483648   | -2147483648
- lineitem_streaming | 1230047 | t            | -2147483647   | -136164586
- orders_streaming   | 1230049 | t            | -2147483647   | -136164586
- lineitem_streaming | 1230041 | t            | -136164585    | -136164585
- orders_streaming   | 1230044 | t            | -136164585    | -136164585
- lineitem_streaming | 1230042 | t            | -136164584    | -85071815
- orders_streaming   | 1230045 | t            | -136164584    | -85071815
+ lineitem_streaming | 1230040 | t            | -2147483648   | -2147483648
+ orders_streaming   | 1230042 | t            | -2147483648   | -2147483648
+ lineitem_streaming | 1230041 | t            | -2147483647   | -136164586
+ orders_streaming   | 1230043 | t            | -2147483647   | -136164586
+ lineitem_streaming | 1230035 | t            | -136164585    | -136164585
+ orders_streaming   | 1230038 | t            | -136164585    | -136164585
+ lineitem_streaming | 1230036 | t            | -136164584    | -85071815
+ orders_streaming   | 1230039 | t            | -136164584    | -85071815
  lineitem_streaming | 1230011 | t            | -85071814     | -85071814
  orders_streaming   | 1230014 | t            | -85071814     | -85071814
  lineitem_streaming | 1230012 | t            | -85071813     | -1
@@ -854,14 +826,14 @@ SELECT * FROM pg_dist_shard
  orders_streaming   | 1230007 | t            | 0             | 108199380
  lineitem_streaming | 1230005 | t            | 108199381     | 108199381
  orders_streaming   | 1230008 | t            | 108199381     | 108199381
- lineitem_streaming | 1230034 | t            | 108199382     | 412880111
- orders_streaming   | 1230037 | t            | 108199382     | 412880111
- lineitem_streaming | 1230035 | t            | 412880112     | 412880112
- orders_streaming   | 1230038 | t            | 412880112     | 412880112
- lineitem_streaming | 1230050 | t            | 412880113     | 2147483646
- orders_streaming   | 1230052 | t            | 412880113     | 2147483646
- lineitem_streaming | 1230051 | t            | 2147483647    | 2147483647
- orders_streaming   | 1230053 | t            | 2147483647    | 2147483647
+ lineitem_streaming | 1230028 | t            | 108199382     | 412880111
+ orders_streaming   | 1230031 | t            | 108199382     | 412880111
+ lineitem_streaming | 1230029 | t            | 412880112     | 412880112
+ orders_streaming   | 1230032 | t            | 412880112     | 412880112
+ lineitem_streaming | 1230044 | t            | 412880113     | 2147483646
+ orders_streaming   | 1230046 | t            | 412880113     | 2147483646
+ lineitem_streaming | 1230045 | t            | 2147483647    | 2147483647
+ orders_streaming   | 1230047 | t            | 2147483647    | 2147483647
 (24 rows)
 
 \c - - - :worker_1_port
@@ -875,30 +847,24 @@ SET citus.override_table_visibility TO false;
  Tenant Isolation | lineitem_streaming         | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230011 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230012 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230028 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230029 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230030 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230035 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230036 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230040 | table | mx_isolation_role_ent
  Tenant Isolation | lineitem_streaming_1230041 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230042 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230046 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230047 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230071 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230072 | table | mx_isolation_role_ent
- Tenant Isolation | lineitem_streaming_1230073 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230056 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230057 | table | mx_isolation_role_ent
+ Tenant Isolation | lineitem_streaming_1230058 | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming           | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230014   | table | mx_isolation_role_ent
  Tenant Isolation | orders_streaming_1230015   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230031   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230032   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230033   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230044   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230045   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230048   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230049   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230074   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230075   | table | mx_isolation_role_ent
- Tenant Isolation | orders_streaming_1230076   | table | mx_isolation_role_ent
-(26 rows)
+ Tenant Isolation | orders_streaming_1230038   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230039   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230042   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230043   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230059   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230060   | table | mx_isolation_role_ent
+ Tenant Isolation | orders_streaming_1230061   | table | mx_isolation_role_ent
+(20 rows)
 
 \c - postgres - :worker_1_port
 DROP EVENT TRIGGER abort_drop;
@@ -1049,11 +1015,7 @@ INSERT INTO composite_table VALUES  ('(1, 2)'::test_composite_type);
 INSERT INTO composite_table VALUES  ('(1, 3)'::test_composite_type);
 INSERT INTO composite_table VALUES  ('(1, 4)'::test_composite_type);
 SELECT isolate_tenant_to_new_shard('composite_table', '(1, 3)');
- isolate_tenant_to_new_shard
----------------------------------------------------------------------
-                     1230082
-(1 row)
-
+ERROR:  cannot isolate tenants when using shard replication
 SELECT count(*) FROM composite_table WHERE composite_key = '(1, 2)'::test_composite_type;
  count
 ---------------------------------------------------------------------
@@ -1113,7 +1075,7 @@ INSERT INTO test_colocated_table_3 SELECT i, i FROM generate_series (0, 100) i;
 SELECT isolate_tenant_to_new_shard('test_colocated_table_2', 1, 'CASCADE');
  isolate_tenant_to_new_shard
 ---------------------------------------------------------------------
-                     1230113
+                     1230095
 (1 row)
 
 SELECT count(*) FROM test_colocated_table_2;
@@ -1132,47 +1094,47 @@ ORDER BY 1, 2;
             relname             |                 Constraint                  |                                        Definition
 ---------------------------------------------------------------------
  test_colocated_table_1         | test_colocated_table_1_id_fkey              | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1(id)
- test_colocated_table_1_1230087 | test_colocated_table_1_id_fkey_1230087      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230087(id)
- test_colocated_table_1_1230089 | test_colocated_table_1_id_fkey_1230089      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230089(id)
+ test_colocated_table_1_1230069 | test_colocated_table_1_id_fkey_1230069      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230069(id)
+ test_colocated_table_1_1230071 | test_colocated_table_1_id_fkey_1230071      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230071(id)
+ test_colocated_table_1_1230073 | test_colocated_table_1_id_fkey_1230073      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230073(id)
  test_colocated_table_1_1230091 | test_colocated_table_1_id_fkey_1230091      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230091(id)
- test_colocated_table_1_1230109 | test_colocated_table_1_id_fkey_1230109      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230109(id)
- test_colocated_table_1_1230110 | test_colocated_table_1_id_fkey_1230110      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230110(id)
- test_colocated_table_1_1230111 | test_colocated_table_1_id_fkey_1230111      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230111(id)
+ test_colocated_table_1_1230092 | test_colocated_table_1_id_fkey_1230092      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230092(id)
+ test_colocated_table_1_1230093 | test_colocated_table_1_id_fkey_1230093      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230093(id)
  test_colocated_table_2         | test_colocated_table_2_id_fkey              | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1(id)
  test_colocated_table_2         | test_colocated_table_2_value_1_fkey         | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey(id)
- test_colocated_table_2_1230095 | test_colocated_table_2_id_fkey_1230095      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230087(id)
- test_colocated_table_2_1230095 | test_colocated_table_2_value_1_fkey_1230095 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_2_1230097 | test_colocated_table_2_id_fkey_1230097      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230089(id)
- test_colocated_table_2_1230097 | test_colocated_table_2_value_1_fkey_1230097 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_2_1230099 | test_colocated_table_2_id_fkey_1230099      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230091(id)
- test_colocated_table_2_1230099 | test_colocated_table_2_value_1_fkey_1230099 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_2_1230112 | test_colocated_table_2_id_fkey_1230112      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230109(id)
- test_colocated_table_2_1230112 | test_colocated_table_2_value_1_fkey_1230112 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_2_1230113 | test_colocated_table_2_id_fkey_1230113      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230110(id)
- test_colocated_table_2_1230113 | test_colocated_table_2_value_1_fkey_1230113 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_2_1230114 | test_colocated_table_2_id_fkey_1230114      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230111(id)
- test_colocated_table_2_1230114 | test_colocated_table_2_value_1_fkey_1230114 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
+ test_colocated_table_2_1230077 | test_colocated_table_2_id_fkey_1230077      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230069(id)
+ test_colocated_table_2_1230077 | test_colocated_table_2_value_1_fkey_1230077 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_2_1230079 | test_colocated_table_2_id_fkey_1230079      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230071(id)
+ test_colocated_table_2_1230079 | test_colocated_table_2_value_1_fkey_1230079 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_2_1230081 | test_colocated_table_2_id_fkey_1230081      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230073(id)
+ test_colocated_table_2_1230081 | test_colocated_table_2_value_1_fkey_1230081 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_2_1230094 | test_colocated_table_2_id_fkey_1230094      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230091(id)
+ test_colocated_table_2_1230094 | test_colocated_table_2_value_1_fkey_1230094 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_2_1230095 | test_colocated_table_2_id_fkey_1230095      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230092(id)
+ test_colocated_table_2_1230095 | test_colocated_table_2_value_1_fkey_1230095 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_2_1230096 | test_colocated_table_2_id_fkey_1230096      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230093(id)
+ test_colocated_table_2_1230096 | test_colocated_table_2_value_1_fkey_1230096 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
  test_colocated_table_3         | test_colocated_table_3_id_fkey              | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1(id)
  test_colocated_table_3         | test_colocated_table_3_id_fkey1             | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2(id)
  test_colocated_table_3         | test_colocated_table_3_value_1_fkey         | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey(id)
- test_colocated_table_3_1230103 | test_colocated_table_3_id_fkey1_1230103     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230095(id)
- test_colocated_table_3_1230103 | test_colocated_table_3_id_fkey_1230103      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230087(id)
- test_colocated_table_3_1230103 | test_colocated_table_3_value_1_fkey_1230103 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_3_1230105 | test_colocated_table_3_id_fkey1_1230105     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230097(id)
- test_colocated_table_3_1230105 | test_colocated_table_3_id_fkey_1230105      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230089(id)
- test_colocated_table_3_1230105 | test_colocated_table_3_value_1_fkey_1230105 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_3_1230107 | test_colocated_table_3_id_fkey1_1230107     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230099(id)
- test_colocated_table_3_1230107 | test_colocated_table_3_id_fkey_1230107      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230091(id)
- test_colocated_table_3_1230107 | test_colocated_table_3_value_1_fkey_1230107 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_3_1230115 | test_colocated_table_3_id_fkey1_1230115     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230112(id)
- test_colocated_table_3_1230115 | test_colocated_table_3_id_fkey_1230115      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230109(id)
- test_colocated_table_3_1230115 | test_colocated_table_3_value_1_fkey_1230115 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_3_1230116 | test_colocated_table_3_id_fkey1_1230116     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230113(id)
- test_colocated_table_3_1230116 | test_colocated_table_3_id_fkey_1230116      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230110(id)
- test_colocated_table_3_1230116 | test_colocated_table_3_value_1_fkey_1230116 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
- test_colocated_table_3_1230117 | test_colocated_table_3_id_fkey1_1230117     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230114(id)
- test_colocated_table_3_1230117 | test_colocated_table_3_id_fkey_1230117      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230111(id)
- test_colocated_table_3_1230117 | test_colocated_table_3_value_1_fkey_1230117 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230084(id)
+ test_colocated_table_3_1230085 | test_colocated_table_3_id_fkey1_1230085     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230077(id)
+ test_colocated_table_3_1230085 | test_colocated_table_3_id_fkey_1230085      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230069(id)
+ test_colocated_table_3_1230085 | test_colocated_table_3_value_1_fkey_1230085 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_3_1230087 | test_colocated_table_3_id_fkey1_1230087     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230079(id)
+ test_colocated_table_3_1230087 | test_colocated_table_3_id_fkey_1230087      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230071(id)
+ test_colocated_table_3_1230087 | test_colocated_table_3_value_1_fkey_1230087 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_3_1230089 | test_colocated_table_3_id_fkey1_1230089     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230081(id)
+ test_colocated_table_3_1230089 | test_colocated_table_3_id_fkey_1230089      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230073(id)
+ test_colocated_table_3_1230089 | test_colocated_table_3_value_1_fkey_1230089 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_3_1230097 | test_colocated_table_3_id_fkey1_1230097     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230094(id)
+ test_colocated_table_3_1230097 | test_colocated_table_3_id_fkey_1230097      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230091(id)
+ test_colocated_table_3_1230097 | test_colocated_table_3_value_1_fkey_1230097 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_3_1230098 | test_colocated_table_3_id_fkey1_1230098     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230095(id)
+ test_colocated_table_3_1230098 | test_colocated_table_3_id_fkey_1230098      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230092(id)
+ test_colocated_table_3_1230098 | test_colocated_table_3_value_1_fkey_1230098 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
+ test_colocated_table_3_1230099 | test_colocated_table_3_id_fkey1_1230099     | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_2_1230096(id)
+ test_colocated_table_3_1230099 | test_colocated_table_3_id_fkey_1230099      | FOREIGN KEY (id) REFERENCES "Tenant Isolation".test_colocated_table_1_1230093(id)
+ test_colocated_table_3_1230099 | test_colocated_table_3_value_1_fkey_1230099 | FOREIGN KEY (value_1) REFERENCES "Tenant Isolation".test_reference_table_fkey_1230066(id)
 (42 rows)
 
 \c - mx_isolation_role_ent - :master_port
@@ -1190,6 +1152,65 @@ SELECT create_reference_table('ref_table');
 
 \c - postgres - :master_port
 SET search_path to "Tenant Isolation";
+-- partitioning tests
+-- create partitioned table
+CREATE TABLE partitioning_test(id int, time date) PARTITION BY RANGE (time);
+-- create a regular partition
+CREATE TABLE partitioning_test_2009 PARTITION OF partitioning_test FOR VALUES FROM ('2009-01-01') TO ('2010-01-01');
+-- create a columnar partition
+CREATE TABLE partitioning_test_2010 PARTITION OF partitioning_test FOR VALUES FROM ('2010-01-01') TO ('2011-01-01') USING columnar;
+-- load some data and distribute tables
+INSERT INTO partitioning_test VALUES (1, '2009-06-06');
+INSERT INTO partitioning_test VALUES (2, '2010-07-07');
+INSERT INTO partitioning_test_2009 VALUES (3, '2009-09-09');
+INSERT INTO partitioning_test_2010 VALUES (4, '2010-03-03');
+-- distribute partitioned table
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('partitioning_test', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$"Tenant Isolation".partitioning_test_2009$$)
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$"Tenant Isolation".partitioning_test_2010$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) FROM pg_dist_shard WHERE logicalrelid = 'partitioning_test'::regclass;
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
+SELECT count(*) FROM partitioning_test;
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
+-- isolate a value into its own shard
+SELECT 1 FROM isolate_tenant_to_new_shard('partitioning_test', 2, 'CASCADE');
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT count(*) FROM pg_dist_shard WHERE logicalrelid = 'partitioning_test'::regclass;
+ count
+---------------------------------------------------------------------
+     6
+(1 row)
+
+SELECT count(*) FROM partitioning_test;
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
 SET citus.replicate_reference_tables_on_activate TO off;
 SET client_min_messages TO WARNING;
 SELECT 1 FROM master_add_node('localhost', :master_port, groupId=>0);

--- a/src/test/regress/sql/multi_create_table.sql
+++ b/src/test/regress/sql/multi_create_table.sql
@@ -260,6 +260,7 @@ DROP TABLE shard_count_table, shard_count_table_2;
 -- ensure there is no colocation group with 9 shards
 SELECT count(*) FROM pg_dist_colocation WHERE shardcount = 9;
 SET citus.shard_count TO 9;
+SET citus.shard_replication_factor TO 1;
 
 CREATE TABLE shard_split_table (a int, b int);
 SELECT create_distributed_table ('shard_split_table', 'a');

--- a/src/test/regress/sql/multi_multiuser_master_protocol.sql
+++ b/src/test/regress/sql/multi_multiuser_master_protocol.sql
@@ -126,6 +126,7 @@ CREATE SCHEMA multiuser_schema;
 CREATE TABLE multiuser_schema.hash_table(a int, b int);
 CREATE TABLE multiuser_schema.reference_table(a int, b int);
 
+SET citus.shard_replication_factor TO 1;
 SELECT create_distributed_table('multiuser_schema.hash_table', 'a', colocate_with => 'none');
 
 


### PR DESCRIPTION
DESCRIPTION: isolate_tenant_to_new_shard drops support for replicated tables
DESCRIPTION: isolate_tenant_to_new_shard now fails when run concurrently with itself
DESCRIPTION: isolate_tenant_to_new_shard adds support for partitioned tables
DESCRIPTION: isolate_tenant_to_new_shard adds support for columnar tables

This PR reimplements isolate_tenant_to_new_shard on top of the SplitShard function to remove a bunch of old code. For now it only uses blocking mode to lean on the existing test coverage, but it should be easy to make it non-blocking.

This introduces a regression on replication factor > 1, but given isolate_tenant_to_new_shard is rarely used (due to blocking behaviour) and replication factor > 1 is also rarely used, the intersection seems unlikely to exist. 