### PR TITLE
Reduce log level to avoid alternative output for PG15

### DIFF
--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -351,6 +351,10 @@ ORDER BY nodeport, shardid;
 
 -- hide postgresql version dependend messages for next test only
 \set VERBOSITY terse
+-- reduce the log level for differences between PG14 and PG15
+-- in PGconn->errorMessage
+-- relevant PG commit b15f254466aefbabcbed001929f6e09db59fd158
+SET client_min_messages to ERROR;
 -- for replicated tables use 2PC even if multi-shard commit protocol
 -- is set to 2PC
 BEGIN;
@@ -358,30 +362,20 @@ DELETE FROM researchers WHERE lab_id = 6;
 \copy researchers FROM STDIN delimiter ','
 \copy researchers FROM STDIN delimiter ','
 COMMIT;
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
 -- single row, multi-row INSERTs should also fail
 -- with or without transaction blocks on the COMMIT time
 INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup');
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
 INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
 BEGIN;
     INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup');
 COMMIT;
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
 BEGIN;
     INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
 COMMIT;
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
 -- and, rollback should be fine
 BEGIN;
@@ -391,6 +385,7 @@ BEGIN;
     INSERT INTO researchers VALUES (31, 6, 'Bjarne Stroustrup'), (32, 7, 'Bjarne Stroustrup');
 ROLLBACK;
 \unset VERBOSITY
+RESET client_min_messages;
 -- verify everyhing including delete is rolled back
 SELECT * FROM researchers WHERE lab_id = 6;
  id | lab_id |         name
@@ -660,15 +655,18 @@ AFTER INSERT ON labs_1200002
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE PROCEDURE reject_bad();
 \c - - - :master_port
+-- reduce the log level for differences between PG14 and PG15
+-- in PGconn->errorMessage
+-- relevant PG commit b15f254466aefbabcbed001929f6e09db59fd158
+SET client_min_messages to ERROR;
 BEGIN;
 INSERT INTO objects VALUES (1, 'apple');
 INSERT INTO objects VALUES (2, 'BAD');
 INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
-WARNING:  illegal value
-WARNING:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
 ERROR:  illegal value
+RESET client_min_messages;
 -- data should NOT be persisted
 SELECT * FROM objects WHERE id = 1;
  id | name

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -299,6 +299,12 @@ ORDER BY nodeport, shardid;
 
 -- hide postgresql version dependend messages for next test only
 \set VERBOSITY terse
+
+-- reduce the log level for differences between PG14 and PG15
+-- in PGconn->errorMessage
+-- relevant PG commit b15f254466aefbabcbed001929f6e09db59fd158
+SET client_min_messages to ERROR;
+
 -- for replicated tables use 2PC even if multi-shard commit protocol
 -- is set to 2PC
 BEGIN;
@@ -334,6 +340,7 @@ BEGIN;
 ROLLBACK;
 
 \unset VERBOSITY
+RESET client_min_messages;
 
 -- verify everyhing including delete is rolled back
 SELECT * FROM researchers WHERE lab_id = 6;
@@ -550,12 +557,19 @@ FOR EACH ROW EXECUTE PROCEDURE reject_bad();
 
 \c - - - :master_port
 
+-- reduce the log level for differences between PG14 and PG15
+-- in PGconn->errorMessage
+-- relevant PG commit b15f254466aefbabcbed001929f6e09db59fd158
+SET client_min_messages to ERROR;
+
 BEGIN;
 INSERT INTO objects VALUES (1, 'apple');
 INSERT INTO objects VALUES (2, 'BAD');
 INSERT INTO labs VALUES (8, 'Aperture Science');
 INSERT INTO labs VALUES (9, 'BAD');
 COMMIT;
+
+RESET client_min_messages;
 
 -- data should NOT be persisted
 SELECT * FROM objects WHERE id = 1;


### PR DESCRIPTION
We are reducing the log level in these places to avoid alternative test output in PG15.
The warnings don't seem necessary for the validity of the tests.
Useful for: [PG15 support #6085](https://github.com/citusdata/citus/pull/6085)

Pre PG15
```
WARNING:  illegal value
WARNING:  connection to the remote node localhost:xxxxx failed with the
following error: another command is already in progress
ERROR:  illegal value
```

PG15
```
ERROR:  illegal value
WARNING:  illegal value
WARNING:  connection to the remote node localhost:xxxxx failed with the
following error: ERROR:  illegal value
CONTEXT:  PL/pgSQL function reject_large_id() line 4 at RAISE
another command is already in progress
```

Relevant PG commit:
https://github.com/postgres/postgres/commit/b15f254466aefbabcbed001929f6e09db59fd158