### PR TITLE
Cleans up large_table_shard_count guc leftovers

### DIFF
--- a/src/test/regress/expected/multi_multiuser_basic_queries.out
+++ b/src/test/regress/expected/multi_multiuser_basic_queries.out
@@ -49,7 +49,6 @@ SELECT count(*) FROM lineitem;
 ERROR:  permission denied for table lineitem
 RESET ROLE;
 -- verify that broadcast joins work
-SET citus.large_table_shard_count TO 2;
 SET ROLE read_access;
 SELECT
 	l_partkey, o_orderkey, count(*)
@@ -112,7 +111,6 @@ LIMIT 30;
 ERROR:  permission denied for table lineitem
 RESET ROLE;
 -- verify that re-partition queries work
-SET citus.large_table_shard_count TO 1;
 SET citus.task_executor_type TO 'task-tracker';
 SET ROLE read_access;
 SELECT

--- a/src/test/regress/sql/multi_multiuser_basic_queries.sql
+++ b/src/test/regress/sql/multi_multiuser_basic_queries.sql
@@ -31,7 +31,6 @@ SELECT count(*) FROM lineitem;
 RESET ROLE;
 
 -- verify that broadcast joins work
-SET citus.large_table_shard_count TO 2;
 
 SET ROLE read_access;
 
@@ -74,7 +73,6 @@ LIMIT 30;
 RESET ROLE;
 
 -- verify that re-partition queries work
-SET citus.large_table_shard_count TO 1;
 SET citus.task_executor_type TO 'task-tracker';
 
 SET ROLE read_access;


### PR DESCRIPTION
Helpful for [Pg15 support #6085](https://github.com/citusdata/citus/pull/6085) because of https://github.com/postgres/postgres/commit/88103567cb8fa5be46dc9fac3e3b8774951a2be7
