### PR TITLE
Adds ORDER BY in pg_locks to avoid output order diffs

### DIFF
--- a/src/test/regress/expected/distributed_locks.out
+++ b/src/test/regress/expected/distributed_locks.out
@@ -84,7 +84,7 @@ SET ROLE TO user_with_view_permissions;
 BEGIN;
 LOCK myview IN ACCESS EXCLUSIVE MODE;
 SELECT run_command_on_workers($$
-    SELECT mode FROM pg_locks WHERE relation = 'distribute_lock_tests.dist_table'::regclass;
+    SELECT mode FROM pg_locks WHERE relation = 'distribute_lock_tests.dist_table'::regclass ORDER BY 1;
 $$);
          run_command_on_workers
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_ref2ref_foreign_keys.out
+++ b/src/test/regress/expected/isolation_ref2ref_foreign_keys.out
@@ -14,7 +14,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -32,7 +33,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -50,7 +52,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -65,7 +68,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -83,7 +87,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -98,7 +103,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -116,7 +122,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -131,7 +138,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -152,7 +160,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -170,7 +179,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -191,7 +201,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode         |count
 ---------------------------------------------------------------------
@@ -209,7 +220,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -227,7 +239,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode            |count
 ---------------------------------------------------------------------
@@ -242,7 +255,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -260,7 +274,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode            |count
 ---------------------------------------------------------------------
@@ -275,7 +290,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------
@@ -293,7 +309,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode            |count
 ---------------------------------------------------------------------
@@ -308,7 +325,8 @@ step s1-view-locks:
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 
 mode|count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_ref2ref_foreign_keys_on_mx.out
+++ b/src/test/regress/expected/isolation_ref2ref_foreign_keys_on_mx.out
@@ -40,7 +40,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -63,7 +63,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -128,7 +128,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -151,7 +151,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -216,7 +216,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -239,7 +239,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -304,7 +304,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -327,7 +327,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -392,7 +392,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -415,7 +415,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -480,7 +480,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -503,7 +503,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -568,7 +568,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -591,7 +591,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -656,7 +656,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -679,7 +679,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -744,7 +744,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result
@@ -767,7 +767,7 @@ step s1-view-locks:
   ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
   false);
 
 node_name|node_port|success|result

--- a/src/test/regress/expected/multi_distribution_metadata.out
+++ b/src/test/regress/expected/multi_distribution_metadata.out
@@ -243,7 +243,7 @@ SELECT acquire_shared_shard_lock(5);
 
 (1 row)
 
-SELECT objid, mode FROM pg_locks WHERE locktype = 'advisory' AND objid = 5;
+SELECT objid, mode FROM pg_locks WHERE locktype = 'advisory' AND objid = 5 ORDER BY 2;
  objid |   mode
 ---------------------------------------------------------------------
      5 | ShareLock

--- a/src/test/regress/spec/isolation_ref2ref_foreign_keys.spec
+++ b/src/test/regress/spec/isolation_ref2ref_foreign_keys.spec
@@ -76,7 +76,8 @@ step "s1-view-locks"
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
-    GROUP BY mode;
+    GROUP BY mode
+    ORDER BY 1, 2;
 }
 
 step "s1-rollback"

--- a/src/test/regress/spec/isolation_ref2ref_foreign_keys_on_mx.spec
+++ b/src/test/regress/spec/isolation_ref2ref_foreign_keys_on_mx.spec
@@ -36,7 +36,7 @@ step "s1-view-locks"
 		ARRAY[$$
           SELECT array_agg(ROW(t.mode, t.count) ORDER BY t.mode) FROM
           (SELECT mode, count(*) count FROM pg_locks
-           WHERE locktype='advisory' GROUP BY mode) t$$]::text[],
+           WHERE locktype='advisory' GROUP BY mode ORDER BY 1, 2) t$$]::text[],
 		false);
 }
 

--- a/src/test/regress/sql/distributed_locks.sql
+++ b/src/test/regress/sql/distributed_locks.sql
@@ -83,7 +83,7 @@ SET ROLE TO user_with_view_permissions;
 BEGIN;
 LOCK myview IN ACCESS EXCLUSIVE MODE;
 SELECT run_command_on_workers($$
-    SELECT mode FROM pg_locks WHERE relation = 'distribute_lock_tests.dist_table'::regclass;
+    SELECT mode FROM pg_locks WHERE relation = 'distribute_lock_tests.dist_table'::regclass ORDER BY 1;
 $$);
 
 ROLLBACK;

--- a/src/test/regress/sql/multi_distribution_metadata.sql
+++ b/src/test/regress/sql/multi_distribution_metadata.sql
@@ -174,7 +174,7 @@ BEGIN;
 
 -- pick up a shard lock and look for it in pg_locks
 SELECT acquire_shared_shard_lock(5);
-SELECT objid, mode FROM pg_locks WHERE locktype = 'advisory' AND objid = 5;
+SELECT objid, mode FROM pg_locks WHERE locktype = 'advisory' AND objid = 5 ORDER BY 2;
 
 -- commit should drop the lock
 COMMIT;


### PR DESCRIPTION
Helpful for [Pg15 support #6085](https://github.com/citusdata/citus/pull/6085)
