### PR TITLE
Share more code between splits and moves

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -427,6 +427,14 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		parsetree = ProcessCreateSubscriptionStmt(createSubStmt);
 	}
 
+	/*
+	 * For security and reliability reasons we disallow altering and dropping
+	 * subscriptions created by citus by non superusers. We could probably
+	 * disallow this for all subscriptions without issues. But out of an
+	 * abundance of caution for breaking subscription logic created by users
+	 * for other purposes, we only disallow it for the subscriptions that we
+	 * create i.e. ones that start with "citus_".
+	 */
 	if (IsA(parsetree, AlterSubscriptionStmt))
 	{
 		AlterSubscriptionStmt *alterSubStmt = (AlterSubscriptionStmt *) parsetree;

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -431,12 +431,12 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 	{
 		AlterSubscriptionStmt *alterSubStmt = (AlterSubscriptionStmt *) parsetree;
 		if (!superuser() &&
-			StringStartsWith(alterSubStmt->subname,
-							 SHARD_MOVE_SUBSCRIPTION_PREFIX))
+			StringStartsWith(alterSubStmt->subname, "citus_"))
 		{
 			ereport(ERROR, (
 						errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-						errmsg("Only superusers can alter shard move subscriptions")));
+						errmsg(
+							"Only superusers can alter subscriptions that are created by citus")));
 		}
 	}
 
@@ -444,11 +444,12 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 	{
 		DropSubscriptionStmt *dropSubStmt = (DropSubscriptionStmt *) parsetree;
 		if (!superuser() &&
-			StringStartsWith(dropSubStmt->subname, SHARD_MOVE_SUBSCRIPTION_PREFIX))
+			StringStartsWith(dropSubStmt->subname, "citus_"))
 		{
 			ereport(ERROR, (
 						errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-						errmsg("Only superusers can drop shard move subscriptions")));
+						errmsg(
+							"Only superusers can drop subscriptions that are created by citus")));
 		}
 	}
 

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -51,6 +51,11 @@ typedef struct ShardCreatedByWorkflowEntry
 	WorkerNode *workerNodeValue;
 } ShardCreatedByWorkflowEntry;
 
+/*
+ * Entry for map that trackes dummy shards.
+ * Key: node + owner
+ * Value: List of dummy shards for that node + owner
+ */
 typedef struct GroupedDummyShards
 {
 	NodeAndOwner key;

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1353,6 +1353,7 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 			groupedLogicalRepTargetsHash,
 			superUser, databaseName);
 
+		char *logicalRepDecoderPlugin = "citus";
 
 		/*
 		 * 6) Create replication slots and keep track of their snapshot.
@@ -1361,7 +1362,7 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 			sourceConnection,
 			sourceReplicationConnection,
 			logicalRepTargetList,
-			"citus");
+			logicalRepDecoderPlugin);
 
 		/*
 		 * 7) Create subscriptions. This isn't strictly needed yet at this

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -21,6 +21,7 @@
 #include "distributed/shared_library_init.h"
 #include "distributed/adaptive_executor.h"
 #include "distributed/colocation_utils.h"
+#include "distributed/hash_helpers.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/coordinator_protocol.h"
@@ -1294,7 +1295,8 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 	HTAB *mapOfShardToPlacementCreatedByWorkflow =
 		CreateEmptyMapForShardsCreatedByWorkflow();
 
-	HTAB *mapOfDummyShardToPlacement = SetupHashMapForShardInfo();
+	HTAB *mapOfDummyShardToPlacement = CreateSimpleHash(NodeAndOwner,
+														GroupedShardSplitInfos);
 	MultiConnection *sourceReplicationConnection =
 		GetReplicationConnection(sourceShardToCopyNode->workerName,
 								 sourceShardToCopyNode->workerPort);

--- a/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
+++ b/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
@@ -173,11 +173,10 @@ SetupHashMapForShardInfo()
 	memset(&info, 0, sizeof(info));
 	info.keysize = sizeof(NodeAndOwner);
 	info.entrysize = sizeof(GroupedShardSplitInfos);
-	info.hash = HashNodeAndOwner;
-	info.match = CompareNodeAndOwner;
+	info.hash = tag_hash;
 	info.hcxt = CurrentMemoryContext;
 
-	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_FUNCTION | HASH_COMPARE);
+	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 
 	HTAB *shardInfoMap = hash_create("ShardInfoMap", 128, &info, hashFlags);
 	return shardInfoMap;

--- a/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
+++ b/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
@@ -53,6 +53,11 @@ static void PopulateShardSplitInfoInSM(ShardSplitInfoSMHeader *shardSplitInfoSMH
 static void ReturnReplicationSlotInfo(Tuplestorestate *tupleStore,
 									  TupleDesc tupleDescriptor);
 
+/*
+ * GroupedShardSplitInfos groups all ShardSplitInfos belonging to the same node
+ * and table owner together. This data structure its only purpose is creating a
+ * hashmap that allows us to search ShardSplitInfos by node and owner.
+ */
 typedef struct GroupedShardSplitInfos
 {
 	NodeAndOwner key;

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -382,17 +382,7 @@ LogicallyReplicateShards(List *shardList, char *sourceNodeName, int sourceNodePo
 HTAB *
 InitPublicationInfoHash(void)
 {
-	HASHCTL info;
-	memset(&info, 0, sizeof(info));
-	info.keysize = sizeof(NodeAndOwner);
-	info.entrysize = sizeof(PublicationInfo);
-	info.hash = tag_hash;
-	info.hcxt = CurrentMemoryContext;
-
-	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
-
-	HTAB *publicationInfoHash = hash_create("PublicationInfoHash", 128, &info, hashFlags);
-	return publicationInfoHash;
+	return CreateSimpleHash(NodeAndOwner, PublicationInfo);
 }
 
 
@@ -403,18 +393,7 @@ InitPublicationInfoHash(void)
 static HTAB *
 InitGroupedLogicalRepTargetsHash(void)
 {
-	HASHCTL info;
-	memset(&info, 0, sizeof(info));
-	info.keysize = sizeof(uint32);
-	info.entrysize = sizeof(GroupedLogicalRepTargets);
-	info.hash = tag_hash;
-	info.hcxt = CurrentMemoryContext;
-
-	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
-
-	HTAB *publicationInfoHash = hash_create("GroupedLogicalRepTargetsHash", 128, &info,
-											hashFlags);
-	return publicationInfoHash;
+	return CreateSimpleHash(uint32, PublicationInfo);
 }
 
 

--- a/src/backend/distributed/shardsplit/shardsplit_logical_replication.c
+++ b/src/backend/distributed/shardsplit/shardsplit_logical_replication.c
@@ -13,6 +13,7 @@
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
 #include "distributed/colocation_utils.h"
+#include "distributed/hash_helpers.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/shardinterval_utils.h"
@@ -64,7 +65,7 @@ CreateShardSplitInfoMapForPublication(List *sourceColocatedShardIntervalList,
 									  List *shardGroupSplitIntervalListList,
 									  List *destinationWorkerNodesList)
 {
-	ShardInfoHashMapForPublications = InitPublicationInfoHash();
+	ShardInfoHashMapForPublications = CreateSimpleHash(NodeAndOwner, PublicationInfo);
 	ShardInterval *sourceShardIntervalToCopy = NULL;
 	List *splitChildShardIntervalList = NULL;
 	forboth_ptr(sourceShardIntervalToCopy, sourceColocatedShardIntervalList,

--- a/src/backend/distributed/shardsplit/shardsplit_shared_memory.c
+++ b/src/backend/distributed/shardsplit/shardsplit_shared_memory.c
@@ -188,32 +188,6 @@ ReleaseSharedMemoryOfShardSplitInfo()
 
 
 /*
- * EncodeReplicationSlot returns an encoded replication slot name
- * in the following format.
- * Slot Name = citus_split_nodeId_tableOwnerOid
- * Max supported length of replication slot name is 64 bytes.
- */
-char *
-EncodeReplicationSlot(uint32_t nodeId,
-					  uint32_t tableOwnerId)
-{
-	StringInfo slotName = makeStringInfo();
-	appendStringInfo(slotName, "%s%u_%u", SHARD_SPLIT_REPLICATION_SLOT_PREFIX, nodeId,
-					 tableOwnerId);
-
-	if (slotName->len > NAMEDATALEN)
-	{
-		ereport(ERROR,
-				(errmsg(
-					 "Replication Slot name:%s having length:%d is greater than maximum allowed length:%d",
-					 slotName->data, slotName->len, NAMEDATALEN)));
-	}
-
-	return slotName->data;
-}
-
-
-/*
  * InitializeShardSplitSMHandleManagement requests the necessary shared memory
  * from Postgres and sets up the shared memory startup hook.
  * This memory is used to store handle of other shared memories allocated during split workflow.

--- a/src/backend/distributed/utils/hash_helpers.c
+++ b/src/backend/distributed/utils/hash_helpers.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "common/hashfn.h"
+#include "distributed/citus_safe_lib.h"
 #include "distributed/hash_helpers.h"
 #include "utils/hsearch.h"
 
@@ -31,6 +33,50 @@ hash_delete_all(HTAB *htab)
 		hash_search(htab, entry, HASH_REMOVE, &found);
 		Assert(found);
 	}
+}
+
+
+/*
+ * CreateSimpleHashWithName creates a hashmap that hashes its key using
+ * tag_hash function and stores the entries in the current memory context.
+ */
+HTAB
+*
+CreateSimpleHashWithName(Size keySize, Size entrySize, char *name)
+{
+	HASHCTL info;
+	memset_struct_0(info);
+	info.keysize = keySize;
+	info.entrysize = entrySize;
+	info.hcxt = CurrentMemoryContext;
+
+	/*
+	 * uint32_hash does the same as tag_hash for keys of 4 bytes, but it's
+	 * faster.
+	 */
+	if (keySize == sizeof(uint32))
+	{
+		info.hash = uint32_hash;
+	}
+	else
+	{
+		info.hash = tag_hash;
+	}
+
+	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+
+	/*
+	 * We use 32 as the initial number of elements that fit into this hash
+	 * table. This value seems a reasonable tradeof between two issues:
+	 * 1. An empty hashmap shouldn't take up a lot of space
+	 * 2. Doing a few inserts shouldn't require growing the hashmap
+	 *
+	 * NOTE: No performance testing has been performed when choosing this
+	 * value. If this ever turns out to be a problem, feel free to do some
+	 * performance tests.
+	 */
+	HTAB *publicationInfoHash = hash_create(name, 32, &info, hashFlags);
+	return publicationInfoHash;
 }
 
 

--- a/src/include/distributed/hash_helpers.h
+++ b/src/include/distributed/hash_helpers.h
@@ -30,4 +30,8 @@ extern void hash_delete_all(HTAB *htab);
 
 extern void foreach_htab_cleanup(void *var, HASH_SEQ_STATUS *status);
 
+extern HTAB * CreateSimpleHashWithName(Size keysize, Size entrysize, char *name);
+
+#define CreateSimpleHash(keyType, entryType) \
+	CreateSimpleHashWithName(sizeof(keyType), sizeof(entryType), # entryType "Hash")
 #endif

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -62,11 +62,19 @@ typedef struct PublicationInfo
  */
 typedef struct LogicalRepTarget
 {
+	/*
+	 * The Oid of the user that owns the shards in newShards. This Oid is the
+	 * Oid of the user on the coordinator, this Oid is likely different than
+	 * the Oid of the user on the logical replication source or target.
+	 */
 	Oid tableOwnerId;
 	char *subscriptionName;
 
 	/*
-	 * The name of the user that's used as the owner of the subscription.
+	 * The name of the user that's used as the owner of the subscription. This
+	 * is not the same as the name of the user that matches tableOwnerId.
+	 * Instead we create a temporary user with the same permissions as that
+	 * user, with its only purpose being owning the subscription.
 	 */
 	char *subscriptionOwnerName;
 	ReplicationSlotInfo *replicationSlot;
@@ -92,9 +100,11 @@ typedef struct LogicalRepTarget
 } LogicalRepTarget;
 
 /*
- * GroupedLogicalRepTargets groups LogicalRepTargets by node, this is useful
+ * GroupedLogicalRepTargets groups LogicalRepTargets by node. This allows to
+ * create a hashmap where we can filter by search by nodeId. Which is useful
  * because these targets can all use the same superuserConection for
- * management.
+ * management, which allows us to batch certain operations such as getting
+ * state of the subscriptions.
  */
 typedef struct GroupedLogicalRepTargets
 {

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -157,8 +157,6 @@ extern void WaitForShardSubscriptionToCatchUp(MultiConnection *targetConnection,
 											  Bitmapset *tableOwnerIds,
 											  char *operationPrefix);
 extern HTAB * InitPublicationInfoHash(void);
-extern uint32 HashNodeAndOwner(const void *key, Size keysize);
-extern int CompareNodeAndOwner(const void *left, const void *right, Size keysize);
 extern HTAB * CreateGroupedLogicalRepTargetsHash(List *subscriptionInfoList);
 extern void CreateGroupedLogicalRepTargetsConnections(HTAB *groupedLogicalRepTargetsHash,
 													  char *user,

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -12,8 +12,10 @@
 #ifndef MULTI_LOGICAL_REPLICATION_H_
 #define MULTI_LOGICAL_REPLICATION_H_
 
+#include "c.h"
 
 #include "nodes/pg_list.h"
+#include "distributed/connection_management.h"
 
 
 /* Config variables managed via guc.c */
@@ -21,49 +23,144 @@ extern int LogicalReplicationTimeout;
 
 extern bool PlacementMovedUsingLogicalReplicationInTX;
 
+/*
+ * NodeAndOwner should be used as a key for structs that should be hashed by a
+ * combination of node and owner.
+ */
+typedef struct NodeAndOwner
+{
+	uint32_t nodeId;
+	Oid tableOwnerId;
+} NodeAndOwner;
+
+
+/*
+ * ReplicationSlotInfo stores the info that defines a replication slot. For
+ * shard splits this information is built by parsing the result of the
+ * 'worker_split_shard_replication_setup' UDF.
+ */
+typedef struct ReplicationSlotInfo
+{
+	uint32 targetNodeId;
+	Oid tableOwnerId;
+	char *name;
+} ReplicationSlotInfo;
+
+/*
+ * PublicationInfo stores the information that defines a publication.
+ */
+typedef struct PublicationInfo
+{
+	NodeAndOwner key;
+	char *name;
+	List *shardIntervals;
+	struct SubscriptionInfo *subscription;
+} PublicationInfo;
+
+/*
+ * Stores information necesary for creating a subscription
+ */
+typedef struct SubscriptionInfo
+{
+	char *name;
+	Oid tableOwnerId;
+
+	/*
+	 * The name of the user that's used as the owner of the subscription.
+	 */
+	char *temporaryOwnerName;
+	ReplicationSlotInfo *replicationSlot;
+	PublicationInfo *publication;
+
+	/*
+	 * The shardIntervals that this subscription is meant to create. For shard
+	 * splits this can be different than the shards that are part of the
+	 * publication, because of the existence of dummy shards.
+	 */
+	List *newShards;
+
+	/*
+	 * The targetConnection is shared between all SubscriptionInfos that have
+	 * the same node. This can be initialized easily by using
+	 * CreateNodeSubscriptionsConnections.
+	 */
+	MultiConnection *targetConnection;
+} SubscriptionInfo;
+
+/*
+ * SubscriptionInfos grouped by node, this is useful because these subscription
+ * infos can all use the same conection for management.
+ */
+typedef struct NodeSubscriptions
+{
+	uint32 nodeId;
+	List *subscriptionInfoList;
+	MultiConnection *targetConnection;
+} NodeSubscriptions;
+
+
+/*
+ * LogicalRepType is used for various functions to do something different for
+ * shard moves than for shard splits. Such as using a different prefix for a
+ * subscription name.
+ */
+typedef enum LogicalRepType
+{
+	SHARD_MOVE,
+	SHARD_SPLIT,
+} LogicalRepType;
 
 extern void LogicallyReplicateShards(List *shardList, char *sourceNodeName,
 									 int sourceNodePort, char *targetNodeName,
 									 int targetNodePort);
 
 extern void ConflictOnlyWithIsolationTesting(void);
-extern void CreateReplicaIdentity(List *shardList, char *nodeName, int32
-								  nodePort);
+extern void CreateReplicaIdentities(List *subscriptionInfoList);
+extern void CreateReplicaIdentitiesOnNode(List *shardList,
+										  char *nodeName,
+										  int32 nodePort);
 extern XLogRecPtr GetRemoteLogPosition(MultiConnection *connection);
 extern List * GetQueryResultStringList(MultiConnection *connection, char *query);
 
-extern void DropShardSubscription(MultiConnection *connection,
-								  char *subscriptionName);
-extern void DropShardPublication(MultiConnection *connection, char *publicationName);
+extern MultiConnection * GetReplicationConnection(char *nodeName, int nodePort);
+extern void CreatePublications(MultiConnection *sourceConnection,
+							   HTAB *publicationInfoHash);
+extern void CreateSubscriptions(MultiConnection *sourceConnection,
+								char *databaseName, List *subscriptionInfoList);
+extern char * CreateReplicationSlots(MultiConnection *sourceConnection,
+									 MultiConnection *sourceReplicationConnection,
+									 List *subscriptionInfoList,
+									 char *outputPlugin);
+extern void EnableSubscriptions(List *subscriptionInfoList);
+extern void DropSubscriptions(List *subscriptionInfoList);
+extern void DropReplicationSlots(MultiConnection *sourceConnection,
+								 List *subscriptionInfoList);
+extern void DropPublications(MultiConnection *sourceConnection,
+							 HTAB *publicationInfoHash);
+extern void DropAllLogicalReplicationLeftovers(LogicalRepType type);
 
-extern void DropShardUser(MultiConnection *connection, char *username);
-extern void DropShardReplicationSlot(MultiConnection *connection,
-									 char *publicationName);
+extern char * PublicationName(LogicalRepType type, uint32_t nodeId, Oid ownerId);
+extern char * ReplicationSlotName(LogicalRepType type, uint32_t nodeId, Oid ownerId);
+extern char * SubscriptionName(LogicalRepType type, Oid ownerId);
+extern char * SubscriptionRoleName(LogicalRepType type, Oid ownerId);
 
-
-extern char * ShardSubscriptionRole(Oid ownerId, char *operationPrefix);
-extern char * ShardSubscriptionName(Oid ownerId, char *operationPrefix);
-extern void CreateShardSplitSubscription(MultiConnection *connection,
-										 char *sourceNodeName,
-										 int sourceNodePort, char *userName,
-										 char *databaseName,
-										 char *publicationName, char *slotName,
-										 Oid ownerId);
-
-extern void WaitForRelationSubscriptionsBecomeReady(MultiConnection *targetConnection,
-													Bitmapset *tableOwnerIds,
-													char *operationPrefix);
+extern void WaitForAllSubscriptionsToBecomeReady(HTAB *nodeSubscriptionsHash);
+extern void WaitForAllSubscriptionsToCatchUp(MultiConnection *sourceConnection,
+											 HTAB *nodeSubscriptionsHash);
 extern void WaitForShardSubscriptionToCatchUp(MultiConnection *targetConnection,
 											  XLogRecPtr sourcePosition,
 											  Bitmapset *tableOwnerIds,
 											  char *operationPrefix);
+extern HTAB * InitPublicationInfoHash(void);
+extern uint32 HashNodeAndOwner(const void *key, Size keysize);
+extern int CompareNodeAndOwner(const void *left, const void *right, Size keysize);
+extern HTAB * CreateNodeSubscriptionsHash(List *subscriptionInfoList);
+extern void CreateNodeSubscriptionsConnections(HTAB *nodeSubscriptionsHash,
+											   char *user,
+											   char *databaseName);
+extern void RecreateNodeSubscriptionsConnections(HTAB *nodeSubscriptionsHash,
+												 char *user,
+												 char *databaseName);
+extern void CloseNodeSubscriptionsConnections(HTAB *nodeSubscriptionsHash);
 
-#define SHARD_MOVE_PUBLICATION_PREFIX "citus_shard_move_publication_"
-#define SHARD_MOVE_SUBSCRIPTION_ROLE_PREFIX "citus_shard_move_subscription_role_"
-#define SHARD_MOVE_SUBSCRIPTION_PREFIX "citus_shard_move_subscription_"
-#define SHARD_SPLIT_PUBLICATION_PREFIX "citus_shard_split_publication_"
-#define SHARD_SPLIT_SUBSCRIPTION_PREFIX "citus_shard_split_subscription_"
-#define SHARD_SPLIT_SUBSCRIPTION_ROLE_PREFIX "citus_shard_split_subscription_role_"
-#define SHARD_SPLIT_TEMPLATE_REPLICATION_SLOT_PREFIX "citus_shard_split_template_slot_"
-#define SHARD_SPLIT_REPLICATION_SLOT_PREFIX "citus_shard_split_"
 #endif /* MULTI_LOGICAL_REPLICATION_H_ */

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -166,7 +166,6 @@ extern void WaitForShardSubscriptionToCatchUp(MultiConnection *targetConnection,
 											  XLogRecPtr sourcePosition,
 											  Bitmapset *tableOwnerIds,
 											  char *operationPrefix);
-extern HTAB * InitPublicationInfoHash(void);
 extern HTAB * CreateGroupedLogicalRepTargetsHash(List *subscriptionInfoList);
 extern void CreateGroupedLogicalRepTargetsConnections(HTAB *groupedLogicalRepTargetsHash,
 													  char *user,

--- a/src/include/distributed/shardsplit_logical_replication.h
+++ b/src/include/distributed/shardsplit_logical_replication.h
@@ -16,7 +16,17 @@
 #include "distributed/multi_logical_replication.h"
 #include "distributed/worker_manager.h"
 
-extern HTAB * SetupHashMapForShardInfo(void);
+/*
+ * GroupedShardSplitInfos groups all ShardSplitInfos belonging to the same node
+ * and table owner together. This data structure its only purpose is creating a
+ * hashmap that allows us to search ShardSplitInfos by node and owner.
+ */
+typedef struct GroupedShardSplitInfos
+{
+	NodeAndOwner key;
+	List *shardSplitInfoList;
+} GroupedShardSplitInfos;
+
 
 /* Functions for subscriber metadata management */
 extern List * PopulateShardSplitSubscriptionsMetadataList(HTAB *shardSplitInfoHashMap,

--- a/src/include/distributed/shardsplit_shared_memory.h
+++ b/src/include/distributed/shardsplit_shared_memory.h
@@ -14,6 +14,8 @@
 #ifndef SHARDSPLIT_SHARED_MEMORY_H
 #define SHARDSPLIT_SHARED_MEMORY_H
 
+#include "postgres.h"
+
 /*
  * In-memory mapping of a split child shard.
  */
@@ -79,6 +81,4 @@ extern ShardSplitInfoSMHeader *  GetShardSplitInfoSMHeader(void);
 
 extern HTAB * PopulateSourceToDestinationShardMapForSlot(char *slotName, MemoryContext
 														 cxt);
-
-extern char * EncodeReplicationSlot(uint32_t nodeId, uint32_t tableOwnerId);
 #endif /* SHARDSPLIT_SHARED_MEMORY_H */

--- a/src/test/regress/expected/failure_online_move_shard_placement.out
+++ b/src/test/regress/expected/failure_online_move_shard_placement.out
@@ -156,6 +156,25 @@ SELECT citus.mitmproxy('conn.onQuery(query="^SELECT min\(latest_end_lsn").cancel
 
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
 ERROR:  canceling statement due to user request
+-- failure on disabling subscription (right before dropping it)
+SELECT citus.mitmproxy('conn.onQuery(query="^ALTER SUBSCRIPTION .* DISABLE").kill()');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
+ERROR:  connection not open
+CONTEXT:  while executing command on localhost:xxxxx
+-- cancellation on disabling subscription (right before dropping it)
+SELECT citus.mitmproxy('conn.onQuery(query="^ALTER SUBSCRIPTION .* DISABLE").cancel(' || :pid || ')');
+ mitmproxy
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
+ERROR:  canceling statement due to user request
 -- failure on dropping subscription
 SELECT citus.mitmproxy('conn.onQuery(query="^DROP SUBSCRIPTION").kill()');
  mitmproxy
@@ -164,15 +183,8 @@ SELECT citus.mitmproxy('conn.onQuery(query="^DROP SUBSCRIPTION").kill()');
 (1 row)
 
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
-WARNING:  connection not open
+ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- cancellation on dropping subscription
 SELECT citus.mitmproxy('conn.onQuery(query="^DROP SUBSCRIPTION").cancel(' || :pid || ')');
  mitmproxy
@@ -209,11 +221,8 @@ SELECT citus.mitmproxy('conn.matches(b"CREATE INDEX").killall()');
 (1 row)
 
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
-WARNING:  connection not open
+ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -241,11 +250,8 @@ SELECT citus.mitmproxy('conn.matches(b"CREATE INDEX").killall()');
 (1 row)
 
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
-WARNING:  connection not open
+ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy
 ---------------------------------------------------------------------
@@ -267,11 +273,8 @@ SELECT citus.mitmproxy('conn.matches(b"CREATE INDEX").killall()');
 (1 row)
 
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
-WARNING:  connection not open
+ERROR:  connection not open
 CONTEXT:  while executing command on localhost:xxxxx
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- Verify that the shard is not moved and the number of rows are still 100k
 SELECT citus.mitmproxy('conn.allow()');
  mitmproxy

--- a/src/test/regress/expected/logical_replication.out
+++ b/src/test/regress/expected/logical_replication.out
@@ -27,8 +27,11 @@ CREATE PUBLICATION citus_shard_move_publication_:postgres_oid FOR TABLE dist_683
 \c - - - :master_port
 SET search_path TO logical_replication;
 \set connection_string '\'user=postgres host=localhost port=' :worker_1_port '\''
-CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid CONNECTION :connection_string PUBLICATION citus_shard_move_publication_:postgres_oid;
-NOTICE:  created replication slot "citus_shard_move_subscription_10" on publisher
+CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid
+    CONNECTION :connection_string
+    PUBLICATION citus_shard_move_publication_:postgres_oid
+    WITH (slot_name=citus_shard_move_slot_:postgres_oid);
+NOTICE:  created replication slot "citus_shard_move_slot_10" on publisher
 SELECT count(*) from pg_subscription;
  count
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/split_shard_replication_colocated_setup.out
+++ b/src/test/regress/expected/split_shard_replication_colocated_setup.out
@@ -78,8 +78,8 @@ WARNING:  Previous split shard worflow was not successfully and could not comple
 
 SELECT relowner AS table_owner_one FROM pg_class WHERE relname='table_first' \gset
 SELECT relowner AS table_owner_two FROM pg_class WHERE relname='table_second' \gset
-SELECT slot_name AS slot_for_first_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_%s', :worker_2_node, :table_owner_one), 'citus') \gset
-SELECT slot_name AS slot_for_second_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_%s', :worker_2_node, :table_owner_two), 'citus') \gset
+SELECT slot_name AS slot_for_first_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_%s', :worker_2_node, :table_owner_one), 'citus') \gset
+SELECT slot_name AS slot_for_second_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_%s', :worker_2_node, :table_owner_two), 'citus') \gset
 -- Create subscription at worker2 with copy_data to 'false'
 \c - postgres - :worker_2_port
 SET search_path TO split_shard_replication_setup_schema;

--- a/src/test/regress/expected/split_shard_replication_setup.out
+++ b/src/test/regress/expected/split_shard_replication_setup.out
@@ -71,7 +71,7 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
      1
 (1 row)
 
-SELECT slot_name FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_2_node), 'citus') \gset
+SELECT slot_name FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_2_node), 'citus') \gset
 -- Create subscription at worker2 with copy_data to 'false' and derived replication slot name
 \c - - - :worker_2_port
 SET search_path TO split_shard_replication_setup_schema;

--- a/src/test/regress/expected/split_shard_replication_setup_local.out
+++ b/src/test/regress/expected/split_shard_replication_setup_local.out
@@ -19,7 +19,7 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
      1
 (1 row)
 
-SELECT slot_name AS local_slot FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_1_node), 'citus') \gset
+SELECT slot_name AS local_slot FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_1_node), 'citus') \gset
 -- Create subscription at worker1 with copy_data to 'false' a
 BEGIN;
 CREATE SUBSCRIPTION local_subscription

--- a/src/test/regress/expected/split_shard_replication_setup_remote_local.out
+++ b/src/test/regress/expected/split_shard_replication_setup_remote_local.out
@@ -18,8 +18,8 @@ WARNING:  Previous split shard worflow was not successfully and could not comple
      2
 (1 row)
 
-SELECT slot_name AS slot_for_worker1 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_1_node), 'citus') \gset
-SELECT slot_name AS slot_for_worker2 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_2_node), 'citus') \gset
+SELECT slot_name AS slot_for_worker1 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_1_node), 'citus') \gset
+SELECT slot_name AS slot_for_worker2 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_2_node), 'citus') \gset
 -- Create subscription at worker1 with copy_data to 'false' and 'slot_for_worker1'
 CREATE SUBSCRIPTION sub_worker1
         CONNECTION 'host=localhost port=xxxxx user=postgres dbname=regression'

--- a/src/test/regress/sql/failure_online_move_shard_placement.sql
+++ b/src/test/regress/sql/failure_online_move_shard_placement.sql
@@ -79,6 +79,14 @@ SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost'
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT min\(latest_end_lsn").cancel(' || :pid || ')');
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
 
+-- failure on disabling subscription (right before dropping it)
+SELECT citus.mitmproxy('conn.onQuery(query="^ALTER SUBSCRIPTION .* DISABLE").kill()');
+SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
+
+-- cancellation on disabling subscription (right before dropping it)
+SELECT citus.mitmproxy('conn.onQuery(query="^ALTER SUBSCRIPTION .* DISABLE").cancel(' || :pid || ')');
+SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
+
 -- failure on dropping subscription
 SELECT citus.mitmproxy('conn.onQuery(query="^DROP SUBSCRIPTION").kill()');
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);

--- a/src/test/regress/sql/logical_replication.sql
+++ b/src/test/regress/sql/logical_replication.sql
@@ -24,7 +24,10 @@ CREATE PUBLICATION citus_shard_move_publication_:postgres_oid FOR TABLE dist_683
 \c - - - :master_port
 SET search_path TO logical_replication;
 \set connection_string '\'user=postgres host=localhost port=' :worker_1_port '\''
-CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid CONNECTION :connection_string PUBLICATION citus_shard_move_publication_:postgres_oid;
+CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid
+    CONNECTION :connection_string
+    PUBLICATION citus_shard_move_publication_:postgres_oid
+    WITH (slot_name=citus_shard_move_slot_:postgres_oid);
 
 SELECT count(*) from pg_subscription;
 SELECT count(*) from pg_publication;

--- a/src/test/regress/sql/split_shard_replication_colocated_setup.sql
+++ b/src/test/regress/sql/split_shard_replication_colocated_setup.sql
@@ -76,9 +76,9 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
 SELECT relowner AS table_owner_one FROM pg_class WHERE relname='table_first' \gset
 SELECT relowner AS table_owner_two FROM pg_class WHERE relname='table_second' \gset
 
-SELECT slot_name AS slot_for_first_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_%s', :worker_2_node, :table_owner_one), 'citus') \gset
+SELECT slot_name AS slot_for_first_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_%s', :worker_2_node, :table_owner_one), 'citus') \gset
 
-SELECT slot_name AS slot_for_second_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_%s', :worker_2_node, :table_owner_two), 'citus') \gset
+SELECT slot_name AS slot_for_second_owner FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_%s', :worker_2_node, :table_owner_two), 'citus') \gset
 
 -- Create subscription at worker2 with copy_data to 'false'
 \c - postgres - :worker_2_port

--- a/src/test/regress/sql/split_shard_replication_setup.sql
+++ b/src/test/regress/sql/split_shard_replication_setup.sql
@@ -71,7 +71,7 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
     ROW(1, 'id', 3, '0', '2147483647', :worker_2_node)::pg_catalog.split_shard_info
     ]);
 
-SELECT slot_name FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_2_node), 'citus') \gset
+SELECT slot_name FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_2_node), 'citus') \gset
 
 -- Create subscription at worker2 with copy_data to 'false' and derived replication slot name
 \c - - - :worker_2_port

--- a/src/test/regress/sql/split_shard_replication_setup_local.sql
+++ b/src/test/regress/sql/split_shard_replication_setup_local.sql
@@ -18,7 +18,7 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
     ROW(1, 'id', 3, '0', '2147483647', :worker_1_node)::pg_catalog.split_shard_info
     ]);
 
-SELECT slot_name AS local_slot FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_1_node), 'citus') \gset
+SELECT slot_name AS local_slot FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_1_node), 'citus') \gset
 
 -- Create subscription at worker1 with copy_data to 'false' a
 BEGIN;

--- a/src/test/regress/sql/split_shard_replication_setup_remote_local.sql
+++ b/src/test/regress/sql/split_shard_replication_setup_remote_local.sql
@@ -16,8 +16,8 @@ SELECT count(*) FROM pg_catalog.worker_split_shard_replication_setup(ARRAY[
     ROW(1, 'id', 3, '0', '2147483647', :worker_2_node)::pg_catalog.split_shard_info
     ]);
 
-SELECT slot_name AS slot_for_worker1 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_1_node), 'citus') \gset
-SELECT slot_name AS slot_for_worker2 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_%s_10', :worker_2_node), 'citus') \gset
+SELECT slot_name AS slot_for_worker1 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_1_node), 'citus') \gset
+SELECT slot_name AS slot_for_worker2 FROM pg_create_logical_replication_slot(FORMAT('citus_shard_split_slot_%s_10', :worker_2_node), 'citus') \gset
 
 -- Create subscription at worker1 with copy_data to 'false' and 'slot_for_worker1'
 CREATE SUBSCRIPTION sub_worker1


### PR DESCRIPTION
When introducing non-blocking shard split functionality it was based
heavily on the non-blocking shard moves. However, differences between
usage was slightly to big to be able to reuse the existing functions
easily. So, most logical replication code was simply copied to dedicated
shard split functions and modified for that purpose.

This PR tries to create a more generic logical replication
infrastructure that can be used by both shard splits and shard moves.
There's probably more code sharing possible in the future, but I believe
this is at least a good start and addresses the lowest hanging fruit.
