### PR TITLE
Remove the GUC mention in the error message as this config is meant for advanced users

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1352,11 +1352,9 @@ EnsureRelationHasNoTriggers(Oid relationId)
 		char *relationName = get_rel_name(relationId);
 
 		Assert(relationName != NULL);
-		ereport(ERROR, (errmsg("cannot distribute relation \"%s\" because it has "
-							   "triggers and \"citus.enable_unsafe_triggers\" is "
-							   "set to \"false\"", relationName),
-						errhint("Consider setting \"citus.enable_unsafe_triggers\" "
-								"to \"true\", or drop all the triggers on \"%s\" "
+		ereport(ERROR, (errmsg("cannot distribute relation \"%s\" because it "
+							   "has triggers", relationName),
+						errhint("Consider dropping all the triggers on \"%s\" "
 								"and retry.", relationName)));
 	}
 }

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1171,7 +1171,7 @@ RegisterCitusConfigVariables(void)
 		&EnableUnsafeTriggers,
 		false,
 		PGC_USERSET,
-		GUC_STANDARD,
+		GUC_STANDARD | GUC_NO_SHOW_ALL,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(

--- a/src/test/regress/expected/citus_table_triggers.out
+++ b/src/test/regress/expected/citus_table_triggers.out
@@ -106,9 +106,9 @@ AFTER INSERT ON reference_table_1
 FOR EACH ROW EXECUTE FUNCTION update_value();
 -- below two should fail
 SELECT create_distributed_table('distributed_table_1', 'value');
-ERROR:  cannot distribute relation "distributed_table_1" because it has triggers and "citus.enable_unsafe_triggers" is set to "false"
+ERROR:  cannot distribute relation "distributed_table_1" because it has triggers
 SELECT create_reference_table('reference_table_1');
-ERROR:  cannot distribute relation "reference_table_1" because it has triggers and "citus.enable_unsafe_triggers" is set to "false"
+ERROR:  cannot distribute relation "reference_table_1" because it has triggers
 ---------------------------------------------------------------------
 -- test deparse logic for CREATE TRIGGER commands
 -- via master_get_table_ddl_events

--- a/src/test/regress/expected/create_ref_dist_from_citus_local.out
+++ b/src/test/regress/expected/create_ref_dist_from_citus_local.out
@@ -346,7 +346,7 @@ BEGIN;
   FOR EACH ROW EXECUTE PROCEDURE update_value();
   -- show that we error out as we don't supprt triggers on distributed tables
   SELECT create_distributed_table('citus_local_table_6', 'col_1');
-ERROR:  cannot distribute relation "citus_local_table_6" because it has triggers and "citus.enable_unsafe_triggers" is set to "false"
+ERROR:  cannot distribute relation "citus_local_table_6" because it has triggers
 ROLLBACK;
 -- make sure that creating append / range distributed tables is also ok
 BEGIN;


### PR DESCRIPTION

DESCRIPTION: Remove the GUC, citus.enable_unsafe_triggers,  mention in the error message as this config is meant for advanced users.
