### PR TITLE
Updated columnar_chunk_filter test for PG15

### DIFF
--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -972,6 +972,7 @@ DETAIL:  unparameterized; 1 clauses pushed down
  203491455
 (1 row)
 
+SET hash_mem_multiplier = 1.0;
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where
 (
@@ -1006,6 +1007,7 @@ DETAIL:  unparameterized; 1 clauses pushed down
                        Columnar Projected Columns: a
 (11 rows)
 
+RESET hash_mem_multiplier;
 SELECT sum(a) FROM pushdown_test where
 (
   a > random()

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -410,6 +410,7 @@ EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where (a > random() and a <= 2000) or (a > 200000-1010);
 SELECT sum(a) FROM pushdown_test where (a > random() and a <= 2000) or (a > 200000-1010);
 
+SET hash_mem_multiplier = 1.0;
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where
 (
@@ -422,6 +423,7 @@ SELECT sum(a) FROM pushdown_test where
 )
 or
 (a > 200000-2010);
+RESET hash_mem_multiplier;
 SELECT sum(a) FROM pushdown_test where
 (
   a > random()


### PR DESCRIPTION
hash_mem_multiplier is set to 1.0 by default in PG13 and PG14 but was changed in PG15 to be 2.0 instead. This caused the planner to use a hashed subplan in PG15. Setting it to 1.0 makes the planner choose a regular subplan and thus makes the test version agnostic again. 