### PR TITLE
Fix HTAB memory leaks

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1281,7 +1281,8 @@ ErrorIfUnsupportedCascadeObjects(Oid relationId)
 	info.keysize = sizeof(Oid);
 	info.entrysize = sizeof(Oid);
 	info.hash = oid_hash;
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION);
+	info.hcxt = CurrentMemoryContext;
+	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 	HTAB *nodeMap = hash_create("object dependency map (oid)", 64, &info, hashFlags);
 
 	bool unsupportedObjectInDepGraph =

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -2099,7 +2099,8 @@ GetDependingViews(Oid relationId)
 	info.keysize = sizeof(Oid);
 	info.entrysize = sizeof(ViewDependencyNode);
 	info.hash = oid_hash;
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION);
+	info.hcxt = CurrentMemoryContext;
+	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 	HTAB *nodeMap = hash_create("view dependency map (oid)", 32, &info, hashFlags);
 
 	ViewDependencyNode *tableNode = BuildViewDependencyGraph(relationId, nodeMap);

--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -2634,7 +2634,8 @@ ShardPlacementsListToHash(List *shardPlacementList)
 	info.entrysize = sizeof(ShardPlacement);
 	info.hash = PlacementsHashHashCode;
 	info.match = PlacementsHashCompare;
-	int hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_COMPARE);
+	info.hcxt = CurrentMemoryContext;
+	int hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_COMPARE | HASH_CONTEXT);
 
 	HTAB *shardPlacementsHash = hash_create("ActivePlacements Hash",
 											shardPlacementCount, &info, hashFlags);


### PR DESCRIPTION
DESCRIPTION: Fix several small memory leaks

Found several places where we create a hash table without supplying a memory context by running `grep -r HASH_ELEM . | grep -v HASH_CONTEXT`. 

In these cases, postgres falls back to using `TopMemoryContext`, meaning these hash tables allocate in a session-level memory context.
https://github.com/postgres/postgres/blob/master/src/backend/utils/hash/dynahash.c#L383

This PR addresses the cases found by the grep command, except those that create a hash table in shared memory.