### PR TITLE
Fix reference table lock contention

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -527,7 +527,7 @@ CreateDistributedTable(Oid relationId, char *distributionColumnName,
 		 * This function does not expect to create Citus local table, so we blindly
 		 * create reference table when the method is DISTRIBUTE_BY_NONE.
 		 */
-		CreateReferenceTableShard(relationId, colocatedTableId);
+		CreateReferenceTableShard(relationId);
 	}
 
 	if (ShouldSyncTableMetadata(relationId))

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -158,7 +158,10 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 		 * prevent concurrent mutations to the placements of the shard groups.
 		 */
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
-		LockColocationId(cacheEntry->colocationId, ShareLock);
+		if (cacheEntry->colocationId != INVALID_COLOCATION_ID)
+		{
+			LockColocationId(cacheEntry->colocationId, ShareLock);
+		}
 
 		/* invalidate foreign key cache if the table involved in any foreign key */
 		if ((TableReferenced(relationId) || TableReferencing(relationId)))

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -153,12 +153,12 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 			continue;
 		}
 
-		if (IsCitusTableType(relationId, REFERENCE_TABLE))
-		{
-			/* prevent concurrent EnsureReferenceTablesExistOnAllNodes */
-			int colocationId = CreateReferenceTableColocationId();
-			LockColocationId(colocationId, ExclusiveLock);
-		}
+		/*
+		 * While changing the tables that are part of a colocation group we need to
+		 * prevent concurrent mutations to the placements of the shard groups.
+		 */
+		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
+		LockColocationId(cacheEntry->colocationId, ShareLock);
 
 		/* invalidate foreign key cache if the table involved in any foreign key */
 		if ((TableReferenced(relationId) || TableReferencing(relationId)))

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -326,7 +326,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
  * Also, the shard is replicated to the all active nodes in the cluster.
  */
 void
-CreateReferenceTableShard(Oid distributedTableId, Oid colocatedTableId)
+CreateReferenceTableShard(Oid distributedTableId)
 {
 	int workerStartIndex = 0;
 	text *shardMinValue = NULL;

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -326,7 +326,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
  * Also, the shard is replicated to the all active nodes in the cluster.
  */
 void
-CreateReferenceTableShard(Oid distributedTableId)
+CreateReferenceTableShard(Oid distributedTableId, Oid colocatedTableId)
 {
 	int workerStartIndex = 0;
 	text *shardMinValue = NULL;
@@ -365,7 +365,7 @@ CreateReferenceTableShard(Oid distributedTableId)
 	List *nodeList = ReferenceTablePlacementNodeList(ShareLock);
 	nodeList = SortList(nodeList, CompareWorkerNodes);
 
-	int replicationFactor = ReferenceTableReplicationFactor();
+	int replicationFactor = list_length(nodeList);
 
 	/* get the next shard id */
 	uint64 shardId = GetNextShardId();

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -99,13 +99,7 @@ EnsureReferenceTablesExistOnAllNodesExtended(char transferMode)
 	uint64 shardId = INVALID_SHARD_ID;
 	List *newWorkersList = NIL;
 	const char *referenceTableName = NULL;
-	int colocationId = GetReferenceTableColocationId();
-
-	if (colocationId == INVALID_COLOCATION_ID)
-	{
-		/* no colocation for reference tables available */
-		return;
-	}
+	int colocationId = CreateReferenceTableColocationId();
 
 	/*
 	 * Most of the time this function should result in a conclusion where we do not need

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -249,7 +249,7 @@ extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shard
 											 bool useExclusiveConnections);
 extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId,
 								  bool useExclusiveConnections);
-extern void CreateReferenceTableShard(Oid distributedTableId);
+extern void CreateReferenceTableShard(Oid distributedTableId, Oid colocatedTableId);
 extern List * WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
 										   List *ddlCommandList,
 										   List *foreignConstraintCommandList);

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -249,7 +249,7 @@ extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shard
 											 bool useExclusiveConnections);
 extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId,
 								  bool useExclusiveConnections);
-extern void CreateReferenceTableShard(Oid distributedTableId, Oid colocatedTableId);
+extern void CreateReferenceTableShard(Oid distributedTableId);
 extern List * WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
 										   List *ddlCommandList,
 										   List *foreignConstraintCommandList);

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -21,10 +21,10 @@
 extern void EnsureReferenceTablesExistOnAllNodes(void);
 extern void EnsureReferenceTablesExistOnAllNodesExtended(char transferMode);
 extern uint32 CreateReferenceTableColocationId(void);
+extern uint32 GetReferenceTableColocationId(void);
 extern void DeleteAllReplicatedTablePlacementsFromNodeGroup(int32 groupId,
 															bool localOnly);
 extern int CompareOids(const void *leftElement, const void *rightElement);
-extern int ReferenceTableReplicationFactor(void);
 extern void ReplicateAllReferenceTablesToNode(WorkerNode *workerNode);
 
 #endif /* REFERENCE_TABLE_UTILS_H_ */

--- a/src/test/regress/expected/isolation_reference_table.out
+++ b/src/test/regress/expected/isolation_reference_table.out
@@ -103,3 +103,37 @@ step s1-drop:
 step s2-commit:
     COMMIT;
 
+
+starting permutation: s2-create s2-begin s2-drop s1-create s2-commit
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-create:
+    CREATE TABLE reference_table_s2(a int);
+ 	SELECT create_reference_table('reference_table_s2');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-begin:
+    BEGIN;
+
+step s2-drop:
+    DROP TABLE reference_table_s2;
+
+step s1-create:
+    CREATE TABLE reference_table_s1(a int);
+ 	SELECT create_reference_table('reference_table_s1');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-commit:
+    COMMIT;
+

--- a/src/test/regress/expected/isolation_reference_table.out
+++ b/src/test/regress/expected/isolation_reference_table.out
@@ -1,0 +1,105 @@
+unused step name: s1-abort
+unused step name: s2-abort
+Parsed test spec with 2 sessions
+
+starting permutation: s1-begin s1-create s2-create s1-commit
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s1-create:
+    CREATE TABLE reference_table_s1(a int);
+ 	SELECT create_reference_table('reference_table_s1');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-create:
+    CREATE TABLE reference_table_s2(a int);
+ 	SELECT create_reference_table('reference_table_s2');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+    COMMIT;
+
+
+starting permutation: s1-create s2-create s1-begin s1-drop s2-drop s1-commit
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-create:
+    CREATE TABLE reference_table_s1(a int);
+ 	SELECT create_reference_table('reference_table_s1');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-create:
+    CREATE TABLE reference_table_s2(a int);
+ 	SELECT create_reference_table('reference_table_s2');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+    BEGIN;
+
+step s1-drop:
+    DROP TABLE reference_table_s1;
+
+step s2-drop:
+    DROP TABLE reference_table_s2;
+
+step s1-commit:
+    COMMIT;
+
+
+starting permutation: s1-create s2-begin s2-create s1-drop s2-commit
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-create:
+    CREATE TABLE reference_table_s1(a int);
+ 	SELECT create_reference_table('reference_table_s1');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-begin:
+    BEGIN;
+
+step s2-create:
+    CREATE TABLE reference_table_s2(a int);
+ 	SELECT create_reference_table('reference_table_s2');
+
+create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-drop:
+    DROP TABLE reference_table_s1;
+
+step s2-commit:
+    COMMIT;
+

--- a/src/test/regress/expected/isolation_reference_table.out
+++ b/src/test/regress/expected/isolation_reference_table.out
@@ -1,5 +1,3 @@
-unused step name: s1-abort
-unused step name: s2-abort
 Parsed test spec with 2 sessions
 
 starting permutation: s1-begin s1-create s2-create s1-commit

--- a/src/test/regress/isolation_schedule
+++ b/src/test/regress/isolation_schedule
@@ -69,6 +69,7 @@ test: isolation_undistribute_table
 test: isolation_fix_partition_shard_index_names
 test: isolation_global_pid
 test: isolation_citus_locks
+test: isolation_reference_table
 
 # Rebalancer
 test: isolation_blocking_move_single_shard_commands

--- a/src/test/regress/spec/isolation_reference_table.spec
+++ b/src/test/regress/spec/isolation_reference_table.spec
@@ -78,3 +78,4 @@ permutation "s1-create" "s2-create" "s1-begin" "s1-drop" "s2-drop" "s1-commit"
 
 // create and drop don't block each other
 permutation "s1-create" "s2-begin" "s2-create" "s1-drop" "s2-commit"
+permutation "s2-create" "s2-begin" "s2-drop" "s1-create" "s2-commit"

--- a/src/test/regress/spec/isolation_reference_table.spec
+++ b/src/test/regress/spec/isolation_reference_table.spec
@@ -32,11 +32,6 @@ step "s1-drop"
     DROP TABLE reference_table_s1;
 }
 
-step "s1-abort"
-{
-    ABORT;
-}
-
 step "s1-commit"
 {
     COMMIT;
@@ -58,11 +53,6 @@ step "s2-create"
 step "s2-drop"
 {
     DROP TABLE reference_table_s2;
-}
-
-step "s2-abort"
-{
-    ABORT;
 }
 
 step "s2-commit"

--- a/src/test/regress/spec/isolation_reference_table.spec
+++ b/src/test/regress/spec/isolation_reference_table.spec
@@ -1,0 +1,80 @@
+// reference tables _do_ lock on the first reference table in the shardgroup due to the lack of shardgroups in the
+// system. When we run the tests we want to make sure the tables we are testing against cannot be the first reference
+// table. For this purpose we create a reference table that we will _not_ interact with during the tests.
+setup
+{
+ 	CREATE TABLE first_reference_table(a int);
+ 	SELECT create_reference_table('first_reference_table');
+}
+
+teardown
+{
+    DROP TABLE first_reference_table;
+    DROP TABLE IF EXISTS reference_table_s1;
+    DROP TABLE IF EXISTS reference_table_s2;
+}
+
+session "s1"
+
+step "s1-begin"
+{
+    BEGIN;
+}
+
+step "s1-create"
+{
+    CREATE TABLE reference_table_s1(a int);
+ 	SELECT create_reference_table('reference_table_s1');
+}
+
+step "s1-drop"
+{
+    DROP TABLE reference_table_s1;
+}
+
+step "s1-abort"
+{
+    ABORT;
+}
+
+step "s1-commit"
+{
+    COMMIT;
+}
+
+session "s2"
+
+step "s2-begin"
+{
+    BEGIN;
+}
+
+step "s2-create"
+{
+    CREATE TABLE reference_table_s2(a int);
+ 	SELECT create_reference_table('reference_table_s2');
+}
+
+step "s2-drop"
+{
+    DROP TABLE reference_table_s2;
+}
+
+step "s2-abort"
+{
+    ABORT;
+}
+
+step "s2-commit"
+{
+    COMMIT;
+}
+
+// creates don't block each other
+permutation "s1-begin" "s1-create" "s2-create" "s1-commit"
+
+// drops don't block each other
+permutation "s1-create" "s2-create" "s1-begin" "s1-drop" "s2-drop" "s1-commit"
+
+// create and drop don't block each other
+permutation "s1-create" "s2-begin" "s2-create" "s1-drop" "s2-commit"


### PR DESCRIPTION
DESCRIPTION: Fix reference table lock contention

Dropping and creating reference tables unintentionally blocked on each other due to the use of an ExclusiveLock for both the Drop and conditionally copying existing reference tables to (new) nodes.

The patch does the following:
 - Lower lock lever for dropping (reference) tables to `ShareLock` so they don't self conflict
 - Treat reference tables and distributed tables equally and acquire the colocation lock when dropping any table that is in a colocation group
 - Perform the precondition check for copying reference tables twice, first time with a lower lock that doesn't conflict with anything. Could have been a NoLock, however, in preparation for dropping a colocation group, it is an `AccessShareLock`

During normal operation the first check will always pass and we don't have to escalate that lock. Making it that we won't be blocked on adding and remove reference tables. Only after a node addition the first `create_reference_table` will still need to acquire an `ExclusiveLock` on the colocation group to perform the copy.
