### PR TITLE
Do not propagate GRANT ON SCHEMA from CREATE EXTENSION

### DIFF
--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -151,6 +151,11 @@ List *
 PreprocessGrantOnSchemaStmt(Node *node, const char *queryString,
 							ProcessUtilityContext processUtilityContext)
 {
+	if (!ShouldPropagate())
+	{
+		return NIL;
+	}
+
 	GrantStmt *stmt = castNode(GrantStmt, node);
 	Assert(stmt->objtype == OBJECT_SCHEMA);
 


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that caused GRANT to propagate within CREATE EXTENSION