### PR TITLE
Use CreateSimpleHash (and variants) whenever possible

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -43,6 +43,7 @@
 #include "distributed/coordinator_protocol.h"
 #include "distributed/deparser.h"
 #include "distributed/distribution_column.h"
+#include "distributed/hash_helpers.h"
 #include "distributed/listutils.h"
 #include "distributed/local_executor.h"
 #include "distributed/metadata/dependency.h"
@@ -1276,14 +1277,7 @@ CreateCitusTableLike(TableConversionState *con)
 static void
 ErrorIfUnsupportedCascadeObjects(Oid relationId)
 {
-	HASHCTL info;
-	memset(&info, 0, sizeof(info));
-	info.keysize = sizeof(Oid);
-	info.entrysize = sizeof(Oid);
-	info.hash = oid_hash;
-	info.hcxt = CurrentMemoryContext;
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
-	HTAB *nodeMap = hash_create("object dependency map (oid)", 64, &info, hashFlags);
+	HTAB *nodeMap = CreateSimpleHashSetWithName(Oid, "object dependency map (oid)");
 
 	bool unsupportedObjectInDepGraph =
 		DoesCascadeDropUnsupportedObject(RelationRelationId, relationId, nodeMap);

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -33,6 +33,7 @@
 #include "distributed/deparse_shard_query.h"
 #include "distributed/distributed_planner.h"
 #include "distributed/foreign_key_relationship.h"
+#include "distributed/hash_helpers.h"
 #include "distributed/listutils.h"
 #include "distributed/lock_graph.h"
 #include "distributed/multi_client_executor.h"
@@ -768,7 +769,8 @@ ReceiveAndUpdateShardsSizes(List *connectionList)
 	 * all the placements. We use a hash table to remember already visited shard ids
 	 * since we update all the different placements of a shard id at once.
 	 */
-	HTAB *alreadyVisitedShardPlacements = CreateOidVisitedHashSet();
+	HTAB *alreadyVisitedShardPlacements = CreateSimpleHashSetWithName(Oid,
+																	  "oid visited hash set");
 
 	MultiConnection *connection = NULL;
 	foreach_ptr(connection, connectionList)

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -20,6 +20,7 @@
 #include "access/table.h"
 #include "catalog/pg_constraint.h"
 #include "distributed/commands.h"
+#include "distributed/hash_helpers.h"
 #include "distributed/foreign_key_relationship.h"
 #include "distributed/hash_helpers.h"
 #include "distributed/listutils.h"
@@ -176,7 +177,7 @@ static List *
 GetRelationshipNodesForFKeyConnectedRelations(
 	ForeignConstraintRelationshipNode *relationshipNode)
 {
-	HTAB *oidVisitedMap = CreateOidVisitedHashSet();
+	HTAB *oidVisitedMap = CreateSimpleHashSetWithName(Oid, "oid visited hash set");
 
 	VisitOid(oidVisitedMap, relationshipNode->relationId);
 	List *relationshipNodeList = list_make1(relationshipNode);
@@ -314,8 +315,6 @@ GetRelationshipNodeForRelationId(Oid relationId, bool *isFound)
 static void
 CreateForeignConstraintRelationshipGraph()
 {
-	HASHCTL info;
-
 	/* if we have already created the graph, use it */
 	if (IsForeignConstraintRelationshipGraphValid())
 	{
@@ -338,17 +337,8 @@ CreateForeignConstraintRelationshipGraph()
 		sizeof(ForeignConstraintRelationshipGraph));
 	fConstraintRelationshipGraph->isValid = false;
 
-	/* create (oid) -> [ForeignConstraintRelationshipNode] hash */
-	memset(&info, 0, sizeof(info));
-	info.keysize = sizeof(Oid);
-	info.entrysize = sizeof(ForeignConstraintRelationshipNode);
-	info.hash = oid_hash;
-	info.hcxt = CurrentMemoryContext;
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
-
-	fConstraintRelationshipGraph->nodeMap = hash_create(
-		"foreign key relationship map (oid)",
-		32, &info, hashFlags);
+	fConstraintRelationshipGraph->nodeMap = CreateSimpleHash(Oid,
+															 ForeignConstraintRelationshipNode);
 
 	PopulateAdjacencyLists();
 
@@ -400,7 +390,7 @@ SetForeignConstraintRelationshipGraphInvalid()
 static List *
 GetConnectedListHelper(ForeignConstraintRelationshipNode *node, bool isReferencing)
 {
-	HTAB *oidVisitedMap = CreateOidVisitedHashSet();
+	HTAB *oidVisitedMap = CreateSimpleHashSetWithName(Oid, "oid visited hash set");
 
 	List *connectedNodeList = NIL;
 
@@ -441,31 +431,6 @@ GetConnectedListHelper(ForeignConstraintRelationshipNode *node, bool isReferenci
 	/* finally remove yourself from list */
 	connectedNodeList = list_delete_first(connectedNodeList);
 	return connectedNodeList;
-}
-
-
-/*
- * CreateOidVisitedHashSet creates and returns an hash-set object in
- * CurrentMemoryContext to store visited oid's.
- * As hash_create allocates memory in heap, callers are responsible to call
- * hash_destroy when appropriate.
- */
-HTAB *
-CreateOidVisitedHashSet(void)
-{
-	HASHCTL info = { 0 };
-
-	info.keysize = sizeof(Oid);
-	info.hash = oid_hash;
-	info.hcxt = CurrentMemoryContext;
-
-	/* we don't have value field as it's a set */
-	info.entrysize = info.keysize;
-
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
-
-	HTAB *oidVisitedMap = hash_create("oid visited hash map", 32, &info, hashFlags);
-	return oidVisitedMap;
 }
 
 

--- a/src/backend/distributed/utils/hash_helpers.c
+++ b/src/backend/distributed/utils/hash_helpers.c
@@ -37,12 +37,12 @@ hash_delete_all(HTAB *htab)
 
 
 /*
- * CreateSimpleHashWithName creates a hashmap that hashes its key using
+ * CreateSimpleHashWithNameAndSize creates a hashmap that hashes its key using
  * tag_hash function and stores the entries in the current memory context.
  */
-HTAB
-*
-CreateSimpleHashWithName(Size keySize, Size entrySize, char *name)
+HTAB *
+CreateSimpleHashWithNameAndSizeInternal(Size keySize, Size entrySize,
+										char *name, long nelem)
 {
 	HASHCTL info;
 	memset_struct_0(info);
@@ -50,32 +50,9 @@ CreateSimpleHashWithName(Size keySize, Size entrySize, char *name)
 	info.entrysize = entrySize;
 	info.hcxt = CurrentMemoryContext;
 
-	/*
-	 * uint32_hash does the same as tag_hash for keys of 4 bytes, but it's
-	 * faster.
-	 */
-	if (keySize == sizeof(uint32))
-	{
-		info.hash = uint32_hash;
-	}
-	else
-	{
-		info.hash = tag_hash;
-	}
-
 	int hashFlags = (HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 
-	/*
-	 * We use 32 as the initial number of elements that fit into this hash
-	 * table. This value seems a reasonable tradeof between two issues:
-	 * 1. An empty hashmap shouldn't take up a lot of space
-	 * 2. Doing a few inserts shouldn't require growing the hashmap
-	 *
-	 * NOTE: No performance testing has been performed when choosing this
-	 * value. If this ever turns out to be a problem, feel free to do some
-	 * performance tests.
-	 */
-	HTAB *publicationInfoHash = hash_create(name, 32, &info, hashFlags);
+	HTAB *publicationInfoHash = hash_create(name, nelem, &info, hashFlags);
 	return publicationInfoHash;
 }
 

--- a/src/include/distributed/foreign_key_relationship.h
+++ b/src/include/distributed/foreign_key_relationship.h
@@ -21,7 +21,6 @@ extern List * ReferencedRelationIdList(Oid relationId);
 extern List * ReferencingRelationIdList(Oid relationId);
 extern void SetForeignConstraintRelationshipGraphInvalid(void);
 extern void ClearForeignConstraintRelationshipGraphContext(void);
-extern HTAB * CreateOidVisitedHashSet(void);
 extern bool OidVisited(HTAB *oidVisitedMap, Oid oid);
 extern void VisitOid(HTAB *oidVisitedMap, Oid oid);
 

--- a/src/include/distributed/hash_helpers.h
+++ b/src/include/distributed/hash_helpers.h
@@ -15,6 +15,27 @@
 
 #include "utils/hsearch.h"
 
+/*
+ * assert_valid_hash_key2 checks if a type that contains 2 fields contains no
+ * padding bytes. This is necessary to use a type as a hash key with tag_hash.
+ */
+#define assert_valid_hash_key2(type, field1, field2) \
+	StaticAssertDecl( \
+		sizeof(type) == sizeof(((type) { 0 }).field1) \
+		+ sizeof(((type) { 0 }).field2), \
+		# type " has padding bytes, but is used as a hash key in a simple hash");
+
+/*
+ * assert_valid_hash_key3 checks if a type that contains 3 fields contains no
+ * padding bytes. This is necessary to use a type as a hash key with tag_hash.
+ */
+#define assert_valid_hash_key3(type, field1, field2, field3) \
+	StaticAssertDecl( \
+		sizeof(type) == sizeof(((type) { 0 }).field1) \
+		+ sizeof(((type) { 0 }).field2) \
+		+ sizeof(((type) { 0 }).field3), \
+		# type " has padding bytes, but is used as a hash key in a simple hash");
+
 extern void hash_delete_all(HTAB *htab);
 
 /*
@@ -30,8 +51,82 @@ extern void hash_delete_all(HTAB *htab);
 
 extern void foreach_htab_cleanup(void *var, HASH_SEQ_STATUS *status);
 
-extern HTAB * CreateSimpleHashWithName(Size keysize, Size entrysize, char *name);
+extern HTAB * CreateSimpleHashWithNameAndSizeInternal(Size keysize, Size entrysize,
+													  char *name, long nelem);
 
+/*
+ * CreatesSimpleHash creates a hash table that hash its key using the tag_hash
+ * and stores then entries in the CurrentMemoryContext.
+ *
+ * We use 32 as the initial number of elements that fit into this hash
+ * table. This value seems a reasonable tradeof between two issues:
+ * 1. An empty hashmap shouldn't take up a lot of space
+ * 2. Doing a few inserts shouldn't require growing the hashmap
+ *
+ * NOTE: No performance testing has been performed when choosing this
+ * value. If this ever turns out to be a problem, feel free to do some
+ * performance tests.
+ *
+ * IMPORTANT: Because this uses tag_hash it's required that the keyType
+ * contains no automatic padding bytes, because that will result in tag_hash
+ * returning undefined values. You can check this using assert_valid_hash_keyX.
+ */
 #define CreateSimpleHash(keyType, entryType) \
-	CreateSimpleHashWithName(sizeof(keyType), sizeof(entryType), # entryType "Hash")
+	CreateSimpleHashWithNameAndSize(keyType, entryType, \
+									# entryType "Hash", 32)
+
+/*
+ * Same as CreateSimpleHash but allows specifying the name
+ */
+#define CreateSimpleHashWithName(keyType, entryType, name) \
+	CreateSimpleHashWithNameAndSize(keyType, entryType, \
+									name, 32)
+
+/*
+ * CreateSimpleHashWithSize is the same as CreateSimpleHash, but allows
+ * configuring of the amount of elements that initially fit in the hash table.
+ */
+#define CreateSimpleHashWithSize(keyType, entryType, size) \
+	CreateSimpleHashWithNameAndSize(keyType, entryType, \
+									# entryType "Hash", size)
+
+#define CreateSimpleHashWithNameAndSize(keyType, entryType, name, size) \
+	CreateSimpleHashWithNameAndSizeInternal(sizeof(keyType), \
+											sizeof(entryType), \
+											name, size)
+
+
+/*
+ * CreatesSimpleHashSet creates a hash set that hashes its values using the
+ * tag_hash and stores the values in the CurrentMemoryContext.
+ */
+#define CreateSimpleHashSet(keyType) \
+	CreateSimpleHashWithName(keyType, keyType, \
+							 # keyType "HashSet")
+
+/*
+ * CreatesSimpleHashSetWithSize creates a hash set that hashes its values using
+ * the tag_hash and stores the values in the CurrentMemoryContext. It allows
+ * specifying its number of elements.
+ */
+#define CreateSimpleHashSetWithSize(keyType, size) \
+	CreateSimpleHashWithNameAndSize(keyType, keyType, # keyType "HashSet", size)
+
+/*
+ * CreatesSimpleHashSetWithName creates a hash set that hashes its values using the
+ * tag_hash and stores the values in the CurrentMemoryContext. It allows
+ * specifying its name.
+ */
+#define CreateSimpleHashSetWithName(keyType, name) \
+	CreateSimpleHashWithName(keyType, keyType, name)
+
+/*
+ * CreatesSimpleHashSetWithName creates a hash set that hashes its values using the
+ * tag_hash and stores the values in the CurrentMemoryContext. It allows
+ * specifying its name and number of elements.
+ */
+#define CreateSimpleHashSetWithNameAndSize(keyType, name, size) \
+	CreateSimpleHashWithNameAndSize(keyType, keyType, name, size)
+
+
 #endif

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -16,6 +16,7 @@
 
 #include "nodes/pg_list.h"
 #include "distributed/connection_management.h"
+#include "distributed/hash_helpers.h"
 
 
 /* Config variables managed via guc.c */
@@ -32,6 +33,7 @@ typedef struct NodeAndOwner
 	uint32_t nodeId;
 	Oid tableOwnerId;
 } NodeAndOwner;
+assert_valid_hash_key2(NodeAndOwner, nodeId, tableOwnerId);
 
 
 /*


### PR DESCRIPTION
This is a refactoring PR that starts using our new hash table creation
helper function. It adds a few more macros for ease of use, because C
doesn't have default arguments. It also adds a macro to check if a
struct contains automatic padding bytes. No struct that is hashed using
tag_hash should have automatic padding bytes, because those bytes are
undefined and thus using them to create a hash will result in undefined
behaviour (usually a random hash).
