### PR TITLE
default mode for shard splitting is set to auto.

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_split_shard_by_split_points/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_split_shard_by_split_points/11.1-1.sql
@@ -5,8 +5,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_split_shard_by_split_points(
     -- Use integer (consistent with other previously defined UDFs that take nodeId as integer) as for all practical purposes it is big enough.
     node_ids integer[],
     -- Three modes to be implemented: block_writes, force_logical and auto.
-    -- Currently, the default / only supported mode is block_writes.
-    shard_transfer_mode citus.shard_transfer_mode default 'block_writes')
+    -- The default mode is auto.
+    shard_transfer_mode citus.shard_transfer_mode default 'auto')
 RETURNS void
 LANGUAGE C STRICT
 AS 'MODULE_PATHNAME', $$citus_split_shard_by_split_points$$;

--- a/src/backend/distributed/sql/udfs/citus_split_shard_by_split_points/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_split_shard_by_split_points/latest.sql
@@ -5,8 +5,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_split_shard_by_split_points(
     -- Use integer (consistent with other previously defined UDFs that take nodeId as integer) as for all practical purposes it is big enough.
     node_ids integer[],
     -- Three modes to be implemented: block_writes, force_logical and auto.
-    -- Currently, the default / only supported mode is block_writes.
-    shard_transfer_mode citus.shard_transfer_mode default 'block_writes')
+    -- The default mode is auto.
+    shard_transfer_mode citus.shard_transfer_mode default 'auto')
 RETURNS void
 LANGUAGE C STRICT
 AS 'MODULE_PATHNAME', $$citus_split_shard_by_split_points$$;

--- a/src/test/regress/expected/citus_non_blocking_split_shards.out
+++ b/src/test/regress/expected/citus_non_blocking_split_shards.out
@@ -446,8 +446,7 @@ SET citus.next_shard_id TO 8981041;
 SELECT pg_catalog.citus_split_shard_by_split_points(
     8981031,
     ARRAY['-2120000000'],
-    ARRAY[:worker_1_node, :worker_2_node],
-    'auto');
+    ARRAY[:worker_1_node, :worker_2_node]);
 ERROR:  cannot use logical replication to transfer shards of the relation table_no_rep_id since it doesn't have a REPLICA IDENTITY or PRIMARY KEY
 DETAIL:  UPDATE and DELETE commands on the shard will error out during logical replication unless there is a REPLICA IDENTITY or PRIMARY KEY.
 HINT:  If you wish to continue without a replica identity set the shard_transfer_mode to 'force_logical' or 'block_writes'.

--- a/src/test/regress/sql/citus_non_blocking_split_shards.sql
+++ b/src/test/regress/sql/citus_non_blocking_split_shards.sql
@@ -242,8 +242,7 @@ SET citus.next_shard_id TO 8981041;
 SELECT pg_catalog.citus_split_shard_by_split_points(
     8981031,
     ARRAY['-2120000000'],
-    ARRAY[:worker_1_node, :worker_2_node],
-    'auto');
+    ARRAY[:worker_1_node, :worker_2_node]);
 
 SELECT shard.shardid, logicalrelid, shardminvalue, shardmaxvalue, nodename, nodeport
   FROM pg_dist_shard AS shard


### PR DESCRIPTION
DESCRIPTION: Default mode for shard splitting is changed to 'auto' from 'block_writes'.

Previously, the default mode for shard splitting was blocking any writes. We changed it into 'auto' which first check if the shard to be splitted has any collocated table without a replica identity and if so, it errors; otherwise, fallbacks to nonblocking mode.