### PR TITLE
Don't run tests in parallel to avoid relation open error

### DIFF
--- a/src/test/regress/columnar_schedule
+++ b/src/test/regress/columnar_schedule
@@ -4,7 +4,8 @@ test: multi_test_catalog_views
 
 test: columnar_create
 test: columnar_load
-test: columnar_query columnar_first_row_number
+test: columnar_query
+test: columnar_first_row_number
 test: columnar_analyze
 test: columnar_data_types
 test: columnar_drop


### PR DESCRIPTION
In PG15, `columnar_first_row_number` test fails like follows
```SQL
-- show that we start with first_row_number=1 after TRUNCATE
SELECT row_count, first_row_number FROM columnar.stripe a
WHERE a.storage_id = columnar.get_storage_id('col_table_1'::regclass)
ORDER BY stripe_num;

ERROR:  could not open relation with OID 17205
```
In this specific error faced, relation with OID 17205 is `columnar_join.union_first`, created and dropped in the parallel run test `columnar_query`, and referenced in `columnar.stripe`'s `storage_id` column .

Hence let's not run these tests in parallel.

Helpful for [Pg15 support #6085](https://github.com/citusdata/citus/pull/6085)