### PR TITLE
Uses object name in cannot distribute object error

### DIFF
--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -675,7 +675,7 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	WITH distributed_object_data(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation)
 		AS (VALUES ('publication', ARRAY['publication_test']::text[], ARRAY[]::text[], -1, 0, false))
 	SELECT citus_internal_add_object_metadata(typetext, objnames, objargs, distargumentindex, colocationid, force_delegation) FROM distributed_object_data;
-ERROR:  Object type 29 can not be distributed by Citus
+ERROR:  publication object can not be distributed by Citus
 ROLLBACK;
 -- Show that citus_internal_add_object_metadata checks the priviliges
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;


### PR DESCRIPTION
Object type ids have changed in PG15 because of at least two added objects in the list: `OBJECT_PARAMETER_ACL`, `OBJECT_PUBLICATION_NAMESPACE`

To avoid different output between pg versions, let's use the object name in the error, and put the object id in the error detail.

Helpful for [Pg15 support #6085](https://github.com/citusdata/citus/pull/6085)

Relevant PG commits:
[a0ffa885e478f5eeacc4e250e35ce25a4740c487](https://github.com/postgres/postgres/commit/a0ffa885e478f5eeacc4e250e35ce25a4740c487)
[5a2832465fd8984d089e8c44c094e6900d987fcd](https://github.com/postgres/postgres/commit/5a2832465fd8984d089e8c44c094e6900d987fcd)
