### PR TITLE
Track rebalance progress at the shard move level

### DIFF
--- a/src/include/distributed/shard_rebalancer.h
+++ b/src/include/distributed/shard_rebalancer.h
@@ -73,10 +73,7 @@
 /* *INDENT-ON* */
 
 #define REBALANCE_ACTIVITY_MAGIC_NUMBER 1337
-#define REBALANCE_PROGRESS_ERROR -1
-#define REBALANCE_PROGRESS_WAITING 0
 #define REBALANCE_PROGRESS_MOVING 1
-#define REBALANCE_PROGRESS_MOVED 2
 
 /* Enumeration that defines different placement update types */
 typedef enum
@@ -196,5 +193,7 @@ extern List * ReplicationPlacementUpdates(List *workerNodeList, List *shardPlace
 extern void ExecuteRebalancerCommandInSeparateTransaction(char *command);
 extern void AcquirePlacementColocationLock(Oid relationId, int lockMode,
 										   const char *operationName);
+extern void SetupRebalanceMonitor(List *placementUpdateList, Oid relationId);
+
 
 #endif   /* SHARD_REBALANCER_H */

--- a/src/test/regress/expected/isolation_shard_rebalancer_progress.out
+++ b/src/test/regress/expected/isolation_shard_rebalancer_progress.out
@@ -1,34 +1,23 @@
-Parsed test spec with 3 sessions
+Parsed test spec with 7 sessions
 
-starting permutation: s2-lock-1 s2-lock-2 s1-rebalance-c1 s3-progress s2-unlock-1 s3-progress s2-unlock-2 s3-progress s1-commit s3-progress
+starting permutation: s2-lock-1-start s1-rebalance-c1-block-writes s7-get-progress s2-unlock-1-start s1-commit s7-get-progress enable-deferred-drop
 master_set_node_property
 ---------------------------------------------------------------------
 
 (1 row)
 
-step s2-lock-1:
- SELECT pg_advisory_lock(29279, 1);
+step s2-lock-1-start:
+ BEGIN;
+ DELETE FROM colocated1 WHERE test_id = 1;
+ DELETE FROM separate WHERE test_id = 1;
 
-pg_advisory_lock
----------------------------------------------------------------------
-
-(1 row)
-
-step s2-lock-2:
- SELECT pg_advisory_lock(29279, 2);
-
-pg_advisory_lock
----------------------------------------------------------------------
-
-(1 row)
-
-step s1-rebalance-c1:
+step s1-rebalance-c1-block-writes:
  BEGIN;
  SELECT * FROM get_rebalance_table_shards_plan('colocated1');
  SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='block_writes');
  <waiting ...>
-step s3-progress: 
- set client_min_messages=NOTICE;
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
  SELECT
   table_name,
   shardid,
@@ -46,50 +35,12 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|                0|       1
 colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|                0|       1
-colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       0
-colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       0
-(4 rows)
+(2 rows)
 
-step s2-unlock-1:
- SELECT pg_advisory_unlock(29279, 1);
+step s2-unlock-1-start:
+ ROLLBACK;
 
-pg_advisory_unlock
----------------------------------------------------------------------
-t
-(1 row)
-
-step s3-progress:
- set client_min_messages=NOTICE;
- SELECT
-  table_name,
-  shardid,
-  shard_size,
-  sourcename,
-  sourceport,
-  source_shard_size,
-  targetname,
-  targetport,
-  target_shard_size,
-  progress
- FROM get_rebalance_progress();
-
-table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
----------------------------------------------------------------------
-colocated1|1500001|     73728|localhost |     57637|            49152|localhost |     57638|            73728|       2
-colocated2|1500005|    401408|localhost |     57637|           376832|localhost |     57638|           401408|       2
-colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       1
-colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       1
-(4 rows)
-
-step s2-unlock-2:
- SELECT pg_advisory_unlock(29279, 2);
-
-pg_advisory_unlock
----------------------------------------------------------------------
-t
-(1 row)
-
-step s1-rebalance-c1: <... completed>
+step s1-rebalance-c1-block-writes: <... completed>
 table_name|shardid|shard_size|sourcename|sourceport|targetname|targetport
 ---------------------------------------------------------------------
 colocated1|1500001|         0|localhost |     57637|localhost |     57638
@@ -103,8 +54,11 @@ rebalance_table_shards
 
 (1 row)
 
-step s3-progress:
- set client_min_messages=NOTICE;
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
  SELECT
   table_name,
   shardid,
@@ -121,12 +75,69 @@ step s3-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
 ---------------------------------------------------------------------
 (0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s3-lock-2-start s1-rebalance-c1-block-writes s7-get-progress s3-unlock-2-start s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s3-lock-2-start:
+ BEGIN;
+ DELETE FROM colocated1 WHERE test_id = 3;
+
+step s1-rebalance-c1-block-writes:
+ BEGIN;
+ SELECT * FROM get_rebalance_table_shards_plan('colocated1');
+ SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       1
+colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       1
+(2 rows)
+
+step s3-unlock-2-start:
+ ROLLBACK;
+
+step s1-rebalance-c1-block-writes: <... completed>
+table_name|shardid|shard_size|sourcename|sourceport|targetname|targetport
+---------------------------------------------------------------------
+colocated1|1500001|         0|localhost |     57637|localhost |     57638
+colocated2|1500005|         0|localhost |     57637|localhost |     57638
+colocated1|1500002|         0|localhost |     57637|localhost |     57638
+colocated2|1500006|         0|localhost |     57637|localhost |     57638
+(4 rows)
+
+rebalance_table_shards
+---------------------------------------------------------------------
+
+(1 row)
 
 step s1-commit:
  COMMIT;
 
-step s3-progress:
- set client_min_messages=NOTICE;
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
  SELECT
   table_name,
   shardid,
@@ -143,4 +154,763 @@ step s3-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
 ---------------------------------------------------------------------
 (0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s7-grab-lock s1-rebalance-c1-block-writes s7-get-progress s7-release-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s7-grab-lock:
+ BEGIN;
+ SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+ SELECT 1 FROM colocated1 LIMIT 1;
+ SELECT 1 FROM separate LIMIT 1;
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+step s1-rebalance-c1-block-writes:
+ BEGIN;
+ SELECT * FROM get_rebalance_table_shards_plan('colocated1');
+ SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
+(2 rows)
+
+step s7-release-lock:
+ COMMIT;
+
+step s1-rebalance-c1-block-writes: <... completed>
+table_name|shardid|shard_size|sourcename|sourceport|targetname|targetport
+---------------------------------------------------------------------
+colocated1|1500001|         0|localhost |     57637|localhost |     57638
+colocated2|1500005|         0|localhost |     57637|localhost |     57638
+colocated1|1500002|         0|localhost |     57637|localhost |     57638
+colocated2|1500006|         0|localhost |     57637|localhost |     57638
+(4 rows)
+
+rebalance_table_shards
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s6-acquire-advisory-lock s1-rebalance-c1-online s7-get-progress s6-release-advisory-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s6-acquire-advisory-lock:
+    SELECT pg_advisory_lock(44000, 55152);
+
+pg_advisory_lock
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-rebalance-c1-online:
+ BEGIN;
+ SELECT * FROM get_rebalance_table_shards_plan('colocated1');
+ SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='force_logical');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|             8192|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|             8192|       1
+(2 rows)
+
+step s6-release-advisory-lock:
+    SELECT pg_advisory_unlock(44000, 55152);
+
+pg_advisory_unlock
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s1-rebalance-c1-online: <... completed>
+table_name|shardid|shard_size|sourcename|sourceport|targetname|targetport
+---------------------------------------------------------------------
+colocated1|1500001|         0|localhost |     57637|localhost |     57638
+colocated2|1500005|         0|localhost |     57637|localhost |     57638
+colocated1|1500002|         0|localhost |     57637|localhost |     57638
+colocated2|1500006|         0|localhost |     57637|localhost |     57638
+(4 rows)
+
+rebalance_table_shards
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s7-grab-lock s1-shard-move-c1-online s7-get-progress s7-release-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s7-grab-lock:
+ BEGIN;
+ SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+ SELECT 1 FROM colocated1 LIMIT 1;
+ SELECT 1 FROM separate LIMIT 1;
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+step s1-shard-move-c1-online:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='force_logical');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
+(2 rows)
+
+step s7-release-lock:
+ COMMIT;
+
+step s1-shard-move-c1-online: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s2-lock-1-start s1-shard-move-c1-block-writes s7-get-progress s2-unlock-1-start s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-lock-1-start:
+ BEGIN;
+ DELETE FROM colocated1 WHERE test_id = 1;
+ DELETE FROM separate WHERE test_id = 1;
+
+step s1-shard-move-c1-block-writes:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|                0|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|                0|       1
+(2 rows)
+
+step s2-unlock-1-start:
+ ROLLBACK;
+
+step s1-shard-move-c1-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s7-grab-lock s1-shard-move-c1-block-writes s7-get-progress s7-release-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s7-grab-lock:
+ BEGIN;
+ SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+ SELECT 1 FROM colocated1 LIMIT 1;
+ SELECT 1 FROM separate LIMIT 1;
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+step s1-shard-move-c1-block-writes:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
+(2 rows)
+
+step s7-release-lock:
+ COMMIT;
+
+step s1-shard-move-c1-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s6-acquire-advisory-lock s1-shard-move-c1-online s7-get-progress s6-release-advisory-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s6-acquire-advisory-lock:
+    SELECT pg_advisory_lock(44000, 55152);
+
+pg_advisory_lock
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-shard-move-c1-online:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='force_logical');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|             8192|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|             8192|       1
+(2 rows)
+
+step s6-release-advisory-lock:
+    SELECT pg_advisory_unlock(44000, 55152);
+
+pg_advisory_unlock
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s1-shard-move-c1-online: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s7-grab-lock s1-shard-move-c1-online s7-get-progress s7-release-lock s1-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s7-grab-lock:
+ BEGIN;
+ SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+ SELECT 1 FROM colocated1 LIMIT 1;
+ SELECT 1 FROM separate LIMIT 1;
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+step s1-shard-move-c1-online:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='force_logical');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
+(2 rows)
+
+step s7-release-lock:
+ COMMIT;
+
+step s1-shard-move-c1-online: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s2-lock-1-start s1-shard-move-c1-block-writes s4-shard-move-sep-block-writes s7-get-progress s2-unlock-1-start s1-commit s4-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s2-lock-1-start:
+ BEGIN;
+ DELETE FROM colocated1 WHERE test_id = 1;
+ DELETE FROM separate WHERE test_id = 1;
+
+step s1-shard-move-c1-block-writes:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s4-shard-move-sep-block-writes: 
+ BEGIN;
+ SELECT citus_move_shard_placement(1500009, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|                0|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|                0|       1
+separate  |1500009|    122880|localhost |     57637|           122880|localhost |     57638|                0|       1
+(3 rows)
+
+step s2-unlock-1-start:
+ ROLLBACK;
+
+step s1-shard-move-c1-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s4-shard-move-sep-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s4-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+
+
+starting permutation: s7-grab-lock s1-shard-move-c1-block-writes s4-shard-move-sep-block-writes s7-get-progress s7-release-lock s1-commit s4-commit s7-get-progress enable-deferred-drop
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s7-grab-lock:
+ BEGIN;
+ SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+ SELECT 1 FROM colocated1 LIMIT 1;
+ SELECT 1 FROM separate LIMIT 1;
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+?column?
+---------------------------------------------------------------------
+       1
+(1 row)
+
+step s1-shard-move-c1-block-writes:
+ BEGIN;
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s4-shard-move-sep-block-writes: 
+ BEGIN;
+ SELECT citus_move_shard_placement(1500009, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress: 
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
+colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
+separate  |1500009|    122880|localhost |     57637|           122880|localhost |     57638|           147456|       1
+(3 rows)
+
+step s7-release-lock:
+ COMMIT;
+
+step s1-shard-move-c1-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s4-shard-move-sep-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-commit:
+ COMMIT;
+
+step s4-commit:
+ COMMIT;
+
+step s7-get-progress:
+ set LOCAL client_min_messages=NOTICE;
+ SELECT
+  table_name,
+  shardid,
+  shard_size,
+  sourcename,
+  sourceport,
+  source_shard_size,
+  targetname,
+  targetport,
+  target_shard_size,
+  progress
+ FROM get_rebalance_progress();
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
+---------------------------------------------------------------------
+(0 rows)
+
+step enable-deferred-drop:
+ ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
 

--- a/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
+++ b/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
@@ -1,6 +1,14 @@
 setup
 {
-	select setval('pg_dist_shardid_seq', GREATEST(1500000, nextval('pg_dist_shardid_seq')));
+	-- We disable deffered drop, so we can easily trigger blocking the shard
+	-- move at the end of the move. This is done in a separate setup step,
+	-- because this cannot run in a transaction.
+	ALTER SYSTEM SET citus.defer_drop_after_shard_move TO OFF;
+}
+setup
+{
+	SELECT pg_reload_conf();
+	ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1500001;
 	SET citus.shard_count TO 4;
 	SET citus.shard_replication_factor TO 1;
 	SELECT 1 FROM master_add_node('localhost', 57637);
@@ -9,27 +17,51 @@ setup
 	SELECT create_distributed_table('colocated1', 'test_id', 'hash', 'none');
 	CREATE TABLE colocated2 (test_id integer NOT NULL, data text);
 	SELECT create_distributed_table('colocated2', 'test_id', 'hash', 'colocated1');
+	CREATE TABLE separate (test_id integer NOT NULL, data text);
+	SELECT create_distributed_table('separate', 'test_id', 'hash', 'none');
 	-- 1 and 3 are chosen so they go to shard 1 and 2
 	INSERT INTO colocated1(test_id) SELECT 1 from generate_series(0, 1000) i;
 	INSERT INTO colocated2(test_id) SELECT 1 from generate_series(0, 10000) i;
 	INSERT INTO colocated1(test_id) SELECT 3 from generate_series(0, 5000) i;
+	INSERT INTO separate(test_id) SELECT 1 from generate_series(0, 3000) i;
 	select * from pg_dist_placement;
 	SELECT master_set_node_property('localhost', 57638, 'shouldhaveshards', true);
 }
 
 teardown
 {
+	SELECT pg_reload_conf();
 	DROP TABLE colocated2;
 	DROP TABLE colocated1;
+	DROP TABLE separate;
 }
 
 session "s1"
 
-step "s1-rebalance-c1"
+step "s1-rebalance-c1-block-writes"
 {
 	BEGIN;
 	SELECT * FROM get_rebalance_table_shards_plan('colocated1');
 	SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='block_writes');
+}
+
+step "s1-rebalance-c1-online"
+{
+	BEGIN;
+	SELECT * FROM get_rebalance_table_shards_plan('colocated1');
+	SELECT rebalance_table_shards('colocated1', shard_transfer_mode:='force_logical');
+}
+
+step "s1-shard-move-c1-block-writes"
+{
+	BEGIN;
+	SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+}
+
+step "s1-shard-move-c1-online"
+{
+	BEGIN;
+	SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='force_logical');
 }
 
 step "s1-commit"
@@ -39,31 +71,81 @@ step "s1-commit"
 
 session "s2"
 
-step "s2-lock-1"
+step "s2-lock-1-start"
 {
-	SELECT pg_advisory_lock(29279, 1);
+	BEGIN;
+	DELETE FROM colocated1 WHERE test_id = 1;
+	DELETE FROM separate WHERE test_id = 1;
 }
 
-step "s2-lock-2"
+step "s2-unlock-1-start"
 {
-	SELECT pg_advisory_lock(29279, 2);
-}
-
-step "s2-unlock-1"
-{
-	SELECT pg_advisory_unlock(29279, 1);
-}
-
-step "s2-unlock-2"
-{
-	SELECT pg_advisory_unlock(29279, 2);
+	ROLLBACK;
 }
 
 session "s3"
 
-step "s3-progress"
+step "s3-lock-2-start"
 {
-	set client_min_messages=NOTICE;
+	BEGIN;
+	DELETE FROM colocated1 WHERE test_id = 3;
+}
+
+step "s3-unlock-2-start"
+{
+	ROLLBACK;
+}
+
+session "s4"
+
+step "s4-shard-move-sep-block-writes"
+{
+	BEGIN;
+	SELECT citus_move_shard_placement(1500009, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+}
+
+step "s4-commit"
+{
+	COMMIT;
+}
+
+session "s6"
+
+// this advisory lock with (almost) random values are only used
+// for testing purposes. For details, check Citus' logical replication
+// source code
+step "s6-acquire-advisory-lock"
+{
+    SELECT pg_advisory_lock(44000, 55152);
+}
+
+step "s6-release-advisory-lock"
+{
+    SELECT pg_advisory_unlock(44000, 55152);
+}
+
+
+session "s7"
+
+// get_rebalance_progress internally calls pg_total_relation_size on all the
+// shards. This means that it takes AccessShareLock on those shards. Because we
+// run with deferred drop that means that get_rebalance_progress actually waits
+// for the shard move to complete the drop. But we want to get the progress
+// before the shards are dropped. So we grab the locks first with a simple
+// query that reads from all shards. We force using a single connection because
+// get_rebalance_progress isn't smart enough to reuse the right connection for
+// the right shards and will simply use a single one for all of them.
+step "s7-grab-lock"
+{
+	BEGIN;
+	SET LOCAL citus.max_adaptive_executor_pool_size = 1;
+	SELECT 1 FROM colocated1 LIMIT 1;
+	SELECT 1 FROM separate LIMIT 1;
+}
+
+step "s7-get-progress"
+{
+	set LOCAL client_min_messages=NOTICE;
 	SELECT
 		table_name,
 		shardid,
@@ -78,4 +160,39 @@ step "s3-progress"
 	FROM get_rebalance_progress();
 }
 
-permutation "s2-lock-1" "s2-lock-2" "s1-rebalance-c1" "s3-progress" "s2-unlock-1" "s3-progress" "s2-unlock-2" "s3-progress" "s1-commit" "s3-progress"
+step "s7-release-lock"
+{
+	COMMIT;
+}
+
+session "s8"
+
+// After running these tests we want to enable deferred-drop again. Sadly
+// the isolation tester framework does not support multiple teardown steps
+// and this cannot be run in a transaction. So we need to do it manually at
+// the end of the last test.
+step "enable-deferred-drop"
+{
+	ALTER SYSTEM RESET citus.defer_drop_after_shard_move;
+}
+// blocking rebalancer does what it should
+permutation "s2-lock-1-start" "s1-rebalance-c1-block-writes" "s7-get-progress" "s2-unlock-1-start" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s3-lock-2-start" "s1-rebalance-c1-block-writes" "s7-get-progress" "s3-unlock-2-start" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s7-grab-lock" "s1-rebalance-c1-block-writes" "s7-get-progress" "s7-release-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+
+// online rebalancer
+permutation "s6-acquire-advisory-lock" "s1-rebalance-c1-online" "s7-get-progress" "s6-release-advisory-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s7-grab-lock" "s1-shard-move-c1-online" "s7-get-progress" "s7-release-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+
+// blocking shard move
+permutation "s2-lock-1-start" "s1-shard-move-c1-block-writes" "s7-get-progress" "s2-unlock-1-start" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s7-grab-lock" "s1-shard-move-c1-block-writes" "s7-get-progress" "s7-release-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+
+// online shard move
+permutation "s6-acquire-advisory-lock" "s1-shard-move-c1-online" "s7-get-progress" "s6-release-advisory-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s7-grab-lock" "s1-shard-move-c1-online" "s7-get-progress" "s7-release-lock" "s1-commit" "s7-get-progress" "enable-deferred-drop"
+
+
+// parallel blocking shard move
+permutation "s2-lock-1-start" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes" "s7-get-progress" "s2-unlock-1-start" "s1-commit" "s4-commit" "s7-get-progress" "enable-deferred-drop"
+permutation "s7-grab-lock" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes" "s7-get-progress" "s7-release-lock" "s1-commit" "s4-commit" "s7-get-progress" "enable-deferred-drop"


### PR DESCRIPTION
DESCRIPTION: Only show shards in moving state in get_rebalance_progress

We're in the processes of totally changing the shard rebalancer
experience and infrastructure. Soon the shard rebalancer will include
retries, crash recovery and support for running in the background.

These improvements come at a cost though, the way the
get_rebalance_progress UDF currently works is very hard to replicate
with this new structure. This is mostly because the old behaviour
doesn't really make sense anymore with this new infrastructure. A new
and better way to track the progress will be included as part of the new
infrastructure.

This PR is in preparation of the new code rebalancer experience.
It changes the get_rebalance_progress UDF to only display the moves that
are in progress at the moment, not the ones that happened in the past or
that are planned in the future. Another option would have been to
completely remove the current get_rebalance_progress functionality and
point people to the new way of tracking progress. But old blogposts
still reference the old UDF and users might have some automation on top
of it. Showing the progress of the current moves is fairly simple to
achieve, even with the new infrastructure.

So this PR is a kind of compromise: It doesn't have complete feature
parity with the old get_rebalance_progress, but the most common use
cases will still work.

There's also an advantage of the change: You can now see progress of
shard moves that were triggered by calling citus_move_shard_placement
manually. Instead of only being able to see progress of moves that were
initiated using get_rebalance_table_shards.
