### PR TITLE
Reduce verbosity in columnar vacuum full isol. test

### DIFF
--- a/src/test/regress/expected/columnar_vacuum_vs_insert.out
+++ b/src/test/regress/expected/columnar_vacuum_vs_insert.out
@@ -49,14 +49,11 @@ step s1-insert:
     INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
 
 step s2-vacuum-full:
-    VACUUM FULL VERBOSE test_vacuum_vs_insert;
+    VACUUM FULL test_vacuum_vs_insert;
  <waiting ...>
 step s1-commit: 
     COMMIT;
 
-s2: INFO:  vacuuming "public.test_vacuum_vs_insert"
-s2: INFO:  "test_vacuum_vs_insert": found 0 removable, 6 nonremovable row versions in 4 pages
-DETAIL:  0 dead row versions cannot be removed yet.
 step s2-vacuum-full: <... completed>
 step s2-select:
     SELECT * FROM test_vacuum_vs_insert;

--- a/src/test/regress/spec/columnar_vacuum_vs_insert.spec
+++ b/src/test/regress/spec/columnar_vacuum_vs_insert.spec
@@ -35,7 +35,7 @@ step "s2-vacuum"
 
 step "s2-vacuum-full"
 {
-    VACUUM FULL VERBOSE test_vacuum_vs_insert;
+    VACUUM FULL test_vacuum_vs_insert;
 }
 
 step "s2-select"


### PR DESCRIPTION
In PG15, namespace is emitted in post-copy errmsg. Hence there would be this output diff in `VACUUM FULL VERBOSE`:
```
INFO:  "test_vacuum_vs_insert": ... (PG13/14)
VS
INFO:  "public.test_vacuum_vs_insert": ... (PG15)
```
Relevant PG commit: [Emit namespace in the post-copy errmsg](https://github.com/postgres/postgres/commit/069d33d0c5a021601245e44df77a0423ddd69359)

NOTE: if reviewer decides that verbosity is important for this test, we can add a normalization rule with this PR. Any other idea?

Helpful for [Pg15 support #6085](https://github.com/citusdata/citus/pull/6085)
