### PR TITLE
Fix flakyness in columnar_first_row_number test

### DIFF
--- a/src/test/regress/columnar_schedule
+++ b/src/test/regress/columnar_schedule
@@ -4,7 +4,8 @@ test: multi_test_catalog_views
 
 test: columnar_create
 test: columnar_load
-test: columnar_query columnar_first_row_number
+test: columnar_query
+test: columnar_first_row_number
 test: columnar_analyze
 test: columnar_data_types
 test: columnar_drop


### PR DESCRIPTION
When running columnar_first_row_number in parallel with the
columnar_query test sometimes it would fail. This bug is tracked
in #6191. For now to make CI less flaky we simply don't run these tests
in parallel.

Example of failed test: https://app.circleci.com/pipelines/github/citusdata/citus/26106/workflows/75d00ea9-23f8-4bff-a927-bced19e1f81b/jobs/736713

Fixes #6184