### PR TITLE
Improve debugability of failures in isolation_ref2ref_foreign_keys

### DIFF
--- a/src/test/regress/expected/isolation_ref2ref_foreign_keys.out
+++ b/src/test/regress/expected/isolation_ref2ref_foreign_keys.out
@@ -11,16 +11,24 @@ step s1-begin:
  BEGIN;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    1
-ShareLock    |    1
+      0|8429800|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_1 SET id = 2 WHERE id = 1;
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_1 SET id = 2 WHERE id = 1;
 (2 rows)
 
 step s1-rollback:
@@ -30,13 +38,21 @@ step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -49,29 +65,45 @@ step s2-delete-table-1:
     DELETE FROM ref_table_1 WHERE id = 1;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    1
-ShareLock    |    1
+      0|8429800|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_1 WHERE id = 1;
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_1 WHERE id = 1;
 (2 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -84,29 +116,46 @@ step s2-update-table-2:
     UPDATE ref_table_2 SET id = 2 WHERE id = 1;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    2
-ShareLock    |    1
-(2 rows)
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_2 SET id = 2 WHERE id = 1;
+      0|8429801|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_2 SET id = 2 WHERE id = 1;
+      0|8429801|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_2 SET id = 2 WHERE id = 1;
+(3 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -119,29 +168,46 @@ step s2-delete-table-2:
     DELETE FROM ref_table_2 WHERE id = 1;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    2
-ShareLock    |    1
-(2 rows)
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_2 WHERE id = 1;
+      0|8429801|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_2 WHERE id = 1;
+      0|8429801|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_2 WHERE id = 1;
+(3 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -157,17 +223,27 @@ step s1-begin:
  BEGIN;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    3
-ShareLock    |    1
-(2 rows)
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_3 SET id = 2 WHERE id = 1;
+      0|8429801|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_3 SET id = 2 WHERE id = 1;
+      0|8429802|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_3 SET id = 2 WHERE id = 1;
+      0|8429802|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     UPDATE ref_table_3 SET id = 2 WHERE id = 1;
+(4 rows)
 
 step s1-rollback:
     ROLLBACK;
@@ -176,13 +252,21 @@ step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -198,17 +282,27 @@ step s1-begin:
  BEGIN;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode         |count
+classid|  objid|objsubid|mode         |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-ExclusiveLock|    3
-ShareLock    |    1
-(2 rows)
+      0|8429800|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_3 WHERE id = 1;
+      0|8429801|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_3 WHERE id = 1;
+      0|8429802|       4|ShareLock    |isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_3 WHERE id = 1;
+      0|8429802|       5|ExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     DELETE FROM ref_table_3 WHERE id = 1;
+(4 rows)
 
 step s1-rollback:
     ROLLBACK;
@@ -217,13 +311,21 @@ step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -236,29 +338,45 @@ step s2-insert-table-1:
     INSERT INTO ref_table_1 VALUES (7, 7);
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode            |count
+classid|  objid|objsubid|mode            |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-RowExclusiveLock|    1
-ShareLock       |    1
+      0|8429800|       4|ShareLock       |isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_1 VALUES (7, 7);
+      0|8429800|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_1 VALUES (7, 7);
 (2 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -271,29 +389,46 @@ step s2-insert-table-2:
     INSERT INTO ref_table_2 VALUES (7, 5);
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode            |count
+classid|  objid|objsubid|mode            |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-RowExclusiveLock|    2
-ShareLock       |    1
-(2 rows)
+      0|8429800|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_2 VALUES (7, 5);
+      0|8429801|       4|ShareLock       |isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_2 VALUES (7, 5);
+      0|8429801|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_2 VALUES (7, 5);
+(3 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 
@@ -306,29 +441,47 @@ step s2-insert-table-3:
     INSERT INTO ref_table_3 VALUES (7, 5);
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode            |count
+classid|  objid|objsubid|mode            |application_name                        |backend_type  |query
 ---------------------------------------------------------------------
-RowExclusiveLock|    3
-ShareLock       |    1
-(2 rows)
+      0|8429800|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_3 VALUES (7, 5);
+      0|8429801|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_3 VALUES (7, 5);
+      0|8429802|       4|ShareLock       |isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_3 VALUES (7, 5);
+      0|8429802|       5|RowExclusiveLock|isolation/isolation_ref2ref_foreign_keys|client backend|     INSERT INTO ref_table_3 VALUES (7, 5);
+(4 rows)
 
 step s2-rollback:
     ROLLBACK;
 
 step s1-view-locks:
-    SELECT mode, count(*)
-    FROM pg_locks
+    SELECT classid,
+        objid,
+        objsubid,
+        mode,
+        application_name,
+        backend_type,
+        regexp_replace(query, E'[\\n\\r\\u2028]+', ' ', 'g' ) query
+    FROM pg_locks l
+    JOIN pg_stat_activity a
+    ON l.pid = a.pid
     WHERE locktype='advisory'
-    GROUP BY mode
-    ORDER BY 1, 2;
+        AND application_name <> 'Citus Maintenance Daemon'
+    ORDER BY 1, 2, 3, 4;
 
-mode|count
+classid|objid|objsubid|mode|application_name|backend_type|query
 ---------------------------------------------------------------------
 (0 rows)
 


### PR DESCRIPTION
As shown in #6196 the output of s1-view-locks is sometimes not as
expected. However, because it's output is very minimal it's hard to
understand the reason for that. This adds some more columns and
aggregates less, so we can more easily see what locks are unexpectedly
held or released.

In passing this also fixes the following flaky part of this test by excluding
locks taken by the maintenance daemon. After running it with this more
detailed output for s1-view-locks it became obvious that that was the
problem here.
```diff
diff -dU10 -w /home/jelte/work/citus/src/test/regress/expected/isolation_ref2ref_foreign_keys.out /home/jelte/work/citus/src/test/regress/results/isolation_ref2ref_foreign_keys.out
--- /home/jelte/work/citus/src/test/regress/expected/isolation_ref2ref_foreign_keys.out.modified	2022-08-18 15:42:08.689525233 +0200
+++ /home/jelte/work/citus/src/test/regress/results/isolation_ref2ref_foreign_keys.out.modified	2022-08-18 15:42:08.729525233 +0200
@@ -288,21 +288,22 @@
 
 step s1-view-locks: 
     SELECT mode, count(*)
     FROM pg_locks
     WHERE locktype='advisory'
     GROUP BY mode
     ORDER BY 1, 2;
 
 mode                    |count
 ------------------------+-----
-(0 rows)
+ShareUpdateExclusiveLock|    1
+(1 row)
 
 
 starting permutation: s2-begin s2-insert-table-3 s1-view-locks s2-rollback s1-view-locks
 step s2-begin: 
  BEGIN;
 
 step s2-insert-table-3: 
     INSERT INTO ref_table_3 VALUES (7, 5);
 
 step s1-view-locks: 
 ```
