### PR TITLE
Fix upgrade script one more time

### DIFF
--- a/src/backend/distributed/sql/citus--10.2-5--10.2-4.sql
+++ b/src/backend/distributed/sql/citus--10.2-5--10.2-4.sql
@@ -1,1 +1,1 @@
-#include "../udfs/citus_finish_pg_upgrade/10.2-4.sql"
+#include "udfs/citus_finish_pg_upgrade/10.2-4.sql"

--- a/src/backend/distributed/sql/downgrades/citus--10.2-5--10.2-4.sql
+++ b/src/backend/distributed/sql/downgrades/citus--10.2-5--10.2-4.sql
@@ -1,1 +1,0 @@
-#include "../udfs/citus_finish_pg_upgrade/10.2-4.sql"


### PR DESCRIPTION
Seems that we incorrectly added the same migration file into downgrades/ and this causes some warnings on Citus repo's CI & when building packages.

The same problem doesn't exist on main, so opened the PR against release-10.2 branch.

```
Makefile:71: warning: overriding recipe for target '/home/onurctirtir/citus/src/backend/distributed/build/sql/citus--10.2-5--10.2-4.sql'
Makefile:62: warning: ignoring old recipe for target '/home/onurctirtir/citus/src/backend/distributed/build/sql/citus--10.2-5--10.2-4.sql'
Makefile:71: warning: overriding recipe for target '/home/onurctirtir/citus/src/backend/distributed/build/sql/citus--10.2-5--10.2-4.sql'
Makefile:62: warning: ignoring old recipe for target '/home/onurctirtir/citus/src/backend/distributed/build/sql/citus--10.2-5--10.2-4.sql'
```