### PR TITLE
Change split logic to avoid EnsureReferenceTablesExistOnAllNodesExtended

### DIFF
--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -501,6 +501,8 @@ SplitShard(SplitMode splitMode,
 
 	List *workersForPlacementList = GetWorkerNodesFromWorkerIds(nodeIdsForPlacementList);
 
+	ErrorIfNotAllNodesHaveReferenceTableReplicas(workersForPlacementList);
+
 	List *sourceColocatedShardIntervalList = NIL;
 	if (colocatedShardIntervalList == NIL)
 	{
@@ -517,7 +519,6 @@ SplitShard(SplitMode splitMode,
 
 	if (splitMode == BLOCKING_SPLIT)
 	{
-		EnsureReferenceTablesExistOnAllNodesExtended(TRANSFER_MODE_BLOCK_WRITES);
 		BlockingShardSplit(
 			splitOperation,
 			splitWorkflowId,

--- a/src/include/distributed/reference_table_utils.h
+++ b/src/include/distributed/reference_table_utils.h
@@ -26,5 +26,6 @@ extern void DeleteAllReplicatedTablePlacementsFromNodeGroup(int32 groupId,
 															bool localOnly);
 extern int CompareOids(const void *leftElement, const void *rightElement);
 extern void ReplicateAllReferenceTablesToNode(WorkerNode *workerNode);
+extern void ErrorIfNotAllNodesHaveReferenceTableReplicas(List *workerNodeList);
 
 #endif /* REFERENCE_TABLE_UTILS_H_ */

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -1150,6 +1150,38 @@ CREATE TABLE test (x int, y int references ref(a));
 SELECT create_distributed_table('test','x');
 ERROR:  canceling the transaction since it was involved in a distributed deadlock
 END;
+-- verify the split fails if we still need to replicate reference tables
+SELECT citus_remove_node('localhost', :worker_2_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('test','x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT citus_add_node('localhost', :worker_2_port);
+ citus_add_node
+---------------------------------------------------------------------
+        1370022
+(1 row)
+
+SELECT
+  citus_split_shard_by_split_points(shardid,
+                                    ARRAY[(shardminvalue::int + (shardmaxvalue::int - shardminvalue::int)/2)::text],
+                                    ARRAY[nodeid, nodeid],
+                                    'force_logical')
+FROM
+  pg_dist_shard, pg_dist_node
+WHERE
+  logicalrelid = 'replicate_reference_table.test'::regclass AND nodename = 'localhost' AND nodeport = :worker_2_port
+ORDER BY shardid LIMIT 1;
+ERROR:  reference tables have not been replicated to node localhost:xxxxx yet
+DETAIL:  Reference tables are lazily replicated after adding a node, but must exist before shards can be created on that node.
+HINT:  Run SELECT replicate_reference_tables(); to ensure reference tables exist on all nodes.
 -- test adding an invalid node while we have reference tables to replicate
 -- set client message level to ERROR and verbosity to terse to supporess
 -- OS-dependent host name resolution warnings


### PR DESCRIPTION
We were doing an EnsureReferenceTablesExistOnAllNodesExtended call only in the blocking code path of shard split.

In general, citus_split_shard_by_split_points is a low-level operation that should probably not concern itself with replicating reference tables. This PR changes the logic to check for the presence of reference tables instead.