### PR TITLE
Adjust some isolation test for the recent PG commits

### DIFF
--- a/src/test/regress/expected/isolation_get_distributed_wait_queries_mx.out
+++ b/src/test/regress/expected/isolation_get_distributed_wait_queries_mx.out
@@ -1200,7 +1200,7 @@ citus_remove_node
 (1 row)
 
 
-starting permutation: s1-begin s1-update-ref-table-from-coordinator s2-start-session-level-connection s2-update-ref-table s3-select-distributed-waiting-queries s1-commit s2-stop-connection s5-begin s5-alter s6-select s3-select-distributed-waiting-queries s3-show-actual-gpids s5-rollback s8-begin s8-select s7-alter s3-select-distributed-waiting-queries s3-show-actual-gpids s8-rollback
+starting permutation: s1-begin s1-update-ref-table-from-coordinator s2-start-session-level-connection s2-update-ref-table s3-select-distributed-waiting-queries s1-commit s2-stop-connection
 step s1-begin:
 	BEGIN;
 
@@ -1245,6 +1245,13 @@ stop_session_level_connection_to_node
 
 (1 row)
 
+citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+
+starting permutation: s5-begin s5-alter s6-select s3-select-distributed-waiting-queries s5-rollback
 step s5-begin:
 	BEGIN;
 
@@ -1266,16 +1273,6 @@ blocked_statement                                        |current_statement_in_b
 
 (1 row)
 
-step s3-show-actual-gpids:
-	SELECT global_pid > 0 as gpid_exists, query FROM citus_stat_activity WHERE state = 'active' AND query IN (SELECT blocked_statement FROM citus_lock_waits UNION SELECT current_statement_in_blocking_process FROM citus_lock_waits) ORDER BY 1 DESC;
-
-gpid_exists|query
----------------------------------------------------------------------
-f          |
-	SELECT user_id FROM tt1 ORDER BY user_id DESC LIMIT 1;
-
-(1 row)
-
 step s5-rollback:
 	ROLLBACK;
 
@@ -1285,6 +1282,13 @@ user_id
       7
 (1 row)
 
+citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+
+starting permutation: s8-begin s8-select s7-alter s3-select-distributed-waiting-queries s3-show-actual-gpids s8-rollback
 step s8-begin:
 	BEGIN;
 

--- a/src/test/regress/spec/isolation_get_distributed_wait_queries_mx.spec
+++ b/src/test/regress/spec/isolation_get_distributed_wait_queries_mx.spec
@@ -275,7 +275,8 @@ permutation "s1-begin" "s1-update-ref-table-from-coordinator" "s2-start-session-
 
 // show that we can see blocking activity even if these are the first commands in the sessions
 // such that global_pids have not been assigned
-// in the second permutation, s3-show-actual-gpids shows the gpid for ALTER TABLE
-// because ALTER TABLE is not blocked on the parser but during the execution (hence gpid already asssigned)
-"s5-begin" "s5-alter" "s6-select" "s3-select-distributed-waiting-queries" "s3-show-actual-gpids" "s5-rollback"
-"s8-begin" "s8-select" "s7-alter" "s3-select-distributed-waiting-queries" "s3-show-actual-gpids" "s8-rollback"
+// in the first permutation, we would normally have s3-show-actual-gpids and it'd show the gpid has NOT been assigned
+// however, as of PG commit 3f323956128ff8589ce4d3a14e8b950837831803, isolation tester sends set application_name command
+// even before we can do anything on the session. That's why we removed s3-show-actual-gpids, but still useful to show waiting queriies
+permutation "s5-begin" "s5-alter" "s6-select" "s3-select-distributed-waiting-queries" "s5-rollback"
+permutation "s8-begin" "s8-select" "s7-alter" "s3-select-distributed-waiting-queries" "s3-show-actual-gpids" "s8-rollback"

--- a/src/test/regress/spec/isolation_get_distributed_wait_queries_mx.spec
+++ b/src/test/regress/spec/isolation_get_distributed_wait_queries_mx.spec
@@ -277,6 +277,6 @@ permutation "s1-begin" "s1-update-ref-table-from-coordinator" "s2-start-session-
 // such that global_pids have not been assigned
 // in the first permutation, we would normally have s3-show-actual-gpids and it'd show the gpid has NOT been assigned
 // however, as of PG commit 3f323956128ff8589ce4d3a14e8b950837831803, isolation tester sends set application_name command
-// even before we can do anything on the session. That's why we removed s3-show-actual-gpids, but still useful to show waiting queriies
+// even before we can do anything on the session. That's why we removed s3-show-actual-gpids, but still useful to show waiting queries
 permutation "s5-begin" "s5-alter" "s6-select" "s3-select-distributed-waiting-queries" "s5-rollback"
 permutation "s8-begin" "s8-select" "s7-alter" "s3-select-distributed-waiting-queries" "s3-show-actual-gpids" "s8-rollback"


### PR DESCRIPTION
In https://github.com/postgres/postgres/commit/3f323956128ff8589ce4d3a14e8b950837831803,
Postgres starts any isolation session with `set application_name`.

However, one of the tests we had expected that it is exactly the first
command in the session. The test tries to show that even if a gpid
has not been assigned, we can show it in the citus_lock_waits graph.

Now that, it is literally not possible to have such test as gpid
would be assigned after `set application_name` command. Still,
it is good to have a test where a command is blocked on the parser

useful for #5987 

enables https://github.com/citusdata/citus/pull/6078, as the PG commit is backported to PG 13/14
