### PR TITLE
Actually connect to the right database in logical_replication test

### DIFF
--- a/src/test/regress/expected/logical_replication.out
+++ b/src/test/regress/expected/logical_replication.out
@@ -21,16 +21,21 @@ NOTICE:  localhost:xxxxx is the coordinator and already contains metadata, skipp
         1
 (1 row)
 
+-- Create a publiction and subscription (including replication slot) manually.
+-- This allows us to test the cleanup logic at the start of the shard move.
 \c - - - :worker_1_port
 SET search_path TO logical_replication;
 CREATE PUBLICATION citus_shard_move_publication_:postgres_oid FOR TABLE dist_6830000;
 \c - - - :master_port
 SET search_path TO logical_replication;
-\set connection_string '\'user=postgres host=localhost port=' :worker_1_port '\''
+CREATE TABLE dist_6830000(
+    id bigserial PRIMARY KEY
+);
+\set connection_string '\'user=postgres host=localhost port=' :worker_1_port ' dbname=regression\''
 CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid
     CONNECTION :connection_string
     PUBLICATION citus_shard_move_publication_:postgres_oid
-    WITH (slot_name=citus_shard_move_slot_:postgres_oid);
+    WITH (enabled=false, slot_name=citus_shard_move_slot_:postgres_oid);
 NOTICE:  created replication slot "citus_shard_move_slot_10" on publisher
 SELECT count(*) from pg_subscription;
  count

--- a/src/test/regress/sql/logical_replication.sql
+++ b/src/test/regress/sql/logical_replication.sql
@@ -17,17 +17,23 @@ INSERT INTO dist SELECT generate_series(1, 100);
 
 SELECT 1 from citus_add_node('localhost', :master_port, groupId := 0);
 
+-- Create a publiction and subscription (including replication slot) manually.
+-- This allows us to test the cleanup logic at the start of the shard move.
 \c - - - :worker_1_port
 SET search_path TO logical_replication;
 CREATE PUBLICATION citus_shard_move_publication_:postgres_oid FOR TABLE dist_6830000;
 
 \c - - - :master_port
 SET search_path TO logical_replication;
-\set connection_string '\'user=postgres host=localhost port=' :worker_1_port '\''
+CREATE TABLE dist_6830000(
+    id bigserial PRIMARY KEY
+);
+\set connection_string '\'user=postgres host=localhost port=' :worker_1_port ' dbname=regression\''
 CREATE SUBSCRIPTION citus_shard_move_subscription_:postgres_oid
     CONNECTION :connection_string
     PUBLICATION citus_shard_move_publication_:postgres_oid
-    WITH (slot_name=citus_shard_move_slot_:postgres_oid);
+    WITH (enabled=false, slot_name=citus_shard_move_slot_:postgres_oid);
+
 
 SELECT count(*) from pg_subscription;
 SELECT count(*) from pg_publication;


### PR DESCRIPTION
In the logical_replication test we test that the cleanup logic at the
start of a shard move works as expected. To do so we create a
subscription and publication slot manually. This changes the test to
make that subscription actually connect to the database that the
publication is in.

Useful for #5987 #6085 
