### PR TITLE
Basic recurring left join distributed support

### DIFF
--- a/src/backend/distributed/planner/local_distributed_join_planner.c
+++ b/src/backend/distributed/planner/local_distributed_join_planner.c
@@ -173,9 +173,6 @@ typedef enum ConversionChoice
 
 static bool HasConstantFilterOnUniqueColumn(RangeTblEntry *rangeTableEntry,
 											RelationRestriction *relationRestriction);
-static List * RequiredAttrNumbersForRelation(RangeTblEntry *relationRte,
-											 PlannerRestrictionContext *
-											 plannerRestrictionContext);
 static ConversionCandidates * CreateConversionCandidates(PlannerRestrictionContext *
 														 plannerRestrictionContext,
 														 List *rangeTableList,
@@ -474,7 +471,7 @@ AppendUniqueIndexColumnsToList(Form_pg_index indexForm, List **uniqueIndexGroups
  * The function could be optimized by not adding the columns that only appear
  * WHERE clause as a filter (e.g., not a join clause).
  */
-static List *
+List *
 RequiredAttrNumbersForRelation(RangeTblEntry *rangeTableEntry,
 							   PlannerRestrictionContext *plannerRestrictionContext)
 {

--- a/src/include/distributed/local_distributed_join_planner.h
+++ b/src/include/distributed/local_distributed_join_planner.h
@@ -30,5 +30,8 @@ extern int LocalTableJoinPolicy;
 extern bool ShouldConvertLocalTableJoinsToSubqueries(List *rangeTableList);
 extern void RecursivelyPlanLocalTableJoins(Query *query,
 										   RecursivePlanningContext *context);
+extern List * RequiredAttrNumbersForRelation(RangeTblEntry *relationRte,
+											 PlannerRestrictionContext *
+											 plannerRestrictionContext);
 
 #endif /* LOCAL_DISTRIBUTED_JOIN_PLANNER_H */


### PR DESCRIPTION
DESCRIPTION: Implement basic recurring left join support

Opening a PR to not lose track of the branch. This is a prototype for reference_table left join distributed_table. It does not optimize the query by doing an inner join first (WrapSubqueryInInnerJoin is not implemented and should be removed for v1), but it does push down projections and filters (using TransformRelationRTEIntoSubqueryRTE).