### PR TITLE
Remove unused reduceQuery from physical planning

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -490,6 +490,10 @@ RangePartitionJoinBaseRelationId(MultiJoin *joinNode)
 	{
 		partitionNode = (MultiPartition *) rightChildNode;
 	}
+	else
+	{
+		Assert(false);
+	}
 
 	Index baseTableId = partitionNode->splitPointTableId;
 	MultiTable *baseTable = FindTableNode((MultiNode *) joinNode, baseTableId);
@@ -575,12 +579,7 @@ BuildJobQuery(MultiNode *multiNode, List *dependentJobList)
 		Job *job = (Job *) linitial(dependentJobList);
 		if (CitusIsA(job, MapMergeJob))
 		{
-			MapMergeJob *mapMergeJob = (MapMergeJob *) job;
 			isRepartitionJoin = true;
-			if (mapMergeJob->reduceQuery)
-			{
-				updateColumnAttributes = false;
-			}
 		}
 	}
 
@@ -4671,18 +4670,13 @@ MergeTaskList(MapMergeJob *mapMergeJob, List *mapTaskList, uint32 taskIdIndex)
 	for (uint32 partitionId = initialPartitionId; partitionId < partitionCount;
 		 partitionId++)
 	{
-		Task *mergeTask = NULL;
 		List *mapOutputFetchTaskList = NIL;
 		ListCell *mapTaskCell = NULL;
 		uint32 mergeTaskId = taskIdIndex;
 
-		Query *reduceQuery = mapMergeJob->reduceQuery;
-		if (reduceQuery == NULL)
-		{
-			/* create logical merge task (not executed, but useful for bookkeeping) */
-			mergeTask = CreateBasicTask(jobId, mergeTaskId, MERGE_TASK,
-										"<merge>");
-		}
+		/* create logical merge task (not executed, but useful for bookkeeping) */
+		Task *mergeTask = CreateBasicTask(jobId, mergeTaskId, MERGE_TASK,
+										  "<merge>");
 		mergeTask->partitionId = partitionId;
 		taskIdIndex++;
 

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -198,7 +198,6 @@ CopyNodeMapMergeJob(COPYFUNC_ARGS)
 
 	copyJobInfo(&newnode->job, &from->job);
 
-	COPY_NODE_FIELD(reduceQuery);
 	COPY_SCALAR_FIELD(partitionType);
 	COPY_NODE_FIELD(partitionColumn);
 	COPY_SCALAR_FIELD(partitionCount);

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -401,7 +401,6 @@ OutMapMergeJob(OUTFUNC_ARGS)
 	WRITE_NODE_TYPE("MAPMERGEJOB");
 
 	OutJobFields(str, (Job *) node);
-	WRITE_NODE_FIELD(reduceQuery);
 	WRITE_ENUM_FIELD(partitionType, PartitionType);
 	WRITE_NODE_FIELD(partitionColumn);
 	WRITE_UINT_FIELD(partitionCount);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -160,7 +160,6 @@ typedef struct Job
 typedef struct MapMergeJob
 {
 	Job job;
-	Query *reduceQuery;
 	PartitionType partitionType;
 	Var *partitionColumn;
 	uint32 partitionCount;


### PR DESCRIPTION
Also found as part of #6220. It was a little more surprising, but it seems reduceQuery is never set.