### PR TITLE
Set application_name to citus_rebalancer when copying reference tables

### DIFF
--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -244,6 +244,16 @@ EnsureReferenceTablesExistOnAllNodesExtended(char transferMode)
 				CopyShardPlacementToWorkerNodeQuery(sourceShardPlacement,
 													newWorkerNode,
 													transferMode);
+
+			/*
+			 * The placement copy command uses distributed execution to create
+			 * indexes. This is allowed when indicating that the backend is a
+			 * rebalancer backend.
+			 */
+			ExecuteCriticalRemoteCommand(connection,
+										 "SET LOCAL application_name TO "
+										 CITUS_REBALANCER_NAME);
+
 			ExecuteCriticalRemoteCommand(connection, placementCopyCommand->data);
 			RemoteTransactionCommit(connection);
 		}

--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -774,6 +774,7 @@ SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 (1 row)
 
 CREATE TABLE ref_table(a int);
+CREATE INDEX ON ref_table (a);
 SELECT create_reference_table('ref_table');
  create_reference_table
 ---------------------------------------------------------------------
@@ -993,6 +994,25 @@ WHERE nodeport=:worker_1_port;
  ?column?
 ---------------------------------------------------------------------
         0
+(1 row)
+
+-- test that we can use non-blocking rebalance
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT rebalance_table_shards(shard_transfer_mode := 'force_logical');
+ rebalance_table_shards
+---------------------------------------------------------------------
+
 (1 row)
 
 -- test that metadata is synced on replicate_reference_tables

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -506,6 +506,7 @@ ORDER BY 1,4,5;
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 
 CREATE TABLE ref_table(a int);
+CREATE INDEX ON ref_table (a);
 SELECT create_reference_table('ref_table');
 INSERT INTO ref_table SELECT * FROM generate_series(1, 10);
 
@@ -610,6 +611,12 @@ SELECT master_copy_shard_placement(
 SELECT result::int - :ref_table_placements
 FROM run_command_on_workers('SELECT count(*) FROM pg_dist_placement a, pg_dist_shard b, pg_class c WHERE a.shardid=b.shardid AND b.logicalrelid=c.oid AND c.relname=''ref_table''')
 WHERE nodeport=:worker_1_port;
+
+-- test that we can use non-blocking rebalance
+SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
+SELECT 1 FROM master_add_node('localhost', :worker_2_port);
+
+SELECT rebalance_table_shards(shard_transfer_mode := 'force_logical');
 
 -- test that metadata is synced on replicate_reference_tables
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);


### PR DESCRIPTION
DESCRIPTION: Fixes an issue can cause logical reference table replication to fail

We were running citus_copy_shard_placement via an internal connection, which is not allowed to perform distributed query execution by default. However, when we use logical replication to replicate reference tables in `rebalance_table_shards`, it performs distributed query execution when creating indexes.

This only affects 11.0, since main already has the fix (for other reasons), and 10.2 did not check for nested execution.

Fixes #6230 

TODO:
- [x] Add tests