### PR TITLE
Simplify foreign key graph invalidation

### DIFF
--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -499,21 +499,6 @@ ForeignConstraintFindDistKeys(HeapTuple pgConstraintTuple,
 
 
 /*
- * ColumnAppearsInForeignKey returns true if there is a foreign key constraint
- * from/to given column. False otherwise.
- */
-bool
-ColumnAppearsInForeignKey(char *columnName, Oid relationId)
-{
-	int searchForeignKeyColumnFlags = SEARCH_REFERENCING_RELATION |
-									  SEARCH_REFERENCED_RELATION;
-	List *foreignKeysColumnAppeared =
-		GetForeignKeyIdsForColumn(columnName, relationId, searchForeignKeyColumnFlags);
-	return list_length(foreignKeysColumnAppeared) > 0;
-}
-
-
-/*
  * ColumnAppearsInForeignKeyToReferenceTable checks if there is a foreign key
  * constraint from/to any reference table on the given column.
  */
@@ -821,23 +806,6 @@ TableReferencing(Oid relationId)
 
 
 /*
- * ConstraintIsAUniquenessConstraint is a wrapper around ConstraintWithNameIsOfType
- * that returns true if given constraint name identifies a uniqueness constraint, i.e:
- *   - primary key constraint, or
- *   - unique constraint
- */
-bool
-ConstraintIsAUniquenessConstraint(char *inputConstaintName, Oid relationId)
-{
-	bool isUniqueConstraint = ConstraintWithNameIsOfType(inputConstaintName, relationId,
-														 CONSTRAINT_UNIQUE);
-	bool isPrimaryConstraint = ConstraintWithNameIsOfType(inputConstaintName, relationId,
-														  CONSTRAINT_PRIMARY);
-	return isUniqueConstraint || isPrimaryConstraint;
-}
-
-
-/*
  * ConstraintIsAForeignKey is a wrapper around ConstraintWithNameIsOfType that returns true
  * if given constraint name identifies a foreign key constraint.
  */
@@ -885,6 +853,29 @@ ConstraintWithIdIsOfType(Oid constraintId, char targetConstraintType)
 	ReleaseSysCache(heapTuple);
 
 	return constraintTypeMatches;
+}
+
+
+/*
+ * ConstraintOnRelationId returns the relationId that the constraint is
+ * defined on.
+ */
+Oid
+ConstraintOnRelationId(Oid constraintId)
+{
+	HeapTuple heapTuple = SearchSysCache1(CONSTROID, ObjectIdGetDatum(constraintId));
+	if (!HeapTupleIsValid(heapTuple))
+	{
+		/* no such constraint */
+		return InvalidOid;
+	}
+
+	Form_pg_constraint constraintForm = (Form_pg_constraint) GETSTRUCT(heapTuple);
+	Oid conrelid = constraintForm->conrelid;
+
+	ReleaseSysCache(heapTuple);
+
+	return conrelid;
 }
 
 

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -754,11 +754,6 @@ PreprocessDropIndexStmt(Node *node, const char *dropIndexCommand,
 
 		ErrorIfUnsupportedDropIndexStmt(dropIndexStatement);
 
-		if (AnyForeignKeyDependsOnIndex(distributedIndexId))
-		{
-			MarkInvalidateForeignKeyGraph();
-		}
-
 		ObjectAddressSet(ddlJob->targetObjectAddress, RelationRelationId,
 						 distributedRelationId);
 

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -112,7 +112,6 @@ PreprocessDropSchemaStmt(Node *node, const char *queryString,
 	{
 		if (SchemaHasDistributedTableWithFKey(strVal(schemaVal)))
 		{
-			MarkInvalidateForeignKeyGraph();
 			break;
 		}
 	}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -162,6 +162,13 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 			LockColocationId(cacheEntry->colocationId, ShareLock);
 		}
 
+		/*
+		 * Invalidate foreign key cache if the table involved in any foreign key. We'd normally  */
+		if ((TableReferenced(relationId) || TableReferencing(relationId)))
+		{
+			MarkInvalidateForeignKeyGraph();
+		}
+
 		/* we're only interested in partitioned and mx tables */
 		if (!ShouldSyncTableMetadata(relationId) || !PartitionedTable(relationId))
 		{

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -1514,16 +1514,6 @@ static void
 PostStandardProcessUtility(Node *parsetree)
 {
 	DecrementUtilityHookCountersIfNecessary(parsetree);
-
-	/*
-	 * Re-forming the foreign key graph relies on the command being executed
-	 * on the local table first. However, in order to decide whether the
-	 * command leads to an invalidation, we need to check before the command
-	 * is being executed since we read pg_constraint table. Thus, we maintain a
-	 * local flag and do the invalidation after multi_ProcessUtility,
-	 * before ExecuteDistributedDDLJob().
-	 */
-	InvalidateForeignKeyGraphForDDL();
 }
 
 
@@ -1555,22 +1545,6 @@ void
 MarkInvalidateForeignKeyGraph()
 {
 	shouldInvalidateForeignKeyGraph = true;
-}
-
-
-/*
- * InvalidateForeignKeyGraphForDDL simply keeps track of whether
- * the foreign key graph should be invalidated due to a DDL.
- */
-void
-InvalidateForeignKeyGraphForDDL(void)
-{
-	if (shouldInvalidateForeignKeyGraph)
-	{
-		InvalidateForeignKeyGraph();
-
-		shouldInvalidateForeignKeyGraph = false;
-	}
 }
 
 

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -254,7 +254,6 @@ extern void ErrorIfUnsupportedForeignConstraintExists(Relation relation,
 													  uint32 colocationId);
 extern void ErrorOutForFKeyBetweenPostgresAndCitusLocalTable(Oid localTableId);
 extern bool ColumnReferencedByAnyForeignKey(char *columnName, Oid relationId);
-extern bool ColumnAppearsInForeignKey(char *columnName, Oid relationId);
 extern bool ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid
 													  relationId);
 extern List * GetReferencingForeignConstaintCommands(Oid relationOid);
@@ -268,11 +267,11 @@ extern bool HasForeignKeyToReferenceTable(Oid relationOid);
 extern List * GetForeignKeysFromLocalTables(Oid relationId);
 extern bool TableReferenced(Oid relationOid);
 extern bool TableReferencing(Oid relationOid);
-extern bool ConstraintIsAUniquenessConstraint(char *inputConstaintName, Oid relationId);
 extern bool ConstraintIsAForeignKey(char *inputConstaintName, Oid relationOid);
 extern bool ConstraintWithNameIsOfType(char *inputConstaintName, Oid relationId,
 									   char targetConstraintType);
 extern bool ConstraintWithIdIsOfType(Oid constraintId, char targetConstraintType);
+extern Oid ConstraintOnRelationId(Oid constraintId);
 extern bool TableHasExternalForeignKeys(Oid relationId);
 extern List * GetForeignKeyOids(Oid relationId, int flags);
 extern Oid GetReferencedTableId(Oid foreignKeyId);

--- a/src/include/distributed/commands/utility_hook.h
+++ b/src/include/distributed/commands/utility_hook.h
@@ -93,7 +93,6 @@ extern void ProcessUtilityParseTree(Node *node, const char *queryString,
 									QueryCompletion *completionTag
 									);
 extern void MarkInvalidateForeignKeyGraph(void);
-extern void InvalidateForeignKeyGraphForDDL(void);
 extern List * DDLTaskList(Oid relationId, const char *commandString);
 extern List * NodeDDLTaskList(TargetWorkerSet targets, List *commands);
 extern bool AlterTableInProgress(void);


### PR DESCRIPTION
Object access hook is much simpler and safer
than trying to find all cases manually.

Fixes #https://github.com/citusdata/citus/issues/4676

TODO:
- Few tests fail due to 
- We should also be able to do this for CREATE path, this is just to show how it'd look like
- Few more unused functions can be removed