### PR TITLE
Fix flakyness in multi_replicate_reference_table

### DIFF
--- a/src/test/regress/expected/multi_replicate_reference_table.out
+++ b/src/test/regress/expected/multi_replicate_reference_table.out
@@ -773,7 +773,7 @@ SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
         1
 (1 row)
 
-CREATE TABLE ref_table(a int);
+CREATE TABLE ref_table(id bigserial PRIMARY KEY, a int);
 CREATE INDEX ON ref_table (a);
 SELECT create_reference_table('ref_table');
  create_reference_table
@@ -781,7 +781,7 @@ SELECT create_reference_table('ref_table');
 
 (1 row)
 
-INSERT INTO ref_table SELECT * FROM generate_series(1, 10);
+INSERT INTO ref_table(a) SELECT * FROM generate_series(1, 10);
 -- verify direct call to citus_copy_shard_placement errors if target node is not yet added
 SELECT citus_copy_shard_placement(
            (SELECT shardid FROM pg_dist_shard WHERE logicalrelid='ref_table'::regclass::oid),
@@ -877,7 +877,7 @@ SELECT replicate_reference_tables('block_writes');
 
 (1 row)
 
-INSERT INTO ref_table VALUES (11);
+INSERT INTO ref_table(a) VALUES (11);
 SELECT count(*), sum(a) FROM ref_table;
  count | sum
 ---------------------------------------------------------------------
@@ -1105,7 +1105,7 @@ SELECT create_distributed_table('dist_table', 'a');
 
 INSERT INTO dist_table SELECT i, i * i FROM generate_series(1, 20) i;
 TRUNCATE ref_table;
-INSERT INTO ref_table SELECT 2 * i FROM generate_series(1, 5) i;
+INSERT INTO ref_table(a) SELECT 2 * i FROM generate_series(1, 5) i;
 \c - - - :worker_1_port
 SET search_path TO replicate_reference_table;
 SELECT array_agg(dist_table.b ORDER BY ref_table.a)

--- a/src/test/regress/sql/multi_replicate_reference_table.sql
+++ b/src/test/regress/sql/multi_replicate_reference_table.sql
@@ -505,10 +505,10 @@ ORDER BY 1,4,5;
 
 SELECT 1 FROM master_remove_node('localhost', :worker_2_port);
 
-CREATE TABLE ref_table(a int);
+CREATE TABLE ref_table(id bigserial PRIMARY KEY, a int);
 CREATE INDEX ON ref_table (a);
 SELECT create_reference_table('ref_table');
-INSERT INTO ref_table SELECT * FROM generate_series(1, 10);
+INSERT INTO ref_table(a) SELECT * FROM generate_series(1, 10);
 
 -- verify direct call to citus_copy_shard_placement errors if target node is not yet added
 SELECT citus_copy_shard_placement(
@@ -569,7 +569,7 @@ ROLLBACK;
 BEGIN;
 SELECT count(*) FROM ref_table;
 SELECT replicate_reference_tables('block_writes');
-INSERT INTO ref_table VALUES (11);
+INSERT INTO ref_table(a) VALUES (11);
 SELECT count(*), sum(a) FROM ref_table;
 UPDATE ref_table SET a = a + 1;
 SELECT sum(a) FROM ref_table;
@@ -667,7 +667,7 @@ SELECT create_distributed_table('dist_table', 'a');
 INSERT INTO dist_table SELECT i, i * i FROM generate_series(1, 20) i;
 
 TRUNCATE ref_table;
-INSERT INTO ref_table SELECT 2 * i FROM generate_series(1, 5) i;
+INSERT INTO ref_table(a) SELECT 2 * i FROM generate_series(1, 5) i;
 
 \c - - - :worker_1_port
 


### PR DESCRIPTION
In CI multi_replicate_reference_table would sometimes fail like this:

```diff
 -- detects correctly that referecence table doesn't have replica identity
 SELECT replicate_reference_tables();
-ERROR:  cannot use logical replication to transfer shards of the relation initially_not_replicated_reference_table since it doesn't have a REPLICA IDENTITY or PRIMARY KEY
+ERROR:  cannot use logical replication to transfer shards of the relation ref_table since it doesn't have a REPLICA IDENTITY or PRIMARY KEY
 DETAIL:  UPDATE and DELETE commands on the shard will error out during logical replication unless there is a REPLICA IDENTITY or PRIMARY KEY.
 HINT:  If you wish to continue without a replica identity set the shard_transfer_mode to 'force_logical' or 'block_writes'.
```

Because `CitusTableTypeIdList` returns tables in heap order so it's
a bit random which one is first in the list. And the test contained
multiple tables that didn't have a primary key or replica identity. So
it made sense that the error could be for either one of these tables.
This PR makes the test output consistent by changing one of the tables
to have a primary key.

Example of failing test: https://app.circleci.com/pipelines/github/citusdata/citus/26387/workflows/fc3196e7-ddf2-4000-a70b-5ac71c836321/jobs/748940
