### PR TITLE
CI: Store postgres logs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,6 +410,15 @@ jobs:
       - store_artifacts:
           name: 'Save core dumps'
           path: /tmp/core_dumps
+      - store_artifacts:
+          name: 'Save coordinator log'
+          path: src/test/regress/tmp_check/master/log
+      - store_artifacts:
+          name: 'Save worker1 log'
+          path: src/test/regress/tmp_check/worker.57637/log
+      - store_artifacts:
+          name: 'Save worker2 log'
+          path: src/test/regress/tmp_check/worker.57638/log
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,<< parameters.make >>'
           when: always


### PR DESCRIPTION
If a test fails sometimes the diff of the output isn't very helpful. In
those cases looking at the postgres logs can help a lot. We were only
storing these logs as artifacts for arbitrary config tests and tap
tests, now we also store them for our regular test runs.
