### PR TITLE
Use C.UTF-8 locale in tests

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -50,7 +50,9 @@ def initialize_db_for_cluster(pg_path, rel_data_path, settings, node_names):
             # private keys correctly
             "--allow-group-access",
             "--encoding",
-            "UTF8"
+            "UTF8",
+            "--locale",
+            "C.UTF-8",
         ]
         subprocess.run(command, check=True)
         add_settings(abs_data_path, settings)

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -704,7 +704,7 @@ if (!$conninfo)
     # Create new data directories, copy workers for speed
     # --allow-group-access is used to ensure we set permissions on private keys
     # correctly
-    system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
+    system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", "--locale", "C.UTF-8", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
         or die "Could not create $MASTERDIR data directory";
 
 	generate_hba("master");


### PR DESCRIPTION
I upgraded my OS to Ubuntu 22.04 a while back and since then some tests
order output slightly differently. I think it might be because of the
glibc upgrade that changed ordering for things like underscores and
spaces.

Changing the locale to C.UTF-8 solves this issue.
