### PR TITLE
Make multi_utilities not leak tables

### DIFF
--- a/src/test/regress/expected/multi_copy.out
+++ b/src/test/regress/expected/multi_copy.out
@@ -650,7 +650,6 @@ INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'packed_numbers_hash'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'super_packed_numbers_hash'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'table_to_distribute'::regclass::oid, 0);
-INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'second_dustbunnies'::regclass::oid, 0);
 SET client_min_messages TO ERROR;
 SELECT 1 FROM master_activate_node('localhost', :worker_1_port);
  ?column?

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -4,6 +4,8 @@ SET citus.next_shard_id TO 990000;
 -- ===================================================================
 SET citus.shard_count TO 2;
 SET citus.shard_replication_factor TO 1;
+CREATE SCHEMA multi_utilities;
+SET search_path TO multi_utilities, public;
 CREATE TABLE sharded_table ( name text, id bigint );
 SELECT create_distributed_table('sharded_table', 'id', 'hash');
  create_distributed_table
@@ -196,22 +198,26 @@ SELECT master_create_worker_shards('second_dustbunnies', 1, 2);
 
 -- run VACUUM and ANALYZE against the table on the master
 \c - - :master_host :master_port
+SET search_path TO multi_utilities, public;
 VACUUM dustbunnies;
 ANALYZE dustbunnies;
 -- send a VACUUM FULL and a VACUUM ANALYZE
 VACUUM (FULL) dustbunnies;
 VACUUM ANALYZE dustbunnies;
 \c - - :public_worker_1_host :worker_1_port
+SET search_path TO multi_utilities, public;
 -- disable auto-VACUUM for next test
 ALTER TABLE dustbunnies_990002 SET (autovacuum_enabled = false);
 SELECT relfrozenxid AS frozenxid FROM pg_class WHERE oid='dustbunnies_990002'::regclass
 \gset
 -- send a VACUUM FREEZE after adding a new row
 \c - - :master_host :master_port
+SET search_path TO multi_utilities, public;
 INSERT INTO dustbunnies VALUES (5, 'peter');
 VACUUM (FREEZE) dustbunnies;
 -- verify that relfrozenxid increased
 \c - - :public_worker_1_host :worker_1_port
+SET search_path TO multi_utilities, public;
 SELECT relfrozenxid::text::integer > :frozenxid AS frozen_performed FROM pg_class
 WHERE oid='dustbunnies_990002'::regclass;
  frozen_performed
@@ -231,10 +237,12 @@ WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
 
 -- add NULL values, then perform column-specific ANALYZE
 \c - - :master_host :master_port
+SET search_path TO multi_utilities, public;
 INSERT INTO dustbunnies VALUES (6, NULL, NULL);
 ANALYZE dustbunnies (name);
 -- verify that name's NULL ratio is updated but age's is not
 \c - - :public_worker_1_host :worker_1_port
+SET search_path TO multi_utilities, public;
 SELECT attname, null_frac FROM pg_stats
 WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
  attname | null_frac
@@ -245,16 +253,17 @@ WHERE tablename = 'dustbunnies_990002' ORDER BY attname;
 (3 rows)
 
 \c - - :master_host :master_port
+SET search_path TO multi_utilities, public;
 SET citus.log_remote_commands TO ON;
 -- check for multiple table vacuum
 VACUUM dustbunnies, second_dustbunnies;
-NOTICE:  issuing VACUUM public.dustbunnies_990002
+NOTICE:  issuing VACUUM multi_utilities.dustbunnies_990002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.dustbunnies_990002
+NOTICE:  issuing VACUUM multi_utilities.dustbunnies_990002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.second_dustbunnies_990003
+NOTICE:  issuing VACUUM multi_utilities.second_dustbunnies_990003
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.second_dustbunnies_990003
+NOTICE:  issuing VACUUM multi_utilities.second_dustbunnies_990003
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- and do not propagate when using targeted VACUUM without DDL propagation
 SET citus.enable_ddl_propagation to false;
@@ -360,27 +369,27 @@ SELECT pg_size_pretty( pg_total_relation_size('local_vacuum_table') );
 
 -- should propagate to all workers because table is reference table
 VACUUM reference_vacuum_table;
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- should propagate to all workers because table is distributed table
 VACUUM distributed_vacuum_table;
-NOTICE:  issuing VACUUM public.distributed_vacuum_table_970001
+NOTICE:  issuing VACUUM multi_utilities.distributed_vacuum_table_970001
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- only distributed_vacuum_table and reference_vacuum_table should propagate
 VACUUM distributed_vacuum_table, local_vacuum_table, reference_vacuum_table;
-NOTICE:  issuing VACUUM public.distributed_vacuum_table_970001
+NOTICE:  issuing VACUUM multi_utilities.distributed_vacuum_table_970001
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- only reference_vacuum_table should propagate
 VACUUM local_vacuum_table, reference_vacuum_table;
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- vacuum (disable_page_skipping) aggressively process pages of the relation, it does not respect visibility map
 VACUUM (DISABLE_PAGE_SKIPPING true) local_vacuum_table;
@@ -428,9 +437,9 @@ select analyze_count from pg_stat_all_tables where relname = 'local_vacuum_table
 (2 rows)
 
 vacuum (analyze) local_vacuum_table, reference_vacuum_table;
-NOTICE:  issuing VACUUM (ANALYZE) public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM (ANALYZE) multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing VACUUM (ANALYZE) public.reference_vacuum_table_970000
+NOTICE:  issuing VACUUM (ANALYZE) multi_utilities.reference_vacuum_table_970000
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- give enough time for stats to be updated.(updated per 500ms by default)
 select pg_sleep(1);
@@ -487,27 +496,27 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 ANALYZE local_analyze_table;
 -- should propagate to all workers because table is reference table
 ANALYZE reference_analyze_table;
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- should propagate to all workers because table is distributed table
 ANALYZE distributed_analyze_table;
-NOTICE:  issuing ANALYZE public.distributed_analyze_table_970003
+NOTICE:  issuing ANALYZE multi_utilities.distributed_analyze_table_970003
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- only distributed_analyze_table and reference_analyze_table should propagate
 ANALYZE distributed_analyze_table, local_analyze_table, reference_analyze_table;
-NOTICE:  issuing ANALYZE public.distributed_analyze_table_970003
+NOTICE:  issuing ANALYZE multi_utilities.distributed_analyze_table_970003
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- only reference_analyze_table should propagate
 ANALYZE local_analyze_table, reference_analyze_table;
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing ANALYZE public.reference_analyze_table_970002
+NOTICE:  issuing ANALYZE multi_utilities.reference_analyze_table_970002
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- should not propagate because ddl propagation is disabled
 SET citus.enable_ddl_propagation TO OFF;
@@ -515,7 +524,9 @@ ANALYZE distributed_analyze_table;
 SET citus.enable_ddl_propagation TO ON;
 -- analyze only specified columns for corresponding tables
 ANALYZE loc(b), dist(a);
-NOTICE:  issuing ANALYZE public.dist_970004 (a)
+NOTICE:  issuing ANALYZE multi_utilities.dist_970004 (a)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 RESET citus.log_remote_commands;
 RESET citus.grep_remote_commands;
+SET client_min_messages TO WARNING;
+DROP SCHEMA multi_utilities CASCADE;

--- a/src/test/regress/sql/multi_copy.sql
+++ b/src/test/regress/sql/multi_copy.sql
@@ -523,7 +523,6 @@ INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'packed_numbers_hash'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'super_packed_numbers_hash'::regclass::oid, 0);
 INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'table_to_distribute'::regclass::oid, 0);
-INSERT INTO pg_catalog.pg_dist_object(classid, objid, objsubid) values('pg_class'::regclass::oid, 'second_dustbunnies'::regclass::oid, 0);
 
 SET client_min_messages TO ERROR;
 SELECT 1 FROM master_activate_node('localhost', :worker_1_port);


### PR DESCRIPTION
When trying to fix #6245 I realized that multi_utilities was leaking
some tables that it created during the test. This fixes that by
creating all these tables in a schema that's dedicated for this test.
