### PR TITLE
Fix errors in base_schedule

### DIFF
--- a/src/test/regress/base_schedule
+++ b/src/test/regress/base_schedule
@@ -4,7 +4,8 @@
 test: multi_test_helpers multi_test_helpers_superuser multi_create_fdw columnar_test_helpers failure_test_helpers
 test: multi_cluster_management
 test: multi_test_catalog_views
-test: multi_create_table multi_behavioral_analytics_create_table
+test: multi_create_table
+test: multi_behavioral_analytics_create_table
 test: multi_create_table_superuser multi_behavioral_analytics_create_table_superuser
 test: multi_load_data multi_load_data_superuser tablespace
 test: check_mx

--- a/src/test/regress/expected/failure_test_helpers.out
+++ b/src/test/regress/expected/failure_test_helpers.out
@@ -10,10 +10,6 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
-    RETURNS void
-    LANGUAGE C STRICT
-    AS 'citus';
 -- Add some helper functions for sending commands to mitmproxy
 CREATE FUNCTION citus.mitmproxy(text) RETURNS TABLE(result text) AS $$
 DECLARE

--- a/src/test/regress/sql/failure_test_helpers.sql
+++ b/src/test/regress/sql/failure_test_helpers.sql
@@ -6,11 +6,6 @@ ALTER SYSTEM SET citus.recover_2pc_interval TO -1;
 ALTER SYSTEM set citus.enable_statistics_collection TO false;
 SELECT pg_reload_conf();
 
-CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
-    RETURNS void
-    LANGUAGE C STRICT
-    AS 'citus';
-
 -- Add some helper functions for sending commands to mitmproxy
 
 CREATE FUNCTION citus.mitmproxy(text) RETURNS TABLE(result text) AS $$


### PR DESCRIPTION
When running `make check-base` locally it would fail with two different
errors.

The first one was this:
```diff
 SELECT create_distributed_table('pg_class', 'relname');
-ERROR:  cannot create a citus table from a catalog table
+ERROR:  deadlock detected
+DETAIL:  Process 28950 waits for ExclusiveLock on relation 16551 of database 16384; blocked by process 28951.
+Process 28951 waits for RowExclusiveLock on relation 1259 of database 16384; blocked by process 28950.
+HINT:  See server log for query details.
 SELECT create_reference_table('pg_class');
```

This happened because multi_behavioral_analytics_create_table and
multi_create_table were being run in parallel. Running them separately
resolved this issue.

The second one was this:
```diff
 CREATE OR REPLACE FUNCTION wait_until_metadata_sync(timeout INTEGER DEFAULT 15000)
     RETURNS void
     LANGUAGE C STRICT
     AS 'citus';
+ERROR:  duplicate key value violates unique constraint "pg_proc_proname_args_nsp_index"
+DETAIL:  Key (proname, proargtypes, pronamespace)=(wait_until_metadata_sync, 23, 2200) already exists.
 -- Add some helper functions for sending commands to mitmproxy
```
Which was because failure_test_helpers and multi_test_helpers were
trying to create the same function at the exact same time. The easy fix
here is to simply not create this function in the failure_test_helpers
file. This is fine, because any test schedule that runs
failure_test_helpers also runs multi_test_helpers.
