### PR TITLE
Fix flakyness in failure_connection_establishment

### DIFF
--- a/src/test/regress/expected/failure_connection_establishment.out
+++ b/src/test/regress/expected/failure_connection_establishment.out
@@ -396,15 +396,6 @@ SELECT * FROM citus_check_cluster_node_health();
  localhost     |         57637 | localhost   |       57637 | t
 (4 rows)
 
--- cancel all connections to this node
-SELECT citus.mitmproxy('conn.onAuthenticationOk().cancel(' || pg_backend_pid() || ')');
- mitmproxy
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT * FROM citus_check_cluster_node_health();
-ERROR:  canceling statement due to user request
 -- kill connection checks to this node
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").kill()');
  mitmproxy

--- a/src/test/regress/sql/failure_connection_establishment.sql
+++ b/src/test/regress/sql/failure_connection_establishment.sql
@@ -181,10 +181,6 @@ SELECT * FROM citus_check_cluster_node_health();
 SELECT citus.mitmproxy('conn.onAuthenticationOk().kill()');
 SELECT * FROM citus_check_cluster_node_health();
 
--- cancel all connections to this node
-SELECT citus.mitmproxy('conn.onAuthenticationOk().cancel(' || pg_backend_pid() || ')');
-SELECT * FROM citus_check_cluster_node_health();
-
 -- kill connection checks to this node
 SELECT citus.mitmproxy('conn.onQuery(query="^SELECT 1$").kill()');
 SELECT * FROM citus_check_cluster_node_health();


### PR DESCRIPTION
In CI sometimes failure_connection_establishment would fail with the
following error:
```diff
 -- cancel all connections to this node
 SELECT citus.mitmproxy('conn.onAuthenticationOk().cancel(' || pg_backend_pid() || ')');
- mitmproxy
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  canceling statement due to user request
+CONTEXT:  COPY mitmproxy_result, line 1: ""
+SQL statement "COPY mitmproxy_result FROM '/home/circleci/project/src/test/regress/tmp_check/mitmproxy.fifo'"
+PL/pgSQL function citus.mitmproxy(text) line 11 at EXECUTE
 SELECT * FROM citus_check_cluster_node_health();
```

The reason for this is that the mitm command that was used is very
broad and doesn't actually do what the comment says. What happens is
that if any connection is made, the current backend is cancelled, which
is not the always the same as the backend that made the connection. My
assessment is that likely the maintenance daemon makes a connection to
the node while we are executing the mitmproxy command. The mitmproxy
command goes through, and then triggers a cancel of itself due to the
connection made by the maintenance daemon.

This PR simply removes this test, since it doesn't seem to test what it
intended to test anyway. There's also still the "kill" version of this
test, which does do the intended thing. So I don't think we lose
important coverage by removing this test.
