### PR TITLE
Always copy normalized files after a regress run

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -137,8 +137,10 @@ def create_citus_extension(pg_path, node_ports):
 
 def run_pg_regress(pg_path, pg_srcdir, port, schedule):
     should_exit = True
-    _run_pg_regress(pg_path, pg_srcdir, port, schedule, should_exit)
-    subprocess.run("bin/copy_modified", check=True)
+    try:
+        _run_pg_regress(pg_path, pg_srcdir, port, schedule, should_exit)
+    finally:
+        subprocess.run("bin/copy_modified", check=True)
 
 
 def run_pg_regress_without_exit(


### PR DESCRIPTION
Our python based tests didn't always copy the normalized files after the
regress run. I had the problem where running the following command would
result in non-normalized files in the expected directory after running
our PG upgrade tests locally:

```
cp src/test/regress/{results,expected}/upgrade_list_citus_objects.out
```

This PR fixes that by always running `copy_modified` even if the tests
fail. The same was already being done for our perl based tests at the
end of the `pg_regress_multi.pl` file.
