### PR TITLE
Don't use parallel shutdown in atexit function

### DIFF
--- a/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
@@ -209,5 +209,7 @@ if __name__ == "__main__":
         config.datadir,
         config.node_name_to_ports,
         config.name,
+        no_output=True,
+        parallel=False,
     )
     main(config)

--- a/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
@@ -66,10 +66,10 @@ def citus_finish_pg_upgrade(pg_path, node_ports):
 
 def stop_all_databases(old_bindir, new_bindir, old_datadir, new_datadir, config):
     common.stop_databases(
-        old_bindir, old_datadir, config.node_name_to_ports, config.name
+        old_bindir, old_datadir, config.node_name_to_ports, config.name, no_output=True, parallel=False,
     )
     common.stop_databases(
-        new_bindir, new_datadir, config.node_name_to_ports, config.name
+        new_bindir, new_datadir, config.node_name_to_ports, config.name, no_output=True, parallel=False,
     )
 
 


### PR DESCRIPTION
Using parallel futures in an atexit callback is not supported by Python
and will result in an error like this being shown:
```
RuntimeError: cannot schedule new futures after interpreter shutdown
```

This was already fixed for arbitrary config tests by not shutting down
in parallel during atexit, but the same was not done for upgrade tests.
This uses the same approach in upgrade tests.
