### PR TITLE
Check WL_SOCKET_CLOSED before using any connection

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -57,8 +57,10 @@ static uint32 ConnectionHashHash(const void *key, Size keysize);
 static int ConnectionHashCompare(const void *a, const void *b, Size keysize);
 static void StartConnectionEstablishment(MultiConnection *connectionn,
 										 ConnectionHashKey *key);
-static MultiConnection * FindAvailableConnection(dlist_head *connections, uint32 flags);
-static void ErrorIfMultipleMetadataConnectionExists(dlist_head *connections);
+static MultiConnection * FindAvailableConnection(List *connections, uint32 flags);
+static List * EnsureAndGetHealthyConnections(dlist_head *connections, uint32 flags);
+static bool RemoteSocketClosed(MultiConnection *connection);
+static void ErrorIfMultipleMetadataConnectionExists(List *connections);
 static void FreeConnParamsHashEntryFields(ConnParamsHashEntry *entry);
 static void AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit);
 static bool ShouldShutdownConnection(MultiConnection *connection, const int
@@ -66,7 +68,6 @@ static bool ShouldShutdownConnection(MultiConnection *connection, const int
 static void ResetConnection(MultiConnection *connection);
 static bool RemoteTransactionIdle(MultiConnection *connection);
 static int EventSetSizeForConnectionList(List *connections);
-
 
 /* types for async connection management */
 enum MultiConnectionPhase
@@ -334,8 +335,11 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 	/* if desired, check whether there's a usable connection */
 	if (!(flags & FORCE_NEW_CONNECTION))
 	{
+		List *healthyConnections = EnsureAndGetHealthyConnections(entry->connections,
+																  flags);
+
 		/* check connection cache for a connection that's not already in use */
-		MultiConnection *connection = FindAvailableConnection(entry->connections, flags);
+		MultiConnection *connection = FindAvailableConnection(healthyConnections, flags);
 		if (connection)
 		{
 			return connection;
@@ -427,16 +431,13 @@ StartNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
  * If no connection is available, FindAvailableConnection returns NULL.
  */
 static MultiConnection *
-FindAvailableConnection(dlist_head *connections, uint32 flags)
+FindAvailableConnection(List *connections, uint32 flags)
 {
 	List *metadataConnectionCandidateList = NIL;
 
-	dlist_iter iter;
-	dlist_foreach(iter, connections)
+	MultiConnection *connection = NULL;
+	foreach_ptr(connection, connections)
 	{
-		MultiConnection *connection =
-			dlist_container(MultiConnection, connectionNode, iter.cur);
-
 		if (flags & OUTSIDE_TRANSACTION)
 		{
 			/* don't return connections that are used in transactions */
@@ -527,19 +528,133 @@ FindAvailableConnection(dlist_head *connections, uint32 flags)
 
 
 /*
- * ErrorIfMultipleMetadataConnectionExists throws an error if the
- * input connection dlist contains more than one metadata connections.
+ * EnsureAndGetHealthyConnections is a helper function that goes over the
+ * input connections, and:
+ *  - Errors for the connections that are not healthy but still part of a
+ *    remote transaction
+ *  - Skips connections that are not healthy, marks them to be closed
+ *    at the end of the transaction such that they do not linger around
+ *
+ * And, finally returns the list (unless already errored out) of connections
+ * that can be reused.
  */
-static void
-ErrorIfMultipleMetadataConnectionExists(dlist_head *connections)
+static List *
+EnsureAndGetHealthyConnections(dlist_head *connections, uint32 flags)
 {
-	bool foundMetadataConnection = false;
+	List *healthyConnections = NIL;
+
 	dlist_iter iter;
 	dlist_foreach(iter, connections)
 	{
 		MultiConnection *connection =
 			dlist_container(MultiConnection, connectionNode, iter.cur);
+		bool healthyConnection = true;
 
+		if (connection->pgConn == NULL || PQsocket(connection->pgConn) == -1 ||
+			PQstatus(connection->pgConn) != CONNECTION_OK ||
+			connection->connectionState != MULTI_CONNECTION_CONNECTED ||
+			RemoteSocketClosed(connection))
+		{
+			/* connection is not healthy */
+			healthyConnection = false;
+		}
+
+		RemoteTransaction *transaction = &connection->remoteTransaction;
+		bool inRemoteTrasaction =
+			transaction->transactionState != REMOTE_TRANS_NOT_STARTED;
+
+		if (inRemoteTrasaction)
+		{
+			PGTransactionStatusType status = PQtransactionStatus(connection->pgConn);
+
+			/* if the connection is in a bad state, so is the transaction's state */
+			if (status == PQTRANS_INERROR || status == PQTRANS_UNKNOWN)
+			{
+				transaction->transactionFailed = true;
+			}
+		}
+
+		if (healthyConnection)
+		{
+			healthyConnections = lappend(healthyConnections, connection);
+		}
+		else if ((inRemoteTrasaction && !(flags & OUTSIDE_TRANSACTION)) &&
+				 (transaction->transactionCritical ||
+				  !dlist_is_empty(&connection->referencedPlacements)))
+		{
+			ReportConnectionError(connection, ERROR);
+
+			/*
+			 * If a connection is executing a critical transaction or accessed any
+			 * placements, we should not continue the execution.
+			 */
+			ereport(WARNING, (errmsg("failure on connection marked as essential: %s:%d",
+									 connection->hostname, connection->port)));
+		}
+		else
+		{
+			/*
+			 * If a connection is not usable and we do not need to throw an error,
+			 * close at the end of the transaction.
+			 */
+			connection->forceCloseAtTransactionEnd = true;
+		}
+	}
+
+	return healthyConnections;
+}
+
+
+/*
+ * RemoteSocketClosed returns true if the remote socket is closed.
+ *
+ * Note that we rely on WL_SOCKET_CLOSED, which is only available
+ * for PG 15+ and for kernels that support the feature.
+ */
+static bool
+RemoteSocketClosed(MultiConnection *connection)
+{
+	bool socketClosed = false;
+#if PG_VERSION_NUM >= PG_VERSION_15
+
+	WaitEventSet *waitEventSet =
+		CreateWaitEventSet(CurrentMemoryContext, 1);
+	int sock = PQsocket(connection->pgConn);
+	WaitEvent *events = palloc0(sizeof(WaitEvent));
+
+	/* TODO: process return value of CitusAddWaitEventSetToSet */
+	CitusAddWaitEventSetToSet(waitEventSet, WL_SOCKET_CLOSED, sock,
+							  NULL, (void *) connection);
+
+	long timeout = 0; /* do not wait at all */
+	int eventCount = WaitEventSetWait(waitEventSet, timeout, events,
+									  1, WAIT_EVENT_CLIENT_READ);
+	if (eventCount > 0)
+	{
+		Assert(eventCount == 1);
+
+		WaitEvent *event = &events[0];
+		socketClosed = (event->events & WL_SOCKET_CLOSED);
+	}
+
+	FreeWaitEventSet(waitEventSet);
+#endif
+
+	return socketClosed;
+}
+
+
+/*
+ * ErrorIfMultipleMetadataConnectionExists throws an error if the
+ * input connection dlist contains more than one metadata connections.
+ */
+static void
+ErrorIfMultipleMetadataConnectionExists(List *connections)
+{
+	bool foundMetadataConnection = false;
+	MultiConnection *connection = NULL;
+	foreach_ptr(connection, connections)
+	{
 		if (connection->useForMetadataOperations)
 		{
 			if (foundMetadataConnection)
@@ -617,7 +732,9 @@ ConnectionAvailableToNode(char *hostName, int nodePort, const char *userName,
 	}
 
 	int flags = 0;
-	MultiConnection *connection = FindAvailableConnection(entry->connections, flags);
+	List *healthyConnections = EnsureAndGetHealthyConnections(entry->connections, flags);
+
+	MultiConnection *connection = FindAvailableConnection(healthyConnections, flags);
 
 	return connection;
 }
@@ -1478,7 +1595,8 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
 		   connection->requiresReplication ||
 		   (MaxCachedConnectionLifetime >= 0 &&
 			MillisecondsToTimeout(connection->connectionEstablishmentStart,
-								  MaxCachedConnectionLifetime) <= 0);
+								  MaxCachedConnectionLifetime) <= 0) ||
+		   RemoteSocketClosed(connection);
 }
 
 

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -1654,8 +1654,7 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
 		   connection->requiresReplication ||
 		   (MaxCachedConnectionLifetime >= 0 &&
 			MillisecondsToTimeout(connection->connectionEstablishmentStart,
-								  MaxCachedConnectionLifetime) <= 0) ||
-		   RemoteSocketClosed(connection);
+								  MaxCachedConnectionLifetime) <= 0);
 }
 
 

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -565,7 +565,7 @@ EnsureAndGetHealthyConnections(dlist_head *connections, bool checkTransactionSta
 		bool inRemoteTrasaction =
 			transaction->transactionState != REMOTE_TRANS_NOT_STARTED;
 
-		if (inRemoteTrasaction && checkTransactionState)
+		if (checkTransactionState && inRemoteTrasaction)
 		{
 			PGTransactionStatusType status = PQtransactionStatus(connection->pgConn);
 
@@ -580,7 +580,8 @@ EnsureAndGetHealthyConnections(dlist_head *connections, bool checkTransactionSta
 		{
 			healthyConnections = lappend(healthyConnections, connection);
 		}
-		else if (inRemoteTrasaction && checkTransactionState &&
+		else if (checkTransactionState && inRemoteTrasaction &&
+				 transaction->transactionFailed &&
 				 (transaction->transactionCritical ||
 				  !dlist_is_empty(&connection->referencedPlacements)))
 		{

--- a/src/test/regress/expected/detect_conn_close.out
+++ b/src/test/regress/expected/detect_conn_close.out
@@ -144,5 +144,40 @@ BEGIN;
 ERROR:  terminating connection due to administrator command
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
+-- although should have no difference, we can recover from the failures on the workers as well
+\c - - - :worker_1_port
+SET search_path TO socket_close;
+-- now, use 16 connections per worker, we can still recover all connections
+SET citus.max_adaptive_executor_pool_size TO 16;
+SET citus.max_cached_conns_per_worker TO 16;
+SET citus.force_max_query_parallelization  TO ON;
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   103
+(1 row)
+
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 16
+ 16
+(2 rows)
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 0
+ 0
+(2 rows)
+
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   103
+(1 row)
+
+\c - - - :master_port
 SET client_min_messages TO ERROR;
 DROP SCHEMA socket_close CASCADE;

--- a/src/test/regress/expected/detect_conn_close.out
+++ b/src/test/regress/expected/detect_conn_close.out
@@ -30,7 +30,7 @@ SELECT count(*) FROM socket_test_table;
 (1 row)
 
 -- kill all the cached backends on the workers
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
  result
 ---------------------------------------------------------------------
  1
@@ -62,19 +62,11 @@ SELECT count(*) FROM socket_test_table;
    101
 (1 row)
 
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
  result
 ---------------------------------------------------------------------
  16
  16
-(2 rows)
-
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
- result
----------------------------------------------------------------------
- 0
- 0
 (2 rows)
 
 SELECT count(*) FROM socket_test_table;
@@ -90,37 +82,21 @@ SET citus.force_max_query_parallelization  TO OFF;
 -- we can recover for modification queries as well
 -- single row INSERT
 INSERT INTO socket_test_table VALUES (1);
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
  result
 ---------------------------------------------------------------------
  1
  1
-(2 rows)
-
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
- result
----------------------------------------------------------------------
- 0
- 0
 (2 rows)
 
 INSERT INTO socket_test_table VALUES (1);
 -- single row UPDATE
 UPDATE socket_test_table SET value = 15 WHERE id = 1;
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
  result
 ---------------------------------------------------------------------
  0
  1
-(2 rows)
-
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
- result
----------------------------------------------------------------------
- 0
- 0
 (2 rows)
 
 UPDATE socket_test_table SET value = 15 WHERE id = 1;
@@ -133,7 +109,7 @@ BEGIN;
 (1 row)
 
   -- kill all the cached backends on the workers
-  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
  result
 ---------------------------------------------------------------------
  1
@@ -156,19 +132,11 @@ SELECT count(*) FROM socket_test_table;
    103
 (1 row)
 
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
  result
 ---------------------------------------------------------------------
  1
  1
-(2 rows)
-
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
- result
----------------------------------------------------------------------
- 0
- 0
 (2 rows)
 
 SELECT count(*) FROM socket_test_table;

--- a/src/test/regress/expected/detect_conn_close.out
+++ b/src/test/regress/expected/detect_conn_close.out
@@ -1,0 +1,148 @@
+--
+-- PG15+ test as WL_SOCKET_CLOSED exposed for PG15+
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+CREATE SCHEMA socket_close;
+SET search_path TO socket_close;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE socket_test_table(id bigserial, value text);
+SELECT create_distributed_table('socket_test_table', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO socket_test_table (value) SELECT i::text FROM generate_series(0,100)i;
+-- first, simulate that we only have one cached connection per node
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+-- kill all the cached backends on the workers
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 1
+ 1
+(2 rows)
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 0
+ 0
+(2 rows)
+
+-- even though the cached connections closed, the execution recovers and establishes new connections
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+-- now, use 16 connections per worker, we can still recover all connections
+SET citus.max_adaptive_executor_pool_size TO 16;
+SET citus.max_cached_conns_per_worker TO 16;
+SET citus.force_max_query_parallelization  TO ON;
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 16
+ 16
+(2 rows)
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 0
+ 0
+(2 rows)
+
+SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+-- now, get back to sane defaults
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
+SET citus.force_max_query_parallelization  TO OFF;
+-- we can recover for modification queries as well
+-- single row INSERT
+INSERT INTO socket_test_table VALUES (1);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+ result
+---------------------------------------------------------------------
+ 1
+ 1
+(2 rows)
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 0
+ 0
+(2 rows)
+
+INSERT INTO socket_test_table VALUES (1);
+-- single row UPDATE
+UPDATE socket_test_table SET value = 15 WHERE id = 1;
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+ result
+---------------------------------------------------------------------
+ 0
+ 1
+(2 rows)
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 0
+ 0
+(2 rows)
+
+UPDATE socket_test_table SET value = 15 WHERE id = 1;
+-- we cannot recover in a transaction block
+BEGIN;
+  SELECT count(*) FROM socket_test_table;
+ count
+---------------------------------------------------------------------
+   103
+(1 row)
+
+  -- kill all the cached backends on the workers
+  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+ result
+---------------------------------------------------------------------
+ 1
+ 1
+(2 rows)
+
+  SELECT count(*) FROM socket_test_table;
+ERROR:  terminating connection due to administrator command
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+SET client_min_messages TO ERROR;
+DROP SCHEMA socket_close CASCADE;

--- a/src/test/regress/expected/detect_conn_close.out
+++ b/src/test/regress/expected/detect_conn_close.out
@@ -147,9 +147,8 @@ ROLLBACK;
 -- although should have no difference, we can recover from the failures on the workers as well
 \c - - - :worker_1_port
 SET search_path TO socket_close;
--- now, use 16 connections per worker, we can still recover all connections
-SET citus.max_adaptive_executor_pool_size TO 16;
-SET citus.max_cached_conns_per_worker TO 16;
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
 SET citus.force_max_query_parallelization  TO ON;
 SELECT count(*) FROM socket_test_table;
  count
@@ -160,8 +159,8 @@ SELECT count(*) FROM socket_test_table;
 SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
  result
 ---------------------------------------------------------------------
- 16
- 16
+ 1
+ 1
 (2 rows)
 
 -- show that none remains

--- a/src/test/regress/expected/detect_conn_close_0.out
+++ b/src/test/regress/expected/detect_conn_close_0.out
@@ -1,0 +1,9 @@
+--
+-- PG15+ test as WL_SOCKET_CLOSED exposed for PG15+
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -55,7 +55,7 @@ test: subquery_in_targetlist subquery_in_where subquery_complex_target_list subq
 test: subquery_prepared_statements
 test: non_colocated_leaf_subquery_joins non_colocated_subquery_joins
 test: cte_inline recursive_view_local_table values sequences_with_different_types
-test: pg13 pg12 pg15_json json_table_select_only
+test: pg13 pg12 pg15_json json_table_select_only detect_conn_close
 # run pg14 sequentially as it syncs metadata
 test: pg14
 test: pg15

--- a/src/test/regress/sql/detect_conn_close.sql
+++ b/src/test/regress/sql/detect_conn_close.sql
@@ -85,9 +85,8 @@ ROLLBACK;
 \c - - - :worker_1_port
 SET search_path TO socket_close;
 
--- now, use 16 connections per worker, we can still recover all connections
-SET citus.max_adaptive_executor_pool_size TO 16;
-SET citus.max_cached_conns_per_worker TO 16;
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
 SET citus.force_max_query_parallelization  TO ON;
 SELECT count(*) FROM socket_test_table;
 SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);

--- a/src/test/regress/sql/detect_conn_close.sql
+++ b/src/test/regress/sql/detect_conn_close.sql
@@ -25,7 +25,7 @@ SET citus.max_cached_conns_per_worker TO 1;
 SELECT count(*) FROM socket_test_table;
 
 -- kill all the cached backends on the workers
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
 
 -- show that none remains
 SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
@@ -39,9 +39,7 @@ SET citus.max_adaptive_executor_pool_size TO 16;
 SET citus.max_cached_conns_per_worker TO 16;
 SET citus.force_max_query_parallelization  TO ON;
 SELECT count(*) FROM socket_test_table;
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
 
 SELECT count(*) FROM socket_test_table;
 
@@ -54,28 +52,20 @@ SET citus.force_max_query_parallelization  TO OFF;
 
 -- single row INSERT
 INSERT INTO socket_test_table VALUES (1);
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
-
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
 INSERT INTO socket_test_table VALUES (1);
-
 
 -- single row UPDATE
 UPDATE socket_test_table SET value = 15 WHERE id = 1;
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
-
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
 UPDATE socket_test_table SET value = 15 WHERE id = 1;
-
 
 -- we cannot recover in a transaction block
 BEGIN;
   SELECT count(*) FROM socket_test_table;
 
   -- kill all the cached backends on the workers
-  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
 
   SELECT count(*) FROM socket_test_table;
 ROLLBACK;
@@ -89,10 +79,7 @@ SET citus.max_adaptive_executor_pool_size TO 1;
 SET citus.max_cached_conns_per_worker TO 1;
 SET citus.force_max_query_parallelization  TO ON;
 SELECT count(*) FROM socket_test_table;
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
--- show that none remains
-SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
-
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid, 1000) FROM pg_stat_activity WHERE query ilike '%socket_test_table_%' AND query not ilike '%pg_stat_activity%' AND pid !=pg_backend_pid()) as foo$$);
 SELECT count(*) FROM socket_test_table;
 
 \c - - - :master_port

--- a/src/test/regress/sql/detect_conn_close.sql
+++ b/src/test/regress/sql/detect_conn_close.sql
@@ -1,0 +1,85 @@
+--
+-- PG15+ test as WL_SOCKET_CLOSED exposed for PG15+
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+
+CREATE SCHEMA socket_close;
+SET search_path TO socket_close;
+
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE socket_test_table(id bigserial, value text);
+SELECT create_distributed_table('socket_test_table', 'id');
+INSERT INTO socket_test_table (value) SELECT i::text FROM generate_series(0,100)i;
+
+-- first, simulate that we only have one cached connection per node
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
+SELECT count(*) FROM socket_test_table;
+
+-- kill all the cached backends on the workers
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+-- even though the cached connections closed, the execution recovers and establishes new connections
+SELECT count(*) FROM socket_test_table;
+
+
+-- now, use 16 connections per worker, we can still recover all connections
+SET citus.max_adaptive_executor_pool_size TO 16;
+SET citus.max_cached_conns_per_worker TO 16;
+SET citus.force_max_query_parallelization  TO ON;
+SELECT count(*) FROM socket_test_table;
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+SELECT count(*) FROM socket_test_table;
+
+-- now, get back to sane defaults
+SET citus.max_adaptive_executor_pool_size TO 1;
+SET citus.max_cached_conns_per_worker TO 1;
+SET citus.force_max_query_parallelization  TO OFF;
+
+-- we can recover for modification queries as well
+
+-- single row INSERT
+INSERT INTO socket_test_table VALUES (1);
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+INSERT INTO socket_test_table VALUES (1);
+
+
+-- single row UPDATE
+UPDATE socket_test_table SET value = 15 WHERE id = 1;
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$) ORDER BY result;
+-- show that none remains
+SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pid FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+UPDATE socket_test_table SET value = 15 WHERE id = 1;
+
+
+-- we cannot recover in a transaction block
+BEGIN;
+  SELECT count(*) FROM socket_test_table;
+
+  -- kill all the cached backends on the workers
+  SELECT result FROM run_command_on_workers($$SELECT count(*) FROM (SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query ilike '%socket_test_table%' AND pid !=pg_backend_pid()) as foo$$);
+
+  SELECT count(*) FROM socket_test_table;
+ROLLBACK;
+
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA socket_close CASCADE;


### PR DESCRIPTION
Fixes https://github.com/citusdata/citus/issues/5538. Another approach for https://github.com/citusdata/citus/pull/5908 on the connection management level, not the executor. 

Postgres added support for WL_SOCKET_CLOSED on PG 15 (https://github.com/postgres/postgres/commit/50e570a59e7f86bb41f029a66b781fc79b8d50f1) for kernels that support this event.

This patch is useful for recovering cached connections if the remote node closes the socket. It means that after `switchover` cases on the worker nodes, we'll not have connection errors such as the following:
```SQL
select count(*) from users_table; 

-- restart one of the worker nodes
pg_ctl -D /Users/onderkalaci/Documents/data_dir/worker_9701 -o "-p 9701" -l   /tmp/logfile_9701 restart -m f

-- as of this patch, this query DOESN'T fail
select count(*) from users_table; 
ERROR:  terminating connection due to administrator command
CONTEXT:  while executing command on localhost:9700
Time: 7.978 ms

```



The patch is NOT useful for:
- Recovering for network failures on the worker node that cannot be detected by the coordinator. Like, the network got cut off on the worker without having chance to close sockets (or let other nodes know about this)
- Recovering from failures during the command execution / distributed execution. This infrastructure can be utilized in the executor later on, but that requires non-trivial changes on the executor state machines. Currently, the executor state machines are not designed to re-connect in case of a failure.


