### PR TITLE
Use Posix locale in the tests

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -52,7 +52,7 @@ def initialize_db_for_cluster(pg_path, rel_data_path, settings, node_names):
             "--encoding",
             "UTF8",
             "--locale",
-            "C.UTF-8",
+            "POSIX"
         ]
         subprocess.run(command, check=True)
         add_settings(abs_data_path, settings)

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -704,7 +704,7 @@ if (!$conninfo)
     # Create new data directories, copy workers for speed
     # --allow-group-access is used to ensure we set permissions on private keys
     # correctly
-    system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", "--locale", "C.UTF-8", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
+    system(catfile("$bindir", "initdb"), ("--no-sync", "--allow-group-access", "-U", $user, "--encoding", "UTF8", "--locale", "POSIX", catfile($TMP_CHECKDIR, $MASTERDIR, "data"))) == 0
         or die "Could not create $MASTERDIR data directory";
 
 	generate_hba("master");


### PR DESCRIPTION
Commit 9653a0065e30edcf415032e17e46b1d33771c6f5 has changed it to C.UTF-8 , which fails on MacOS. Related to #6242