### PR TITLE
Fixes flakyness in columnar_permissions test

### DIFF
--- a/src/test/regress/expected/columnar_permissions.out
+++ b/src/test/regress/expected/columnar_permissions.out
@@ -37,7 +37,8 @@ ERROR:  must be owner of table no_access
 -- only tuples related to columnar_permissions should be visible
 select relation, chunk_group_row_limit, stripe_row_limit, compression, compression_level
   from columnar.options
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation;
        relation       | chunk_group_row_limit | stripe_row_limit | compression | compression_level
 ---------------------------------------------------------------------
  columnar_permissions |                 10000 |             2222 | none        |                 3
@@ -45,7 +46,8 @@ select relation, chunk_group_row_limit, stripe_row_limit, compression, compressi
 
 select relation, stripe_num, row_count, first_row_number
   from columnar.stripe
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | row_count | first_row_number
 ---------------------------------------------------------------------
  columnar_permissions |          1 |         1 |                1
@@ -54,7 +56,8 @@ select relation, stripe_num, row_count, first_row_number
 
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | attr_num | chunk_group_num | value_count
 ---------------------------------------------------------------------
  columnar_permissions |          1 |        1 |               0 |           1
@@ -63,7 +66,8 @@ select relation, stripe_num, attr_num, chunk_group_num, value_count
 
 select relation, stripe_num, chunk_group_num, row_count
   from columnar.chunk_group
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | chunk_group_num | row_count
 ---------------------------------------------------------------------
  columnar_permissions |          1 |               0 |         1
@@ -93,7 +97,8 @@ PL/pgSQL function alter_columnar_table_set(regclass,integer,integer,name,integer
 -- should see tuples from both columnar_permissions and no_access
 select relation, chunk_group_row_limit, stripe_row_limit, compression, compression_level
   from columnar.options
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation;
        relation       | chunk_group_row_limit | stripe_row_limit | compression | compression_level
 ---------------------------------------------------------------------
  no_access            |                 10000 |           150000 | zstd        |                 3
@@ -102,7 +107,8 @@ select relation, chunk_group_row_limit, stripe_row_limit, compression, compressi
 
 select relation, stripe_num, row_count, first_row_number
   from columnar.stripe
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | row_count | first_row_number
 ---------------------------------------------------------------------
  no_access            |          1 |         1 |                1
@@ -116,7 +122,8 @@ select relation, stripe_num, row_count, first_row_number
 
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | attr_num | chunk_group_num | value_count
 ---------------------------------------------------------------------
  no_access            |          1 |        1 |               0 |           1
@@ -134,7 +141,8 @@ select relation, stripe_num, attr_num, chunk_group_num, value_count
 
 select relation, stripe_num, chunk_group_num, row_count
   from columnar.chunk_group
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
        relation       | stripe_num | chunk_group_num | row_count
 ---------------------------------------------------------------------
  no_access            |          1 |               0 |         1

--- a/src/test/regress/sql/columnar_permissions.sql
+++ b/src/test/regress/sql/columnar_permissions.sql
@@ -31,16 +31,20 @@ select 1 from columnar.get_storage_id('no_access'::regclass);
 -- only tuples related to columnar_permissions should be visible
 select relation, chunk_group_row_limit, stripe_row_limit, compression, compression_level
   from columnar.options
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation;
 select relation, stripe_num, row_count, first_row_number
   from columnar.stripe
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 select relation, stripe_num, chunk_group_num, row_count
   from columnar.chunk_group
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 
 truncate columnar_permissions;
 
@@ -62,16 +66,20 @@ select alter_columnar_table_set('no_access', chunk_group_row_limit => 1111);
 -- should see tuples from both columnar_permissions and no_access
 select relation, chunk_group_row_limit, stripe_row_limit, compression, compression_level
   from columnar.options
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation;
 select relation, stripe_num, row_count, first_row_number
   from columnar.stripe
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 select relation, stripe_num, chunk_group_num, row_count
   from columnar.chunk_group
-  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
+  where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
+  order by relation, stripe_num;
 
 drop table columnar_permissions;
 drop table no_access;


### PR DESCRIPTION
`columnar_permissions.sql` test is flaky due to a missing `ORDER BY` clauses.
Added the other `ORDER BY` clauses for consistency in the test.

```diff
   where relation in ('no_access'::regclass, 'columnar_permissions'::regclass);
        relation       | chunk_group_row_limit | stripe_row_limit | compression | compression_level 
 ----------------------+-----------------------+------------------+-------------+-------------------
- no_access            |                 10000 |           150000 | zstd        |                 3
  columnar_permissions |                 10000 |             2222 | none        |                 3
+ no_access            |                 10000 |           150000 | zstd        |                 3
 (2 rows)
```

https://app.circleci.com/pipelines/github/citusdata/citus/26610/workflows/79f03ef9-7674-4567-a087-02536c9ddf04/jobs/760942