### PR TITLE
Hopefully fix flakyeness in drop_partitioned_table

### DIFF
--- a/src/test/regress/expected/drop_partitioned_table.out
+++ b/src/test/regress/expected/drop_partitioned_table.out
@@ -326,6 +326,7 @@ SET search_path = drop_partitioned_table;
 SET citus.shard_count TO 1;
 SET citus.shard_replication_factor TO 1;
 SET citus.next_shard_id TO 727000;
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1344400;
 DROP EVENT TRIGGER new_trigger_for_drops;
 -- Case 1 - we should skip
 CREATE TABLE parent (x text, t timestamptz DEFAULT now()) PARTITION BY RANGE (t);
@@ -353,8 +354,8 @@ NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.pa
 NOTICE:  issuing DROP TABLE IF EXISTS drop_partitioned_table.parent_xxxxx CASCADE
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(1344400)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(1344400)
 ROLLBACK;
 NOTICE:  issuing ROLLBACK
 NOTICE:  issuing ROLLBACK
@@ -376,8 +377,8 @@ NOTICE:  issuing DROP TABLE IF EXISTS drop_partitioned_table.parent_xxxxx CASCAD
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
 NOTICE:  issuing DROP TABLE IF EXISTS drop_partitioned_table.child1_xxxxx CASCADE
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(1344400)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(1344400)
 ROLLBACK;
 NOTICE:  issuing ROLLBACK
 NOTICE:  issuing ROLLBACK

--- a/src/test/regress/sql/drop_partitioned_table.sql
+++ b/src/test/regress/sql/drop_partitioned_table.sql
@@ -204,6 +204,7 @@ SET search_path = drop_partitioned_table;
 SET citus.shard_count TO 1;
 SET citus.shard_replication_factor TO 1;
 SET citus.next_shard_id TO 727000;
+ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1344400;
 DROP EVENT TRIGGER new_trigger_for_drops;
 
 -- Case 1 - we should skip


### PR DESCRIPTION
Sometimes in CI our drop_partitioned_talbe test would fail with the
following error:

```diff
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
 NOTICE:  issuing SELECT worker_drop_distributed_table('drop_partitioned_table.child1')
 NOTICE:  issuing DROP TABLE IF EXISTS drop_partitioned_table.child1_727001 CASCADE
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
-NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100047)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100046)
+NOTICE:  issuing SELECT pg_catalog.citus_internal_delete_colocation_metadata(100046)
 ROLLBACK;
 NOTICE:  issuing ROLLBACK
 NOTICE:  issuing ROLLBACK
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/26631/workflows/31536032-e1ba-493b-b12a-f40757f3a7d6/jobs/762170

For some reason the colocationid of the distributed partitioned table
would be one less than we expected. Why this happens I'm not sure, but
it seems fairly harmless that it does.

In an attempt to work around this flakyness I now reset the colocation
id sequence right before creating the table in question. This is good
practice in general, because it allows us to run the test successfully
using `check-minimal` and it also allows us to rerun it multiple times.
