### PR TITLE
Fix flakyness in citus_split_shard_columnar_partitioned

### DIFF
--- a/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
+++ b/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
@@ -89,7 +89,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
  shardid |              logicalrelid              | shardminvalue | shardmaxvalue | nodename  | nodeport
 ---------------------------------------------------------------------
  8970000 | sensors                                | -2147483648   | 2147483647    | localhost |    57637
@@ -273,7 +273,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
  shardid |              logicalrelid              | shardminvalue | shardmaxvalue | nodename  | nodeport
 ---------------------------------------------------------------------
  8999000 | sensors                                | -2147483648   | -2120000000   | localhost |    57637
@@ -520,7 +520,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
  shardid |              logicalrelid              | shardminvalue | shardmaxvalue | nodename  | nodeport
 ---------------------------------------------------------------------
  8999100 | sensors                                | -2147483648   | -2127770000   | localhost |    57637

--- a/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
+++ b/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
@@ -79,7 +79,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
 -- END: Create table to split, along with other co-located tables. Add indexes, statistics etc.
 
 -- BEGIN: Create constraints for tables.
@@ -176,7 +176,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
 
     SELECT count(*) FROM reference_table;
     SELECT count(*) FROM colocated_partitioned_table;
@@ -243,7 +243,7 @@ SET citus.shard_replication_factor TO 1;
     INNER JOIN pg_catalog.pg_class cls     ON shard.logicalrelid = cls.oid
     INNER JOIN pg_catalog.pg_namespace ns  ON cls.relnamespace = ns.oid
     WHERE node.noderole = 'primary' AND ns.nspname = 'citus_split_test_schema_columnar_partitioned'
-    ORDER BY logicalrelid, shardminvalue::BIGINT;
+    ORDER BY logicalrelid, shardminvalue::BIGINT, nodeport;
 
     SELECT count(*) FROM reference_table;
     SELECT count(*) FROM colocated_partitioned_table;


### PR DESCRIPTION
On CI our citus_split_shard_columnar_partitioned test would sometimes
randomly fail like this:
```diff
  8970008 | colocated_dist_table                   | -2147483648   | 2147483647    | localhost |    57637
  8970009 | colocated_partitioned_table            | -2147483648   | 2147483647    | localhost |    57637
  8970010 | colocated_partitioned_table_2020_01_01 | -2147483648   | 2147483647    | localhost |    57637
- 8970011 | reference_table                        |               |               | localhost |    57637
  8970011 | reference_table                        |               |               | localhost |    57638
+ 8970011 | reference_table                        |               |               | localhost |    57637
 (13 rows)
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/26651/workflows/f695b4fb-ad81-46ff-b97e-0100e5d167ea/jobs/763517

This is a harmless diff due to a missing column in the order by list.
This fixes that by adding the nodeport as a tiebreaker.
