### PR TITLE
Fix reporting of progress on waiting and moved shards

### DIFF
--- a/src/backend/distributed/progress/multi_progress.c
+++ b/src/backend/distributed/progress/multi_progress.c
@@ -109,11 +109,17 @@ GetCurrentProgressMonitor(void)
 /*
  * FinalizeCurrentProgressMonitor releases the dynamic memory segment of the current
  * progress monitoring data structure and removes the process from
- * pg_stat_get_progress_info() output.
+ * pg_stat_get_progress_info() output. If there's no such dynamic memory
+ * segment this is a no-op.
  */
 void
 FinalizeCurrentProgressMonitor(void)
 {
+	if (currentProgressDSMHandle == DSM_HANDLE_INVALID)
+	{
+		return;
+	}
+
 	dsm_segment *dsmSegment = dsm_find_mapping(currentProgressDSMHandle);
 
 	if (dsmSegment != NULL)

--- a/src/include/distributed/shard_rebalancer.h
+++ b/src/include/distributed/shard_rebalancer.h
@@ -73,7 +73,9 @@
 /* *INDENT-ON* */
 
 #define REBALANCE_ACTIVITY_MAGIC_NUMBER 1337
+#define REBALANCE_PROGRESS_WAITING 0
 #define REBALANCE_PROGRESS_MOVING 1
+#define REBALANCE_PROGRESS_MOVED 2
 
 /* Enumeration that defines different placement update types */
 typedef enum
@@ -193,7 +195,9 @@ extern List * ReplicationPlacementUpdates(List *workerNodeList, List *shardPlace
 extern void ExecuteRebalancerCommandInSeparateTransaction(char *command);
 extern void AcquirePlacementColocationLock(Oid relationId, int lockMode,
 										   const char *operationName);
-extern void SetupRebalanceMonitor(List *placementUpdateList, Oid relationId);
 
+extern void SetupRebalanceMonitor(List *placementUpdateList,
+								  Oid relationId,
+								  uint64 initialProgressState);
 
 #endif   /* SHARD_REBALANCER_H */

--- a/src/test/regress/expected/isolation_shard_rebalancer_progress.out
+++ b/src/test/regress/expected/isolation_shard_rebalancer_progress.out
@@ -35,7 +35,9 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|                0|       1
 colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|                0|       1
-(2 rows)
+colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       0
+colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       0
+(4 rows)
 
 step s2-unlock-1-start:
  ROLLBACK;
@@ -112,9 +114,11 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress
 ---------------------------------------------------------------------
+colocated1|1500001|     73728|localhost |     57637|                0|localhost |     57638|            73728|       2
+colocated2|1500005|    401408|localhost |     57637|                0|localhost |     57638|           401408|       2
 colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       1
 colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       1
-(2 rows)
+(4 rows)
 
 step s3-unlock-2-start:
  ROLLBACK;
@@ -205,7 +209,9 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|            73728|       1
 colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|           401408|       1
-(2 rows)
+colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       0
+colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       0
+(4 rows)
 
 step s7-release-lock:
  COMMIT;
@@ -288,7 +294,9 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     49152|localhost |     57637|            49152|localhost |     57638|             8192|       1
 colocated2|1500005|    376832|localhost |     57637|           376832|localhost |     57638|             8192|       1
-(2 rows)
+colocated1|1500002|    196608|localhost |     57637|           196608|localhost |     57638|                0|       0
+colocated2|1500006|      8192|localhost |     57637|             8192|localhost |     57638|                0|       0
+(4 rows)
 
 step s6-release-advisory-lock:
     SELECT pg_advisory_unlock(44000, 55152);


### PR DESCRIPTION
In commit 31faa88a4e I removed some features of the rebalance progress
monitor. I did this because the plan was to remove the foreground shard
rebalancer later in the PR that would add the background shard
rebalancer. So, I didn't want to spend time fixing something that we
would throw away anyway.

As it turns out we're not removing the foreground shard rebalancer after
all, so it made sens to fix the stuff that I broke. This PR does that.
For the most part this commit reverts the changes in commit 31faa88a4e.
It's not a full revert though, because it keeps the improved tests and
the changes to `citus_move_shard_placement`.
