### PR TITLE
Allow citus_internal application_name with additional suffix

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -1064,16 +1064,16 @@ ExtractGlobalPID(char *applicationName)
 		return INVALID_CITUS_INTERNAL_BACKEND_GPID;
 	}
 
-	/* are the remaining characters of the application name numbers */
-	uint64 numberOfRemainingChars = strlen(applicationNameCopy) - prefixLength;
-	if (numberOfRemainingChars <= 0 ||
-		!strisdigit_s(applicationNameCopy + prefixLength, numberOfRemainingChars))
-	{
-		return INVALID_CITUS_INTERNAL_BACKEND_GPID;
-	}
-
 	char *globalPIDString = &applicationNameCopy[prefixLength];
 	uint64 globalPID = strtoul(globalPIDString, NULL, 10);
+	if (globalPID == 0)
+	{
+		/*
+		 * INVALID_CITUS_INTERNAL_BACKEND_GPID is 0, but just to be explicit
+		 * about how we handle strtoul errors.
+		 */
+		return INVALID_CITUS_INTERNAL_BACKEND_GPID;
+	}
 
 	return globalPID;
 }

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -109,6 +109,22 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
 ERROR:  This is an internal Citus function can only be used in a distributed transaction
 ROLLBACK;
+-- application_name with suffix is ok (e.g. pgbouncer might add this)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001 - from 10.12.14.16:10370';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ citus_internal_add_partition_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
 -- application_name with empty gpid
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -75,6 +75,13 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
 ROLLBACK;
 
+-- application_name with suffix is ok (e.g. pgbouncer might add this)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001 - from 10.12.14.16:10370';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ROLLBACK;
+
 -- application_name with empty gpid
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');


### PR DESCRIPTION
DESCRIPTION: Allow citus_internal application_name with additional suffix

We designed the GPID-passing mechanism to be robust to intermediate pgbouncers because it always propagates application_name, but when application_name_add_host is enabled it adds an additional suffix, which breaks our GPID-passing logic.

This PR makes ExtractGlobalPID less sensitive to suffixes and relies on strtoul to read until the next non-digit.