### PR TITLE
Add a single connection retry in MULTI_CONNECTION_LOST state

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -1483,6 +1483,30 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
 
 
 /*
+ * RestartConnection starts a new connection attempt for the given
+ * MultiConnection.
+ *
+ * We assume that we already went through all the other initialization steps in
+ * StartNodeUserDatabaseConnection, such as incrementing shared connection
+ * counters.
+ */
+void
+RestartConnection(MultiConnection *connection)
+{
+	ShutdownConnection(connection);
+
+	ConnectionHashKey key;
+	strlcpy(key.hostname, connection->hostname, MAX_NODE_LENGTH);
+	key.port = connection->port;
+	strlcpy(key.user, connection->user, NAMEDATALEN);
+	strlcpy(key.database, connection->database, NAMEDATALEN);
+	key.replicationConnParam = connection->requiresReplication;
+
+	StartConnectionEstablishment(connection, &key);
+}
+
+
+/*
  * ResetConnection preserves the given connection for later usage by
  * resetting its states.
  */

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -256,7 +256,7 @@ ReportConnectionError(MultiConnection *connection, int elevel)
 		messageDetail = pchomp(PQerrorMessage(pgConn));
 	}
 
-	if (messageDetail)
+	if (messageDetail && messageDetail[0] != '\0')
 	{
 		ereport(elevel, (errcode(ERRCODE_CONNECTION_FAILURE),
 						 errmsg("connection to the remote node %s:%d failed with the "

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -294,6 +294,7 @@ extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 int32 port,
 														 const char *user,
 														 const char *database);
+extern void RestartConnection(MultiConnection *connection);
 extern void CloseAllConnectionsAfterTransaction(void);
 extern void CloseNodeConnectionsAfterTransaction(char *nodeName, int nodePort);
 extern MultiConnection * ConnectionAvailableToNode(char *hostName, int nodePort,


### PR DESCRIPTION
(experimental)

DESCRIPTION: Add a single connection retry after losing a connection

This PR adds a single connection retry in the adaptive executor after losing the connection. That way, we can recover from scenarios where we have a cached connection to a node that restarted or failed over long ago. This works best on PostgreSQL 15 where we can check for WL_SOCKET_CLOSED.