### PR TITLE
Address race condition in InitializeBackendData

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2643,10 +2643,17 @@ StatisticsCollectionGucCheckHook(bool *newval, void **extra, GucSource source)
 static void
 CitusAuthHook(Port *port, int status)
 {
-	uint64 gpid = ExtractGlobalPID(port->application_name);
+	/*
+	 * We determine the backend type here because other calls in this hook rely
+	 * on it, both IsExternalClientBackend and InitializeBackendData. These
+	 * calls would normally initialize its value based on the application_name
+	 * global, but this global is not set yet at this point in the connection
+	 * initialization. So here we determine it based on the value from Port.
+	 */
+	DetermineCitusBackendType(port->application_name);
 
 	/* external connections to not have a GPID immediately */
-	if (gpid == INVALID_CITUS_INTERNAL_BACKEND_GPID)
+	if (IsExternalClientBackend())
 	{
 		/*
 		 * We raise the shared connection counter pre-emptively. As a result, we may
@@ -2698,7 +2705,8 @@ CitusAuthHook(Port *port, int status)
 	 * replication connection. A replication connection backend will never call
 	 * StartupCitusBackend, which normally sets up the global PID.
 	 */
-	InitializeBackendData(gpid);
+	InitializeBackendData(port->application_name);
+
 
 	/* let other authentication hooks to kick in first */
 	if (original_client_auth_hook)

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -50,7 +50,7 @@ extern void BackendManagementShmemInit(void);
 extern size_t BackendManagementShmemSize(void);
 extern void InitializeBackendManagement(void);
 extern int TotalProcCount(void);
-extern void InitializeBackendData(uint64 globalPID);
+extern void InitializeBackendData(const char *applicationName);
 extern void LockBackendSharedMemory(LWLockMode lockMode);
 extern void UnlockBackendSharedMemory(void);
 extern void UnSetDistributedTransactionId(void);
@@ -62,7 +62,7 @@ extern void SetBackendDataGlobalPID(uint64 globalPID);
 extern uint64 GetGlobalPID(void);
 extern void SetBackendDataDistributedCommandOriginator(bool
 													   distributedCommandOriginator);
-extern uint64 ExtractGlobalPID(char *applicationName);
+extern uint64 ExtractGlobalPID(const char *applicationName);
 extern int ExtractNodeIdFromGlobalPID(uint64 globalPID, bool missingOk);
 extern int ExtractProcessIdFromGlobalPID(uint64 globalPID);
 extern void GetBackendDataForProc(PGPROC *proc, BackendData *result);
@@ -74,9 +74,11 @@ extern LocalTransactionId GetMyProcLocalTransactionId(void);
 extern int GetExternalClientBackendCount(void);
 extern uint32 IncrementExternalClientBackendCounter(void);
 extern void DecrementExternalClientBackendCounter(void);
+extern void DetermineCitusBackendType(const char *applicationName);
 extern bool IsCitusInternalBackend(void);
 extern bool IsRebalancerInternalBackend(void);
 extern bool IsCitusRunCommandBackend(void);
+extern bool IsExternalClientBackend(void);
 extern void ResetCitusBackendType(void);
 
 #define INVALID_CITUS_INTERNAL_BACKEND_GPID 0

--- a/src/test/regress/expected/isolation_citus_dist_activity.out
+++ b/src/test/regress/expected/isolation_citus_dist_activity.out
@@ -15,16 +15,16 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s3-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-alter-table:
     ALTER TABLE test_table ADD COLUMN x INT;
 
 step s2-sleep:
-	SELECT pg_sleep(0.5);
+ SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -32,7 +32,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                         |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -42,7 +42,7 @@ query                                         |citus_nodename_for_nodeid|citus_n
 (1 row)
 
 step s3-view-worker:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                                                                                      |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -61,13 +61,13 @@ SELECT worker_apply_shard_ddl_command (1300001, 'public', '
 (4 rows)
 
 step s2-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-insert s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -85,16 +85,16 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s3-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-insert:
- 	INSERT INTO test_table VALUES (100, 100);
+  INSERT INTO test_table VALUES (100, 100);
 
 step s2-sleep:
-	SELECT pg_sleep(0.5);
+ SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -102,31 +102,31 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                        |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
 
- 	INSERT INTO test_table VALUES (100, 100);
+  INSERT INTO test_table VALUES (100, 100);
 |localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
 (1 row)
 
 step s3-view-worker:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                                                     |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
-INSERT INTO public.test_table_1300008 (column1, column2) VALUES (100, 100)|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+INSERT INTO public.test_table_1300003 (column1, column2) VALUES (100, 100)|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
 (1 row)
 
 step s2-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-select s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -144,10 +144,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s3-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-select:
    SELECT count(*) FROM test_table;
@@ -158,7 +158,7 @@ count
 (1 row)
 
 step s2-sleep:
-	SELECT pg_sleep(0.5);
+ SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -166,7 +166,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -176,24 +176,24 @@ query                                |citus_nodename_for_nodeid|citus_nodeport_f
 (1 row)
 
 step s3-view-worker:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                                                        |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
-SELECT count(*) AS count FROM public.test_table_1300014 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
-SELECT count(*) AS count FROM public.test_table_1300013 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
-SELECT count(*) AS count FROM public.test_table_1300012 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
-SELECT count(*) AS count FROM public.test_table_1300011 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+SELECT count(*) AS count FROM public.test_table_1300004 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+SELECT count(*) AS count FROM public.test_table_1300003 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+SELECT count(*) AS count FROM public.test_table_1300002 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+SELECT count(*) AS count FROM public.test_table_1300001 test_table WHERE true|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
 (4 rows)
 
 step s2-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 
 starting permutation: s1-cache-connections s1-begin s2-begin s3-begin s1-select-router s2-sleep s2-view-dist s3-view-worker s2-rollback s1-commit s3-rollback
@@ -211,10 +211,10 @@ step s1-begin:
     BEGIN;
 
 step s2-begin:
-	BEGIN;
+ BEGIN;
 
 step s3-begin:
-	BEGIN;
+ BEGIN;
 
 step s1-select-router:
    SELECT count(*) FROM test_table WHERE column1 = 55;
@@ -225,7 +225,7 @@ count
 (1 row)
 
 step s2-sleep:
-	SELECT pg_sleep(0.5);
+ SELECT pg_sleep(0.5);
 
 pg_sleep
 ---------------------------------------------------------------------
@@ -233,7 +233,7 @@ pg_sleep
 (1 row)
 
 step s2-view-dist:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                                   |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
@@ -243,19 +243,19 @@ query                                                   |citus_nodename_for_node
 (1 row)
 
 step s3-view-worker:
-	SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
+ SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%csa_from_one_node%')) AND is_worker_query = true AND backend_type = 'client backend' ORDER BY query DESC;
 
 query                                                                                                       |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ---------------------------------------------------------------------
-SELECT count(*) AS count FROM public.test_table_1300017 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
+SELECT count(*) AS count FROM public.test_table_1300002 test_table WHERE (column1 OPERATOR(pg_catalog.=) 55)|localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
 (1 row)
 
 step s2-rollback:
-	ROLLBACK;
+ ROLLBACK;
 
 step s1-commit:
     COMMIT;
 
 step s3-rollback:
-	ROLLBACK;
+ ROLLBACK;
 

--- a/src/test/regress/spec/isolation_citus_dist_activity.spec
+++ b/src/test/regress/spec/isolation_citus_dist_activity.spec
@@ -9,7 +9,7 @@ setup
     AS 'citus', $$test_assign_global_pid$$;
     SET citus.shard_replication_factor TO 1;
     SET citus.shard_count TO 4;
-    select setval('pg_dist_shardid_seq', GREATEST(1300000, nextval('pg_dist_shardid_seq')));
+    ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1300001;
 
     CREATE TABLE test_table(column1 int, column2 int);
     SELECT create_distributed_table('test_table', 'column1');


### PR DESCRIPTION
Sometimes in CI our isolation_citus_dist_activity test fails randomly
like this:
```diff
 step s2-view-dist:
  SELECT query, citus_nodename_for_nodeid(citus_nodeid_for_gpid(global_pid)), citus_nodeport_for_nodeid(citus_nodeid_for_gpid(global_pid)), state, wait_event_type, wait_event, usename, datname FROM citus_dist_stat_activity WHERE query NOT ILIKE ALL(VALUES('%pg_prepared_xacts%'), ('%COMMIT%'), ('%BEGIN%'), ('%pg_catalog.pg_isolation_test_session_is_blocked%'), ('%citus_add_node%')) AND backend_type = 'client backend' ORDER BY query DESC;

 query                                                                                                                                                                                                                                                                                                                                                                 |citus_nodename_for_nodeid|citus_nodeport_for_nodeid|state              |wait_event_type|wait_event|usename |datname
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------------------+-------------------+---------------+----------+--------+----------

   INSERT INTO test_table VALUES (100, 100);
                                                                                                                                                                                                                                                                                                                          |localhost                |                    57636|idle in transaction|Client         |ClientRead|postgres|regression
-(1 row)
+
+                SELECT coalesce(to_jsonb(array_agg(csa_from_one_node.*)), '[{}]'::JSONB)
+                FROM (
+                    SELECT global_pid, worker_query AS is_worker_query, pg_stat_activity.* FROM
+                    pg_stat_activity LEFT JOIN get_all_active_transactions() ON process_id = pid
+                ) AS csa_from_one_node;
+            |localhost                |                    57636|active             |               |          |postgres|regression
+(2 rows)

 step s3-view-worker:
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/26692/workflows/3406e4b4-b686-4667-bec6-8253ee0809b1/jobs/765119

I intended to fix this with #6263, but the fix turned out to be
insufficient. This PR tries to address the issue by setting
distributedCommandOriginator correctly in more situations. However, even
with this change it's still possible to reproduce the flaky test in CI.
In any case this should fix at least some instances of this issue.

In passing this changes the isolation_citus_dist_activity test to allow
running it multiple times in a row.