### PR TITLE
Add citus.skip_advisory_lock_permission_checks

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2077,6 +2077,20 @@ RegisterCitusConfigVariables(void)
 		NULL);
 
 	DefineCustomBoolVariable(
+		"citus.skip_advisory_lock_permission_checks",
+		gettext_noop("Postgres would normally enforce some "
+					 "ownership checks while acquiring locks. "
+					 "When this setting is 'off', Citus skips"
+					 "ownership checks on internal advisory "
+					 "locks."),
+		NULL,
+		&SkipAdvisoryLockPermissionChecks,
+		false,
+		GUC_SUPERUSER_ONLY,
+		GUC_NO_SHOW_ALL,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.skip_jsonb_validation_in_copy",
 		gettext_noop("Skip validation of JSONB columns on the coordinator during COPY "
 					 "into a distributed table"),

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -109,6 +109,8 @@ PG_FUNCTION_INFO_V1(lock_relation_if_exists);
 
 /* Config variable managed via guc.c */
 bool EnableAcquiringUnsafeLockFromWorkers = false;
+bool SkipAdvisoryLockPermissionChecks = false;
+
 
 /*
  * lock_shard_metadata allows the shard distribution metadata to be locked
@@ -248,7 +250,10 @@ lock_shard_resources(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		EnsureTablePermissions(relationId, aclMask);
+		if (!SkipAdvisoryLockPermissionChecks)
+		{
+			EnsureTablePermissions(relationId, aclMask);
+		}
 
 		LockShardResource(shardId, lockMode);
 	}

--- a/src/include/distributed/resource_lock.h
+++ b/src/include/distributed/resource_lock.h
@@ -149,6 +149,7 @@ enum DistLockConfigs
 	DIST_LOCK_NOWAIT = 2
 };
 
+
 /* Lock shard/relation metadata for safe modifications */
 extern void LockShardDistributionMetadata(int64 shardId, LOCKMODE lockMode);
 extern void LockPlacementCleanup(void);
@@ -194,5 +195,6 @@ extern void AcquireDistributedLockOnRelations(List *relationList, LOCKMODE lockM
 extern void PreprocessLockStatement(LockStmt *stmt, ProcessUtilityContext context);
 
 extern bool EnableAcquiringUnsafeLockFromWorkers;
+extern bool SkipAdvisoryLockPermissionChecks;
 
 #endif /* RESOURCE_LOCK_H */

--- a/src/test/regress/expected/adv_lock_permission.out
+++ b/src/test/regress/expected/adv_lock_permission.out
@@ -1,0 +1,41 @@
+CREATE SCHEMA adv_lock_permission;
+SET search_path to adv_lock_permission;
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+CREATE ROLE user_1 WITH LOGIN;
+CREATE TABLE reference_table_1 (A int);
+SELECT create_reference_table('reference_table_1');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE reference_table_2 (A int);
+SELECT create_reference_table('reference_table_2');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+GRANT USAGE ON SCHEMA adv_lock_permission TO user_1;
+GRANT SELECT ON reference_table_1 TO user_1;
+GRANT INSERT, UPDATE ON reference_table_2 TO user_1;
+SET ROLE user_1;
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+SET search_path to adv_lock_permission;
+INSERT INTO reference_table_2 SELECT * FROM reference_table_1;
+ERROR:  permission denied for table reference_table_1
+CONTEXT:  while executing command on localhost:xxxxx
+SET ROLE postgres;
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+-- change the role so that it can skip permission checks
+ALTER ROLE user_1 SET citus.skip_advisory_lock_permission_checks TO on;
+SET ROLE user_1;
+SET citus.max_cached_conns_per_worker TO 0;
+INSERT INTO reference_table_2 SELECT * FROM reference_table_1;
+SET ROLE postgres;
+SET client_min_messages TO ERROR;
+DROP SCHEMA adv_lock_permission CASCADE;
+DROP ROLE user_1;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -86,7 +86,7 @@ test: multi_agg_type_conversion multi_count_type_conversion recursive_relation_p
 test: multi_partition_pruning single_hash_repartition_join unsupported_lateral_subqueries
 test: multi_join_pruning multi_hash_pruning intermediate_result_pruning
 test: multi_null_minmax_value_pruning cursors
-test: modification_correctness
+test: modification_correctness adv_lock_permission
 test: multi_query_directory_cleanup
 test: multi_task_assignment_policy multi_cross_shard
 test: multi_utility_statements

--- a/src/test/regress/sql/adv_lock_permission.sql
+++ b/src/test/regress/sql/adv_lock_permission.sql
@@ -1,0 +1,42 @@
+CREATE SCHEMA adv_lock_permission;
+SET search_path to adv_lock_permission;
+
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+
+CREATE ROLE user_1 WITH LOGIN;
+
+CREATE TABLE reference_table_1 (A int);
+SELECT create_reference_table('reference_table_1');
+
+CREATE TABLE reference_table_2 (A int);
+SELECT create_reference_table('reference_table_2');
+
+GRANT USAGE ON SCHEMA adv_lock_permission TO user_1;
+GRANT SELECT ON reference_table_1 TO user_1;
+GRANT INSERT, UPDATE ON reference_table_2 TO user_1;
+
+SET ROLE user_1;
+
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+SET search_path to adv_lock_permission;
+
+INSERT INTO reference_table_2 SELECT * FROM reference_table_1;
+
+SET ROLE postgres;
+-- do not cache any connections, we change some settings and don't want old ones cached
+SET citus.max_cached_conns_per_worker TO 0;
+
+-- change the role so that it can skip permission checks
+ALTER ROLE user_1 SET citus.skip_advisory_lock_permission_checks TO on;
+
+SET ROLE user_1;
+
+SET citus.max_cached_conns_per_worker TO 0;
+INSERT INTO reference_table_2 SELECT * FROM reference_table_1;
+
+SET ROLE postgres;
+SET client_min_messages TO ERROR;
+DROP SCHEMA adv_lock_permission CASCADE;
+DROP ROLE user_1;


### PR DESCRIPTION
While dealing with replicated tables, Citus acquires some locks that Postgres
would not need. This might create some compatibility issues. And, with
this commit, we aim to provide a workaround for this.

For example, even if a table is read, it might be required to acquire
an update lock on the read shard. When Citus deals with replicated tables (
e.g. ,reference tables or distributed tables with replication > 1),
modification queries that involve subqueries needs some special attention.

For example, the queries can be in the following forms:
```SQL

-- Citus acquires EXCLUSIVE lock on both reference_table_1 and reference_table_2
INSERT INTO reference_table_1 SELECT * FROM reference_table_2;
```
For the queries like the above, the modification queries needs to read from the
different replicas of the the same reference table shard placement.

To ensure that the replicas of the same shard of the reference table
never diverges, Citus acquires an EXCLUSIVE lock on the
`reference_table_2`, in order to prevent diverging placements of
`reference_table_1`. This is a different lock level than a user might
expect, as we are seeming only READ from reference_table_2. In essence,
we acquire a heavier lock in order to preserve the correctness
in a distributed system.

This commit relaxes that by adding a new GUC, which can only be
changed by a superuser. The superuser may decide to skip
these checks by setting it to on:

ALTER ROLE user_1 SET citus.skip_advisory_lock_permission_checks TO on;

DESCRIPTION: PR description that will go into the change log, up to 78 characters
