### PR TITLE
Disallow distributing by numeric with negative scale

### DIFF
--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -392,9 +392,37 @@ ON (true)
 WHEN MATCHED THEN
     UPDATE SET x = (SELECT count(*) FROM tbl2);
 ERROR:  MERGE command is not supported on Citus tables yet
+-- test numeric types with negative scale
+CREATE TABLE numeric_negative_scale(numeric_column numeric(3,-1), orig_value int);
+INSERT into numeric_negative_scale SELECT x,x FROM generate_series(111, 115) x;
+-- verify that we can not distribute by a column that has numeric type with negative scale
+SELECT create_distributed_table('numeric_negative_scale','numeric_column');
+ERROR:  cannot distribute relation: numeric_negative_scale
+DETAIL:  Distribution column must not use numeric type with negative scale
+-- However, we can distribute by other columns
+SELECT create_distributed_table('numeric_negative_scale','orig_value');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$pg15.numeric_negative_scale$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM numeric_negative_scale ORDER BY 1,2;
+ numeric_column | orig_value
+---------------------------------------------------------------------
+            110 |        111
+            110 |        112
+            110 |        113
+            110 |        114
+            120 |        115
+(5 rows)
+
 -- Clean up
 DROP SCHEMA pg15 CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to collation german_phonebook_test
 drop cascades to collation default_provider
 drop cascades to table sale
@@ -404,3 +432,4 @@ drop cascades to view sale_triggers
 drop cascades to table generated_stored_ref
 drop cascades to table tbl1
 drop cascades to table tbl2
+drop cascades to table numeric_negative_scale

--- a/src/test/regress/sql/pg15.sql
+++ b/src/test/regress/sql/pg15.sql
@@ -245,5 +245,15 @@ ON (true)
 WHEN MATCHED THEN
     UPDATE SET x = (SELECT count(*) FROM tbl2);
 
+-- test numeric types with negative scale
+CREATE TABLE numeric_negative_scale(numeric_column numeric(3,-1), orig_value int);
+INSERT into numeric_negative_scale SELECT x,x FROM generate_series(111, 115) x;
+-- verify that we can not distribute by a column that has numeric type with negative scale
+SELECT create_distributed_table('numeric_negative_scale','numeric_column');
+-- However, we can distribute by other columns
+SELECT create_distributed_table('numeric_negative_scale','orig_value');
+
+SELECT * FROM numeric_negative_scale ORDER BY 1,2;
+
 -- Clean up
 DROP SCHEMA pg15 CASCADE;


### PR DESCRIPTION
DESCRIPTION: Disallows distribution by a numeric with negative scale

As discussed in https://github.com/citusdata/citus/pull/6256#discussion_r957091838 we ran into issues if we distribute a table by a column with a numeric data type with negative scale.

We want to disallow distributing tables on such columns until the underlying issue is fixed.

Relevant PG commit https://github.com/postgres/postgres/commit/085f931f52494e1f304e35571924efa6fcdc2b44