### PR TITLE
remove redundant call to TerminateBackgroundWorker

### DIFF
--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -479,7 +479,6 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		{
 			if (metadataSyncBgwHandle)
 			{
-				TerminateBackgroundWorker(metadataSyncBgwHandle);
 				pfree(metadataSyncBgwHandle);
 				metadataSyncBgwHandle = NULL;
 			}


### PR DESCRIPTION
https://github.com/citusdata/citus/pull/6296#discussion_r965926695 found that the call to `TerminateBackgroundWorker` is redundant in this code. Before we reach here we have already checked that the background worker has stopped.

For details it is best to go the the linked discussion
