### PR TITLE
Reuse connections for Splits and Logical Replication

### DIFF
--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -16,7 +16,7 @@
 #include "miscadmin.h"
 
 #include "safe_lib.h"
-
+#include "postmaster/postmaster.h"
 #include "access/hash.h"
 #include "commands/dbcommands.h"
 #include "distributed/backend_data.h"
@@ -239,6 +239,28 @@ GetNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 	Assert(connection != NULL);
 
 	FinishConnectionEstablishment(connection);
+
+	return connection;
+}
+
+
+/*
+ * GetLocalConnectionForSubtransaction returns a localhost connection for subtransaction.
+ * To avoid creating excessive connections, we reuse an existing connection.
+ */
+MultiConnection *
+GetLocalConnectionForSubtransactionAsUser(char *userName)
+{
+	int connectionFlag = OUTSIDE_TRANSACTION;
+	MultiConnection *connection = GetNodeUserDatabaseConnection(connectionFlag,
+																LocalHostName,
+																PostPortNumber,
+																userName,
+																get_database_name(
+																	MyDatabaseId));
+
+	/* Don't cache connection for the lifetime of the entire session. */
+	connection->forceCloseAtTransactionEnd = true;
 
 	return connection;
 }

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -703,7 +703,7 @@ CloseConnection(MultiConnection *connection)
 		dlist_delete(&connection->connectionNode);
 
 		/* same for transaction state and shard/placement machinery */
-		CloseRemoteTransaction(connection);
+		ResetRemoteTransaction(connection);
 		CloseShardPlacementAssociation(connection);
 
 		/* we leave the per-host entry alive */
@@ -1458,7 +1458,7 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 			/*
 			 * reset healthy session lifespan connections.
 			 */
-			CloseRemoteTransaction(connection);
+			ResetRemoteTransaction(connection);
 
 			UnclaimConnection(connection);
 

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -1458,7 +1458,7 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 			/*
 			 * reset healthy session lifespan connections.
 			 */
-			ResetConnection(connection);
+			CloseRemoteTransaction(connection);
 
 			UnclaimConnection(connection);
 
@@ -1497,22 +1497,6 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
 		   (MaxCachedConnectionLifetime >= 0 &&
 			MillisecondsToTimeout(connection->connectionEstablishmentStart,
 								  MaxCachedConnectionLifetime) <= 0);
-}
-
-
-/*
- * ResetConnection preserves the given connection for later usage by
- * resetting its states.
- */
-void
-ResetConnection(MultiConnection *connection)
-{
-	/* reset per-transaction state */
-	ResetRemoteTransaction(connection);
-	ResetShardPlacementAssociation(connection);
-
-	/* reset copy state */
-	connection->copyBytesWrittenSinceLastFlush = 0;
 }
 
 

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -244,11 +244,12 @@ GetNodeUserDatabaseConnection(uint32 flags, const char *hostname, int32 port,
 
 
 /*
- * GetLocalConnectionForSubtransaction returns a localhost connection for subtransaction.
- * To avoid creating excessive connections, we reuse an existing connection.
+ * GetConnectionForLocalQueriesOutsideTransaction returns a localhost connection for
+ * subtransaction. To avoid creating excessive connections, we reuse an
+ * existing connection.
  */
 MultiConnection *
-GetLocalConnectionForSubtransactionAsUser(char *userName)
+GetConnectionForLocalQueriesOutsideTransaction(char *userName)
 {
 	int connectionFlag = OUTSIDE_TRANSACTION;
 	MultiConnection *connection =
@@ -703,8 +704,8 @@ CloseConnection(MultiConnection *connection)
 		dlist_delete(&connection->connectionNode);
 
 		/* same for transaction state and shard/placement machinery */
-		ResetRemoteTransaction(connection);
 		CloseShardPlacementAssociation(connection);
+		ResetRemoteTransaction(connection);
 
 		/* we leave the per-host entry alive */
 		pfree(connection);

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -63,7 +63,6 @@ static void FreeConnParamsHashEntryFields(ConnParamsHashEntry *entry);
 static void AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit);
 static bool ShouldShutdownConnection(MultiConnection *connection, const int
 									 cachedConnectionCount);
-static void ResetConnection(MultiConnection *connection);
 static bool RemoteTransactionIdle(MultiConnection *connection);
 static int EventSetSizeForConnectionList(List *connections);
 
@@ -252,15 +251,9 @@ MultiConnection *
 GetLocalConnectionForSubtransactionAsUser(char *userName)
 {
 	int connectionFlag = OUTSIDE_TRANSACTION;
-	MultiConnection *connection = GetNodeUserDatabaseConnection(connectionFlag,
-																LocalHostName,
-																PostPortNumber,
-																userName,
-																get_database_name(
-																	MyDatabaseId));
-
-	/* Don't cache connection for the lifetime of the entire session. */
-	connection->forceCloseAtTransactionEnd = true;
+	MultiConnection *connection =
+		GetNodeUserDatabaseConnection(connectionFlag, LocalHostName, PostPortNumber,
+									  userName, get_database_name(MyDatabaseId));
 
 	return connection;
 }
@@ -1467,6 +1460,9 @@ AfterXactHostConnectionHandling(ConnectionHashEntry *entry, bool isCommit)
 			 */
 			ResetConnection(connection);
 
+			UnclaimConnection(connection);
+
+
 			cachedConnectionCount++;
 		}
 	}
@@ -1508,7 +1504,7 @@ ShouldShutdownConnection(MultiConnection *connection, const int cachedConnection
  * ResetConnection preserves the given connection for later usage by
  * resetting its states.
  */
-static void
+void
 ResetConnection(MultiConnection *connection)
 {
 	/* reset per-transaction state */
@@ -1517,8 +1513,6 @@ ResetConnection(MultiConnection *connection)
 
 	/* reset copy state */
 	connection->copyBytesWrittenSinceLastFlush = 0;
-
-	UnclaimConnection(connection);
 }
 
 

--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -712,8 +712,8 @@ InsertCleanupRecordInSubtransaction(CleanupObject objectType,
 					 nodeGroupId,
 					 policy);
 
-	MultiConnection *connection = GetLocalConnectionForSubtransactionAsUser(
-		CitusExtensionOwnerName());
+	MultiConnection *connection =
+		GetLocalConnectionForSubtransactionAsUser(CitusExtensionOwnerName());
 	SendCommandListToWorkerOutsideTransactionWithConnection(connection,
 															list_make1(command->data));
 }
@@ -796,8 +796,6 @@ TryDropShardOutsideTransaction(OperationId operationId,
 																	  nodeName, nodePort,
 																	  CurrentUserName(),
 																	  NULL);
-	workerConnection->forceCloseAtTransactionEnd = true;
-
 	bool success = SendOptionalCommandListToWorkerOutsideTransactionWithConnection(
 		workerConnection,
 		dropCommandList);

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1056,12 +1056,13 @@ static void
 CreateObjectOnPlacement(List *objectCreationCommandList,
 						WorkerNode *workerPlacementNode)
 {
-	MultiConnection *c =
+	MultiConnection *connection =
 		GetNodeUserDatabaseConnection(OUTSIDE_TRANSACTION,
 									  workerPlacementNode->workerName,
 									  workerPlacementNode->workerPort,
 									  NULL, NULL);
-	SendCommandListToWorkerOutsideTransactionWithConnection(c, objectCreationCommandList);
+	SendCommandListToWorkerOutsideTransactionWithConnection(connection,
+															objectCreationCommandList);
 }
 
 

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1056,11 +1056,12 @@ static void
 CreateObjectOnPlacement(List *objectCreationCommandList,
 						WorkerNode *workerPlacementNode)
 {
-	char *currentUser = CurrentUserName();
-	SendCommandListToWorkerOutsideTransaction(workerPlacementNode->workerName,
-											  workerPlacementNode->workerPort,
-											  currentUser,
-											  objectCreationCommandList);
+	MultiConnection *c =
+		GetNodeUserDatabaseConnection(OUTSIDE_TRANSACTION,
+									  workerPlacementNode->workerName,
+									  workerPlacementNode->workerPort,
+									  NULL, NULL);
+	SendCommandListToWorkerOutsideTransactionWithConnection(c, objectCreationCommandList);
 }
 
 

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -1157,11 +1157,15 @@ CreatePartitioningHierarchy(List *logicalRepTargetList)
 				 * parallel, so create them sequentially. Also attaching partition
 				 * is a quick operation, so it is fine to execute sequentially.
 				 */
-				SendCommandListToWorkerOutsideTransaction(
-					target->superuserConnection->hostname,
-					target->superuserConnection->port,
-					tableOwner,
-					list_make1(attachPartitionCommand));
+
+				MultiConnection *c =
+					GetNodeUserDatabaseConnection(OUTSIDE_TRANSACTION,
+												  target->superuserConnection->hostname,
+												  target->superuserConnection->port,
+												  tableOwner, NULL);
+				SendCommandListToWorkerOutsideTransactionWithConnection(c, list_make1(
+																			attachPartitionCommand));
+
 				MemoryContextReset(localContext);
 			}
 		}
@@ -1640,7 +1644,7 @@ DropUser(MultiConnection *connection, char *username)
 		connection,
 		list_make2(
 			"SET LOCAL citus.enable_ddl_propagation TO OFF;",
-			psprintf("DROP USER IF EXISTS %s",
+			psprintf("DROP USER IF EXISTS %s;",
 					 quote_identifier(username))));
 }
 

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -1210,10 +1210,8 @@ CreateUncheckedForeignKeyConstraints(List *logicalRepTargetList)
 				list_make1("SET LOCAL citus.skip_constraint_validation TO ON;"),
 				commandList);
 
-			SendCommandListToWorkerOutsideTransaction(
-				target->superuserConnection->hostname,
-				target->superuserConnection->port,
-				target->superuserConnection->user,
+			SendCommandListToWorkerOutsideTransactionWithConnection(
+				target->superuserConnection,
 				commandList);
 
 			MemoryContextReset(localContext);
@@ -1638,8 +1636,8 @@ DropUser(MultiConnection *connection, char *username)
 	 * The DROP USER command should not propagate, so we temporarily disable
 	 * DDL propagation.
 	 */
-	SendCommandListToWorkerOutsideTransaction(
-		connection->hostname, connection->port, connection->user,
+	SendCommandListToWorkerOutsideTransactionWithConnection(
+		connection,
 		list_make2(
 			"SET LOCAL citus.enable_ddl_propagation TO OFF;",
 			psprintf("DROP USER IF EXISTS %s",
@@ -1824,10 +1822,8 @@ CreateSubscriptions(MultiConnection *sourceConnection,
 		 * create a user with SUPERUSER permissions and then alter it to NOSUPERUSER.
 		 * This prevents permission escalations.
 		 */
-		SendCommandListToWorkerOutsideTransaction(
-			target->superuserConnection->hostname,
-			target->superuserConnection->port,
-			target->superuserConnection->user,
+		SendCommandListToWorkerOutsideTransactionWithConnection(
+			target->superuserConnection,
 			list_make2(
 				"SET LOCAL citus.enable_ddl_propagation TO OFF;",
 				psprintf(
@@ -1885,10 +1881,8 @@ CreateSubscriptions(MultiConnection *sourceConnection,
 		 * The ALTER ROLE command should not propagate, so we temporarily
 		 * disable DDL propagation.
 		 */
-		SendCommandListToWorkerOutsideTransaction(
-			target->superuserConnection->hostname,
-			target->superuserConnection->port,
-			target->superuserConnection->user,
+		SendCommandListToWorkerOutsideTransactionWithConnection(
+			target->superuserConnection,
 			list_make2(
 				"SET LOCAL citus.enable_ddl_propagation TO OFF;",
 				psprintf(

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -566,10 +566,9 @@ DropAllLogicalReplicationLeftovers(LogicalRepType type)
 	char *databaseName = get_database_name(MyDatabaseId);
 
 	/*
-	 * We open new connections to all nodes. The reason for this is that
-	 * operations on subscriptions, publications and replication slotscannot be
-	 * run in a transaction. By forcing a new connection we make sure no
-	 * transaction is active on the connection.
+	 * We need connections that are not currently inside a transaction. The
+	 * reason for this is that operations on subscriptions, publications and
+	 * replication slots cannot be run in a transaction.
 	 */
 	int connectionFlags = OUTSIDE_TRANSACTION;
 
@@ -607,7 +606,9 @@ DropAllLogicalReplicationLeftovers(LogicalRepType type)
 		/*
 		 * We close all connections that we opened for the dropping here. That
 		 * way we don't keep these connections open unnecessarily during the
-		 * 'LogicalRepType' operation (which can take a long time).
+		 * 'LogicalRepType' operation (which can take a long time). We might
+		 * need to reopen a few later on, but that seems better than keeping
+		 * many open for no reason for a long time.
 		 */
 		CloseConnection(cleanupConnection);
 	}

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -768,7 +768,12 @@ CloseRemoteTransaction(struct MultiConnection *connection)
 		dlist_delete(&connection->transactionNode);
 	}
 
-	ResetConnection(connection);
+	/* reset per-transaction state */
+	ResetRemoteTransaction(connection);
+	ResetShardPlacementAssociation(connection);
+
+	/* reset copy state */
+	connection->copyBytesWrittenSinceLastFlush = 0;
 }
 
 

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -766,18 +766,9 @@ CloseRemoteTransaction(struct MultiConnection *connection)
 		/* XXX: Should we error out for a critical transaction? */
 
 		dlist_delete(&connection->transactionNode);
-
-		/*
-		 * If the transaction was completed, we have now cleaned it up, so we
-		 * can reset the state to REMOTE_TRANS_NOT_STARTED. This allows us to
-		 * start a new transaction without running into errors.
-		 */
-		if (transaction->transactionState == REMOTE_TRANS_ABORTED ||
-			transaction->transactionState == REMOTE_TRANS_COMMITTED)
-		{
-			transaction->transactionState = REMOTE_TRANS_NOT_STARTED;
-		}
 	}
+
+	ResetConnection(connection);
 }
 
 

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -751,12 +751,11 @@ MarkRemoteTransactionCritical(struct MultiConnection *connection)
 
 
 /*
- * CloseRemoteTransaction handles closing a connection that, potentially, is
- * part of a coordinated transaction.  This should only ever be called from
- * connection_management.c, while closing a connection during a transaction.
+ * ResetRemoteTransaction resets the state of the transaction after the end of
+ * the main transaction, if the connection is being reused.
  */
 void
-CloseRemoteTransaction(struct MultiConnection *connection)
+ResetRemoteTransaction(struct MultiConnection *connection)
 {
 	RemoteTransaction *transaction = &connection->remoteTransaction;
 
@@ -768,26 +767,13 @@ CloseRemoteTransaction(struct MultiConnection *connection)
 		dlist_delete(&connection->transactionNode);
 	}
 
-	/* reset per-transaction state */
-	ResetRemoteTransaction(connection);
+	/* just reset the entire state, relying on 0 being invalid/false */
+	memset(transaction, 0, sizeof(*transaction));
+
 	ResetShardPlacementAssociation(connection);
 
 	/* reset copy state */
 	connection->copyBytesWrittenSinceLastFlush = 0;
-}
-
-
-/*
- * ResetRemoteTransaction resets the state of the transaction after the end of
- * the main transaction, if the connection is being reused.
- */
-void
-ResetRemoteTransaction(struct MultiConnection *connection)
-{
-	RemoteTransaction *transaction = &connection->remoteTransaction;
-
-	/* just reset the entire state, relying on 0 being invalid/false */
-	memset(transaction, 0, sizeof(*transaction));
 }
 
 

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -766,6 +766,17 @@ CloseRemoteTransaction(struct MultiConnection *connection)
 		/* XXX: Should we error out for a critical transaction? */
 
 		dlist_delete(&connection->transactionNode);
+
+		/*
+		 * If the transaction was completed, we have now cleaned it up, so we
+		 * can reset the state to REMOTE_TRANS_NOT_STARTED. This allows us to
+		 * start a new transaction without running into errors.
+		 */
+		if (transaction->transactionState == REMOTE_TRANS_ABORTED ||
+			transaction->transactionState == REMOTE_TRANS_COMMITTED)
+		{
+			transaction->transactionState = REMOTE_TRANS_NOT_STARTED;
+		}
 	}
 }
 

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -370,7 +370,7 @@ SendCommandListToWorkerOutsideTransactionWithConnection(MultiConnection *workerC
 	}
 
 	RemoteTransactionCommit(workerConnection);
-	CloseRemoteTransaction(workerConnection);
+	ResetRemoteTransaction(workerConnection);
 }
 
 
@@ -488,7 +488,7 @@ SendOptionalCommandListToWorkerOutsideTransactionWithConnection(
 		RemoteTransactionCommit(workerConnection);
 	}
 
-	CloseRemoteTransaction(workerConnection);
+	ResetRemoteTransaction(workerConnection);
 
 	return !failed;
 }

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -303,6 +303,7 @@ extern MultiConnection * ConnectionAvailableToNode(char *hostName, int nodePort,
 extern void CloseConnection(MultiConnection *connection);
 extern void ShutdownAllConnections(void);
 extern void ShutdownConnection(MultiConnection *connection);
+extern void ResetConnection(MultiConnection *connection);
 
 /* dealing with a connection */
 extern void FinishConnectionListEstablishment(List *multiConnectionList);

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -289,7 +289,7 @@ extern MultiConnection * StartNodeConnection(uint32 flags, const char *hostname,
 extern MultiConnection * GetNodeUserDatabaseConnection(uint32 flags, const char *hostname,
 													   int32 port, const char *user,
 													   const char *database);
-extern MultiConnection * GetLocalConnectionForSubtransactionAsUser(char *userName);
+extern MultiConnection * GetConnectionForLocalQueriesOutsideTransaction(char *userName);
 extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 const char *hostname,
 														 int32 port,

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -289,6 +289,7 @@ extern MultiConnection * StartNodeConnection(uint32 flags, const char *hostname,
 extern MultiConnection * GetNodeUserDatabaseConnection(uint32 flags, const char *hostname,
 													   int32 port, const char *user,
 													   const char *database);
+extern MultiConnection * GetLocalConnectionForSubtransactionAsUser(char *userName);
 extern MultiConnection * StartNodeUserDatabaseConnection(uint32 flags,
 														 const char *hostname,
 														 int32 port,

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -303,7 +303,6 @@ extern MultiConnection * ConnectionAvailableToNode(char *hostName, int nodePort,
 extern void CloseConnection(MultiConnection *connection);
 extern void ShutdownAllConnections(void);
 extern void ShutdownConnection(MultiConnection *connection);
-extern void ResetConnection(MultiConnection *connection);
 
 /* dealing with a connection */
 extern void FinishConnectionListEstablishment(List *multiConnectionList);

--- a/src/include/distributed/multi_logical_replication.h
+++ b/src/include/distributed/multi_logical_replication.h
@@ -172,10 +172,6 @@ extern HTAB * CreateGroupedLogicalRepTargetsHash(List *subscriptionInfoList);
 extern void CreateGroupedLogicalRepTargetsConnections(HTAB *groupedLogicalRepTargetsHash,
 													  char *user,
 													  char *databaseName);
-extern void RecreateGroupedLogicalRepTargetsConnections(
-	HTAB *groupedLogicalRepTargetsHash,
-	char *user,
-	char *databaseName);
 extern void CloseGroupedLogicalRepTargetsConnections(HTAB *groupedLogicalRepTargetsHash);
 extern void CompleteNonBlockingShardTransfer(List *shardList,
 											 MultiConnection *sourceConnection,

--- a/src/include/distributed/remote_transaction.h
+++ b/src/include/distributed/remote_transaction.h
@@ -130,7 +130,6 @@ extern void MarkRemoteTransactionCritical(struct MultiConnection *connection);
  * transaction managment code.
  */
 
-extern void CloseRemoteTransaction(struct MultiConnection *connection);
 extern void ResetRemoteTransaction(struct MultiConnection *connection);
 
 /* perform handling for all in-progress transactions */

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -12,6 +12,7 @@
 #ifndef WORKER_TRANSACTION_H
 #define WORKER_TRANSACTION_H
 
+#include "distributed/connection_management.h"
 #include "distributed/worker_manager.h"
 #include "storage/lockdefs.h"
 
@@ -59,6 +60,10 @@ extern bool SendOptionalCommandListToWorkerOutsideTransaction(const char *nodeNa
 															  int32 nodePort,
 															  const char *nodeUser,
 															  List *commandList);
+extern bool SendOptionalCommandListToWorkerOutsideTransactionWithConnection(
+	MultiConnection *workerConnection,
+	List *
+	commandList);
 extern bool SendOptionalMetadataCommandListToWorkerInCoordinatedTransaction(const
 																			char *nodeName,
 																			int32 nodePort,
@@ -74,6 +79,9 @@ extern void SendCommandListToWorkerOutsideTransaction(const char *nodeName,
 													  int32 nodePort,
 													  const char *nodeUser,
 													  List *commandList);
+extern void SendCommandListToWorkerOutsideTransactionWithConnection(
+	MultiConnection *workerConnection,
+	List *commandList);
 extern void SendMetadataCommandListToWorkerListInCoordinatedTransaction(
 	List *workerNodeList,
 	const char *

--- a/src/test/regress/expected/failure_on_create_subscription.out
+++ b/src/test/regress/expected/failure_on_create_subscription.out
@@ -41,8 +41,13 @@ SELECT * FROM shards_in_workers;
      103 | worker1
 (4 rows)
 
--- failure on creating the subscription
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE SUBSCRIPTION").kill()');
+-- Failure on creating the subscription
+-- Failing exactly on CREATE SUBSCRIPTION is causing flaky test where we fail with either:
+-- 1) ERROR:  connection to the remote node localhost:xxxxx failed with the following error: ERROR:  subscription "citus_shard_move_subscription_xxxxxxx" does not exist
+-- another command is already in progress
+-- 2) ERROR:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+-- Instead fail on the next step (ALTER SUBSCRIPTION) instead which is also required logically as part of uber CREATE SUBSCRIPTION operation.
+SELECT citus.mitmproxy('conn.onQuery(query="ALTER SUBSCRIPTION").kill()');
  mitmproxy
 ---------------------------------------------------------------------
 

--- a/src/test/regress/sql/failure_on_create_subscription.sql
+++ b/src/test/regress/sql/failure_on_create_subscription.sql
@@ -32,8 +32,14 @@ INSERT INTO t SELECT x, x+1, MD5(random()::text) FROM generate_series(1,100000) 
 -- Initial shard placements
 SELECT * FROM shards_in_workers;
 
--- failure on creating the subscription
-SELECT citus.mitmproxy('conn.onQuery(query="CREATE SUBSCRIPTION").kill()');
+-- Failure on creating the subscription
+-- Failing exactly on CREATE SUBSCRIPTION is causing flaky test where we fail with either:
+-- 1) ERROR:  connection to the remote node localhost:xxxxx failed with the following error: ERROR:  subscription "citus_shard_move_subscription_xxxxxxx" does not exist
+-- another command is already in progress
+-- 2) ERROR:  connection to the remote node localhost:xxxxx failed with the following error: another command is already in progress
+-- Instead fail on the next step (ALTER SUBSCRIPTION) instead which is also required logically as part of uber CREATE SUBSCRIPTION operation.
+
+SELECT citus.mitmproxy('conn.onQuery(query="ALTER SUBSCRIPTION").kill()');
 SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost', :worker_2_proxy_port);
 
 -- Verify that the shard is not moved and the number of rows are still 100k


### PR DESCRIPTION
DESCRIPTION: Reuse connections for shard splits and logical replication

In Split, Logical replication logic and ShardCleaner we call `SendCommandListToWorkerOutsideTransaction` and `SendOptionalCommandListToWorkerOutsideTransaction` frequently. This opens new connection for each of those calls, even though we already have a perfectly good connection lying around.

This PR adds two new APIs `SendCommandListToWorkerOutsideTransactionWithConnection` and `SendOptionalCommandListToWorkerOutsideTransactionWithConnection`  that allow sending a list of queries in a transaction over an existing connection. We also update the callers (Split, ShardCleaner, Logical Replication) to use these new APIs instead.
