### PR TITLE
Remove missing declaration warning

### DIFF
--- a/src/backend/distributed/utils/background_jobs.c
+++ b/src/backend/distributed/utils/background_jobs.c
@@ -899,8 +899,9 @@ ConsumeTaskWorkerOutput(shm_mq_handle *responseq, StringInfo message, bool *hadE
 				{
 					*hadError = true;
 				}
-				__attribute__((fallthrough));
 			}
+
+			/* FALLTHROUGH */
 
 			case 'N': /* NoticeResponse */
 			{


### PR DESCRIPTION
When I built Citus on PG15beta4 locally, I get a warning message.

```
utils/background_jobs.c:902:5: warning: declaration does not declare anything
      [-Wmissing-declarations]
                                __attribute__((fallthrough));
                                ^
1 warning generated.
```

This is a hint to the compiler that we are deliberately falling through in a switch-case block.