### PR TITLE
Shard Split : Add / Update logging 

### DIFF
--- a/src/include/distributed/shard_cleaner.h
+++ b/src/include/distributed/shard_cleaner.h
@@ -103,13 +103,13 @@ extern void InsertCleanupRecordInSubtransaction(CleanupObject objectType,
  * completion on failure. This will trigger cleanup of appropriate resources
  * and cleanup records.
  */
-extern void FinalizeOperationNeedingCleanupOnFailure(void);
+extern void FinalizeOperationNeedingCleanupOnFailure(const char *operationName);
 
 /*
  * FinalizeOperationNeedingCleanupOnSuccess is be called by an operation to signal
  * completion on success. This will trigger cleanup of appropriate resources
  * and cleanup records.
  */
-extern void FinalizeOperationNeedingCleanupOnSuccess(void);
+extern void FinalizeOperationNeedingCleanupOnSuccess(const char *operationName);
 
 #endif /*CITUS_SHARD_CLEANER_H */

--- a/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
+++ b/src/test/regress/expected/isolation_rebalancer_deferred_drop.out
@@ -91,7 +91,7 @@ step s1-drop-marked-shards:
  <waiting ...>
 s1: WARNING:  canceling statement due to lock timeout
 step s1-drop-marked-shards: <... completed>
-s1: WARNING:  Failed to drop 1 orphaned shards out of 1
+s1: WARNING:  failed to clean up 1 orphaned shards out of 1
 step s1-commit:
     COMMIT;
 

--- a/src/test/regress/expected/multi_colocated_shard_rebalance.out
+++ b/src/test/regress/expected/multi_colocated_shard_rebalance.out
@@ -740,7 +740,7 @@ DETAIL:  from localhost:xxxxx
 (1 row)
 
 CALL citus_cleanup_orphaned_shards();
-LOG:  cleaning up public.test_with_pkey_13000042 on localhost:xxxxx which was left after a move
+LOG:  deferred drop of orphaned shard public.test_with_pkey_13000042 on localhost:xxxxx after a move completed
 NOTICE:  cleaned up 1 orphaned shards
 SET client_min_messages TO DEFAULT;
 -- we don't support multiple shard moves in a single transaction

--- a/src/test/regress/expected/multi_tenant_isolation.out
+++ b/src/test/regress/expected/multi_tenant_isolation.out
@@ -758,7 +758,7 @@ SET search_path to "Tenant Isolation";
 \set VERBOSITY terse
 SELECT isolate_tenant_to_new_shard('orders_streaming', 104, 'CASCADE', shard_transfer_mode => 'block_writes');
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 1 shards out of 1 as part of failed operation
+WARNING:  failed to clean up 1 orphaned shards out of 1 after a isolate_tenant_to_new_shard operation failed
 ERROR:  command CREATE TABLE is disabled
 \set VERBOSITY default
 \c - postgres - :worker_1_port
@@ -811,7 +811,7 @@ WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 6 shards out of 6 as part of failed operation
+WARNING:  failed to clean up 6 orphaned shards out of 6 after a isolate_tenant_to_new_shard operation failed
 ERROR:  command DROP TABLE is disabled
 \set VERBOSITY default
 -- check if metadata is changed

--- a/src/test/regress/expected/multi_tenant_isolation.out
+++ b/src/test/regress/expected/multi_tenant_isolation.out
@@ -758,7 +758,7 @@ SET search_path to "Tenant Isolation";
 \set VERBOSITY terse
 SELECT isolate_tenant_to_new_shard('orders_streaming', 104, 'CASCADE', shard_transfer_mode => 'block_writes');
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 1 shards out of 1
+WARNING:  Failed to cleanup 1 shards out of 1 as part of failed operation
 ERROR:  command CREATE TABLE is disabled
 \set VERBOSITY default
 \c - postgres - :worker_1_port
@@ -811,7 +811,7 @@ WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 6 shards out of 6
+WARNING:  Failed to cleanup 6 shards out of 6 as part of failed operation
 ERROR:  command DROP TABLE is disabled
 \set VERBOSITY default
 -- check if metadata is changed

--- a/src/test/regress/expected/multi_tenant_isolation_nonblocking.out
+++ b/src/test/regress/expected/multi_tenant_isolation_nonblocking.out
@@ -790,7 +790,7 @@ SET search_path to "Tenant Isolation";
 \set VERBOSITY terse
 SELECT isolate_tenant_to_new_shard('orders_streaming', 104, 'CASCADE', shard_transfer_mode => 'force_logical');
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 1 shards out of 1
+WARNING:  Failed to cleanup 1 shards out of 1 as part of failed operation
 ERROR:  command CREATE TABLE is disabled
 \set VERBOSITY default
 \c - postgres - :worker_1_port

--- a/src/test/regress/expected/multi_tenant_isolation_nonblocking.out
+++ b/src/test/regress/expected/multi_tenant_isolation_nonblocking.out
@@ -790,7 +790,7 @@ SET search_path to "Tenant Isolation";
 \set VERBOSITY terse
 SELECT isolate_tenant_to_new_shard('orders_streaming', 104, 'CASCADE', shard_transfer_mode => 'force_logical');
 WARNING:  command DROP TABLE is disabled
-WARNING:  Failed to cleanup 1 shards out of 1 as part of failed operation
+WARNING:  failed to clean up 1 orphaned shards out of 1 after a isolate_tenant_to_new_shard operation failed
 ERROR:  command CREATE TABLE is disabled
 \set VERBOSITY default
 \c - postgres - :worker_1_port


### PR DESCRIPTION
DESCRIPTION: Improve logging during shard split and resource cleanup

### DESCRIPTION

This PR makes logging improvements to Shard Split : 

1. Update confusing logging to fix #6312
2. Added new `ereport(LOG` to make debugging easier as part of telemetry review.

### UPDATE
I have removed all connection reuse changes and will make them together as part of updating PR #6314.

Fixes #6312