### PR TITLE
[Columnar] Bugfix for Columnar: options ignored during ALTER TABLE rewrite

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -739,19 +739,8 @@ columnar_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 	 */
 	ColumnarWriteState *writeState = columnar_init_write_state(relation,
 															   RelationGetDescr(relation),
+															   slot->tts_tableOid,
 															   GetCurrentSubTransactionId());
-
-	/*
-	 * Setting the original relation's columnar options to the new relation
-	 * so that the original data is compressed with the same option in case of
-	 * an ALTER rewrite
-	 */
-	if (slot->tts_tableOid != relation->rd_id)
-	{
-		ColumnarOptions columnarOptions;
-		ReadColumnarOptions(slot->tts_tableOid, &columnarOptions);
-		ColumnarSetWriteStateOptions(writeState, columnarOptions);
-	}
 
 	MemoryContext oldContext = MemoryContextSwitchTo(ColumnarWritePerTupleContext(
 														 writeState));
@@ -796,6 +785,7 @@ columnar_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 
 	ColumnarWriteState *writeState = columnar_init_write_state(relation,
 															   RelationGetDescr(relation),
+															   slots[0]->tts_tableOid,
 															   GetCurrentSubTransactionId());
 
 	ColumnarCheckLogicalReplication(relation);

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -732,6 +732,7 @@ columnar_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 					  int options, BulkInsertState bistate)
 {
 	CheckCitusColumnarVersion(ERROR);
+
 	/*
 	 * Setting the original relation's columnar options to the new relation
 	 * so that the original data is compressed with the same option
@@ -739,9 +740,9 @@ columnar_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 
 	ColumnarOptions columnarOptions;
 	Relation oldRel = relation_open(slot->tts_tableOid, AccessShareLock);
-    ReadColumnarOptions(oldRel->rd_id, &columnarOptions);
-    SetColumnarOptions(relation->rd_id, &columnarOptions);
-    relation_close(oldRel, AccessShareLock);
+	ReadColumnarOptions(oldRel->rd_id, &columnarOptions);
+	SetColumnarOptions(relation->rd_id, &columnarOptions);
+	relation_close(oldRel, AccessShareLock);
 
 	/*
 	 * columnar_init_write_state allocates the write state in a longer
@@ -894,7 +895,7 @@ columnar_relation_set_new_filenode(Relation rel,
 	ColumnarOptions options;
 	ReadColumnarOptions(rel->rd_id, &options);
 	SetColumnarOptions(newRel->rd_id, &options);
-	//InitColumnarOptions(newRel->rd_id);
+	/*InitColumnarOptions(newRel->rd_id); */
 	relation_close(newRel, AccessShareLock);
 	smgrclose(srel);
 

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -734,23 +734,25 @@ columnar_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 	CheckCitusColumnarVersion(ERROR);
 
 	/*
-	 * Setting the original relation's columnar options to the new relation
-	 * so that the original data is compressed with the same option
-	 */
-
-	ColumnarOptions columnarOptions;
-	Relation oldRel = relation_open(slot->tts_tableOid, AccessShareLock);
-	ReadColumnarOptions(oldRel->rd_id, &columnarOptions);
-	SetColumnarOptions(relation->rd_id, &columnarOptions);
-	relation_close(oldRel, AccessShareLock);
-
-	/*
 	 * columnar_init_write_state allocates the write state in a longer
 	 * lasting context, so no need to worry about it.
 	 */
 	ColumnarWriteState *writeState = columnar_init_write_state(relation,
 															   RelationGetDescr(relation),
 															   GetCurrentSubTransactionId());
+
+	/*
+	 * Setting the original relation's columnar options to the new relation
+	 * so that the original data is compressed with the same option in case of
+	 * an ALTER rewrite
+	 */
+	if (slot->tts_tableOid != relation->rd_id)
+	{
+		ColumnarOptions columnarOptions;
+		ReadColumnarOptions(slot->tts_tableOid, &columnarOptions);
+		ColumnarSetWriteStateOptions(writeState, columnarOptions);
+	}
+
 	MemoryContext oldContext = MemoryContextSwitchTo(ColumnarWritePerTupleContext(
 														 writeState));
 
@@ -890,13 +892,10 @@ columnar_relation_set_new_filenode(Relation rel,
 	*freezeXid = RecentXmin;
 	*minmulti = GetOldestMultiXactId();
 	SMgrRelation srel = RelationCreateStorage_compat(*newrnode, persistence, true);
+
 	ColumnarStorageInit(srel, ColumnarMetadataNewStorageId());
-	Relation newRel = relation_open(newrnode->relNode, AccessShareLock);
-	ColumnarOptions options;
-	ReadColumnarOptions(rel->rd_id, &options);
-	SetColumnarOptions(newRel->rd_id, &options);
-	/*InitColumnarOptions(newRel->rd_id); */
-	relation_close(newRel, AccessShareLock);
+	InitColumnarOptions(rel->rd_id);
+
 	smgrclose(srel);
 
 	/* we will lazily initialize metadata in first stripe reservation */

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -783,9 +783,14 @@ columnar_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 {
 	CheckCitusColumnarVersion(ERROR);
 
+	/*
+	 * The callback to .multi_insert is table_multi_insert() and this is only used for the COPY
+	 * command, so slot[i]->tts_tableoid will always be equal to relation->id. Thus, we can send
+	 * RelationGetRelid(relation) as the tupSlotTableOid
+	 */
 	ColumnarWriteState *writeState = columnar_init_write_state(relation,
 															   RelationGetDescr(relation),
-															   slots[0]->tts_tableOid,
+															   RelationGetRelid(relation),
 															   GetCurrentSubTransactionId());
 
 	ColumnarCheckLogicalReplication(relation);

--- a/src/backend/columnar/columnar_writer.c
+++ b/src/backend/columnar/columnar_writer.c
@@ -79,6 +79,24 @@ static Datum DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength);
 static StringInfo CopyStringInfo(StringInfo sourceString);
 
 /*
+ * ColumnarSetWriteStateOptions gives the ability to update the writestate's
+ * columnar.options outside of columnar_writer.c. This is used when a ALTER TABLE ...
+ * SET/RESET is called and the temporary table does not have the old table's options.
+ */
+bool
+ColumnarSetWriteStateOptions(ColumnarWriteState *writeState, ColumnarOptions options)
+{
+	if (writeState == false)
+	{
+		return false;
+	}
+
+	writeState->options = options;
+	return true;
+}
+
+
+/*
  * ColumnarBeginWrite initializes a columnar data load operation and returns a table
  * handle. This handle should be used for adding the row values and finishing the
  * data load operation.

--- a/src/backend/columnar/columnar_writer.c
+++ b/src/backend/columnar/columnar_writer.c
@@ -79,24 +79,6 @@ static Datum DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength);
 static StringInfo CopyStringInfo(StringInfo sourceString);
 
 /*
- * ColumnarSetWriteStateOptions gives the ability to update the writestate's
- * columnar.options outside of columnar_writer.c. This is used when a ALTER TABLE ...
- * SET/RESET is called and the temporary table does not have the old table's options.
- */
-bool
-ColumnarSetWriteStateOptions(ColumnarWriteState *writeState, ColumnarOptions options)
-{
-	if (writeState == false)
-	{
-		return false;
-	}
-
-	writeState->options = options;
-	return true;
-}
-
-
-/*
  * ColumnarBeginWrite initializes a columnar data load operation and returns a table
  * handle. This handle should be used for adding the row values and finishing the
  * data load operation.

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -234,6 +234,10 @@ extern void ColumnarEndWrite(ColumnarWriteState *state);
 extern bool ContainsPendingWrites(ColumnarWriteState *state);
 extern MemoryContext ColumnarWritePerTupleContext(ColumnarWriteState *state);
 
+/* Function declaration for updating Columnar.options */
+extern bool ColumnarSetWriteStateOptions(ColumnarWriteState *writeState, ColumnarOptions
+										 options);
+
 /* Function declarations for reading from columnar table */
 
 /* functions applicable for both sequential and random access */

--- a/src/include/columnar/columnar.h
+++ b/src/include/columnar/columnar.h
@@ -234,10 +234,6 @@ extern void ColumnarEndWrite(ColumnarWriteState *state);
 extern bool ContainsPendingWrites(ColumnarWriteState *state);
 extern MemoryContext ColumnarWritePerTupleContext(ColumnarWriteState *state);
 
-/* Function declaration for updating Columnar.options */
-extern bool ColumnarSetWriteStateOptions(ColumnarWriteState *writeState, ColumnarOptions
-										 options);
-
 /* Function declarations for reading from columnar table */
 
 /* functions applicable for both sequential and random access */
@@ -318,6 +314,7 @@ extern Datum columnar_relation_storageid(PG_FUNCTION_ARGS);
 /* write_state_management.c */
 extern ColumnarWriteState * columnar_init_write_state(Relation relation, TupleDesc
 													  tupdesc,
+													  Oid tupSlotRelationId,
 													  SubTransactionId currentSubXid);
 extern void FlushWriteStateForRelfilenode(Oid relfilenode, SubTransactionId
 										  currentSubXid);

--- a/src/test/regress/expected/columnar_alter_set_type.out
+++ b/src/test/regress/expected/columnar_alter_set_type.out
@@ -50,6 +50,9 @@ SELECT * FROM test_alter_table ORDER BY a;
 (4 rows)
 
 DROP TABLE test_alter_table;
+--  Make sure that the correct table options are used when rewriting the table.
+-- This is reflected by the VACUUM VERBOSE output right after a rewrite showing
+-- that all chunks are compressed with the configured compression algorithm
 -- https://github.com/citusdata/citus/issues/5927
 CREATE TABLE test(i int) USING columnar;
 ALTER TABLE test SET (columnar.compression = lz4);

--- a/src/test/regress/expected/columnar_alter_set_type.out
+++ b/src/test/regress/expected/columnar_alter_set_type.out
@@ -50,3 +50,25 @@ SELECT * FROM test_alter_table ORDER BY a;
 (4 rows)
 
 DROP TABLE test_alter_table;
+-- https://github.com/citusdata/citus/issues/5927
+CREATE TABLE test(i int) USING columnar;
+ALTER TABLE test SET (columnar.compression = lz4);
+INSERT INTO test VALUES(1);
+VACUUM VERBOSE test;
+INFO:  statistics for "test":
+storage id: xxxxx
+total file size: 24576, total data size: 6
+compression rate: 0.83x
+total row count: 1, stripe count: 1, average rows per stripe: 1
+chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
+
+ALTER TABLE test ALTER COLUMN i TYPE int8;
+VACUUM VERBOSE test;
+INFO:  statistics for "test":
+storage id: xxxxx
+total file size: 24576, total data size: 10
+compression rate: 0.90x
+total row count: 1, stripe count: 1, average rows per stripe: 1
+chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
+
+DROP TABLE test;

--- a/src/test/regress/sql/columnar_alter_set_type.sql
+++ b/src/test/regress/sql/columnar_alter_set_type.sql
@@ -29,3 +29,14 @@ ALTER TABLE test_alter_table ALTER COLUMN b TYPE float USING (b::float + 0.5);
 SELECT * FROM test_alter_table ORDER BY a;
 
 DROP TABLE test_alter_table;
+
+-- https://github.com/citusdata/citus/issues/5927
+CREATE TABLE test(i int) USING columnar;
+ALTER TABLE test SET (columnar.compression = lz4);
+INSERT INTO test VALUES(1);
+VACUUM VERBOSE test;
+
+ALTER TABLE test ALTER COLUMN i TYPE int8;
+VACUUM VERBOSE test;
+
+DROP TABLE test;

--- a/src/test/regress/sql/columnar_alter_set_type.sql
+++ b/src/test/regress/sql/columnar_alter_set_type.sql
@@ -30,6 +30,9 @@ SELECT * FROM test_alter_table ORDER BY a;
 
 DROP TABLE test_alter_table;
 
+-- Make sure that the correct table options are used when rewriting the table.
+-- This is reflected by the VACUUM VERBOSE output right after a rewrite showing
+-- that all chunks are compressed with the configured compression algorithm
 -- https://github.com/citusdata/citus/issues/5927
 CREATE TABLE test(i int) USING columnar;
 ALTER TABLE test SET (columnar.compression = lz4);


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that prevents retaining columnar table options after a table-rewrite
A fix for this issue: Columnar: options ignored during ALTER TABLE rewrite #5927 
The OID for the temporary table created during ALTER TABLE was not the same as the original table's OID so the columnar options were not being applied during rewrite. 

The change is that I applied the original table's columnar options to the new table so that it has the correct options during write. I also added a test.