### PR TITLE
Add changelog entries for 11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,36 @@
 ### citus v11.1.0 (September 15, 2022) ###
 
-* Adds `citus_split_shard_by_split_points()` function
-
-* Adds `create_distributed_table_concurrently()` which distributes tables without blocking writes
+* Adds support for PostgreSQL 15beta3
 
 * Adds a rebalancer that uses background tasks for its execution
 
-* Adds an `allow_unsafe_constraints` flag for constraints without distribution column
+* Adds `create_distributed_table_concurrently()` which distributes tables without blocking writes
 
-* Adds support for PostgreSQL 15beta3
+* Adds `citus_split_shard_by_split_points()` function
+
+* Adds support for non-blocking tenant isolation
+
+* Separates columnar storage AM into a separate logical extension
+
+* Supports logical replication in `replicate_reference_tables()`
+
+* Improves performance of blocking shard moves
+
+* Uses a faster custom copy logic for non-blocking shard moves
+
+* `isolate_tenant_to_new_shard()` adds support for columnar tables
+
+* `isolate_tenant_to_new_shard()` adds support for partitioned tables
+
+* `isolate_tenant_to_new_shard()` drops support for replicated tables
+
+* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
+
+* Adds an `allow_unsafe_constraints` flag for constraints without distribution column
 
 * Adds support for `GRANT/REVOKE` ON aggregates
 
 * Adds support for `NULLS NOT DISTINCT` clauses for indexes
-
-* Adds support for non-blocking tenant isolation
 
 * Adds support for setting relation options for columnar tables using `ALTER TABLE`
 
@@ -22,11 +38,45 @@
 
 * Adds the GUC `enable_unsupported_feature_messages` to control some of the citus related messages
 
-* Changes the default mode for shard splitting to 'auto' from 'block_writes'
-
 * Checks existence of the shards before insert, delete, and update
 
 * Creates all foreign keys quickly at the end of a shard move
+
+* Hides tables owned by extensions from `citus_tables` and `citus_shards`
+
+* Introduces GUC `citus.skip_constraint_validation`
+
+* Introduces `citus_locks` view
+
+* Propagates `VACUUM` and `ANALYZE` to worker nodes
+
+* Makes non-partitioned table size calculation quicker
+
+* Only shows shards in moving state in `get_rebalance_progress()`
+
+* Removes `do_repair` option from `citus_copy_shard_placement()`
+
+* Removes deprecated re-partitioning functions like `worker_hash_partition_table()`
+
+* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
+
+* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
+
+* Shows local tables added to metadata in `citus_tables`
+
+* Supports changing CPU priorities for backends and shard moves
+
+* Tightens security and improves visibility for columnar table access method
+
+* `citus_move_shard_placement()` becomes a noop if shard already exists on node
+
+* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
+
+* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
+
+* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
+
+* Prevents creating a new colocation entry when replicating reference tables
 
 * Fixes a bug in query escaping in `undistribute_table()` and `alter_distributed_table()`
 
@@ -56,59 +106,7 @@
 
 * Fixes the transaction timestamp column of the `get_current_transaction_id()` on coordinator
 
-* Hides tables owned by extensions from `citus_tables` and `citus_shards`
-
-* Improves performance of blocking shard moves
-
-* Introduces GUC `citusskip_constraint_validation`
-
-* Introduces `citus_locks` view
-
-* Makes non-partitioned table size calculation quicker
-
-* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
-
-* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
-
 * Maps any unused parameters to a generic type in prepared statements
-
-* Only shows shards in moving state in `get_rebalance_progress()`
-
-* Prevents creating a new colocation entry when replicating reference tables
-
-* Propagates `VACUUM` and `ANALYZE` to worker nodes
-
-* Removes `do_repair` option from `citus_copy_shard_placement()`
-
-* Removes deprecated re-partitioning functions like `worker_hash_partition_table()`
-
-* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
-
-* Separates columnar storage AM into a separate logical extension
-
-* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
-
-* Shows local tables added to metadata in `citus_tables`
-
-* Supports logical replication in `replicate_reference_tables()`
-
-* Supports changing CPU priorities for backends and shard moves
-
-* Tightens security and improves visibility for columnar table access method
-
-* Uses a faster custom copy logic for non-blocking shard moves
-
-* `citus_move_shard_placement()` becomes a noop if shard already exists on node
-
-* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
-
-* `isolate_tenant_to_new_shard()` adds support for columnar tables
-
-* `isolate_tenant_to_new_shard()` adds support for partitioned tables
-
-* `isolate_tenant_to_new_shard()` drops support for replicated tables
-
-* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
 
 ### citus v10.2.8 (August 19, 2022) ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,6 @@
 
 * Fixes an issue that can cause logical reference table replication to fail
 
-* Fixes floating exception during `create_distributed_table_concurrently()`
-
 * Fixes schema name qualification for `RENAME SEQUENCE` statement
 
 * Fixes several small memory leaks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Adds an `allow_unsafe_constraints` flag for constraints without distribution
   column
 
-* Adds support for `GRANT/REVOKE` ON aggregates
+* Adds support for `GRANT/REVOKE` on aggregates
 
 * Adds support for `NULLS NOT DISTINCT` clauses for indexes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 * Adds support for PostgreSQL 15beta4
 
-* Adds a rebalancer that uses background tasks for its execution
+* Adds ability to run shard rebalancer in the background
 
 * Adds `create_distributed_table_concurrently()` UDF to distribute tables
-  without blocking writes
+  without interrupting the application
 
 * Adds `citus_split_shard_by_split_points()` UDF that allows
   splitting a shard to specified set of nodes without blocking writes
@@ -16,23 +16,29 @@
 * Adds support for isolation tenants that use partitioned tables
   or columnar tables
 
-* Drops support for isolation tenants that use replicated tables
-
 * Separates columnar table access method into a separate logical extension
 
-* Adds support for logical replication in `replicate_reference_tables()`
+* Adds support for online replication in `replicate_reference_tables()`
 
 * Improves performance of blocking shard moves
 
 * Improves non-blocking shard moves with a faster custom copy logic
 
-* Adds the GUC `allow_unsafe_constraints` to allow constraints without
+* Creates all foreign keys quickly at the end of a shard move
+
+* Limits `get_rebalance_progress()` to show shards in moving state
+
+* Makes `citus_move_shard_placement()` idempotent if shard already exists
+  on target node
+
+* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
+
+* Supports changing CPU priorities for backends and shard moves
+
+* Adds the GUC `citus.allow_unsafe_constraints` to allow constraints without
   distribution column
 
 * Introduces GUC `citus.skip_constraint_validation`
-
-* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with
-  `citus.show_shards_for_app_name_prefixes`
 
 * Introduces `citus_locks` view
 
@@ -42,38 +48,29 @@
   an internal schema and introduces more secure & informative views based
   on them
 
-* Removes `do_repair` option from `citus_copy_shard_placement()`
-
-* Removes deprecated re-partitioning functions like
-  `worker_hash_partition_table()`
-
 * Adds support for `GRANT/REVOKE` on aggregates
 
-* Adds support for `NULLS NOT DISTINCT` clauses for indexes
+* Adds support for `NULLS NOT DISTINCT` clauses for indexes for PG15+
 
 * Adds support for setting relation options for columnar tables using
   `ALTER TABLE`
 
 * Adds support for unlogged distributed sequences
 
+* Removes `do_repair` option from `citus_copy_shard_placement()`
+
+* Removes deprecated re-partitioning functions like
+  `worker_hash_partition_table()`
+
+* Drops support for isolation tenants that use replicated tables
+
 * Checks existence of the shards before insert, delete, and update
 
-* Creates all foreign keys quickly at the end of a shard move
-
 * Hides tables owned by extensions from `citus_tables` and `citus_shards`
-
-* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
 
 * Propagates `VACUUM` and `ANALYZE` to worker nodes
 
 * Makes non-partitioned table size calculation quicker
-
-* Limits `get_rebalance_progress()` to show shards in moving state
-
-* Supports changing CPU priorities for backends and shard moves
-
-* Makes `citus_move_shard_placement()` idempotent if shard already exists
-  on target node
 
 * Improves `create_distributed_table()` by creating new colocation entries when
   using `colocate_with => 'none'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,120 +1,114 @@
 ### citus v11.1.0 (September 15, 2022) ###
 
-* Fixes floating exception during create_distributed_table_concurrently.
+* Fixes floating exception during create_distributed_table_concurrently
 
-* Fixes a bug in query escaping in undistribute_table and alter_distributed_table
+* Fixes a bug in query escaping in `undistribute_table()` and `alter_distributed_table()`
 
-* Show citus_copy_shard_placement progress in get_rebalance_progres
+* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
 
 * Adds support for unlogged distributed sequences
 
-* Adds support for NULLS NOT DISTINCT clauses for indexes
+* Adds support for `NULLS NOT DISTINCT` clauses for indexes
 
-* Add a rebalancer that uses background tasks for its execution
+* Adds a rebalancer that uses background tasks for its execution
 
-* Show Citus local tables in citus_tables
+* Shows local tables added to metadata in `citus_tables`
 
-* Hide tables owned by extensions from citus_tables and citus_shards
+* Hides tables owned by extensions from `citus_tables` and `citus_shards`
 
-* Fix bug preventing isolate_tenant_to_new_shard with text column
+* Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text column
 
-* citus_move_shard_placement becomes a noop if shard already exists on node
+* `citus_move_shard_placement()` becomes a noop if shard already exists on node
 
-* Remove do_repair option from citus_copy_shard_placement
+* Removes `do_repair` option from `citus_copy_shard_placement()`
 
-* Create all foreign keys quickly at the end of a shard mov
+* Creates all foreign keys quickly at the end of a shard move
 
-* Introduce GUC `citus.skip_constraint_validation`
+* Introduces GUC `citusskip_constraint_validation`
 
-* Makes sure that `SELECT .. FOR UPDATE `opens a transaction block when used in a function call
+* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
 
 * Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
 
-* Checks existence of the shards before insert, delete, and update.
+* Checks existence of the shards before insert, delete, and update
 
-* Disallows distribution by a numeric with negative scale
+* Adds `create_distributed_table_concurrently()` which distributes tables without blocking writes
 
-* Add create_distributed_table_concurrently which distributes tables without blocking
+* Makes non-partitioned table size calculation quicker
 
-* Adds SUM for calculating non-partitioned table sizes
+* Adds an `allow_unsafe_constraints` flag for constraints without distribution column
 
-* Add an allow_unsafe_constraints flag for constraints without distribution column
-
-* Fixes a bug that prevents setting colocation group of a partitioned distributed table to 'none'
+* Fixes a bug that prevents setting colocation group of a partitioned distributed table to `none`
 
 * Adds support for PostgreSQL 15beta3
 
-* Creates new colocation entries when colocate_with => 'none'.
+* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
 
-* Fixes an issue can cause logical reference table replication to fail
+* Fixes an issue that can cause logical reference table replication to fail
 
-* Stops creating colocation entry at EnsureReferenceTablesExistOnAllNodes.
+* Prevents creating a new colocation entry when replicating reference tables
 
-* Fix compilation warning on PG13 + OpenSSL 3.0
+* Fixes a bug that caused `GRANT` to propagate within `CREATE EXTENSION`
 
-* Fixes a bug that caused GRANT to propagate within CREATE EXTENSION
+* Only shows shards in moving state in `get_rebalance_progress()`
 
-* Only show shards in moving state in get_rebalance_progress
+* Changes the default mode for shard splitting to 'auto' from 'block_writes'
 
-* Default mode for shard splitting is changed to 'auto' from 'block_writes'.
+* Adds support for non-blocking tenant isolation
 
-* Supports non blocking tenant isolation.
+* Supports changing CPU priorities for backends and shard moves
 
-* Support changing CPU priorities for backends and shard moves
+* Fixes several small memory leaks
 
-* Fix several small memory leaks
+* Support logical replication in `replicate_reference_tables()`
 
-* Support logical replication in replicate_reference_tables()
+* Fixes a segfault in `citus_copy_shard_placement()`
 
-* Fixes a segfault in citus_copy_shard_placement
+* Uses a faster custom copy logic for non-blocking shard moves
 
-* Use faster custom copy logic for non-blocking shard moves
+* `isolate_tenant_to_new_shard()` drops support for replicated tables
 
-* isolate_tenant_to_new_shard drops support for replicated tables
+* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
 
-* isolate_tenant_to_new_shard now fails when run concurrently with itself
+* `isolate_tenant_to_new_shard()` adds support for partitioned tables
 
-* isolate_tenant_to_new_shard adds support for partitioned tables
+* `isolate_tenant_to_new_shard()` adds support for columnar tables
 
-* isolate_tenant_to_new_shard adds support for columnar tables
+* Fixes the transaction timestamp column of the `get_current_transaction_id()` on coordinator
 
-* Fixes the transaction timestamp column of the get_current_transaction_id() on coordinator.
+* Adds support for `GRANT/REVOKE` ON aggregates
 
-* Adds support for GRANT/REVOKE ON aggregates.
+* Improves performance of blocking shard moves
 
-* Improve performance of blocking shard moves
-
-* Adds the GUC enable_unsupported_feature_messages to control some of the citus related messages.
+* Adds the GUC `enable_unsupported_feature_messages` to control some of the citus related messages
 
 * Introduces `citus_locks` view
 
-* Adds a `citus_split_shard_by_split_points` function
+* Adds `citus_split_shard_by_split_points()` function
 
-* Separate columnar storage AM into a separate logical extension
+* Separates columnar storage AM into a separate logical extension
 
 * Fixes a bug that prevents promoting read-replicas as primaries
 
-* Fixes a bug that prevents using auto option for VACUUM (INDEX_CLEANUP) operation
+* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)` operation
 
-* VACUUM and ANALYZE commands are propagated to worker nodes.
+* Propagates `VACUUM` and `ANALYZE` to worker nodes
 
-* Columnar: tighten security and improve visibility
+* Tightens security and improves visibility for columnar table access method
 
-* Columnar: support relation options with ALTER TABLE.
+* Adds support for setting relation options for columnar tables using `ALTER TABLE`
 
-* LOCK commands on distributed tables are supported from worker nodes
+* Fixes schema name qualification for `RENAME SEQUENCE` statement
 
-* Fix schema name qualification for rename sequence statement
+* Maps any unused parameters to a generic type in prepared statements
 
-* In prepared statements, map any unused parameters to a generic type.
+* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
 
-* Convert citus.hide_shards_from_app_name_prefixes to citus.show_shards_for_app_name_prefixes
-
-* Fixes a bug that marks metadatasynced of coordinator
+* Fixes a bug that causes incorrectly marking `metadatasynced` flag for coordinator
 
 * Fixes a bug that may cause Citus not to create function in transaction block properly
 
-* Removes deprecated re-partitioning functions like worker_hash_partition_table
+* Removes deprecated re-partitioning functions like `worker_hash_partition_table()`
 
 ### citus v10.2.8 (August 19, 2022) ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@
 
 * Supports changing CPU priorities for backends and shard moves
 
-* Adds the GUC `citus.allow_unsafe_constraints` to allow constraints without
-  distribution column
+* Adds the GUC `citus.allow_unsafe_constraints` to allow unique/exclusion/
+  primary key constraints without distribution column
 
 * Introduces GUC `citus.skip_constraint_validation`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,6 @@
 
 * Adds support for unlogged distributed sequences
 
-* Adds the GUC `enable_unsupported_feature_messages` to control some of the
-  Citus related messages
-
 * Checks existence of the shards before insert, delete, and update
 
 * Creates all foreign keys quickly at the end of a shard move

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,114 +1,114 @@
 ### citus v11.1.0 (September 15, 2022) ###
 
-* Fixes floating exception during create_distributed_table_concurrently
-
-* Fixes a bug in query escaping in `undistribute_table()` and `alter_distributed_table()`
-
-* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
-
-* Adds support for unlogged distributed sequences
-
-* Adds support for `NULLS NOT DISTINCT` clauses for indexes
-
-* Adds a rebalancer that uses background tasks for its execution
-
-* Shows local tables added to metadata in `citus_tables`
-
-* Hides tables owned by extensions from `citus_tables` and `citus_shards`
-
-* Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text column
-
-* `citus_move_shard_placement()` becomes a noop if shard already exists on node
-
-* Removes `do_repair` option from `citus_copy_shard_placement()`
-
-* Creates all foreign keys quickly at the end of a shard move
-
-* Introduces GUC `citusskip_constraint_validation`
-
-* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
-
-* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
-
-* Checks existence of the shards before insert, delete, and update
+* Adds `citus_split_shard_by_split_points()` function
 
 * Adds `create_distributed_table_concurrently()` which distributes tables without blocking writes
 
-* Makes non-partitioned table size calculation quicker
+* Adds a rebalancer that uses background tasks for its execution
 
 * Adds an `allow_unsafe_constraints` flag for constraints without distribution column
 
-* Fixes a bug that prevents setting colocation group of a partitioned distributed table to `none`
-
 * Adds support for PostgreSQL 15beta3
-
-* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
-
-* Fixes an issue that can cause logical reference table replication to fail
-
-* Prevents creating a new colocation entry when replicating reference tables
-
-* Fixes a bug that caused `GRANT` to propagate within `CREATE EXTENSION`
-
-* Only shows shards in moving state in `get_rebalance_progress()`
-
-* Changes the default mode for shard splitting to 'auto' from 'block_writes'
-
-* Adds support for non-blocking tenant isolation
-
-* Supports changing CPU priorities for backends and shard moves
-
-* Fixes several small memory leaks
-
-* Support logical replication in `replicate_reference_tables()`
-
-* Fixes a segfault in `citus_copy_shard_placement()`
-
-* Uses a faster custom copy logic for non-blocking shard moves
-
-* `isolate_tenant_to_new_shard()` drops support for replicated tables
-
-* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
-
-* `isolate_tenant_to_new_shard()` adds support for partitioned tables
-
-* `isolate_tenant_to_new_shard()` adds support for columnar tables
-
-* Fixes the transaction timestamp column of the `get_current_transaction_id()` on coordinator
 
 * Adds support for `GRANT/REVOKE` ON aggregates
 
-* Improves performance of blocking shard moves
+* Adds support for `NULLS NOT DISTINCT` clauses for indexes
 
-* Adds the GUC `enable_unsupported_feature_messages` to control some of the citus related messages
-
-* Introduces `citus_locks` view
-
-* Adds `citus_split_shard_by_split_points()` function
-
-* Separates columnar storage AM into a separate logical extension
-
-* Fixes a bug that prevents promoting read-replicas as primaries
-
-* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)` operation
-
-* Propagates `VACUUM` and `ANALYZE` to worker nodes
-
-* Tightens security and improves visibility for columnar table access method
+* Adds support for non-blocking tenant isolation
 
 * Adds support for setting relation options for columnar tables using `ALTER TABLE`
 
-* Fixes schema name qualification for `RENAME SEQUENCE` statement
+* Adds support for unlogged distributed sequences
 
-* Maps any unused parameters to a generic type in prepared statements
+* Adds the GUC `enable_unsupported_feature_messages` to control some of the citus related messages
 
-* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
+* Changes the default mode for shard splitting to 'auto' from 'block_writes'
+
+* Checks existence of the shards before insert, delete, and update
+
+* Creates all foreign keys quickly at the end of a shard move
+
+* Fixes a bug in query escaping in `undistribute_table()` and `alter_distributed_table()`
+
+* Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text column
+
+* Fixes a bug that caused `GRANT` to propagate within `CREATE EXTENSION`
 
 * Fixes a bug that causes incorrectly marking `metadatasynced` flag for coordinator
 
 * Fixes a bug that may cause Citus not to create function in transaction block properly
 
+* Fixes a bug that prevents promoting read-replicas as primaries
+
+* Fixes a bug that prevents setting colocation group of a partitioned distributed table to `none`
+
+* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)` operation
+
+* Fixes a segfault in `citus_copy_shard_placement()`
+
+* Fixes an issue that can cause logical reference table replication to fail
+
+* Fixes floating exception during create_distributed_table_concurrently
+
+* Fixes schema name qualification for `RENAME SEQUENCE` statement
+
+* Fixes several small memory leaks
+
+* Fixes the transaction timestamp column of the `get_current_transaction_id()` on coordinator
+
+* Hides tables owned by extensions from `citus_tables` and `citus_shards`
+
+* Improves performance of blocking shard moves
+
+* Introduces GUC `citusskip_constraint_validation`
+
+* Introduces `citus_locks` view
+
+* Makes non-partitioned table size calculation quicker
+
+* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
+
+* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
+
+* Maps any unused parameters to a generic type in prepared statements
+
+* Only shows shards in moving state in `get_rebalance_progress()`
+
+* Prevents creating a new colocation entry when replicating reference tables
+
+* Propagates `VACUUM` and `ANALYZE` to worker nodes
+
+* Removes `do_repair` option from `citus_copy_shard_placement()`
+
 * Removes deprecated re-partitioning functions like `worker_hash_partition_table()`
+
+* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
+
+* Separates columnar storage AM into a separate logical extension
+
+* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
+
+* Shows local tables added to metadata in `citus_tables`
+
+* Supports logical replication in `replicate_reference_tables()`
+
+* Supports changing CPU priorities for backends and shard moves
+
+* Tightens security and improves visibility for columnar table access method
+
+* Uses a faster custom copy logic for non-blocking shard moves
+
+* `citus_move_shard_placement()` becomes a noop if shard already exists on node
+
+* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
+
+* `isolate_tenant_to_new_shard()` adds support for columnar tables
+
+* `isolate_tenant_to_new_shard()` adds support for partitioned tables
+
+* `isolate_tenant_to_new_shard()` drops support for replicated tables
+
+* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
 
 ### citus v10.2.8 (August 19, 2022) ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 * Fixes floating exception during create_distributed_table_concurrently.
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Fixes a bug in query escaping in undistribute_table and alter_distributed_table
-
-* PR description that will go into the change log, up to 78 characters
 
 * Show citus_copy_shard_placement progress in get_rebalance_progres
 
@@ -15,7 +12,7 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * Add a rebalancer that uses background tasks for its execution
 
-* Show Citus local tables in citus_tables 
+* Show Citus local tables in citus_tables
 
 * Hide tables owned by extensions from citus_tables and citus_shards
 
@@ -25,37 +22,24 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * Remove do_repair option from citus_copy_shard_placement
 
-* Add infrastructure to run long running management operations in background
-
 * Create all foreign keys quickly at the end of a shard mov
 
 * Introduce GUC `citus.skip_constraint_validation`
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Makes sure that `SELECT .. FOR UPDATE `opens a transaction block when used in a function call
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
 
 * Checks existence of the shards before insert, delete, and update.
 
 * Disallows distribution by a numeric with negative scale
 
-* PR description that will go into the change log, up to 78 characters
-
-* Fixes flaky test for views, in `citus_local_tables_mx
-
-* Allow citus_internal application_name with additional suffix
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Add create_distributed_table_concurrently which distributes tables without blocking
 
 * Adds SUM for calculating non-partitioned table sizes
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Add an allow_unsafe_constraints flag for constraints without distribution column
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Fixes a bug that prevents setting colocation group of a partitioned distributed table to 'none'
 
 * Adds support for PostgreSQL 15beta3
@@ -68,17 +52,9 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * Fix compilation warning on PG13 + OpenSSL 3.0
 
-* Fixes a bug that caused GRANT to propagate within CREATE EXTENSIO
+* Fixes a bug that caused GRANT to propagate within CREATE EXTENSION
 
-* Only show shards in moving state in get_rebalance_progres
-
-* Fixes a bug that prevents distributing tables that depend on sequences
-
-* Fixes a bug that could cause failures in create_distributed_tabl
-
-* Fix reference table lock contention
-
-* Fixes upgrade paths for earlier versions
+* Only show shards in moving state in get_rebalance_progress
 
 * Default mode for shard splitting is changed to 'auto' from 'block_writes'.
 
@@ -88,12 +64,7 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * Fix several small memory leaks
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Remove the GUC, citus.enable_unsafe_triggers,  mention in the error message as this config is meant for advanced users.
-
-* Fixes a bug that can cause failure in CREATE ROLE statement.
-
-* Support logical replication in replicate_reference_tables(
+* Support logical replication in replicate_reference_tables()
 
 * Fixes a segfault in citus_copy_shard_placement
 
@@ -107,32 +78,13 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * isolate_tenant_to_new_shard adds support for columnar tables
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Fixes the transaction timestamp column of the get_current_transaction_id() on coordinator.
 
 * Adds support for GRANT/REVOKE ON aggregates.
 
-* Fixes unexpected error for foreign tables when upgrading pg
-
 * Improve performance of blocking shard moves
 
-* Fixes a crash that can happen due to catalog read in shmem_exit
-
-* Fixes a bug that could cause failures in insert into select
-
-* Avoid possible information leakage about existing user
-
-* Adds error check for views with circular dependencies
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Fixes a concurrency bug between creating colocated distributed table and shard move
-
-* Reduces memory consumption of index name fix for partitioned tables
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Adds the GUC enable_unsupported_feature_messages to control some of the citus related messages.
-
-* Allow WITH HOLD cursors with parameters
 
 * Introduces `citus_locks` view
 
@@ -142,105 +94,27 @@ TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHAR
 
 * Fixes a bug that prevents promoting read-replicas as primaries
 
-* 
-
-* Fixes #6032.
-
-* Fix upgrades to Citus 11 when there are no nodes in the metadata
-
-* Fixes a bug that prevents using COMPRESSION and CONSTRAINT on a column
+* Fixes a bug that prevents using auto option for VACUUM (INDEX_CLEANUP) operation
 
 * VACUUM and ANALYZE commands are propagated to worker nodes.
 
-* Fixes qualify CREATE STATISTICS statements
-
-* Fixes a bug that could cause unqualified DROP DOMAIN IF EXISTS to fail
-
-* Fixes a bug that could cause leaking files when mat. view refreshed
-
-* Introduce a citus_finish_citus_upgrade() procedure
-
-* PR description that will go into the change log, up to 78 characters
-
-* Prevents alter table functions from dropping extensions
-
-* honor enable_metadata_sync in node operations
-
-* Fix `invalid read of size 1` memory error with citus_add_node
-
-* PR description that will go into the change log, up to 78 characters
-
-* PR description that will go into the change log, up to 78 characters
-
-* PR description that will go into the change log, up to 78 characters
-
-* Propagate views when syncing Citus table metadata
-
-* Fix columnar freezing/wraparound bug.
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Fixes a bug that could cause wrong schema and ownership after alter_distributed_table
-
-* Parallelize metadata syncing on node activat
-
 * Columnar: tighten security and improve visibility
-
-* Improve nested execution checks and add GUC to disable
 
 * Columnar: support relation options with ALTER TABLE.
 
-* Enable distributed execution from run_command_on_* functions 
-
 * LOCK commands on distributed tables are supported from worker nodes
-
-* Add a run_command_on_coordinator function
 
 * Fix schema name qualification for rename sequence statement
 
-* Adds "synchronous" option to citus_disable_node() UDF
-
-* Fixes a bug that prevents dropping/altering indexes
-
-* Fixes schema name qualification for ALTER and DROP SEQUENCE
-
 * In prepared statements, map any unused parameters to a generic type.
 
-* Adds support for propagating ALTER VIEW commands
-
-* Add a citus_is_coordinator function to check whether a node is the coordinator
-
-* Fixes schema name qualification for ALTER and DROP STATISTICS
-
-* `lock_table_if_exits` no longer raises an error when called outside of a xact
-
-* Adds support for distributing CREATE/DROP VIEW commands
-
-* Refrain reading the metadata cache for all tables during upgrade
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Convert citus.hide_shards_from_app_name_prefixes to citus.show_shards_for_app_name_prefixes
 
 * Fixes a bug that marks metadatasynced of coordinator
 
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Fixes a bug that cause false positive distributed deadlocks due to local execution
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
 * Fixes a bug that may cause Citus not to create function in transaction block properly
 
-* Allow adding a unique constraint with an index
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Fixes a bug that could cause invalid JSON when running EXPLAIN ANALYZE with subplans
-
-TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
-* Fixes a bug that could cause EXPLAIN ANALYZE to fail for prepared statements with custom type
-
 * Removes deprecated re-partitioning functions like worker_hash_partition_table
-
-* Add TABLESAMPLE support
-
-* Fixes a bug that prevents non-client backends to access shards
 
 ### citus v10.2.8 (August 19, 2022) ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### citus v11.1.0 (September 15, 2022) ###
 
-* Adds support for PostgreSQL 15beta3
+* Adds support for PostgreSQL 15beta4
 
 * Adds a rebalancer that uses background tasks for its execution
 
@@ -11,13 +11,13 @@
 
 * Adds support for non-blocking tenant isolation
 
-* Separates columnar storage AM into a separate logical extension
+* Separates columnar table access method into a separate logical extension
 
-* Supports logical replication in `replicate_reference_tables()`
+* Adds support for logical replication in `replicate_reference_tables()`
 
 * Improves performance of blocking shard moves
 
-* Uses a faster custom copy logic for non-blocking shard moves
+* Improves non-blocking shard moves with a faster custom copy logic
 
 * `isolate_tenant_to_new_shard()` adds support for columnar tables
 
@@ -27,8 +27,8 @@
 
 * `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
 
-* Adds an `allow_unsafe_constraints` flag for constraints without distribution
-  column
+* Adds the GUC `allow_unsafe_constraints` to allow constraints without
+  distribution column
 
 * Adds support for `GRANT/REVOKE` on aggregates
 
@@ -53,7 +53,7 @@
 
 * Makes non-partitioned table size calculation quicker
 
-* Only shows shards in moving state in `get_rebalance_progress()`
+* Limits `get_rebalance_progress()` to show shards in moving state
 
 * Removes `do_repair` option from `citus_copy_shard_placement()`
 
@@ -65,7 +65,7 @@
 
 * Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
 
-* Shows local tables added to metadata in `citus_tables`
+* Improves `citus_tables` view by showing local tables added to metadata
 
 * Supports changing CPU priorities for backends and shard moves
 
@@ -73,14 +73,14 @@
 
 * `citus_move_shard_placement()` becomes a noop if shard already exists on node
 
-* `create_distributed_table()` creates new colocation entries when using
-  `colocate_with => 'none'`
+* Improves `create_distributed_table()` by creating new colocation entries when
+  using `colocate_with => 'none'`
 
-* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in
+* Ensures that `SELECT .. FOR UPDATE` opens a transaction block when used in
   a function call
 
-* Makes sure to disallow usage of SQL functions referencing to a distributed
-  table and prevents a segfault
+* Prevents a segfault by disallowing usage of SQL functions referencing to a
+  distributed table
 
 * Prevents creating a new colocation entry when replicating reference tables
 
@@ -90,20 +90,20 @@
 * Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text
   column
 
-* Fixes a bug that caused `GRANT` to propagate within `CREATE EXTENSION`
+* Fixes a bug that may cause `GRANT` to propagate within `CREATE EXTENSION`
 
 * Fixes a bug that causes incorrectly marking `metadatasynced` flag for
   coordinator
 
-* Fixes a bug that may cause Citus not to create function in transaction block
-  properly
+* Fixes a bug that may prevent Citus from creating function in transaction
+  block properly
 
 * Fixes a bug that prevents promoting read-replicas as primaries
 
 * Fixes a bug that prevents setting colocation group of a partitioned
   distributed table to `none`
 
-* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)`
+* Fixes a bug that prevents using `AUTO` option for `VACUUM (INDEX_CLEANUP)`
   operation
 
 * Fixes a segfault in `citus_copy_shard_placement()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Adds a rebalancer that uses background tasks for its execution
 
-* Adds `create_distributed_table_concurrently()` which distributes tables without blocking writes
+* Adds `create_distributed_table_concurrently()` which distributes tables
+  without blocking writes
 
 * Adds `citus_split_shard_by_split_points()` function
 
@@ -26,17 +27,20 @@
 
 * `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
 
-* Adds an `allow_unsafe_constraints` flag for constraints without distribution column
+* Adds an `allow_unsafe_constraints` flag for constraints without distribution
+  column
 
 * Adds support for `GRANT/REVOKE` ON aggregates
 
 * Adds support for `NULLS NOT DISTINCT` clauses for indexes
 
-* Adds support for setting relation options for columnar tables using `ALTER TABLE`
+* Adds support for setting relation options for columnar tables using
+  `ALTER TABLE`
 
 * Adds support for unlogged distributed sequences
 
-* Adds the GUC `enable_unsupported_feature_messages` to control some of the citus related messages
+* Adds the GUC `enable_unsupported_feature_messages` to control some of the
+  Citus related messages
 
 * Checks existence of the shards before insert, delete, and update
 
@@ -56,9 +60,11 @@
 
 * Removes `do_repair` option from `citus_copy_shard_placement()`
 
-* Removes deprecated re-partitioning functions like `worker_hash_partition_table()`
+* Removes deprecated re-partitioning functions like
+  `worker_hash_partition_table()`
 
-* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with `citus.show_shards_for_app_name_prefixes`
+* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with
+  `citus.show_shards_for_app_name_prefixes`
 
 * Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
 
@@ -70,41 +76,51 @@
 
 * `citus_move_shard_placement()` becomes a noop if shard already exists on node
 
-* `create_distributed_table()` creates new colocation entries when using `colocate_with => 'none'`
+* `create_distributed_table()` creates new colocation entries when using
+  `colocate_with => 'none'`
 
-* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in a function call
+* Makes sure that `SELECT . FOR UPDATE `opens a transaction block when used in
+  a function call
 
-* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
+* Makes sure to disallow usage of SQL functions referencing to a distributed
+  table and prevents a segfault
 
 * Prevents creating a new colocation entry when replicating reference tables
 
-* Fixes a bug in query escaping in `undistribute_table()` and `alter_distributed_table()`
+* Fixes a bug in query escaping in `undistribute_table()` and
+  `alter_distributed_table()`
 
-* Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text column
+* Fixes a bug preventing the usage of `isolate_tenant_to_new_shard()` with text
+  column
 
 * Fixes a bug that caused `GRANT` to propagate within `CREATE EXTENSION`
 
-* Fixes a bug that causes incorrectly marking `metadatasynced` flag for coordinator
+* Fixes a bug that causes incorrectly marking `metadatasynced` flag for
+  coordinator
 
-* Fixes a bug that may cause Citus not to create function in transaction block properly
+* Fixes a bug that may cause Citus not to create function in transaction block
+  properly
 
 * Fixes a bug that prevents promoting read-replicas as primaries
 
-* Fixes a bug that prevents setting colocation group of a partitioned distributed table to `none`
+* Fixes a bug that prevents setting colocation group of a partitioned
+  distributed table to `none`
 
-* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)` operation
+* Fixes a bug that prevents using `auto` option for `VACUUM (INDEX_CLEANUP)`
+  operation
 
 * Fixes a segfault in `citus_copy_shard_placement()`
 
 * Fixes an issue that can cause logical reference table replication to fail
 
-* Fixes floating exception during create_distributed_table_concurrently
+* Fixes floating exception during `create_distributed_table_concurrently()`
 
 * Fixes schema name qualification for `RENAME SEQUENCE` statement
 
 * Fixes several small memory leaks
 
-* Fixes the transaction timestamp column of the `get_current_transaction_id()` on coordinator
+* Fixes the transaction timestamp column of the `get_current_transaction_id()`
+  on coordinator
 
 * Maps any unused parameters to a generic type in prepared statements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@
 
 * Adds a rebalancer that uses background tasks for its execution
 
-* Adds `create_distributed_table_concurrently()` which distributes tables
+* Adds `create_distributed_table_concurrently()` UDF to distribute tables
   without blocking writes
 
-* Adds `citus_split_shard_by_split_points()` function
+* Adds `citus_split_shard_by_split_points()` UDF that allows
+  splitting a shard to specified set of nodes without blocking writes
+  and based on given split points
 
 * Adds support for non-blocking tenant isolation
+
+* Adds support for isolation tenants that use partitioned tables
+  or columnar tables
+
+* Drops support for isolation tenants that use replicated tables
 
 * Separates columnar table access method into a separate logical extension
 
@@ -19,16 +26,26 @@
 
 * Improves non-blocking shard moves with a faster custom copy logic
 
-* `isolate_tenant_to_new_shard()` adds support for columnar tables
-
-* `isolate_tenant_to_new_shard()` adds support for partitioned tables
-
-* `isolate_tenant_to_new_shard()` drops support for replicated tables
-
-* `isolate_tenant_to_new_shard()` now fails when run concurrently with itself
-
 * Adds the GUC `allow_unsafe_constraints` to allow constraints without
   distribution column
+
+* Introduces GUC `citus.skip_constraint_validation`
+
+* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with
+  `citus.show_shards_for_app_name_prefixes`
+
+* Introduces `citus_locks` view
+
+* Improves `citus_tables` view by showing local tables added to metadata
+
+* Improves columnar table access method by moving old catalog tables into
+  an internal schema and introduces more secure & informative views based
+  on them
+
+* Removes `do_repair` option from `citus_copy_shard_placement()`
+
+* Removes deprecated re-partitioning functions like
+  `worker_hash_partition_table()`
 
 * Adds support for `GRANT/REVOKE` on aggregates
 
@@ -45,9 +62,7 @@
 
 * Hides tables owned by extensions from `citus_tables` and `citus_shards`
 
-* Introduces GUC `citus.skip_constraint_validation`
-
-* Introduces `citus_locks` view
+* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
 
 * Propagates `VACUUM` and `ANALYZE` to worker nodes
 
@@ -55,23 +70,10 @@
 
 * Limits `get_rebalance_progress()` to show shards in moving state
 
-* Removes `do_repair` option from `citus_copy_shard_placement()`
-
-* Removes deprecated re-partitioning functions like
-  `worker_hash_partition_table()`
-
-* Replaces `citus.hide_shards_from_app_name_prefixes` GUC with
-  `citus.show_shards_for_app_name_prefixes`
-
-* Shows `citus_copy_shard_placement()` progress in `get_rebalance_progres()`
-
-* Improves `citus_tables` view by showing local tables added to metadata
-
 * Supports changing CPU priorities for backends and shard moves
 
-* Tightens security and improves visibility for columnar table access method
-
-* `citus_move_shard_placement()` becomes a noop if shard already exists on node
+* Makes `citus_move_shard_placement()` idempotent if shard already exists
+  on target node
 
 * Improves `create_distributed_table()` by creating new colocation entries when
   using `colocate_with => 'none'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,247 @@
+### citus v11.1.0 (September 15, 2022) ###
+
+* Fixes floating exception during create_distributed_table_concurrently.
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug in query escaping in undistribute_table and alter_distributed_table
+
+* PR description that will go into the change log, up to 78 characters
+
+* Show citus_copy_shard_placement progress in get_rebalance_progres
+
+* Adds support for unlogged distributed sequences
+
+* Adds support for NULLS NOT DISTINCT clauses for indexes
+
+* Add a rebalancer that uses background tasks for its execution
+
+* Show Citus local tables in citus_tables 
+
+* Hide tables owned by extensions from citus_tables and citus_shards
+
+* Fix bug preventing isolate_tenant_to_new_shard with text column
+
+* citus_move_shard_placement becomes a noop if shard already exists on node
+
+* Remove do_repair option from citus_copy_shard_placement
+
+* Add infrastructure to run long running management operations in background
+
+* Create all foreign keys quickly at the end of a shard mov
+
+* Introduce GUC `citus.skip_constraint_validation`
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Makes sure that `SELECT .. FOR UPDATE `opens a transaction block when used in a function call
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Makes sure to disallow usage of SQL functions referencing to a distributed table and prevents a segfault
+
+* Checks existence of the shards before insert, delete, and update.
+
+* Disallows distribution by a numeric with negative scale
+
+* PR description that will go into the change log, up to 78 characters
+
+* Fixes flaky test for views, in `citus_local_tables_mx
+
+* Allow citus_internal application_name with additional suffix
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Add create_distributed_table_concurrently which distributes tables without blocking
+
+* Adds SUM for calculating non-partitioned table sizes
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Add an allow_unsafe_constraints flag for constraints without distribution column
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that prevents setting colocation group of a partitioned distributed table to 'none'
+
+* Adds support for PostgreSQL 15beta3
+
+* Creates new colocation entries when colocate_with => 'none'.
+
+* Fixes an issue can cause logical reference table replication to fail
+
+* Stops creating colocation entry at EnsureReferenceTablesExistOnAllNodes.
+
+* Fix compilation warning on PG13 + OpenSSL 3.0
+
+* Fixes a bug that caused GRANT to propagate within CREATE EXTENSIO
+
+* Only show shards in moving state in get_rebalance_progres
+
+* Fixes a bug that prevents distributing tables that depend on sequences
+
+* Fixes a bug that could cause failures in create_distributed_tabl
+
+* Fix reference table lock contention
+
+* Fixes upgrade paths for earlier versions
+
+* Default mode for shard splitting is changed to 'auto' from 'block_writes'.
+
+* Supports non blocking tenant isolation.
+
+* Support changing CPU priorities for backends and shard moves
+
+* Fix several small memory leaks
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Remove the GUC, citus.enable_unsafe_triggers,  mention in the error message as this config is meant for advanced users.
+
+* Fixes a bug that can cause failure in CREATE ROLE statement.
+
+* Support logical replication in replicate_reference_tables(
+
+* Fixes a segfault in citus_copy_shard_placement
+
+* Use faster custom copy logic for non-blocking shard moves
+
+* isolate_tenant_to_new_shard drops support for replicated tables
+
+* isolate_tenant_to_new_shard now fails when run concurrently with itself
+
+* isolate_tenant_to_new_shard adds support for partitioned tables
+
+* isolate_tenant_to_new_shard adds support for columnar tables
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes the transaction timestamp column of the get_current_transaction_id() on coordinator.
+
+* Adds support for GRANT/REVOKE ON aggregates.
+
+* Fixes unexpected error for foreign tables when upgrading pg
+
+* Improve performance of blocking shard moves
+
+* Fixes a crash that can happen due to catalog read in shmem_exit
+
+* Fixes a bug that could cause failures in insert into select
+
+* Avoid possible information leakage about existing user
+
+* Adds error check for views with circular dependencies
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a concurrency bug between creating colocated distributed table and shard move
+
+* Reduces memory consumption of index name fix for partitioned tables
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Adds the GUC enable_unsupported_feature_messages to control some of the citus related messages.
+
+* Allow WITH HOLD cursors with parameters
+
+* Introduces `citus_locks` view
+
+* Adds a `citus_split_shard_by_split_points` function
+
+* Separate columnar storage AM into a separate logical extension
+
+* Fixes a bug that prevents promoting read-replicas as primaries
+
+* 
+
+* Fixes #6032.
+
+* Fix upgrades to Citus 11 when there are no nodes in the metadata
+
+* Fixes a bug that prevents using COMPRESSION and CONSTRAINT on a column
+
+* VACUUM and ANALYZE commands are propagated to worker nodes.
+
+* Fixes qualify CREATE STATISTICS statements
+
+* Fixes a bug that could cause unqualified DROP DOMAIN IF EXISTS to fail
+
+* Fixes a bug that could cause leaking files when mat. view refreshed
+
+* Introduce a citus_finish_citus_upgrade() procedure
+
+* PR description that will go into the change log, up to 78 characters
+
+* Prevents alter table functions from dropping extensions
+
+* honor enable_metadata_sync in node operations
+
+* Fix `invalid read of size 1` memory error with citus_add_node
+
+* PR description that will go into the change log, up to 78 characters
+
+* PR description that will go into the change log, up to 78 characters
+
+* PR description that will go into the change log, up to 78 characters
+
+* Propagate views when syncing Citus table metadata
+
+* Fix columnar freezing/wraparound bug.
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that could cause wrong schema and ownership after alter_distributed_table
+
+* Parallelize metadata syncing on node activat
+
+* Columnar: tighten security and improve visibility
+
+* Improve nested execution checks and add GUC to disable
+
+* Columnar: support relation options with ALTER TABLE.
+
+* Enable distributed execution from run_command_on_* functions 
+
+* LOCK commands on distributed tables are supported from worker nodes
+
+* Add a run_command_on_coordinator function
+
+* Fix schema name qualification for rename sequence statement
+
+* Adds "synchronous" option to citus_disable_node() UDF
+
+* Fixes a bug that prevents dropping/altering indexes
+
+* Fixes schema name qualification for ALTER and DROP SEQUENCE
+
+* In prepared statements, map any unused parameters to a generic type.
+
+* Adds support for propagating ALTER VIEW commands
+
+* Add a citus_is_coordinator function to check whether a node is the coordinator
+
+* Fixes schema name qualification for ALTER and DROP STATISTICS
+
+* `lock_table_if_exits` no longer raises an error when called outside of a xact
+
+* Adds support for distributing CREATE/DROP VIEW commands
+
+* Refrain reading the metadata cache for all tables during upgrade
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Convert citus.hide_shards_from_app_name_prefixes to citus.show_shards_for_app_name_prefixes
+
+* Fixes a bug that marks metadatasynced of coordinator
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that cause false positive distributed deadlocks due to local execution
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that may cause Citus not to create function in transaction block properly
+
+* Allow adding a unique constraint with an index
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that could cause invalid JSON when running EXPLAIN ANALYZE with subplans
+
+TODO: PLEASE SHORTEN THE NEXT LINE MANUALLY, IT SHOULD BE NO LONGER THAN 78 CHARS
+* Fixes a bug that could cause EXPLAIN ANALYZE to fail for prepared statements with custom type
+
+* Removes deprecated re-partitioning functions like worker_hash_partition_table
+
+* Add TABLESAMPLE support
+
+* Fixes a bug that prevents non-client backends to access shards
+
 ### citus v10.2.8 (August 19, 2022) ###
 
 * Fixes compilation warning caused by latest upgrade script changes


### PR DESCRIPTION
Created by executing `prepare_changelog.pl citus 11.1.0 2022-03-29`.

(Also, had some troubles when running the script and pushed a fix for that too https://github.com/citusdata/tools/pull/241.)