### PR TITLE
Tests moving a shard with RLS owned by nonbypassrls & nonsuperuser

### DIFF
--- a/src/test/regress/enterprise_isolation_logicalrep_1_schedule
+++ b/src/test/regress/enterprise_isolation_logicalrep_1_schedule
@@ -6,6 +6,7 @@ test: isolation_setup
 test: isolation_cluster_management
 
 test: isolation_logical_replication_single_shard_commands
+test: isolation_logical_replication_nonsu_nonbypassrls
 test: isolation_logical_replication_multi_shard_commands
 test: isolation_non_blocking_shard_split
 test: isolation_create_distributed_concurrently_after_drop_column

--- a/src/test/regress/expected/isolation_logical_replication_nonsu_nonbypassrls.out
+++ b/src/test/regress/expected/isolation_logical_replication_nonsu_nonbypassrls.out
@@ -1,0 +1,78 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1-table-owner-new_user s1-table-enable-rls s1-get-shard-distribution s1-user-spec s3-acquire-advisory-lock s1-begin s1-set-role s1-move-placement s2-insert s3-release-advisory-lock s1-end s1-select s1-get-shard-distribution
+step s1-table-owner-new_user:
+    ALTER TABLE dist OWNER TO new_user;
+
+step s1-table-enable-rls:
+    ALTER TABLE dist ENABLE ROW LEVEL SECURITY;
+
+step s1-get-shard-distribution:
+    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+
+nodeport
+---------------------------------------------------------------------
+   57638
+(1 row)
+
+step s1-user-spec:
+    SELECT rolname, rolsuper, rolbypassrls FROM pg_authid WHERE rolname = 'new_user';
+
+rolname |rolsuper|rolbypassrls
+---------------------------------------------------------------------
+new_user|f       |f
+(1 row)
+
+step s3-acquire-advisory-lock:
+    SELECT pg_advisory_lock(44000, 55152);
+
+pg_advisory_lock
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+ BEGIN;
+
+step s1-set-role:
+    SET ROLE new_user;
+
+step s1-move-placement:
+    SELECT citus_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57638, 'localhost', 57637);
+ <waiting ...>
+step s2-insert: 
+    INSERT INTO dist VALUES (23, 23);
+
+step s3-release-advisory-lock:
+    SELECT pg_advisory_unlock(44000, 55152);
+
+pg_advisory_unlock
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s1-move-placement: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-end:
+ COMMIT;
+
+step s1-select:
+    SELECT * FROM dist ORDER BY column1;
+
+column1|column2
+---------------------------------------------------------------------
+     23|     23
+(1 row)
+
+step s1-get-shard-distribution:
+    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+
+nodeport
+---------------------------------------------------------------------
+   57637
+(1 row)
+

--- a/src/test/regress/expected/isolation_logical_replication_nonsu_nonbypassrls.out
+++ b/src/test/regress/expected/isolation_logical_replication_nonsu_nonbypassrls.out
@@ -1,6 +1,6 @@
 Parsed test spec with 3 sessions
 
-starting permutation: s1-table-owner-new_user s1-table-enable-rls s1-get-shard-distribution s1-user-spec s3-acquire-advisory-lock s1-begin s1-set-role s1-move-placement s2-insert s3-release-advisory-lock s1-end s1-select s1-get-shard-distribution
+starting permutation: s1-table-owner-new_user s1-table-enable-rls s1-get-shard-distribution s1-user-spec s3-acquire-advisory-lock s1-begin s1-set-role s1-move-placement s2-insert s3-release-advisory-lock s1-reset-role s1-end s1-select s1-get-shard-distribution
 step s1-table-owner-new_user:
     ALTER TABLE dist OWNER TO new_user;
 
@@ -8,11 +8,11 @@ step s1-table-enable-rls:
     ALTER TABLE dist ENABLE ROW LEVEL SECURITY;
 
 step s1-get-shard-distribution:
-    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+    SELECT shardid, nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
 
-nodeport
+shardid|nodeport
 ---------------------------------------------------------------------
-   57638
+1234003|   57638
 (1 row)
 
 step s1-user-spec:
@@ -57,6 +57,9 @@ citus_move_shard_placement
 
 (1 row)
 
+step s1-reset-role:
+ RESET ROLE;
+
 step s1-end:
  COMMIT;
 
@@ -69,10 +72,99 @@ column1|column2
 (1 row)
 
 step s1-get-shard-distribution:
-    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+    SELECT shardid, nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
 
-nodeport
+shardid|nodeport
 ---------------------------------------------------------------------
-   57637
+1234003|   57637
+(1 row)
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s3-no-connection-cache s1-table-owner-new_user s1-table-force-rls s1-get-shard-distribution s1-user-spec s3-acquire-advisory-lock s1-begin s1-set-role s1-move-placement s2-insert s3-release-advisory-lock s1-reset-role s1-end s1-select s1-get-shard-distribution
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s3-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-table-owner-new_user:
+    ALTER TABLE dist OWNER TO new_user;
+
+step s1-table-force-rls:
+    ALTER TABLE dist FORCE ROW LEVEL SECURITY;
+
+step s1-get-shard-distribution:
+    SELECT shardid, nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+
+shardid|nodeport
+---------------------------------------------------------------------
+1234003|   57638
+(1 row)
+
+step s1-user-spec:
+    SELECT rolname, rolsuper, rolbypassrls FROM pg_authid WHERE rolname = 'new_user';
+
+rolname |rolsuper|rolbypassrls
+---------------------------------------------------------------------
+new_user|f       |f
+(1 row)
+
+step s3-acquire-advisory-lock:
+    SELECT pg_advisory_lock(44000, 55152);
+
+pg_advisory_lock
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-begin:
+ BEGIN;
+
+step s1-set-role:
+    SET ROLE new_user;
+
+step s1-move-placement:
+    SELECT citus_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57638, 'localhost', 57637);
+ <waiting ...>
+step s2-insert: 
+    INSERT INTO dist VALUES (23, 23);
+
+step s3-release-advisory-lock:
+    SELECT pg_advisory_unlock(44000, 55152);
+
+pg_advisory_unlock
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s1-move-placement: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-reset-role:
+ RESET ROLE;
+
+step s1-end:
+ COMMIT;
+
+step s1-select:
+    SELECT * FROM dist ORDER BY column1;
+
+column1|column2
+---------------------------------------------------------------------
+     23|     23
+(1 row)
+
+step s1-get-shard-distribution:
+    SELECT shardid, nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+
+shardid|nodeport
+---------------------------------------------------------------------
+1234003|   57637
 (1 row)
 

--- a/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
+++ b/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
@@ -1,10 +1,15 @@
+// isolation_logical_replication_nonsu_nonbypassrls
 // test moving a single shard that has rls
 // owned by a user that is neither superuser nor bypassrls
 // PG15 added extra permission checks within logical replication
 // this test makes sure that target table owners should still
 // be able to replicate despite RLS policies.
+// Relevant PG commit: a2ab9c06ea15fbcb2bfde570986a06b37f52bcca
+
 setup
 {
+    SET citus.max_cached_conns_per_worker to 0;
+    SET citus.next_shard_id TO 1234000;
 	SET citus.shard_count TO 4;
 	SET citus.shard_replication_factor TO 1;
 
@@ -28,6 +33,11 @@ teardown
 
 session "s1"
 
+step "s1-no-connection-cache"
+{
+	SET citus.max_cached_conns_per_worker to 0;
+}
+
 step "s1-table-owner-new_user"
 {
     ALTER TABLE dist OWNER TO new_user;
@@ -36,6 +46,11 @@ step "s1-table-owner-new_user"
 step "s1-table-enable-rls"
 {
     ALTER TABLE dist ENABLE ROW LEVEL SECURITY;
+}
+
+step "s1-table-force-rls"
+{
+    ALTER TABLE dist FORCE ROW LEVEL SECURITY;
 }
 
 step "s1-user-spec"
@@ -58,6 +73,11 @@ step "s1-move-placement"
     SELECT citus_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57638, 'localhost', 57637);
 }
 
+step "s1-reset-role"
+{
+	RESET ROLE;
+}
+
 step "s1-end"
 {
 	COMMIT;
@@ -70,10 +90,15 @@ step "s1-select"
 
 step "s1-get-shard-distribution"
 {
-    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+    SELECT shardid, nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
 }
 
 session "s2"
+
+step "s2-no-connection-cache"
+{
+	SET citus.max_cached_conns_per_worker to 0;
+}
 
 step "s2-insert"
 {
@@ -81,6 +106,11 @@ step "s2-insert"
 }
 
 session "s3"
+
+step "s3-no-connection-cache"
+{
+	SET citus.max_cached_conns_per_worker to 0;
+}
 
 step "s3-acquire-advisory-lock"
 {
@@ -92,4 +122,12 @@ step "s3-release-advisory-lock"
     SELECT pg_advisory_unlock(44000, 55152);
 }
 
-permutation "s1-table-owner-new_user" "s1-table-enable-rls" "s1-get-shard-distribution" "s1-user-spec" "s3-acquire-advisory-lock" "s1-begin" "s1-set-role" "s1-move-placement" "s2-insert" "s3-release-advisory-lock" "s1-end" "s1-select" "s1-get-shard-distribution"
+// first permutation enables row level security
+// second permutation forces row level security
+// either way we should be able to complete the shard move
+// Check out https://github.com/citusdata/citus/pull/6369#discussion_r979823178 for details
+
+permutation "s1-table-owner-new_user" "s1-table-enable-rls" "s1-get-shard-distribution" "s1-user-spec" "s3-acquire-advisory-lock" "s1-begin" "s1-set-role" "s1-move-placement" "s2-insert" "s3-release-advisory-lock" "s1-reset-role" "s1-end" "s1-select" "s1-get-shard-distribution"
+// running no connection cache commands on 2nd permutation because of #3785
+// otherwise citus_move_shard_placement fails with permission error of new_user
+permutation "s1-no-connection-cache" "s2-no-connection-cache" "s3-no-connection-cache" "s1-table-owner-new_user" "s1-table-force-rls" "s1-get-shard-distribution" "s1-user-spec" "s3-acquire-advisory-lock" "s1-begin" "s1-set-role" "s1-move-placement" "s2-insert" "s3-release-advisory-lock" "s1-reset-role" "s1-end" "s1-select" "s1-get-shard-distribution"

--- a/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
+++ b/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
@@ -1,0 +1,95 @@
+// test moving a single shard that has rls
+// owned by a user that is neither superuser nor bypassrls
+// PG15 added extra permission checks within logical replication
+// this test makes sure that target table owners should still
+// be able to replicate despite RLS policies.
+setup
+{
+	SET citus.shard_count TO 4;
+	SET citus.shard_replication_factor TO 1;
+
+    CREATE USER new_user;
+    GRANT ALL ON SCHEMA public TO new_user;
+
+    CREATE TABLE dist(column1 int PRIMARY KEY, column2 int);
+    SELECT create_distributed_table('dist', 'column1');
+
+	SELECT get_shard_id_for_distribution_column('dist', 23) INTO selected_shard;
+    GRANT ALL ON TABLE selected_shard TO new_user;
+}
+
+teardown
+{
+    DROP TABLE selected_shard;
+    DROP TABLE dist;
+    REVOKE ALL ON SCHEMA public FROM new_user;
+    DROP USER new_user;
+}
+
+session "s1"
+
+step "s1-table-owner-new_user"
+{
+    ALTER TABLE dist OWNER TO new_user;
+}
+
+step "s1-table-enable-rls"
+{
+    ALTER TABLE dist ENABLE ROW LEVEL SECURITY;
+}
+
+step "s1-user-spec"
+{
+    SELECT rolname, rolsuper, rolbypassrls FROM pg_authid WHERE rolname = 'new_user';
+}
+
+step "s1-begin"
+{
+	BEGIN;
+}
+
+step "s1-set-role"
+{
+    SET ROLE new_user;
+}
+
+step "s1-move-placement"
+{
+    SELECT citus_move_shard_placement((SELECT * FROM selected_shard), 'localhost', 57638, 'localhost', 57637);
+}
+
+step "s1-end"
+{
+	COMMIT;
+}
+
+step "s1-select"
+{
+    SELECT * FROM dist ORDER BY column1;
+}
+
+step "s1-get-shard-distribution"
+{
+    SELECT nodeport FROM pg_dist_placement INNER JOIN pg_dist_node ON (pg_dist_placement.groupid = pg_dist_node.groupid) WHERE shardstate != 4 AND shardid IN (SELECT * FROM selected_shard) ORDER BY nodeport;
+}
+
+session "s2"
+
+step "s2-insert"
+{
+    INSERT INTO dist VALUES (23, 23);
+}
+
+session "s3"
+
+step "s3-acquire-advisory-lock"
+{
+    SELECT pg_advisory_lock(44000, 55152);
+}
+
+step "s3-release-advisory-lock"
+{
+    SELECT pg_advisory_unlock(44000, 55152);
+}
+
+permutation "s1-table-owner-new_user" "s1-table-enable-rls" "s1-get-shard-distribution" "s1-user-spec" "s3-acquire-advisory-lock" "s1-begin" "s1-set-role" "s1-move-placement" "s2-insert" "s3-release-advisory-lock" "s1-end" "s1-select" "s1-get-shard-distribution"

--- a/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
+++ b/src/test/regress/spec/isolation_logical_replication_nonsu_nonbypassrls.spec
@@ -8,16 +8,19 @@
 
 setup
 {
+    -- setup involves a lot of DDL inside a single tx block, so use sequential mode
+    SET LOCAL citus.multi_shard_modify_mode TO 'sequential';
+
     SET citus.max_cached_conns_per_worker to 0;
     SET citus.next_shard_id TO 1234000;
 	SET citus.shard_count TO 4;
 	SET citus.shard_replication_factor TO 1;
 
-    CREATE USER new_user;
-    GRANT ALL ON SCHEMA public TO new_user;
-
     CREATE TABLE dist(column1 int PRIMARY KEY, column2 int);
     SELECT create_distributed_table('dist', 'column1');
+
+    CREATE USER new_user;
+    GRANT ALL ON SCHEMA public TO new_user;
 
 	SELECT get_shard_id_for_distribution_column('dist', 23) INTO selected_shard;
     GRANT ALL ON TABLE selected_shard TO new_user;


### PR DESCRIPTION
Here we test moving a shard with RLS that's not owned by superuser or bypassrls user. It should work fine in all cases since the shard's owner should still be able to logically replicate despite RLS.

Trigger for this test was the below relevant PG commit: https://github.com/postgres/postgres/commit/a2ab9c06ea15fbcb2bfde570986a06b37f52bcca
