### PR TITLE
Cleanup multi_utility_warnings test

### DIFF
--- a/src/test/regress/expected/multi_utility_warnings.out
+++ b/src/test/regress/expected/multi_utility_warnings.out
@@ -2,13 +2,8 @@
 -- MULTI_UTILITY_WARNINGS
 --
 -- Tests to check if we inform the user about potential caveats of creating new
--- databases, schemas.
-SET citus.next_shard_id TO 1010000;
+-- databases.
 CREATE DATABASE new_database;
 NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
 DETAIL:  Citus does not propagate CREATE DATABASE command to workers
 HINT:  You can manually create a database and its extensions on workers.
-BEGIN;
-INSERT INTO pg_dist_node VALUES (1234567890, 1234567890, 'localhost', 5432);
-INSERT INTO pg_dist_poolinfo VALUES (1234567890, 'port=1234');
-ROLLBACK;

--- a/src/test/regress/sql/multi_utility_warnings.sql
+++ b/src/test/regress/sql/multi_utility_warnings.sql
@@ -3,15 +3,6 @@
 --
 
 -- Tests to check if we inform the user about potential caveats of creating new
--- databases, schemas.
-
-
-SET citus.next_shard_id TO 1010000;
-
+-- databases.
 
 CREATE DATABASE new_database;
-
-BEGIN;
-INSERT INTO pg_dist_node VALUES (1234567890, 1234567890, 'localhost', 5432);
-INSERT INTO pg_dist_poolinfo VALUES (1234567890, 'port=1234');
-ROLLBACK;


### PR DESCRIPTION
This test used to contain some utility commands that Citus did not support. However we added support for most of the commands, and this test got outdated.

We used to error out on community when user attempted to use pooler options. Now that we open sourced all enterprise features, the test can now be removed.

Related: #6008 
