### PR TITLE
Add tests for CREATE DATABASE with OID option

### DIFF
--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -1371,6 +1371,11 @@ SELECT 1 FROM citus_remove_node('localhost', :master_port);
 
 DROP SERVER foreign_server CASCADE;
 NOTICE:  drop cascades to 2 other objects
+-- PG15 now supports specifying oid on CREATE DATABASE
+-- verify that we print meaningful notice messages.
+CREATE DATABASE db_with_oid OID 987654;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DROP DATABASE db_with_oid;
 -- Clean up
 \set VERBOSITY terse
 SET client_min_messages TO ERROR;

--- a/src/test/regress/sql/pg15.sql
+++ b/src/test/regress/sql/pg15.sql
@@ -873,6 +873,11 @@ SELECT undistribute_table('foreign_table_test');
 SELECT 1 FROM citus_remove_node('localhost', :master_port);
 DROP SERVER foreign_server CASCADE;
 
+-- PG15 now supports specifying oid on CREATE DATABASE
+-- verify that we print meaningful notice messages.
+CREATE DATABASE db_with_oid OID 987654;
+DROP DATABASE db_with_oid;
+
 -- Clean up
 \set VERBOSITY terse
 SET client_min_messages TO ERROR;


### PR DESCRIPTION
PG15 now allows users to specify oids when creating databases. This feature is a side effect of a bigger feature in pg_upgrade.

Relevant PG Commit:
pg_upgrade: Preserve database OIDs.
aa01051418f10afbdfa781b8dc109615ca785ff9
