### PR TITLE
Bump PG15 CI images to rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-vcd9d3a2'
+    default: '-vf83b06c'
   pg13_version:
     type: string
     default: '13.8'
@@ -15,10 +15,10 @@ parameters:
     default: '14.5'
   pg15_version:
     type: string
-    default: '15beta4'
+    default: '15rc1'
   upgrade_pg_versions:
     type: string
-    default: '13.8-14.5-15beta4'
+    default: '13.8-14.5-15rc1'
   style_checker_tools_version:
     type: string
     default: '0.8.18'

--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -171,7 +171,7 @@ SELECT * FROM sale_triggers ORDER BY 1, 2;
 -- test that we can't rename a distributed clone trigger
 ALTER TRIGGER "new_record_sale_trigger" ON "pg15"."sale_newyork" RENAME TO "another_trigger_name";
 ERROR:  cannot rename trigger "new_record_sale_trigger" on table "sale_newyork"
-HINT:  Rename trigger on partitioned table "sale" instead.
+HINT:  Rename the trigger on the partitioned table "sale" instead.
 --
 -- In PG15, For GENERATED columns, all dependencies of the generation
 -- expression are recorded as NORMAL dependencies of the column itself.

--- a/src/test/regress/expected/upgrade_distributed_triggers_after.out
+++ b/src/test/regress/expected/upgrade_distributed_triggers_after.out
@@ -221,7 +221,7 @@ SELECT * FROM sale_triggers ORDER BY 1, 2;
 -- after upgrade to PG15, test that we can't rename a distributed clone trigger
 ALTER TRIGGER "renamed_yet_another_trigger" ON "sale_alabama" RENAME TO "another_trigger_name";
 ERROR:  cannot rename trigger "renamed_yet_another_trigger" on table "sale_alabama"
-HINT:  Rename trigger on partitioned table "sale" instead.
+HINT:  Rename the trigger on the partitioned table "sale" instead.
 SELECT count(*) FROM pg_trigger WHERE tgname like 'another_trigger_name%';
  count
 ---------------------------------------------------------------------


### PR DESCRIPTION
Update the test images from PG15beta4 to PG15rc1.

There is a new commit in 15rc1 that improves message styles. We also update the messages accordingly.

Relevant PG commit:
[517484b5820e9e20057ff066b5df7d09cbb5f464](https://github.com/postgres/postgres/commit/517484b5820e9e20057ff066b5df7d09cbb5f464)

Depends on: https://github.com/citusdata/the-process/pull/93