### PR TITLE
Remove dependency on placement caches from DROP

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1435,7 +1435,7 @@ ActiveShardPlacementListOnGroup(uint64 shardId, int32 groupId)
 
 /*
  * ActiveShardPlacementList finds shard placements for the given shardId from
- * system catalogs, chooses placements that are in active state, and returns
+ * metadata cache, chooses placements that are in active state, and returns
  * these shard placements in a new list.
  */
 List *

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -374,7 +374,7 @@ DropTaskList(Oid relationId, char *schemaName, char *relationName,
 		task->replicationModel = REPLICATION_MODEL_INVALID;
 		task->anchorShardId = shardId;
 		task->taskPlacementList =
-			ShardPlacementListIncludingOrphanedPlacements(shardId);
+			ShardPlacementListIncludingOrphanedPlacementsViaCatalog(shardId);
 
 		taskList = lappend(taskList, task);
 	}

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -175,6 +175,7 @@ extern int32 GetLocalNodeId(void);
 extern void CitusTableCacheFlushInvalidatedEntries(void);
 extern Oid LookupShardRelationFromCatalog(int64 shardId, bool missing_ok);
 extern List * ShardPlacementListIncludingOrphanedPlacements(uint64 shardId);
+extern List * ShardPlacementListIncludingOrphanedPlacementsViaCatalog(uint64 shardId);
 extern void CitusInvalidateRelcacheByRelid(Oid relationId);
 extern void CitusInvalidateRelcacheByShardId(int64 shardId);
 extern void InvalidateForeignKeyGraph(void);


### PR DESCRIPTION
When dropping objects, citus_drop_trigger should not depend on the validity of the caches for placements as it ~causes~ may cause error messages from time to time. With this commit we remove the depencency on the validity on caches for shard placements.

However, citus_drop_trigger still depends on WorkerNodeCache in 3 different codepaths listed below:

```
- master_remove_distributed_table_metadata_from_workers
 -> MasterRemoveDistributedTableMetadataFromWorkers
  -> SendCommandToWorkersWithMetadata
   -> SendCommandToMetadataWorkersParams
    -> TargetWorkerSetNodeList
     -> ActivePrimaryNonCoordinatorNodeList
      -> FilterActiveNodeListFunc
       -> GetWorkerNodeHash

- citus_drop_all_shards
 -> DropShards
  -> DropTaskList
   -> ShardPlacementListIncludingOrphanedPlacementsViaCatalog
    -> LookupNodeForGroup
     -> PrepareWorkerNodeCache

- master_remove_partition_metadata
 -> DeleteColocationGroupIfNoTablesBelong
  -> DeleteColocationGroup
   -> SyncDeleteColocationGroupToNodes
    -> SendCommandToWorkersWithMetadataViaSuperUser
     -> SendCommandToMetadataWorkersParams
      -> TargetWorkerSetNodeList
       -> ActivePrimaryNonCoordinatorNodeList
        -> FilterActiveNodeListFunc
         -> GetWorkerNodeHash
```
Related: #5372 #6041