### PR TITLE
Fix the crash that happens when using auto_explain extension with recursive queries

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -203,7 +203,10 @@ CitusExplainScan(CustomScanState *node, List *ancestors, struct ExplainState *es
 
 	if (distributedPlan->subPlanList != NIL)
 	{
+		/* ExplainSubPlans calls ExplainOnePlan which uses the ActiveSnapshot.*/
+		PushActiveSnapshot(executorState->es_snapshot);
 		ExplainSubPlans(distributedPlan, es);
+		PopActiveSnapshot();
 	}
 
 	ExplainJob(scanState, distributedPlan->workerJob, es, params);

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -201,15 +201,21 @@ CitusExplainScan(CustomScanState *node, List *ancestors, struct ExplainState *es
 
 	ExplainOpenGroup("Distributed Query", "Distributed Query", true, es);
 
+	/*
+	 * ExplainOnePlan function of postgres might be called in this codepath.
+	 * It requires an ActiveSnapshot being set. Make sure to make ActiveSnapshot available before calling into
+	 * Citus Explain functions.
+	 */
+	PushActiveSnapshot(executorState->es_snapshot);
+
 	if (distributedPlan->subPlanList != NIL)
 	{
-		/* ExplainSubPlans calls ExplainOnePlan which uses the ActiveSnapshot.*/
-		PushActiveSnapshot(executorState->es_snapshot);
 		ExplainSubPlans(distributedPlan, es);
-		PopActiveSnapshot();
 	}
 
 	ExplainJob(scanState, distributedPlan->workerJob, es, params);
+
+	PopActiveSnapshot();
 
 	ExplainCloseGroup("Distributed Query", "Distributed Query", true, es);
 }


### PR DESCRIPTION
This crash happens with recursively planned queries. For such queries, subplans are explained via the ExplainOnePlan function of postgresql. This function reconstructs the query description from the plan therefore it expects the ActiveSnaphot for the query be available. This fix makes sure that the snapshot is in the stack before calling ExplainOnePlan.

Fixes #2920.