### PR TITLE
Fix use-after-free in GetAlterTriggerStateCommand()

### DIFF
--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -176,11 +176,11 @@ GetAlterTriggerStateCommand(Oid triggerId)
 	appendStringInfo(alterTriggerStateCommand, "ALTER TABLE %s %s TRIGGER %s;",
 					 qualifiedRelName, alterTriggerStateStr, quotedTrigName);
 
-    /*
-     * Free triggerTuple at the end since quote_identifier() might not return
-     * a palloc'd string if given identifier doesn't need to be quoted, and in
-     * that case quotedTrigName would still be bound to triggerTuple.
-     */
+	/*
+	 * Free triggerTuple at the end since quote_identifier() might not return
+	 * a palloc'd string if given identifier doesn't need to be quoted, and in
+	 * that case quotedTrigName would still be bound to triggerTuple.
+	 */
 	heap_freetuple(triggerTuple);
 
 	return alterTriggerStateCommand->data;

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -139,8 +139,6 @@ GetAlterTriggerStateCommand(Oid triggerId)
 	const char *quotedTrigName = quote_identifier(NameStr(triggerForm->tgname));
 	char enableDisableState = triggerForm->tgenabled;
 
-	heap_freetuple(triggerTuple);
-
 	const char *alterTriggerStateStr = NULL;
 	switch (enableDisableState)
 	{
@@ -177,6 +175,13 @@ GetAlterTriggerStateCommand(Oid triggerId)
 
 	appendStringInfo(alterTriggerStateCommand, "ALTER TABLE %s %s TRIGGER %s;",
 					 qualifiedRelName, alterTriggerStateStr, quotedTrigName);
+
+    /*
+     * Free triggerTuple at the end since quote_identifier() might not return
+     * a palloc'd string if given identifier doesn't need to be quoted, and in
+     * that case quotedTrigName would still be bound to triggerTuple.
+     */
+	heap_freetuple(triggerTuple);
 
 	return alterTriggerStateCommand->data;
 }


### PR DESCRIPTION
Fix use-after-free in GetAlterTriggerStateCommand() introduced in #6398.

Since we didn't do any releases for #6398, not writing a DESCRIPTION.

Given that #6398 is backported to 11.0 & 11.1 release branches, I need to backport this to those branches too.
