### PR TITLE
pg_regress needs the option dlpath for postgres tests to find regress.so

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -1098,7 +1098,10 @@ sub RunVanillaTests
     system("mkdir", ("-p", "$pgregressOutputdir/sql")) == 0
             or die "Could not create vanilla sql dir.";
 
+    # we need to add regress.so path to dlpath because some tests need to find that lib
+    my $regresslibdir = $pgregressdir;
     $exitcode = system("$plainRegress",
+                        ("--dlpath", $regresslibdir),
                         ("--inputdir",  $pgregressdir),
                         ("--outputdir",  $pgregressOutputdir),
                         ("--schedule",  catfile("$pgregressdir", "parallel_schedule")),


### PR DESCRIPTION
When you run vanilla tests in your local environment, some of the tests tries to find path for regress.so which is not in default lib path. That is why we need to specify regress.so path as dlpath option.

Example failure:
```
LOAD :'regresslib';
+ERROR:  could not access file "/home/aykutbozkurt/.pgenv/pgsql-15beta4/lib/regress.so": No such file or directory
```

It is actually in `~/.pgenv/src/postgresql-15beta4/src/test/regress/regress.so` which is found by `$regresslibdir`.