### PR TITLE
Use memcpy instead of memcpy_s to avoid pointless limits in columnar

### DIFF
--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -1650,6 +1650,9 @@ create_estate_for_relation(Relation rel)
 
 /*
  * DatumToBytea serializes a datum into a bytea value.
+ *
+ * Since we don't want to limit datum size to RSIZE_MAX unnecessarily,
+ * we use memcpy instead of memcpy_s several places in this function.
  */
 static bytea *
 DatumToBytea(Datum value, Form_pg_attribute attrForm)
@@ -1666,19 +1669,16 @@ DatumToBytea(Datum value, Form_pg_attribute attrForm)
 			Datum tmp;
 			store_att_byval(&tmp, value, attrForm->attlen);
 
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 &tmp, attrForm->attlen);
+			memcpy(VARDATA(result), &tmp, attrForm->attlen); /* IGNORE-BANNED */
 		}
 		else
 		{
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 DatumGetPointer(value), attrForm->attlen);
+			memcpy(VARDATA(result), DatumGetPointer(value), attrForm->attlen); /* IGNORE-BANNED */
 		}
 	}
 	else
 	{
-		memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-				 DatumGetPointer(value), datumLength);
+		memcpy(VARDATA(result), DatumGetPointer(value), datumLength); /* IGNORE-BANNED */
 	}
 
 	return result;
@@ -1697,8 +1697,12 @@ ByteaToDatum(bytea *bytes, Form_pg_attribute attrForm)
 	 * after the byteaDatum is freed.
 	 */
 	char *binaryDataCopy = palloc0(VARSIZE_ANY_EXHDR(bytes));
-	memcpy_s(binaryDataCopy, VARSIZE_ANY_EXHDR(bytes),
-			 VARDATA_ANY(bytes), VARSIZE_ANY_EXHDR(bytes));
+
+	/*
+	 * We use IGNORE-BANNED here since we don't want to limit datum size to
+	 * RSIZE_MAX unnecessarily.
+	 */
+	memcpy(binaryDataCopy, VARDATA_ANY(bytes), VARSIZE_ANY_EXHDR(bytes)); /* IGNORE-BANNED */
 
 	return fetch_att(binaryDataCopy, attrForm->attbyval, attrForm->attlen);
 }

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2576,8 +2576,13 @@ detoast_values(TupleDesc tupleDesc, Datum *orig_values, bool *isnull)
 			if (values == orig_values)
 			{
 				values = palloc(sizeof(Datum) * natts);
-				memcpy_s(values, sizeof(Datum) * natts,
-						 orig_values, sizeof(Datum) * natts);
+
+				/*
+				 * We use IGNORE-BANNED here since we don't want to limit
+				 * size of the buffer that holds the datum array to RSIZE_MAX
+				 * unnecessarily.
+				 */
+				memcpy(values, orig_values, sizeof(Datum) * natts); /* IGNORE-BANNED */
 			}
 
 			/* will be freed when per-tuple context is reset */


### PR DESCRIPTION
DESCRIPTION: Raises memory limits in columnar from 256MB to 1GB for reads and writes

This doesn't completely fix #5918 but at least increases the
buffer limits that might cause throwing an error when reading
from or writing into into columnar storage. A way better approach
to fix this is documented in #6420.

Replacing memcpy_s with memcpy is quite safe in those places
since we anyway make sure to allocate enough amount of memory
before writing into related buffers.