### PR TITLE
Fix flakyness in multi_partitioning

### DIFF
--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -85,7 +85,8 @@ test: ensure_no_intermediate_data_leak
 # Tests for partitioning support
 # ----------
 test: multi_partitioning_utils replicated_partitioned_table
-test: multi_partitioning partitioning_issue_3970
+test: multi_partitioning
+test: partitioning_issue_3970
 test: drop_partitioned_table
 test: multi_fix_partition_shard_index_names
 test: partition_wise_join


### PR DESCRIPTION
In CI multi_partitioning sometimes fails with this error:
```diff
 SELECT citus_remove_node('localhost', :master_port);
- citus_remove_node
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  tuple concurrently deleted
 -- d) invalid tables for helper UDFs
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/27993/workflows/685e5b20-c923-43e5-8a0d-b932ef4c4914/jobs/839466

This PR avoids this concurrency issue by not running the
multi_partitioning test in parallel with other tests.
