### PR TITLE
Properly set col names for shard rels that citus_extradata_container points to

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_13.c
+++ b/src/backend/distributed/deparser/ruleutils_13.c
@@ -1003,7 +1003,8 @@ set_relation_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 	 * get_rte_attribute_name, except that it's important to disregard dropped
 	 * columns.  We put NULL into the array for a dropped column.
 	 */
-	if (rte->rtekind == RTE_RELATION)
+	if (rte->rtekind == RTE_RELATION ||
+        GetRangeTblKind(rte) == CITUS_RTE_SHARD)
 	{
 		/* Relation --- look to the system catalogs for up-to-date info */
 		Relation	rel;

--- a/src/backend/distributed/deparser/ruleutils_14.c
+++ b/src/backend/distributed/deparser/ruleutils_14.c
@@ -1125,7 +1125,8 @@ set_relation_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 	 * get_rte_attribute_name, except that it's important to disregard dropped
 	 * columns.  We put NULL into the array for a dropped column.
 	 */
-	if (rte->rtekind == RTE_RELATION)
+	if (rte->rtekind == RTE_RELATION ||
+        GetRangeTblKind(rte) == CITUS_RTE_SHARD)
 	{
 		/* Relation --- look to the system catalogs for up-to-date info */
 		Relation	rel;

--- a/src/backend/distributed/deparser/ruleutils_15.c
+++ b/src/backend/distributed/deparser/ruleutils_15.c
@@ -1133,7 +1133,8 @@ set_relation_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 	 * real_colnames[] will be indexed by physical column number, with NULL
 	 * entries for dropped columns.
 	 */
-	if (rte->rtekind == RTE_RELATION)
+	if (rte->rtekind == RTE_RELATION ||
+        GetRangeTblKind(rte) == CITUS_RTE_SHARD)
 	{
 		/* Relation --- look to the system catalogs for up-to-date info */
 		Relation	rel;

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -1330,6 +1330,54 @@ SELECT * FROM ref_1 ORDER BY key, value;
 ---------------------------------------------------------------------
 (0 rows)
 
+-- show that we correctly handle renamed columns when expanding view query
+CREATE TABLE column_alias_test_1(a int, b int);
+SELECT create_distributed_table('column_alias_test_1', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO column_alias_test_1 VALUES (1, 2);
+CREATE VIEW column_alias_test_1_view AS
+SELECT * FROM column_alias_test_1;
+ALTER TABLE column_alias_test_1 RENAME COLUMN a TO tmp;
+ALTER TABLE column_alias_test_1 RENAME COLUMN b TO a;
+ALTER TABLE column_alias_test_1 RENAME COLUMN tmp TO b;
+-- A tricky implication of #5932:
+--
+-- Even if we renamed column names, this should normally print:
+-- a | b
+-- 1 | 2
+--
+-- This is because, views preserve original column names by
+-- aliasing renamed columns.
+--
+-- But before fixing #5932, this was printing:
+-- a | b
+-- 2 | 1
+--
+-- which was not correct.
+SELECT * FROM column_alias_test_1_view;
+ a | b
+---------------------------------------------------------------------
+ 2 | 1
+(1 row)
+
+CREATE TABLE column_alias_test_2(a int, b int);
+SELECT create_distributed_table('column_alias_test_2', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO column_alias_test_2 VALUES (1, 2);
+CREATE VIEW column_alias_test_2_view AS
+SELECT * FROM column_alias_test_2;
+ALTER TABLE column_alias_test_2 RENAME COLUMN a TO a_renamed;
+SELECT * FROM column_alias_test_2_view;
+ERROR:  column "a" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
 DROP TABLE large, small, ref_1 CASCADE;
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to view v1

--- a/src/test/regress/expected/multi_view.out
+++ b/src/test/regress/expected/multi_view.out
@@ -1361,7 +1361,7 @@ ALTER TABLE column_alias_test_1 RENAME COLUMN tmp TO b;
 SELECT * FROM column_alias_test_1_view;
  a | b
 ---------------------------------------------------------------------
- 2 | 1
+ 1 | 2
 (1 row)
 
 CREATE TABLE column_alias_test_2(a int, b int);
@@ -1376,8 +1376,11 @@ CREATE VIEW column_alias_test_2_view AS
 SELECT * FROM column_alias_test_2;
 ALTER TABLE column_alias_test_2 RENAME COLUMN a TO a_renamed;
 SELECT * FROM column_alias_test_2_view;
-ERROR:  column "a" does not exist
-CONTEXT:  while executing command on localhost:xxxxx
+ a | b
+---------------------------------------------------------------------
+ 1 | 2
+(1 row)
+
 DROP TABLE large, small, ref_1 CASCADE;
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to view v1


### PR DESCRIPTION
Deparser function set_relation_column_names() knows that it needs to
re-evaluate column names based on relation's tuple descriptor when
the rte belongs to a relation (RTE_RELATION).

However before this commit, it didn't know about the fact that citus
might wrap such an rte with an rte that points to
citus_extradata_container() placeholder.

And because of this, it was simply taking the column aliases
(e.g., "bar" in "foo AS bar") into the account and this might result in
an incorrectly deparsed query as in below case:

* Say, if we had view based on following query:
  ```sql
  SELECT a FROM table;
  ```
* And if we rename column "a" to "b", the view query normally becomes:
  ```sql
  SELECT b AS a FROM table;
  ```
* So before this commit, deparsing a query based on that view was
  resulting in such a query due to deparsing based on the column aliases,
  which is not correct:
  ```sql
  SELECT a FROM table;
  ```

Fixes #5932.

DESCRIPTION: Fixes a bug that might cause failing to query the views based on tables that have renamed columns
