### PR TITLE
Include gpid in all internal application names

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -2085,8 +2085,10 @@ ExecuteRebalancerCommandInSeparateTransaction(char *command)
 													PostPortNumber);
 	List *commandList = NIL;
 
-	commandList = lappend(commandList, psprintf("SET LOCAL application_name TO %s;",
-												CITUS_REBALANCER_NAME));
+	commandList = lappend(commandList, psprintf(
+							  "SET LOCAL application_name TO '%s%ld'",
+							  CITUS_REBALANCER_APPLICATION_NAME_PREFIX,
+							  GetGlobalPID()));
 
 	if (PropagateSessionSettingsForLoopbackConnection)
 	{

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -92,13 +92,13 @@ typedef enum CitusBackendType
 	EXTERNAL_CLIENT_BACKEND
 } CitusBackendType;
 
-static const char *citusBackendPrefixes[] = {
+static const char *CitusBackendPrefixes[] = {
 	CITUS_APPLICATION_NAME_PREFIX,
 	CITUS_REBALANCER_APPLICATION_NAME_PREFIX,
 	CITUS_RUN_COMMAND_APPLICATION_NAME_PREFIX,
 };
 
-static const CitusBackendType citusBackendTypes[] = {
+static const CitusBackendType CitusBackendTypes[] = {
 	CITUS_INTERNAL_BACKEND,
 	CITUS_REBALANCER_BACKEND,
 	CITUS_RUN_COMMAND_BACKEND,
@@ -1078,12 +1078,12 @@ ExtractGlobalPID(const char *applicationName)
 	/* we create our own copy of application name incase the original changes */
 	char *applicationNameCopy = pstrdup(applicationName);
 
-	for (int i = 0; i < lengthof(citusBackendPrefixes); i++)
+	for (int i = 0; i < lengthof(CitusBackendPrefixes); i++)
 	{
-		uint64 prefixLength = strlen(citusBackendPrefixes[i]);
+		uint64 prefixLength = strlen(CitusBackendPrefixes[i]);
 
 		/* does application name start with this prefix prefix */
-		if (strncmp(applicationNameCopy, citusBackendPrefixes[i], prefixLength) != 0)
+		if (strncmp(applicationNameCopy, CitusBackendPrefixes[i], prefixLength) != 0)
 		{
 			continue;
 		}
@@ -1457,14 +1457,14 @@ DetermineCitusBackendType(const char *applicationName)
 	if (applicationName &&
 		ExtractGlobalPID(applicationName) != INVALID_CITUS_INTERNAL_BACKEND_GPID)
 	{
-		for (int i = 0; i < lengthof(citusBackendPrefixes); i++)
+		for (int i = 0; i < lengthof(CitusBackendPrefixes); i++)
 		{
-			uint64 prefixLength = strlen(citusBackendPrefixes[i]);
+			uint64 prefixLength = strlen(CitusBackendPrefixes[i]);
 
 			/* does application name start with this prefix prefix */
-			if (strncmp(applicationName, citusBackendPrefixes[i], prefixLength) == 0)
+			if (strncmp(applicationName, CitusBackendPrefixes[i], prefixLength) == 0)
 			{
-				CurrentBackendType = citusBackendTypes[i];
+				CurrentBackendType = CitusBackendTypes[i];
 				return;
 			}
 		}

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -15,6 +15,7 @@
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/genam.h"
+#include "distributed/backend_data.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/commands.h"
 #include "distributed/listutils.h"
@@ -257,9 +258,10 @@ EnsureReferenceTablesExistOnAllNodesExtended(char transferMode)
 			 * the shard. This is allowed when indicating that the backend is a
 			 * rebalancer backend.
 			 */
-			ExecuteCriticalRemoteCommand(connection,
-										 "SET LOCAL application_name TO "
-										 CITUS_REBALANCER_NAME);
+			ExecuteCriticalRemoteCommand(connection, psprintf(
+											 "SET LOCAL application_name TO '%s%ld'",
+											 CITUS_REBALANCER_APPLICATION_NAME_PREFIX,
+											 GetGlobalPID()));
 			ExecuteCriticalRemoteCommand(connection, placementCopyCommand->data);
 			RemoteTransactionCommit(connection);
 		}

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -37,10 +37,10 @@
 #define CITUS_APPLICATION_NAME_PREFIX "citus_internal gpid="
 
 /* application name used for internal connections in rebalancer */
-#define CITUS_REBALANCER_NAME "citus_rebalancer"
+#define CITUS_REBALANCER_APPLICATION_NAME_PREFIX "citus_rebalancer gpid="
 
 /* application name used for connections made by run_command_on_* */
-#define CITUS_RUN_COMMAND_APPLICATION_NAME "citus_run_command"
+#define CITUS_RUN_COMMAND_APPLICATION_NAME_PREFIX "citus_run_command gpid="
 
 /* deal with waiteventset errors */
 #define WAIT_EVENT_SET_INDEX_NOT_INITIALIZED -1

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -301,3 +301,5 @@ s/^(NOTICE:  )(clock).*LC:[0-9]+,.*C:[0-9]+,.*$/\1\2 xxxxxx/g
 # The following 2 lines are to normalize duration and cost in the EXPLAIN output
 s/LOG:  duration: [0-9].[0-9]+ ms/LOG:  duration: xxxx ms/g
 s/"Total Cost": [0-9].[0-9]+/"Total Cost": xxxx/g
+
+s/(NOTICE:  issuing SET LOCAL application_name TO 'citus_rebalancer gpid=)[0-9]+/\1xxxxx/g

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -97,6 +97,22 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 (1 row)
 
 ROLLBACK;
+-- also works if done by the rebalancer
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_rebalancer gpid=10000000001';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ citus_internal_add_partition_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
 -- application_name with incorrect gpid
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
@@ -106,6 +122,18 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 (1 row)
 
 	SET application_name to 'citus_internal gpid=not a correct gpid';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ERROR:  This is an internal Citus function can only be used in a distributed transaction
+ROLLBACK;
+-- also faills if done by the rebalancer
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_rebalancer gpid=not a correct gpid';
 	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
 ERROR:  This is an internal Citus function can only be used in a distributed transaction
 ROLLBACK;

--- a/src/test/regress/expected/shard_rebalancer.out
+++ b/src/test/regress/expected/shard_rebalancer.out
@@ -204,7 +204,7 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
+NOTICE:  issuing SET LOCAL application_name TO 'citus_rebalancer gpid=xxxxx'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -225,7 +225,7 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
+NOTICE:  issuing SET LOCAL application_name TO 'citus_rebalancer gpid=xxxxx'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -246,7 +246,7 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
+NOTICE:  issuing SET LOCAL application_name TO 'citus_rebalancer gpid=xxxxx'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -267,7 +267,7 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
+NOTICE:  issuing SET LOCAL application_name TO 'citus_rebalancer gpid=xxxxx'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -68,10 +68,24 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT count(*) FROM pg_dist_partition WHERE logicalrelid = 'metadata_sync_helpers.test_2'::regclass;
 ROLLBACK;
 
+-- also works if done by the rebalancer
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_rebalancer gpid=10000000001';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ROLLBACK;
+
 -- application_name with incorrect gpid
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
 	SET application_name to 'citus_internal gpid=not a correct gpid';
+	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
+ROLLBACK;
+
+-- also faills if done by the rebalancer
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_rebalancer gpid=not a correct gpid';
 	SELECT citus_internal_add_partition_metadata ('test_2'::regclass, 'h', 'col_1', 0, 's');
 ROLLBACK;
 


### PR DESCRIPTION
DESCRIPTION: Include gpid in all internal application names

When debugging issues it's quite useful to see the originating gpid in
the application_name of a query on a worker. This already happens for most
queries, but not for queries created by the rebalancer or by
run_command_on_worker. This adds a gpid to those two application_names too.

Note, that if the GPID of the new application_names is different than the current
GPID of the backend the backend will continue to keep the old gpid as its actual
GPID. This PR is just meant to make sure that the application_name is as
useful as it can be for users to look at. Updating of gpids will be done in a 
follow-up PR, and adding gpids to all internal connections will make this easier.