### PR TITLE
Drop worker_fetch_foreign_file/worker_repartition_cleanup only if they exist when upgrading Citus

### DIFF
--- a/src/backend/distributed/sql/citus--11.0-4--11.1-1.sql
+++ b/src/backend/distributed/sql/citus--11.0-4--11.1-1.sql
@@ -5,14 +5,23 @@
 #include "udfs/citus_internal_delete_partition_metadata/11.1-1.sql"
 #include "udfs/citus_copy_shard_placement/11.1-1.sql"
 
+-- We should not introduce breaking sql changes to upgrade files after they are released.
+-- We did that for worker_fetch_foreign_file in v9.0.0 and worker_repartition_cleanup in v9.2.0.
+-- When we try to drop those udfs in that file, they were missing for some clients unexpectedly
+-- due to buggy changes in old upgrade scripts. For that case, the fix is to change DROP statements
+-- with DROP IF EXISTS for those 2 udfs in 11.0-4--11.1-1.
+-- Fixes an upgrade problem for worker_fetch_foreign_file when upgrade starts from 8.3 up to 11.1
+-- Fixes an upgrade problem for worker_repartition_cleanup when upgrade starts from 9.1 up to 11.1
+-- Refer the related PR https://github.com/citusdata/citus/pull/6441 for more information
+DROP FUNCTION IF EXISTS pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[]);
+DROP FUNCTION IF EXISTS pg_catalog.worker_repartition_cleanup(bigint);
+
 DROP FUNCTION pg_catalog.worker_create_schema(bigint,text);
 DROP FUNCTION pg_catalog.worker_cleanup_job_schema_cache();
-DROP FUNCTION pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[]);
 DROP FUNCTION pg_catalog.worker_fetch_partition_file(bigint, integer, integer, integer, text, integer);
 DROP FUNCTION pg_catalog.worker_hash_partition_table(bigint, integer, text, text, oid, anyarray);
 DROP FUNCTION pg_catalog.worker_merge_files_into_table(bigint, integer, text[], text[]);
 DROP FUNCTION pg_catalog.worker_range_partition_table(bigint, integer, text, text, oid, anyarray);
-DROP FUNCTION pg_catalog.worker_repartition_cleanup(bigint);
 
 DO $check_columnar$
 BEGIN


### PR DESCRIPTION
DESCRIPTION: Fixes an upgrade problem for worker_fetch_foreign_file when upgrade path starts from 8.3 up to 11.1
DESCRIPTION: Fixes an upgrade problem for worker_repartition_cleanup when upgrade path starts from 9.1 up to 11.1

We should not introduce breaking sql changes to upgrade files after they are released. We did that for worker_fetch_foreign_file in v9.0.0 and worker_repartition_cleanup in v9.2.0. Later when we try to drop those udfs, they were missing for some clients unexpectedly due to breaking change in an old upgrade script. For that case, the fix is to add DROP IF EXISTS for those 2 udfs in 11.0-4--11.1-1.

## How to resolve if you get error on any of 2 udfs missing
You can only get those error on v11.1.0, v11.1.1, v11.1.2 and v11.1.3. If you are already below v11.1.0, you can directly install a version above v11.1.4.

In case you want to use any of those versions, you can fix the upgrade as follows:

- If you had error `ERROR:  function pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[]) does not exist`, apply below only on coordinator.
```sql
BEGIN;
  SET LOCAL citus.enable_ddl_propagation TO off;

  CREATE FUNCTION pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[])
    RETURNS void
    LANGUAGE c
    STRICT
  AS 'citus.so', $function$worker_fetch_foreign_file$function$;

  ALTER EXTENSION citus ADD FUNCTION pg_catalog.worker_fetch_foreign_file(text, text, bigint, text[], integer[]);
COMMIT;
```

- If you had error `ERROR:  function pg_catalog.worker_repartition_cleanup(bigint) does not exist`, apply below only on coordinator.
```sql
BEGIN;
  SET LOCAL citus.enable_ddl_propagation TO off;

CREATE FUNCTION pg_catalog.worker_repartition_cleanup(bigint)
 RETURNS void
 LANGUAGE c
 STRICT
AS 'citus.so', $function$worker_repartition_cleanup$function$;

  ALTER EXTENSION citus ADD FUNCTION pg_catalog.worker_repartition_cleanup(bigint);
COMMIT;
```