### PR TITLE
Don't leak search_path to workers on DDL

### DIFF
--- a/src/test/regress/expected/distributed_triggers.out
+++ b/src/test/regress/expected/distributed_triggers.out
@@ -5,6 +5,15 @@ CREATE SCHEMA distributed_triggers;
 SET search_path TO 'distributed_triggers';
 SET citus.shard_replication_factor = 1;
 SET citus.next_shard_id TO 800000;
+-- idempotently add node to allow this test to run without add_coordinator
+SET client_min_messages TO WARNING;
+SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+RESET client_min_messages;
 --
 -- Test citus.enable_unsafe_triggers
 -- Enables arbitrary triggers on distributed tables
@@ -275,7 +284,7 @@ DETAIL:  Executing a distributed query in a function call that may be pushed to 
 HINT:  Avoid nesting of distributed queries or use alter user current_user set citus.allow_nested_distributed_execution to on to allow it with possible incorrectness.
 CONTEXT:  SQL statement "INSERT INTO distributed_triggers.data_changes (shard_key_value, object_id, change_id, operation_type, new_value)
     VALUES ('BAD', NEW.object_id, COALESCE(last_change_id + 1, 1), TG_OP, NEW.value)"
-PL/pgSQL function bad_shardkey_record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.bad_shardkey_record_change() line XX at SQL statement
 while executing command on localhost:xxxxx
 -- Bad trigger fired from SQL inside a force-delegated function
 -- Incorrect distribution key exception should catch this
@@ -315,7 +324,6 @@ ORDER BY shard_key_value, object_id, change_id;
 DROP TRIGGER bad_shardkey_record_change_trigger ON data;
 CREATE OR REPLACE FUNCTION remote_shardkey_record_change()
 RETURNS trigger
-SET search_path = 'distributed_triggers'
 LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -331,7 +339,6 @@ FOR EACH ROW EXECUTE FUNCTION distributed_triggers.remote_shardkey_record_change
 CREATE FUNCTION insert_document(key text, id text)
 RETURNS void
 LANGUAGE plpgsql
-SET search_path = 'distributed_triggers'
 AS $fn$
 BEGIN
 	INSERT INTO distributed_triggers.data VALUES (key, id, '{"id1":"id2"}');
@@ -354,7 +361,7 @@ ERROR:  cannot execute a distributed query from a query on a shard
 DETAIL:  Executing a distributed query in a function call that may be pushed to a remote node can lead to incorrect results.
 HINT:  Avoid nesting of distributed queries or use alter user current_user set citus.allow_nested_distributed_execution to on to allow it with possible incorrectness.
 CONTEXT:  SQL statement "UPDATE distributed_triggers.data_changes SET operation_type = TG_OP"
-PL/pgSQL function remote_shardkey_record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.remote_shardkey_record_change() line XX at SQL statement
 while executing command on localhost:xxxxx
 SQL statement "INSERT INTO distributed_triggers.data VALUES (key, id, '{"id1":"id2"}')"
 PL/pgSQL function insert_document(text,text) line XX at SQL statement
@@ -364,9 +371,9 @@ ERROR:  cannot execute a distributed query from a query on a shard
 DETAIL:  Executing a distributed query in a function call that may be pushed to a remote node can lead to incorrect results.
 HINT:  Avoid nesting of distributed queries or use alter user current_user set citus.allow_nested_distributed_execution to on to allow it with possible incorrectness.
 CONTEXT:  SQL statement "UPDATE distributed_triggers.data_changes SET operation_type = TG_OP"
-PL/pgSQL function remote_shardkey_record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.remote_shardkey_record_change() line XX at SQL statement
 SQL statement "INSERT INTO distributed_triggers.data VALUES (key, id, '{"id1":"id2"}')"
-PL/pgSQL function insert_document(text,text) line XX at SQL statement
+PL/pgSQL function distributed_triggers.insert_document(text,text) line XX at SQL statement
 while executing command on localhost:xxxxx
 SELECT * FROM data
 ORDER BY shard_key_value, object_id;
@@ -509,7 +516,7 @@ ERROR:  cannot execute a distributed query from a query on a shard
 DETAIL:  Executing a distributed query in a function call that may be pushed to a remote node can lead to incorrect results.
 HINT:  Avoid nesting of distributed queries or use alter user current_user set citus.allow_nested_distributed_execution to on to allow it with possible incorrectness.
 CONTEXT:  SQL statement "INSERT INTO distributed_triggers.record_op SELECT 'dummy', TG_OP, now()"
-PL/pgSQL function record_emp() line XX at SQL statement
+PL/pgSQL function distributed_triggers.record_emp() line XX at SQL statement
 while executing command on localhost:xxxxx
 DELETE FROM emptest;
 ERROR:  cannot execute a distributed query from a query on a shard
@@ -557,7 +564,7 @@ HINT:  Avoid nesting of distributed queries or use alter user current_user set c
 CONTEXT:  SQL statement "SELECT change_id                           FROM distributed_triggers.data_changes
       WHERE shard_key_value = NEW.shard_key_value AND object_id = NEW.object_id
       ORDER BY change_id DESC LIMIT 1"
-PL/pgSQL function record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.record_change() line XX at SQL statement
 while executing command on localhost:xxxxx
 INSERT INTO data_ref_table VALUES ('hello2','world2','{"ref":"table"}');
 ERROR:  cannot execute a distributed query from a query on a shard
@@ -566,7 +573,7 @@ HINT:  Avoid nesting of distributed queries or use alter user current_user set c
 CONTEXT:  SQL statement "SELECT change_id                           FROM distributed_triggers.data_changes
       WHERE shard_key_value = NEW.shard_key_value AND object_id = NEW.object_id
       ORDER BY change_id DESC LIMIT 1"
-PL/pgSQL function record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.record_change() line XX at SQL statement
 while executing command on localhost:xxxxx
 DELETE FROM data_ref_table where shard_key_value = 'hello';
 BEGIN;
@@ -605,7 +612,7 @@ DETAIL:  Executing a distributed query in a function call that may be pushed to 
 HINT:  Avoid nesting of distributed queries or use alter user current_user set citus.allow_nested_distributed_execution to on to allow it with possible incorrectness.
 CONTEXT:  SQL statement "INSERT INTO distributed_triggers.data_changes (shard_key_value, object_id, change_id, operation_type, new_value)
       VALUES (NEW.shard_key_value, NEW.object_id, COALESCE(last_change_id + 1, 1), TG_OP, NEW.value)"
-PL/pgSQL function record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.record_change() line XX at SQL statement
 while executing command on localhost:xxxxx
 TABLE data_changes ORDER BY shard_key_value, object_id, change_id;
  shard_key_value | object_id | change_id | change_time | operation_type | new_value
@@ -743,18 +750,18 @@ CREATE VIEW sale_triggers AS
     WHERE tgrelid::regclass::text = 'sale'
     ORDER BY 1, 2;
 SELECT * FROM sale_triggers ORDER BY 1,2;
-         tgname         |     tgrelid     | tgenabled
+         tgname         | tgrelid | tgenabled
 ---------------------------------------------------------------------
- record_sale_trigger    | sale            | O
- truncate_trigger_xxxxxxx | sale            | O
+ record_sale_trigger    | sale    | O
+ truncate_trigger_xxxxxxx | sale    | O
 (2 rows)
 
 ALTER TRIGGER "record_sale_trigger" ON "distributed_triggers"."sale" RENAME TO "new_record_sale_trigger";
 SELECT * FROM sale_triggers ORDER BY 1,2;
-         tgname          |     tgrelid     | tgenabled
+         tgname          | tgrelid | tgenabled
 ---------------------------------------------------------------------
- new_record_sale_trigger | sale            | O
- truncate_trigger_xxxxxxx  | sale            | O
+ new_record_sale_trigger | sale    | O
+ truncate_trigger_xxxxxxx  | sale    | O
 (2 rows)
 
 CREATE EXTENSION seg;

--- a/src/test/regress/expected/multi_fix_partition_shard_index_names.out
+++ b/src/test/regress/expected/multi_fix_partition_shard_index_names.out
@@ -493,6 +493,7 @@ SELECT tablename, indexname FROM pg_indexes WHERE schemaname = 'fix_idx_names' A
 \c - - - :master_port
 SET search_path TO fix_idx_names, public;
 DROP TABLE dist_partitioned_table;
+SET citus.next_shard_id TO 910040;
 -- test with citus local table
 SET client_min_messages TO WARNING;
 SELECT 1 FROM citus_add_node('localhost', :master_port, groupid=>0);
@@ -521,9 +522,9 @@ SELECT tablename, indexname FROM pg_indexes WHERE schemaname = 'fix_idx_names' O
                  tablename                 |                        indexname
 ---------------------------------------------------------------------
  date_partitioned_citus_local_table        | date_partitioned_citus_local_table_measureid_idx
- date_partitioned_citus_local_table_361377 | date_partitioned_citus_local_table_measureid_idx_361377
+ date_partitioned_citus_local_table_910040 | date_partitioned_citus_local_table_measureid_idx_910040
  partition_local_table                     | partition_local_table_measureid_idx
- partition_local_table_361378              | partition_local_table_measureid_idx_361378
+ partition_local_table_910041              | partition_local_table_measureid_idx_910041
 (4 rows)
 
 -- creating a single object should only need to trigger fixing the single object
@@ -555,9 +556,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing CREATE INDEX i4 ON parent_table(dist_col);
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -585,9 +586,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing ALTER TABLE parent_table ADD CONSTRAINT pkey_cst PRIMARY KEY (dist_col, partition_col);
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -614,9 +615,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing ALTER TABLE parent_table ADD CONSTRAINT unique_cst UNIQUE (dist_col, partition_col);
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -723,9 +724,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO fix_idx_names,public;
+NOTICE:  issuing SET LOCAL search_path TO fix_idx_names,public;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing ALTER TABLE parent_table ATTACH PARTITION p2 FOR VALUES FROM ('2019-01-01') TO ('2020-01-01');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -747,15 +748,8 @@ RESET citus.log_remote_commands;
 DROP INDEX i4_renamed CASCADE;
 ALTER TABLE parent_table DROP CONSTRAINT pkey_cst CASCADE;
 ALTER TABLE parent_table DROP CONSTRAINT unique_cst CASCADE;
+SET client_min_messages TO WARNING;
 DROP SCHEMA fix_idx_names CASCADE;
-NOTICE:  drop cascades to 7 other objects
-DETAIL:  drop cascades to table not_partitioned
-drop cascades to table not_distributed
-drop cascades to table fk_table
-drop cascades to table p
-drop cascades to table date_partitioned_citus_local_table_361377
-drop cascades to table date_partitioned_citus_local_table
-drop cascades to table parent_table
 SELECT citus_remove_node('localhost', :master_port);
  citus_remove_node
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_mx_alter_distributed_table.out
+++ b/src/test/regress/expected/multi_mx_alter_distributed_table.out
@@ -174,8 +174,8 @@ AS $$
 DECLARE
     res INT := 0;
 BEGIN
-    INSERT INTO test_proc_colocation_0 VALUES (dist_key);
-    SELECT count(*) INTO res FROM test_proc_colocation_0;
+    INSERT INTO mx_alter_distributed_table.test_proc_colocation_0 VALUES (dist_key);
+    SELECT count(*) INTO res FROM mx_alter_distributed_table.test_proc_colocation_0;
     RAISE NOTICE 'Res: %', res;
     COMMIT;
 END;$$;
@@ -372,8 +372,8 @@ AS $$
 DECLARE
     res INT := 0;
 BEGIN
-    INSERT INTO test_proc_colocation_0 VALUES (dist_key);
-    SELECT count(*) INTO res FROM test_proc_colocation_0;
+    INSERT INTO mx_alter_distributed_table.test_proc_colocation_0 VALUES (dist_key);
+    SELECT count(*) INTO res FROM mx_alter_distributed_table.test_proc_colocation_0;
     RAISE NOTICE 'Res: %', res;
     COMMIT;
 END;$$;

--- a/src/test/regress/expected/multi_partitioning.out
+++ b/src/test/regress/expected/multi_partitioning.out
@@ -1940,11 +1940,11 @@ DROP TABLE partitioning_test_2008, partitioning_test_2009, partitioning_test_201
 -- verify this doesn't crash and gives a debug message for dropped table
 SET client_min_messages TO DEBUG1;
 DROP TABLE partitioning_test, reference_table;
-DEBUG:  drop cascades to constraint partitioning_reference_fkey on table partitioning_test
+DEBUG:  drop cascades to constraint partitioning_reference_fkey on table partitioning_schema.partitioning_test
 DETAIL:  from localhost:xxxxx
 CONTEXT:  SQL statement "SELECT master_remove_distributed_table_metadata_from_workers(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
-DEBUG:  drop cascades to constraint partitioning_reference_fkey on table partitioning_test
+DEBUG:  drop cascades to constraint partitioning_reference_fkey on table partitioning_schema.partitioning_test
 DETAIL:  from localhost:xxxxx
 CONTEXT:  SQL statement "SELECT master_remove_distributed_table_metadata_from_workers(v_obj.objid, v_obj.schema_name, v_obj.object_name)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
@@ -1953,14 +1953,14 @@ DETAIL:  Table "<dropped>" is modified, which might lead to data inconsistencies
 CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
 DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660302 on table partitioning_test_1660302
-drop cascades to constraint partitioning_reference_fkey_1660304 on table partitioning_test_1660304
+DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660302 on table partitioning_schema.partitioning_test_1660302
+drop cascades to constraint partitioning_reference_fkey_1660304 on table partitioning_schema.partitioning_test_1660304
 DETAIL:  from localhost:xxxxx
 CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
 DEBUG:  drop cascades to 2 other objects
-DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660303 on table partitioning_test_1660303
-drop cascades to constraint partitioning_reference_fkey_1660305 on table partitioning_test_1660305
+DETAIL:  drop cascades to constraint partitioning_reference_fkey_1660303 on table partitioning_schema.partitioning_test_1660303
+drop cascades to constraint partitioning_reference_fkey_1660305 on table partitioning_schema.partitioning_test_1660305
 DETAIL:  from localhost:xxxxx
 CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -125,9 +125,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing reindex(TABLESPACE test_tablespace) index idx;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -155,9 +155,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing reindex(TABLESPACE test_tablespace, verbose) index idx;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -184,9 +184,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing reindex(TABLESPACE test_tablespace, verbose false) index idx ;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -214,9 +214,9 @@ NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET citus.enable_ddl_propagation TO 'off'
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET search_path TO pg14;
+NOTICE:  issuing SET LOCAL search_path TO pg14;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing reindex(verbose, TABLESPACE test_tablespace) index idx ;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx

--- a/src/test/regress/sql/distributed_triggers.sql
+++ b/src/test/regress/sql/distributed_triggers.sql
@@ -5,6 +5,11 @@ SET search_path TO 'distributed_triggers';
 SET citus.shard_replication_factor = 1;
 SET citus.next_shard_id TO 800000;
 
+-- idempotently add node to allow this test to run without add_coordinator
+SET client_min_messages TO WARNING;
+SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
+RESET client_min_messages;
+
 --
 -- Test citus.enable_unsafe_triggers
 -- Enables arbitrary triggers on distributed tables
@@ -174,7 +179,6 @@ DROP TRIGGER bad_shardkey_record_change_trigger ON data;
 
 CREATE OR REPLACE FUNCTION remote_shardkey_record_change()
 RETURNS trigger
-SET search_path = 'distributed_triggers'
 LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -192,7 +196,6 @@ FOR EACH ROW EXECUTE FUNCTION distributed_triggers.remote_shardkey_record_change
 CREATE FUNCTION insert_document(key text, id text)
 RETURNS void
 LANGUAGE plpgsql
-SET search_path = 'distributed_triggers'
 AS $fn$
 BEGIN
 	INSERT INTO distributed_triggers.data VALUES (key, id, '{"id1":"id2"}');

--- a/src/test/regress/sql/multi_fix_partition_shard_index_names.sql
+++ b/src/test/regress/sql/multi_fix_partition_shard_index_names.sql
@@ -275,6 +275,7 @@ SELECT tablename, indexname FROM pg_indexes WHERE schemaname = 'fix_idx_names' A
 \c - - - :master_port
 SET search_path TO fix_idx_names, public;
 DROP TABLE dist_partitioned_table;
+SET citus.next_shard_id TO 910040;
 
 -- test with citus local table
 SET client_min_messages TO WARNING;
@@ -342,5 +343,6 @@ DROP INDEX i4_renamed CASCADE;
 ALTER TABLE parent_table DROP CONSTRAINT pkey_cst CASCADE;
 ALTER TABLE parent_table DROP CONSTRAINT unique_cst CASCADE;
 
+SET client_min_messages TO WARNING;
 DROP SCHEMA fix_idx_names CASCADE;
 SELECT citus_remove_node('localhost', :master_port);

--- a/src/test/regress/sql/multi_mx_alter_distributed_table.sql
+++ b/src/test/regress/sql/multi_mx_alter_distributed_table.sql
@@ -59,8 +59,8 @@ AS $$
 DECLARE
     res INT := 0;
 BEGIN
-    INSERT INTO test_proc_colocation_0 VALUES (dist_key);
-    SELECT count(*) INTO res FROM test_proc_colocation_0;
+    INSERT INTO mx_alter_distributed_table.test_proc_colocation_0 VALUES (dist_key);
+    SELECT count(*) INTO res FROM mx_alter_distributed_table.test_proc_colocation_0;
     RAISE NOTICE 'Res: %', res;
     COMMIT;
 END;$$;
@@ -126,8 +126,8 @@ AS $$
 DECLARE
     res INT := 0;
 BEGIN
-    INSERT INTO test_proc_colocation_0 VALUES (dist_key);
-    SELECT count(*) INTO res FROM test_proc_colocation_0;
+    INSERT INTO mx_alter_distributed_table.test_proc_colocation_0 VALUES (dist_key);
+    SELECT count(*) INTO res FROM mx_alter_distributed_table.test_proc_colocation_0;
     RAISE NOTICE 'Res: %', res;
     COMMIT;
 END;$$;


### PR DESCRIPTION
DESCRIPTION: Don't leak search_path to workers on DDL

For DDL we have to set the `search_path` on workers to the same as on
the coordinator for some DDL to work. Previously this search_path would
leak outside of the transaction that was used for the DDL. This fixes
that by using `SET LOCAL` instead of `SET`. The only place where we
still use plain `SET` is for DDL commands that are not allowed within
transactions, such as `CREATE INDEX CONCURRENLTY`.

This fixes this flaky test:
```diff
 CONTEXT:  SQL statement "SELECT change_id                           FROM distributed_triggers.data_changes
       WHERE shard_key_value = NEW.shard_key_value AND object_id = NEW.object_id
       ORDER BY change_id DESC LIMIT 1"
-PL/pgSQL function record_change() line XX at SQL statement
+PL/pgSQL function distributed_triggers.record_change() line 17 at SQL statement
 while executing command on localhost:57638
 DELETE FROM data_ref_table where shard_key_value = 'hello';
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/27849/workflows/75ae5f1a-100b-4b7a-b991-7de069f39ee1/jobs/831429

I had tried to fix this flaky test in #5894 and then I tried
implementing a better fix in #5896, where @marcocitus suggested this
better fix. This change reverts the fix from #5894 and implements the
fix suggested by Marco.


Our multi_mx_alter_distributed_table test actually depended on the old
buggy search_path leaking behavior. After fixing the bug that test would 
fail like this:
```diff
 CALL proc_0(1.0);
 DEBUG:  pushing down the procedure
-NOTICE:  Res: 3
-DETAIL:  from localhost:xxxxx
+ERROR:  relation "test_proc_colocation_0" does not exist
+CONTEXT:  PL/pgSQL function mx_alter_distributed_table.proc_0(double precision) line 5 at SQL statement
+while executing command on localhost:57637
 RESET client_min_messages;
```

I fixed this test by fully qualifying the table names used in the procedure. 
I think it's quite unlikely that actual users depend on this behavior though. 
Since it would require first doing DDL before calling a procedure in a session 
where the search path was changed after connecting.