### PR TITLE
Increase node_connection_timeout to prevent flakiness in shard_rebalancer regression tests

### DIFF
--- a/src/test/regress/expected/shard_rebalancer.out
+++ b/src/test/regress/expected/shard_rebalancer.out
@@ -194,7 +194,7 @@ SELECT pg_sleep(.1); -- wait to make sure the config has changed before running 
 (1 row)
 
 -- replicate reference table should ignore the coordinator
-SET citus.node_connection_timeout to 60;
+SET citus.node_connection_timeout to '35s';
 BEGIN;
     SET LOCAL citus.shard_replication_factor TO 2;
     SET citus.log_remote_commands TO ON;
@@ -213,7 +213,7 @@ NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '60';
+NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -234,7 +234,7 @@ NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '60';
+NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -255,7 +255,7 @@ NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '60';
+NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -276,7 +276,7 @@ NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '60';
+NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx

--- a/src/test/regress/sql/shard_rebalancer.sql
+++ b/src/test/regress/sql/shard_rebalancer.sql
@@ -97,7 +97,7 @@ SELECT pg_reload_conf();
 SELECT pg_sleep(.1); -- wait to make sure the config has changed before running the GUC
 
 -- replicate reference table should ignore the coordinator
-SET citus.node_connection_timeout to 60;
+SET citus.node_connection_timeout to '35s';
 BEGIN;
     SET LOCAL citus.shard_replication_factor TO 2;
     SET citus.log_remote_commands TO ON;


### PR DESCRIPTION
In CI shard_rebalancer sometimes fails with this error:

```diff
SET citus.node_connection_timeout to 60;
 BEGIN;
     SET LOCAL citus.shard_replication_factor TO 2;
     SET citus.log_remote_commands TO ON;
     SET SESSION citus.max_adaptive_executor_pool_size TO 5;
     SELECT replicate_table_shards('dist_table_test_2',  max_shard_copies := 4,  shard_transfer_mode:='block_writes');
+WARNING:  could not establish connection after 60 ms
```
Source https://app.circleci.com/pipelines/github/citusdata/citus/28128/workflows/38eeacc4-4191-4366-87ed-9a628414965a/jobs/847458?invite=true#step-107-21

This PR avoids this issue by increasing ```citus.node_connection_timeout``` to 35s. 