### PR TITLE
Not hardcode "false" in UpdateAutoConvertedForConnectedRelations

### DIFF
--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -641,7 +641,7 @@ UpdateAutoConvertedForConnectedRelations(List *relationIds, bool autoConverted)
 
 	foreach_oid(relid, relationIdList)
 	{
-		UpdatePgDistPartitionAutoConverted(relid, false);
+		UpdatePgDistPartitionAutoConverted(relid, autoConverted);
 	}
 }
 


### PR DESCRIPTION
This didn't cause any bugs since today we're always calling UpdateAutoConvertedForConnectedRelations with autoconverted=false, so we don't need to backport this to anywhere.
