### PR TITLE
Intial commit for CDC using Logical Replication

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -57,6 +57,7 @@
 #include "distributed/relation_access_tracking.h"
 #include "distributed/shared_library_init.h"
 #include "distributed/shard_utils.h"
+#include "distributed/replication_origin_session_utils.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/worker_transaction.h"
 #include "executor/spi.h"
@@ -402,7 +403,10 @@ UndistributeTable(TableConversionParameters *params)
 	params->conversionType = UNDISTRIBUTE_TABLE;
 	params->shardCountIsNull = true;
 	TableConversionState *con = CreateTableConversion(params);
-	return ConvertTable(con);
+	ReplicationOriginSessionSetup(NULL);
+	TableConversionReturn *conv = ConvertTable(con);
+	ReplicationOriginSessionReset(NULL);
+	return conv;
 }
 
 
@@ -441,7 +445,11 @@ AlterDistributedTable(TableConversionParameters *params)
 		ereport(DEBUG1, (errmsg("setting multi shard modify mode to sequential")));
 		SetLocalMultiShardModifyModeToSequential();
 	}
-	return ConvertTable(con);
+	ReplicationOriginSessionSetup(NULL);
+	TableConversionReturn *conv = ConvertTable(con);
+	ReplicationOriginSessionReset(NULL);
+
+	return conv;
 }
 
 

--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -403,9 +403,9 @@ UndistributeTable(TableConversionParameters *params)
 	params->conversionType = UNDISTRIBUTE_TABLE;
 	params->shardCountIsNull = true;
 	TableConversionState *con = CreateTableConversion(params);
-	ReplicationOriginSessionSetup(NULL);
+	SetupReplicationOriginLocalSession();
 	TableConversionReturn *conv = ConvertTable(con);
-	ReplicationOriginSessionReset(NULL);
+	ResetReplicationOriginLocalSession();
 	return conv;
 }
 
@@ -445,9 +445,9 @@ AlterDistributedTable(TableConversionParameters *params)
 		ereport(DEBUG1, (errmsg("setting multi shard modify mode to sequential")));
 		SetLocalMultiShardModifyModeToSequential();
 	}
-	ReplicationOriginSessionSetup(NULL);
+	SetupReplicationOriginLocalSession();
 	TableConversionReturn *conv = ConvertTable(con);
-	ReplicationOriginSessionReset(NULL);
+	ResetReplicationOriginLocalSession();
 
 	return conv;
 }

--- a/src/backend/distributed/commands/local_multi_copy.c
+++ b/src/backend/distributed/commands/local_multi_copy.c
@@ -36,6 +36,7 @@
 #include "distributed/local_multi_copy.h"
 #include "distributed/shard_utils.h"
 #include "distributed/version_compat.h"
+#include "distributed/replication_origin_session_utils.h"
 
 /* managed via GUC, default is 512 kB */
 int LocalCopyFlushThresholdByte = 512 * 1024;
@@ -206,6 +207,8 @@ DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStat
 	 */
 	LocalCopyBuffer = buffer;
 
+	SetupReplicationOriginLocalSession();
+
 	Oid shardOid = GetTableLocalShardOid(relationId, shardId);
 	Relation shard = table_open(shardOid, RowExclusiveLock);
 	ParseState *pState = make_parsestate(NULL);
@@ -219,6 +222,7 @@ DoLocalCopy(StringInfo buffer, Oid relationId, int64 shardId, CopyStmt *copyStat
 	EndCopyFrom(cstate);
 
 	table_close(shard, NoLock);
+	ResetReplicationOriginLocalSession();
 	free_parsestate(pState);
 }
 

--- a/src/backend/distributed/executor/partitioned_intermediate_results.c
+++ b/src/backend/distributed/executor/partitioned_intermediate_results.c
@@ -26,6 +26,7 @@
 #include "distributed/multi_executor.h"
 #include "distributed/pg_dist_shard.h"
 #include "distributed/remote_commands.h"
+#include "distributed/replication_origin_session_utils.h"
 #include "distributed/tuplestore.h"
 #include "distributed/utils/array_type.h"
 #include "distributed/utils/function.h"
@@ -539,6 +540,12 @@ PartitionedResultDestReceiverShutdown(DestReceiver *dest)
 	{
 		DestReceiver *partitionDest = self->partitionDestReceivers[i];
 		partitionDest->rShutdown(partitionDest);
+	}
+	i = -1;
+	while ((i = bms_next_member(self->startedDestReceivers, i)) >= 0)
+	{
+		DestReceiver *partitionDest = self->partitionDestReceivers[i];
+		partitionDest->rDestroy(partitionDest);
 	}
 
 	/* empty the set of started receivers which allows them to be restarted again */

--- a/src/backend/distributed/operations/worker_shard_copy.c
+++ b/src/backend/distributed/operations/worker_shard_copy.c
@@ -288,6 +288,9 @@ ShardCopyDestReceiverStartup(DestReceiver *dest, int operation, TupleDesc
 }
 
 
+/* CreateReplicationOriginIfNotExists creates a replication origin if it does
+ * not already exist already. To make the origin id unique for different nodes,
+ * origin node's id is appended to the prefix citus_cdc_.*/
 static void
 CreateReplicationOriginIfNotExists(ShardCopyDestReceiver *dest)
 {

--- a/src/backend/distributed/operations/worker_shard_copy.c
+++ b/src/backend/distributed/operations/worker_shard_copy.c
@@ -103,11 +103,14 @@ CanUseLocalCopy(uint32_t destinationNodeId)
 	return GetLocalNodeId() == (int32) destinationNodeId;
 }
 
+
 /*
  * SetupReplicationOriginSessionIfNotSetupAlready sets up the replication origin session
  * if it is not already setup.
  */
- static void SetupReplicationOriginSessionIfNotSetupAlready(MultiConnection *connection) {
+static void
+SetupReplicationOriginSessionIfNotSetupAlready(MultiConnection *connection)
+{
 	/* Setup replication Origin if not setup already */
 	if (!SendRemoteCommand(connection, CDC_REPLICATION_ORIGIN_SESION_SETUP_CMD))
 	{
@@ -116,17 +119,21 @@ CanUseLocalCopy(uint32_t destinationNodeId)
 	ForgetResults(connection);
 }
 
+
 /*
  * ResetReplicationOriginSessionIfSetupAlready resets the replication origin session
  * if it has been setup currently.
  */
-static void ResetReplicationOriginSessionIfSetupAlready(MultiConnection *connection) {
+static void
+ResetReplicationOriginSessionIfSetupAlready(MultiConnection *connection)
+{
 	if (!SendRemoteCommand(connection, CDC_REPLICATION_ORIGIN_SESION_RESET_CMD))
 	{
 		ReportConnectionError(connection, ERROR);
 	}
 	ForgetResults(connection);
 }
+
 
 /* Connect to node with source shard and trigger copy start.  */
 static void
@@ -143,8 +150,8 @@ ConnectToRemoteAndStartCopy(ShardCopyDestReceiver *copyDest)
 														 NULL /* database (current) */);
 	ClaimConnectionExclusively(copyDest->connection);
 
-	/* Setup Replication Origin Session if not setup already for 
-	avoiding publication of events more than once. */
+	/* Setup Replication Origin Session if not setup already for
+	 * avoiding publication of events more than once. */
 	SetupReplicationOriginSessionIfNotSetupAlready(copyDest->connection);
 
 	StringInfo copyStatement = ConstructShardCopyStatement(

--- a/src/backend/distributed/shardsplit/shardsplit_decoder.c
+++ b/src/backend/distributed/shardsplit/shardsplit_decoder.c
@@ -40,10 +40,11 @@ static Oid FindTargetRelationOid(Relation sourceShardRelation,
 static HeapTuple GetTupleForTargetSchema(HeapTuple sourceRelationTuple,
 										 TupleDesc sourceTupleDesc,
 										 TupleDesc targetTupleDesc);
-static bool replication_origin_filter_cb(LogicalDecodingContext *ctx, RepOriginId origin_id);
+static bool replication_origin_filter_cb(LogicalDecodingContext *ctx, RepOriginId
+										 origin_id);
 
 static bool PublishChangesIfCdcSlot(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
-						Relation relation, ReorderBufferChange *change);
+									Relation relation, ReorderBufferChange *change);
 
 /* used in the replication_origin_filter_cb function. */
 #define InvalidRepOriginId 0
@@ -84,7 +85,7 @@ _PG_output_plugin_init(OutputPluginCallbacks *cb)
  * identified by the "origin_id" of the changes. The origin_id is set to
  * a non-zero value in the origin node as part of WAL replication.
  */
- static bool
+static bool
 replication_origin_filter_cb(LogicalDecodingContext *ctx, RepOriginId origin_id)
 {
 	if (origin_id != InvalidRepOriginId)
@@ -94,25 +95,29 @@ replication_origin_filter_cb(LogicalDecodingContext *ctx, RepOriginId origin_id)
 	return false;
 }
 
-/* 
+
+/*
  * PublishChangesIfCdcSlot checks if the current slot is a CDC slot. If so, it publishes
- * the changes as the change for the distributed table instead of shard. 
+ * the changes as the change for the distributed table instead of shard.
  * If not, it returns false. It also skips the Citus metadata tables.
  */
 static bool
 PublishChangesIfCdcSlot(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
-				   Relation relation, ReorderBufferChange *change)
+						Relation relation, ReorderBufferChange *change)
 {
 	char *replicationSlotName = ctx->slot->data.name.data;
+
 	/* Check if the replication slot is CITUS_CDC_SLOT*/
-	if (replicationSlotName != NULL && strcmp(replicationSlotName, CITUS_CDC_SLOT_NAME) == 0)
+	if (replicationSlotName != NULL && strcmp(replicationSlotName, CITUS_CDC_SLOT_NAME) ==
+		0)
 	{
 		/* Skip publishing changes for Citus metadata tables*/
-		ObjectAddress objectAdress = {RelationRelationId, relation->rd_id, 0};
-		if (IsObjectAddressOwnedByCitus(&objectAdress))    
+		ObjectAddress objectAdress = { RelationRelationId, relation->rd_id, 0 };
+		if (IsObjectAddressOwnedByCitus(&objectAdress))
 		{
 			return true;
-		}   
+		}
+
 		/* Check if this change is for a shard in distributed table. */
 		if (RelationIsAKnownShard(relation->rd_id))
 		{
@@ -130,7 +135,7 @@ PublishChangesIfCdcSlot(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		}
 		pgoutputChangeCB(ctx, txn, relation, change);
 		return true;
-	} 
+	}
 	return false;
 }
 

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -34,6 +34,7 @@
 #include "distributed/multi_logical_replication.h"
 #include "distributed/multi_explain.h"
 #include "distributed/repartition_join_execution.h"
+#include "distributed/replication_origin_session_utils.h"
 #include "distributed/transaction_management.h"
 #include "distributed/placement_connection.h"
 #include "distributed/relation_access_tracking.h"
@@ -381,6 +382,9 @@ CoordinatedTransactionCallback(XactEvent event, void *arg)
 			ResetGlobalVariables();
 			ResetRelationAccessHash();
 
+			/* Reset any local replication origin session since transaction has been aborted.*/
+			ResetReplicationOriginLocalSession();
+
 			/*
 			 * Clear MetadataCache table if we're aborting from a CREATE EXTENSION Citus
 			 * so that any created OIDs from the table are cleared and invalidated. We
@@ -684,6 +688,9 @@ CoordinatedSubTransactionCallback(SubXactEvent event, SubTransactionId subId,
 				InvalidateMetadataSystemCache();
 				SetCreateCitusTransactionLevel(0);
 			}
+
+			/* Reset any local replication origin session since subtransaction has been aborted.*/
+			ResetReplicationOriginLocalSession();
 			break;
 		}
 

--- a/src/backend/distributed/utils/replication_origin_session_utils.c
+++ b/src/backend/distributed/utils/replication_origin_session_utils.c
@@ -1,0 +1,222 @@
+/*-------------------------------------------------------------------------
+ *
+ * replication_origin_session_utils.c
+ *   Functions for managing replication origin session.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "distributed/replication_origin_session_utils.h"
+#include "distributed/remote_commands.h"
+#include "distributed/metadata_cache.h"
+
+static bool isReplicationOriginSessionSetup(MultiConnection *connection);
+static bool isReplicationOriginCreated(MultiConnection *connection, char *originName,
+									   RepOriginId *originId);
+static RepOriginId ReplicationOriginSessionCreate(MultiConnection *connection,
+												  char *originName);
+static void ReplicationOriginSessionSetupHelper(MultiConnection *connection,
+												RepOriginId originId, char *originName);
+static bool ExecuteRemoteCommandAndCheckResult(MultiConnection *connection, char *command,
+											   char *expected);
+
+/* ReplicationOriginSessionSetup sets up a new replication origin session in a
+ * local or remote session depending on the useLocalCopy flag. If useLocalCopy
+ * is set, a local replication origin session is setup, otherwise a remote
+ * replication origin session is setup to the destination node.
+ */
+void
+ReplicationOriginSessionSetup(MultiConnection *connection)
+{
+	if (!isReplicationOriginSessionSetup(connection))
+	{
+		int localid = GetLocalNodeId();
+		RepOriginId originId = InvalidRepOriginId;
+		StringInfo originNameString = makeStringInfo();
+		appendStringInfo(originNameString, "citus_internal_%d", localid);
+		if (!isReplicationOriginCreated(connection, originNameString->data, &originId))
+		{
+			originId = ReplicationOriginSessionCreate(connection, originNameString->data);
+		}
+		ReplicationOriginSessionSetupHelper(connection, originId, originNameString->data);
+	}
+}
+
+
+/* ReplicationOriginSessionReset resets the replication origin session in a
+ * local or remote session depending on the useLocalCopy flag.
+ */
+void
+ReplicationOriginSessionReset(MultiConnection *connection)
+{
+	if (connection == NULL)
+	{
+		/*Reset Replication Origin in local session */
+		if (replorigin_session_origin != InvalidRepOriginId)
+		{
+			replorigin_session_reset();
+			replorigin_session_origin = InvalidRepOriginId;
+		}
+	}
+	else
+	{
+		/*Reset Replication Origin in remote session */
+		StringInfo replicationOriginSessionResetQuery = makeStringInfo();
+		appendStringInfo(replicationOriginSessionResetQuery,
+						 "select pg_catalog.pg_replication_origin_session_reset()");
+		ExecuteCriticalRemoteCommand(connection,
+									 replicationOriginSessionResetQuery->data);
+	}
+}
+
+
+/* isReplicationOriginSessionSetup checks if the replication origin is setup
+ * already in the local or remote session.
+ */
+static bool
+isReplicationOriginSessionSetup(MultiConnection *connection)
+{
+	bool result = false;
+	if (connection == NULL)
+	{
+		return replorigin_session_origin != InvalidRepOriginId;
+	}
+	else
+	{
+		/*Setup Replication Origin in remote session */
+		StringInfo isReplicationOriginSessionSetupQuery = makeStringInfo();
+		appendStringInfo(isReplicationOriginSessionSetupQuery,
+						 "SELECT pg_catalog.pg_replication_origin_session_is_setup()");
+		result =
+			ExecuteRemoteCommandAndCheckResult(connection,
+											   isReplicationOriginSessionSetupQuery->data,
+											   "t");
+	}
+	return result;
+}
+
+
+/* isReplicationOriginCreated checks if the replication origin is created
+ * in the local or remote session.*/
+static bool
+isReplicationOriginCreated(MultiConnection *connection, char *originName,
+						   RepOriginId *originId)
+{
+	bool result = false;
+	if (connection == NULL)
+	{
+		*originId = replorigin_by_name(originName, true);
+		result = (*originId != InvalidRepOriginId);
+	}
+	else
+	{
+		/*Setup Replication Origin in remote session */
+		StringInfo isReplicationOriginSessionSetupQuery = makeStringInfo();
+		appendStringInfo(isReplicationOriginSessionSetupQuery,
+						 "SELECT pg_catalog.pg_replication_origin_oid('%s');",
+						 originName);
+
+		/* If the replication origin was already created the above command
+		 * will return the id of the entry in pg_replication_origin table.
+		 * So to check if the entry is there alreay, the retuen value should
+		 * be non-empty and the condition below checks that. */
+		result = !ExecuteRemoteCommandAndCheckResult(connection,
+													 isReplicationOriginSessionSetupQuery
+													 ->data, "");
+	}
+	return result;
+}
+
+
+/* ReplicationOriginSessionCreate creates a new replication origin if it does
+ * not already exist already. To make the replication origin name unique
+ * for different nodes, origin node's id is appended to the prefix citus_internal_.*/
+static RepOriginId
+ReplicationOriginSessionCreate(MultiConnection *connection, char *originName)
+{
+	RepOriginId originId = InvalidRepOriginId;
+	if (connection == NULL)
+	{
+		originId = replorigin_create(originName);
+	}
+	else
+	{
+		StringInfo replicationOriginCreateQuery = makeStringInfo();
+		appendStringInfo(replicationOriginCreateQuery,
+						 "select pg_catalog.pg_replication_origin_create('%s')",
+						 originName);
+		ExecuteCriticalRemoteCommand(connection, replicationOriginCreateQuery->data);
+	}
+	return originId;
+}
+
+
+/* ReplicationOriginSessionSetupHelper sets up a new replication origin session in a
+ * local or remote session depending on the useLocalCopy flag. If useLocalCopy
+ * is set, a local replication origin session is setup, otherwise a remote
+ * replication origin session is setup to the destination node.
+ */
+static void
+ReplicationOriginSessionSetupHelper(MultiConnection *connection,
+									RepOriginId originId, char *originName)
+{
+	if (connection == NULL)
+	{
+		/*Setup Replication Origin in local session */
+		replorigin_session_setup(originId);
+		replorigin_session_origin = originId;
+	}
+	else
+	{
+		/*Setup Replication Origin in remote session */
+		StringInfo replicationOriginSessionSetupQuery = makeStringInfo();
+		appendStringInfo(replicationOriginSessionSetupQuery,
+						 "select pg_catalog.pg_replication_origin_session_setup('%s')",
+						 originName);
+		ExecuteCriticalRemoteCommand(connection,
+									 replicationOriginSessionSetupQuery->data);
+	}
+}
+
+
+/* ExecuteRemoteCommandAndCheckResult executes the given command in the remote node and
+ * checks if the result is equal to the expected result. If the result is equal to the
+ * expected result, the function returns true, otherwise it returns false.
+ */
+static bool
+ExecuteRemoteCommandAndCheckResult(MultiConnection *connection, char *command,
+								   char *expected)
+{
+	if (!SendRemoteCommand(connection, command))
+	{
+		/* if we cannot connect, we warn and report false */
+		ReportConnectionError(connection, WARNING);
+		return false;
+	}
+	bool raiseInterrupts = true;
+	PGresult *queryResult = GetRemoteCommandResult(connection, raiseInterrupts);
+
+	/* if remote node throws an error, we also throw an error */
+	if (!IsResponseOK(queryResult))
+	{
+		ReportResultError(connection, queryResult, ERROR);
+	}
+
+	StringInfo queryResultString = makeStringInfo();
+
+	/* Evaluate the queryResult and store it into the queryResultString */
+	bool success = EvaluateSingleQueryResult(connection, queryResult, queryResultString);
+	bool result = false;
+	if (success && strcmp(queryResultString->data, expected) == 0)
+	{
+		result = true;
+	}
+
+	PQclear(queryResult);
+	bool raiseErrors = false;
+	ClearResults(connection, raiseErrors);
+
+	return result;
+}

--- a/src/include/distributed/replication_origin_session_utils.h
+++ b/src/include/distributed/replication_origin_session_utils.h
@@ -15,8 +15,11 @@
 #include "replication/origin.h"
 #include "distributed/connection_management.h"
 
-void ReplicationOriginSessionSetup(MultiConnection *connection);
-void ReplicationOriginSessionReset(MultiConnection *connection);
+void SetupReplicationOriginRemoteSession(MultiConnection *connection, char *identifier);
+void ResetReplicationOriginRemoteSession(MultiConnection *connection, char *identifier);
+
+void SetupReplicationOriginLocalSession(void);
+void ResetReplicationOriginLocalSession(void);
 
 
 #endif /* REPLICATION_ORIGIN_SESSION_UTILS_H */

--- a/src/include/distributed/replication_origin_session_utils.h
+++ b/src/include/distributed/replication_origin_session_utils.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * replication_origin_utils.h
+ *   Utilities related to replication origin.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef REPLICATION_ORIGIN_SESSION_UTILS_H
+#define REPLICATION_ORIGIN_SESSION_UTILS_H
+
+#include "postgres.h"
+#include "replication/origin.h"
+#include "distributed/connection_management.h"
+
+void ReplicationOriginSessionSetup(MultiConnection *connection);
+void ReplicationOriginSessionReset(MultiConnection *connection);
+
+
+#endif /* REPLICATION_ORIGIN_SESSION_UTILS_H */


### PR DESCRIPTION
DESCRIPTION: Skip changes by internal data moves in citus output plug-in
DESCRIPTION: Map shard to distributed table IDs in citus output plug-in

This is for implementing CDC using Logical replication so that changes to distributed table are published only once  for shard move/split and other metadata operations.

TODO:
- [ ] Translate tuples in case of dropped columns in decoder
- [ ] Add tests
- [ ] Handle other data transfers: alter_distributed_table, undistribute_table, create_distributed_table (could be a separate PR)
