### PR TITLE
Add missing space to citus.shard_count description

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2113,7 +2113,7 @@ RegisterCitusConfigVariables(void)
 
 	DefineCustomIntVariable(
 		"citus.shard_count",
-		gettext_noop("Sets the number of shards for a new hash-partitioned table"
+		gettext_noop("Sets the number of shards for a new hash-partitioned table "
 					 "created with create_distributed_table()."),
 		NULL,
 		&ShardCount,


### PR DESCRIPTION
DESCRIPTION: Add missing space to citus.shard_count description
