### PR TITLE
Allow citus_update_node() to work with nodes from different clusters

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -1420,7 +1420,7 @@ citus_update_node(PG_FUNCTION_ARGS)
 	UpdateNodeLocation(nodeId, newNodeNameString, newNodePort);
 
 	/* we should be able to find the new node from the metadata */
-	workerNode = FindWorkerNode(newNodeNameString, newNodePort);
+	workerNode = FindWorkerNodeAnyCluster(newNodeNameString, newNodePort);
 	Assert(workerNode->nodeId == nodeId);
 
 	/*

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -969,10 +969,34 @@ SELECT citus_update_node(:worker_1_node, 'localhost', 9991);
 
 (1 row)
 
+SELECT citus_nodename_for_nodeid(:worker_1_node);
+ citus_nodename_for_nodeid
+---------------------------------------------------------------------
+ localhost
+(1 row)
+
+SELECT citus_nodeport_for_nodeid(:worker_1_node);
+ citus_nodeport_for_nodeid
+---------------------------------------------------------------------
+                      9991
+(1 row)
+
 SELECT citus_update_node(:worker_1_node, 'localhost', 9992);
  citus_update_node
 ---------------------------------------------------------------------
 
+(1 row)
+
+SELECT citus_nodename_for_nodeid(:worker_1_node);
+ citus_nodename_for_nodeid
+---------------------------------------------------------------------
+ localhost
+(1 row)
+
+SELECT citus_nodeport_for_nodeid(:worker_1_node);
+ citus_nodeport_for_nodeid
+---------------------------------------------------------------------
+                      9992
 (1 row)
 
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -961,6 +961,20 @@ SELECT master_add_secondary_node('localhost', 9992, 'localhost', :worker_1_port,
                         29
 (1 row)
 
+SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=9992 \gset
+-- citus_update_node allows updating a node from the non-default cluster
+SELECT citus_update_node(:worker_1_node, 'localhost', 9991);
+ citus_update_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT citus_update_node(:worker_1_node, 'localhost', 9992);
+ citus_update_node
+---------------------------------------------------------------------
+
+(1 row)
+
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
 -- master_update_node checks node exists
 SELECT master_update_node(100, 'localhost', 8000);

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -372,6 +372,13 @@ SELECT master_add_secondary_node('localhost', 9994, primaryname => 'localhost', 
 SELECT master_add_secondary_node('localhost', 9993, 'localhost', 2000);
 SELECT master_add_secondary_node('localhost', 9992, 'localhost', :worker_1_port, nodecluster => 'second-cluster');
 
+SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=9992 \gset
+
+-- citus_update_node allows updating a node from the non-default cluster
+SELECT citus_update_node(:worker_1_node, 'localhost', 9991);
+SELECT citus_update_node(:worker_1_node, 'localhost', 9992);
+
+
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
 
 -- master_update_node checks node exists

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -376,7 +376,11 @@ SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=9992 \gset
 
 -- citus_update_node allows updating a node from the non-default cluster
 SELECT citus_update_node(:worker_1_node, 'localhost', 9991);
+SELECT citus_nodename_for_nodeid(:worker_1_node);
+SELECT citus_nodeport_for_nodeid(:worker_1_node);
 SELECT citus_update_node(:worker_1_node, 'localhost', 9992);
+SELECT citus_nodename_for_nodeid(:worker_1_node);
+SELECT citus_nodeport_for_nodeid(:worker_1_node);
 
 
 SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset


### PR DESCRIPTION
DESCRIPTION: Allow citus_update_node() to work with nodes from different clusters

citus_update_node(), citus_nodename_for_nodeid(), and citus_nodeport_for_nodeid() functions only checked for nodes in their own clusters and hence last two returned NULLs and the first one showed an error is the nodeId was from a different cluster.

Fixes https://github.com/citusdata/citus/issues/6433