### PR TITLE
Add changelog entries for 11.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+### citus v11.0.7 (November 8, 2022) ###
+* Adds the GUC `citus.allow_unsafe_constraints` to allow unique/exclusion/
+  primary key constraints without distribution column
+
+* Allows `citus_internal` `application_name` with additional suffix
+
+* Disallows having `ON DELETE/UPDATE SET DEFAULT` actions on columns that
+  default to sequences
+
+* Fixes a bug in `ALTER EXTENSION citus UPDATE`
+
+* Fixes a bug that causes a crash with empty/null password
+
+* Fixes a bug that causes not retaining trigger enable/disable settings when
+  re-creating them on shards
+
+* Fixes a bug that might cause inserting incorrect `DEFAULT` values when
+  applying foreign key actions
+
+* Fixes a bug that prevents retaining columnar table options after a
+  table-rewrite
+
+* Fixes a bug that prevents setting colocation group of a partitioned
+  distributed table to `none`
+
+* Fixes an issue that can cause logical reference table replication to fail
+
+* Raises memory limits in columnar from 256MB to 1GB for reads and writes
+
 ### citus v11.1.4 (October 24, 2022) ###
 
 * Fixes an upgrade problem for `worker_fetch_foreign_file` when upgrade path


### PR DESCRIPTION
There are 3 discussions that needs to be resolved before we merge this changelog PR:
- [x] https://github.com/citusdata/citus/pull/6262 is missing a changelog entry. Author Naisila and I are ok with skipping an entry for that one.
- [x] https://github.com/citusdata/citus/pull/6282 from @marcocitus made its way to 11.1.0 but it is missing an entry for that version. However we added that here.
- [x] #6387 is missing an entry and the author Naisila is ok with it because it is an implementation detail that is hard to express in a single line.