### PR TITLE
Remove the explicit-transaction requirement for the UDF citus_get_tra…

### DIFF
--- a/src/backend/distributed/clock/causal_clock.c
+++ b/src/backend/distributed/clock/causal_clock.c
@@ -415,8 +415,6 @@ PrepareAndSetTransactionClock(void)
 		return NULL;
 	}
 
-	RequireTransactionBlock(true, "citus_get_transaction_clock");
-
 	dlist_iter iter;
 	List *transactionNodeList = NIL;
 	List *nodeList = NIL;

--- a/src/test/regress/expected/clock.out
+++ b/src/test/regress/expected/clock.out
@@ -259,9 +259,6 @@ SELECT ABS(:epoch - cluster_clock_logical(:'latest_clock')) < 25;
  t
 (1 row)
 
--- This should fail as there is no explicit transaction
-SELECT citus_get_transaction_clock();
-ERROR:  citus_get_transaction_clock can only be used in transaction blocks
 BEGIN;
 SELECT citus_get_transaction_clock();
  citus_get_transaction_clock

--- a/src/test/regress/sql/clock.sql
+++ b/src/test/regress/sql/clock.sql
@@ -101,9 +101,6 @@ SELECT (extract(epoch from now()) * 1000)::bigint AS epoch,
 -- Returns true
 SELECT ABS(:epoch - cluster_clock_logical(:'latest_clock')) < 25;
 
--- This should fail as there is no explicit transaction
-SELECT citus_get_transaction_clock();
-
 BEGIN;
 SELECT citus_get_transaction_clock();
 END;


### PR DESCRIPTION
Remove the explicit-transaction requirement for the UDF citus_get_transaction_clock() as implicit transactions too use (via pre-commit hooks) this UDF.

