### PR TITLE
Propagate BEGIN properties to worker nodes

### DIFF
--- a/src/backend/distributed/commands/begin.c
+++ b/src/backend/distributed/commands/begin.c
@@ -1,0 +1,61 @@
+/*-------------------------------------------------------------------------
+ *
+ * begin.c
+ *    Processing of the BEGIN command.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "c.h"
+
+#include "distributed/commands.h"
+#include "distributed/listutils.h"
+#include "distributed/transaction_management.h"
+#include "nodes/parsenodes.h"
+
+
+/*
+ * SaveBeginCommandProperties stores the transaction properties passed
+ * via BEGIN.
+ */
+void
+SaveBeginCommandProperties(TransactionStmt *transactionStmt)
+{
+	DefElem *item = NULL;
+
+	/*
+	 * This loop is similar to the one in standard_ProcessUtility.
+	 *
+	 * While BEGIN can be quite frequent it will rarely have options set.
+	 */
+	foreach_ptr(item, transactionStmt->options)
+	{
+		A_Const *constant = (A_Const *) item->arg;
+
+		if (strcmp(item->defname, "transaction_read_only") == 0)
+		{
+			if (intVal(&constant->val) == 1)
+			{
+				BeginXactReadOnly = BeginXactReadOnly_Enabled;
+			}
+			else
+			{
+				BeginXactReadOnly = BeginXactReadOnly_Disabled;
+			}
+		}
+		else if (strcmp(item->defname, "transaction_deferrable") == 0)
+		{
+			if (intVal(&constant->val) == 1)
+			{
+				BeginXactDeferrable = BeginXactDeferrable_Enabled;
+			}
+			else
+			{
+				BeginXactDeferrable = BeginXactDeferrable_Disabled;
+			}
+		}
+	}
+}

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -125,6 +125,13 @@ bool FunctionOpensTransactionBlock = true;
 /* if true, we should trigger node metadata sync on commit */
 bool NodeMetadataSyncOnCommit = false;
 
+/*
+ * In an explicit BEGIN ...; we keep track of top-level transaction characteristics
+ * specified by the user.
+ */
+BeginXactReadOnlyState BeginXactReadOnly = BeginXactReadOnly_NotSet;
+BeginXactDeferrableState BeginXactDeferrable = BeginXactDeferrable_NotSet;
+
 
 /* transaction management functions */
 static void CoordinatedTransactionCallback(XactEvent event, void *arg);
@@ -608,6 +615,8 @@ ResetGlobalVariables()
 	InTopLevelDelegatedFunctionCall = false;
 	InTableTypeConversionFunctionCall = false;
 	CurrentOperationId = INVALID_OPERATION_ID;
+	BeginXactReadOnly = BeginXactReadOnly_NotSet;
+	BeginXactDeferrable = BeginXactDeferrable_NotSet;
 	ResetWorkerErrorIndication();
 	memset(&AllowedDistributionColumnValue, 0,
 		   sizeof(AllowedDistributionColumn));

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -153,6 +153,8 @@ typedef enum SearchForeignKeyColumnFlags
 	/* callers can also pass union of above flags */
 } SearchForeignKeyColumnFlags;
 
+/* begin.c - forward declarations */
+extern void SaveBeginCommandProperties(TransactionStmt *transactionStmt);
 
 /* cluster.c - forward declarations */
 extern List * PreprocessClusterStmt(Node *node, const char *clusterCommand,

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -9,6 +9,7 @@
 #ifndef TRANSACTION_MANAGMENT_H
 #define TRANSACTION_MANAGMENT_H
 
+#include "access/xact.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
@@ -76,6 +77,28 @@ typedef struct AllowedDistributionColumn
 } AllowedDistributionColumn;
 
 /*
+ * BeginXactDeferrableState reflects the value of the DEFERRABLE property
+ * in the BEGIN of a transaction block.
+ */
+typedef enum BeginXactDeferrableState
+{
+	BeginXactDeferrable_NotSet,
+	BeginXactDeferrable_Disabled,
+	BeginXactDeferrable_Enabled,
+} BeginXactDeferrableState;
+
+/*
+ * BeginXactReadOnlyState reflects the value of the READ ONLY property
+ * in the BEGIN of a transaction block.
+ */
+typedef enum BeginXactReadOnlyState
+{
+	BeginXactReadOnly_NotSet,
+	BeginXactReadOnly_Disabled,
+	BeginXactReadOnly_Enabled,
+} BeginXactReadOnlyState;
+
+/*
  * The current distribution column value passed as an argument to a forced
  * function call delegation.
  */
@@ -118,6 +141,10 @@ extern StringInfo activeSetStmts;
 
 /* did current transaction modify pg_dist_node? */
 extern bool TransactionModifiedNodeMetadata;
+
+/* after an explicit BEGIN, keep track of top-level transaction characteristics */
+extern BeginXactReadOnlyState BeginXactReadOnly;
+extern BeginXactDeferrableState BeginXactDeferrable;
 
 /*
  * Coordinated transaction management.

--- a/src/test/regress/expected/propagate_set_commands.out
+++ b/src/test/regress/expected/propagate_set_commands.out
@@ -31,6 +31,142 @@ SET TRANSACTION READ ONLY;
 INSERT INTO test VALUES (2,2);
 ERROR:  cannot execute INSERT in a read-only transaction
 END;
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+-- should reflect isolation level of current transaction
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ read committed
+(1 row)
+
+END;
+START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+-- should reflect isolation level of current transaction
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+-- should reflect isolation level of current transaction
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ serializable
+(1 row)
+
+END;
+BEGIN READ ONLY;
+-- should reflect read-only status of current transaction
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+END;
+BEGIN READ WRITE;
+-- should reflect read-only status of current transaction
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ off
+(1 row)
+
+SET TRANSACTION READ ONLY;
+-- should reflect writable status of current transaction
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+END;
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE DEFERRABLE;
+-- should reflect deferrable status of the current transaction
+SELECT current_setting('transaction_deferrable') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+END;
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE DEFERRABLE READ ONLY;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+SELECT current_setting('transaction_deferrable') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+END;
+-- postgres warns against, but does not disallow multiple BEGIN
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+WARNING:  there is already a transaction in progress
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ read committed
+(1 row)
+
+-- but not after a query (SET TRANSACTION error is consistent with postgres)
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+WARNING:  there is already a transaction in progress
+ERROR:  SET TRANSACTION ISOLATION LEVEL must be called before any query
+END;
+BEGIN READ WRITE;
+SAVEPOINT goback;
+SET TRANSACTION READ ONLY;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ on
+(1 row)
+
+ROLLBACK TO SAVEPOINT goback;
+SELECT current_setting('transaction_read_only') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ off
+(1 row)
+
+END;
+SET default_transaction_isolation TO 'repeatable read';
+BEGIN;
+-- should reflect isolation level of local session
+SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
+ current_setting
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+END;
+-- SET is not propagated and plain SELECT does not use transaction blocks
+SELECT DISTINCT current_setting('transaction_isolation') FROM test;
+ current_setting
+---------------------------------------------------------------------
+ read committed
+(1 row)
+
+-- the CTE will trigger transaction blocks
+WITH cte AS MATERIALIZED (
+  SELECT DISTINCT current_setting('transaction_isolation') iso FROM test
+)
+SELECT iso FROM cte;
+       iso
+---------------------------------------------------------------------
+ repeatable read
+(1 row)
+
+RESET default_transaction_isolation;
 BEGIN;
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 -- should reflect new isolation level


### PR DESCRIPTION
DESCRIPTION: Propagate BEGIN properties to worker nodes

This PR aims to bring some more sanity to the way we propagate transaction properties to worker nodes. We currently always send `BEGIN TRANSACTION ISOLATION READ COMMITTED` to worker nodes even if the user asks for repeatable read or serializable. While we clearly do not provide comprehensive repeatable read / serializable semantics, regressing to not-quite-read-committed seems no better and by propagating the level our semantics will be mostly correct for workloads without multi-shard queries (e.g. multi-tenant). 

In addition, we added SET TRANSACTION propagation in #4945, which means users actually can set the isolation leven, read-only, and deferrable properties in the transaction by using `SET TRANSACTION`. However, it is weird and unexpected that `SET TRANSACTION READ ONLY` works while `BEGIN TRANSACTION READ ONLY` does not. After this PR, both work.

A slight challenge with the read-only behaviour is that it can be changed by subtransactions if the outer transaction is read-write. Therefore, we cannot simply look at the current `XactReadOnly`, which might reflect the value within the subtransaction that was set using `SET TRANSACTION`. We cannot easily know the original value, since it is captured in the GUC stack. We therefore add a small hook to capture explicit `BEGIN` properties from the utility hook.