### PR TITLE
Improve GUC settings propagation to new connections.

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -1261,7 +1261,8 @@ IsSettingSafeToPropagate(const char *name)
 		"citus.propagate_set_commands",
 		"client_encoding",
 		"exit_on_error",
-		"max_stack_depth"
+		"max_stack_depth",
+		"citus.next_shard_id"
 	};
 
 	for (Index settingIndex = 0; settingIndex < lengthof(skipSettings); settingIndex++)

--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -260,7 +260,6 @@ static void AddToWorkerShardIdSet(HTAB *shardsByWorker, char *workerName, int wo
 								  uint64 shardId);
 static HTAB * BuildShardSizesHash(ProgressMonitorData *monitor, HTAB *shardStatistics);
 static void ErrorOnConcurrentRebalance(RebalanceOptions *);
-static List * GetSetCommandListForNewConnections(void);
 
 /* declarations for dynamic loading */
 PG_FUNCTION_INFO_V1(rebalance_table_shards);
@@ -278,7 +277,6 @@ PG_FUNCTION_INFO_V1(citus_rebalance_wait);
 
 bool RunningUnderIsolationTest = false;
 int MaxRebalancerLoggedIgnoredMoves = 5;
-bool PropagateSessionSettingsForLoopbackConnection = false;
 
 static const char *PlacementUpdateTypeNames[] = {
 	[PLACEMENT_UPDATE_INVALID_FIRST] = "unknown",
@@ -2087,49 +2085,9 @@ ExecuteRebalancerCommandInSeparateTransaction(char *command)
 
 	commandList = lappend(commandList, psprintf("SET LOCAL application_name TO %s;",
 												CITUS_REBALANCER_NAME));
-
-	if (PropagateSessionSettingsForLoopbackConnection)
-	{
-		List *setCommands = GetSetCommandListForNewConnections();
-		char *setCommand = NULL;
-
-		foreach_ptr(setCommand, setCommands)
-		{
-			commandList = lappend(commandList, setCommand);
-		}
-	}
-
 	commandList = lappend(commandList, command);
-
 	SendCommandListToWorkerOutsideTransactionWithConnection(connection, commandList);
 	CloseConnection(connection);
-}
-
-
-/*
- * GetSetCommandListForNewConnections returns a list of SET statements to
- * be executed in new connections to worker nodes.
- */
-static List *
-GetSetCommandListForNewConnections(void)
-{
-	List *commandList = NIL;
-
-	struct config_generic **guc_vars = get_guc_variables();
-	int gucCount = GetNumConfigOptions();
-
-	for (int gucIndex = 0; gucIndex < gucCount; gucIndex++)
-	{
-		struct config_generic *var = (struct config_generic *) guc_vars[gucIndex];
-		if (var->source == PGC_S_SESSION && IsSettingSafeToPropagate(var->name))
-		{
-			const char *variableValue = GetConfigOption(var->name, true, true);
-			commandList = lappend(commandList, psprintf("SET LOCAL %s TO '%s';",
-														var->name, variableValue));
-		}
-	}
-
-	return commandList;
 }
 
 

--- a/src/include/distributed/shard_rebalancer.h
+++ b/src/include/distributed/shard_rebalancer.h
@@ -189,7 +189,6 @@ typedef struct RebalancePlanFunctions
 extern char *VariablesToBePassedToNewConnections;
 extern int MaxRebalancerLoggedIgnoredMoves;
 extern bool RunningUnderIsolationTest;
-extern bool PropagateSessionSettingsForLoopbackConnection;
 
 /* External function declarations */
 extern Datum shard_placement_rebalance_array(PG_FUNCTION_ARGS);

--- a/src/include/distributed/worker_transaction.h
+++ b/src/include/distributed/worker_transaction.h
@@ -46,6 +46,7 @@ typedef enum TargetWorkerSet
 	METADATA_NODES
 } TargetWorkerSet;
 
+extern bool PropagateSessionSettingsForLoopbackConnection;
 
 /* Functions declarations for worker transactions */
 extern List * GetWorkerTransactions(void);

--- a/src/test/regress/expected/cpu_priority.out
+++ b/src/test/regress/expected/cpu_priority.out
@@ -141,7 +141,37 @@ SELECT pg_catalog.citus_split_shard_by_split_points(
     ARRAY['-1500000000'],
     ARRAY[:worker_1_node, :worker_2_node],
     'force_logical');
-NOTICE:  issuing CREATE SUBSCRIPTION citus_shard_split_subscription_xxxxxxx CONNECTION 'host=''localhost'' port=xxxxx user=''postgres'' dbname=''regression'' connect_timeout=20' PUBLICATION citus_shard_split_publication_xxxxxxx_xxxxxxx WITH (citus_use_authinfo=true, create_slot=false, copy_data=false, enabled=false, slot_name=citus_shard_split_slot_xxxxxxx_xxxxxxx)
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing CREATE SUBSCRIPTION citus_shard_split_subscription_xxxxxxx CONNECTION 'host=''localhost'' port=xxxxx user=''postgres'' dbname=''regression'' connect_timeout=20' PUBLICATION citus_shard_split_publication_xxxxxxx_xxxxxxx WITH (citus_use_authinfo=true, create_slot=false, copy_data=false, enabled=false, slot_name=citus_shard_split_slot_xxxxxxx_xxxxxxx)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -156,6 +186,24 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing CREATE SUBSCRIPTION citus_shard_split_subscription_xxxxxxx CONNECTION 'host=''localhost'' port=xxxxx user=''postgres'' dbname=''regression'' connect_timeout=20' PUBLICATION citus_shard_split_publication_xxxxxxx_xxxxxxx WITH (citus_use_authinfo=true, create_slot=false, copy_data=false, enabled=false, slot_name=citus_shard_split_slot_xxxxxxx_xxxxxxx)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing CREATE SUBSCRIPTION citus_shard_split_subscription_xxxxxxx CONNECTION 'host=''localhost'' port=xxxxx user=''postgres'' dbname=''regression'' connect_timeout=20' PUBLICATION citus_shard_split_publication_xxxxxxx_xxxxxxx WITH (citus_use_authinfo=true, create_slot=false, copy_data=false, enabled=false, slot_name=citus_shard_split_slot_xxxxxxx_xxxxxxx)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing CREATE SUBSCRIPTION citus_shard_split_subscription_xxxxxxx CONNECTION 'host=''localhost'' port=xxxxx user=''postgres'' dbname=''regression'' connect_timeout=20' PUBLICATION citus_shard_split_publication_xxxxxxx_xxxxxxx WITH (citus_use_authinfo=true, create_slot=false, copy_data=false, enabled=false, slot_name=citus_shard_split_slot_xxxxxxx_xxxxxxx)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL citus.grep_remote_commands TO '%CREATE SUBSCRIPTION%';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
  citus_split_shard_by_split_points
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/isolation_master_update_node_0.out
+++ b/src/test/regress/expected/isolation_master_update_node_0.out
@@ -6,9 +6,9 @@ create_distributed_table
 
 (1 row)
 
-step s1-begin: BEGIN;
+step s1-begin: BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE;
 step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
-step s2-begin: BEGIN;
+step s2-begin: BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE;
 step s2-update-node-1:
     -- update a specific node by address
     SELECT master_update_node(nodeid, 'localhost', nodeport + 10)
@@ -37,9 +37,9 @@ create_distributed_table
 
 (1 row)
 
-step s1-begin: BEGIN;
+step s1-begin: BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE;
 step s1-insert: INSERT INTO t1 SELECT generate_series(1, 100);
-step s2-begin: BEGIN;
+step s2-begin: BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE;
 step s2-update-node-1-force:
     -- update a specific node by address (force)
     SELECT master_update_node(nodeid, 'localhost', nodeport + 10, force => true, lock_cooldown => 100)

--- a/src/test/regress/expected/shard_rebalancer.out
+++ b/src/test/regress/expected/shard_rebalancer.out
@@ -204,19 +204,17 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_replication_factor TO '2';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SELECT citus_copy_shard_placement(433101,'localhost',57637,'localhost',57638,'block_writes')
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -225,19 +223,17 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_replication_factor TO '2';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SELECT citus_copy_shard_placement(433102,'localhost',57638,'localhost',57637,'block_writes')
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -246,19 +242,17 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_replication_factor TO '2';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SELECT citus_copy_shard_placement(433103,'localhost',57637,'localhost',57638,'block_writes')
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
@@ -267,19 +261,17 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  Copying shard xxxxx from localhost:xxxxx to localhost:xxxxx ...
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.log_remote_commands TO 'on';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.max_adaptive_executor_pool_size TO '5';
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SET LOCAL citus.next_shard_id TO '433105';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.node_connection_timeout TO '35000';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_count TO '4';
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SET LOCAL citus.shard_replication_factor TO '2';
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SET LOCAL application_name TO citus_rebalancer;
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 NOTICE:  issuing SELECT citus_copy_shard_placement(433104,'localhost',57638,'localhost',57637,'block_writes')
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx

--- a/src/test/regress/spec/isolation_master_update_node.spec
+++ b/src/test/regress/spec/isolation_master_update_node.spec
@@ -27,12 +27,12 @@ teardown
 }
 
 session "s1"
-step "s1-begin" { BEGIN; }
+step "s1-begin" { BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE; }
 step "s1-insert" { INSERT INTO t1 SELECT generate_series(1, 100); }
 step "s1-abort" { ABORT; }
 
 session "s2"
-step "s2-begin" { BEGIN; }
+step "s2-begin" { BEGIN; SET citus.propagate_session_settings_for_loopback_connection TO FALSE; }
 step "s2-update-node-1" {
     -- update a specific node by address
     SELECT master_update_node(nodeid, 'localhost', nodeport + 10)


### PR DESCRIPTION
Fixes #6357 

This PR makes GUC settings propagation to new connections has a broader coverage by moving initial implementation from `shard_rebalancer` to `worker_transaction `.