### PR TITLE
Fix dangling pointer warning in AnyTableReplicated

### DIFF
--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -801,10 +801,10 @@ AnyTableReplicated(List *shardIntervalList, List **replicatedShardIntervalList)
 		}
 	}
 
-    if (replicatedShardIntervalList != NULL)
-    {
-        *replicatedShardIntervalList = localList;
-    }
+	if (replicatedShardIntervalList != NULL)
+	{
+		*replicatedShardIntervalList = localList;
+	}
 
 	return list_length(localList) > 0;
 }

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -781,14 +781,7 @@ SerializeNonCommutativeWrites(List *shardIntervalList, LOCKMODE lockMode)
 static bool
 AnyTableReplicated(List *shardIntervalList, List **replicatedShardIntervalList)
 {
-	if (replicatedShardIntervalList == NULL)
-	{
-		/* the caller is not interested in the replicatedShardIntervalList */
-		List *localList = NIL;
-		replicatedShardIntervalList = &localList;
-	}
-
-	*replicatedShardIntervalList = NIL;
+	List *localList = NIL;
 
 	ShardInterval *shardInterval = NULL;
 	foreach_ptr(shardInterval, shardIntervalList)
@@ -798,17 +791,22 @@ AnyTableReplicated(List *shardIntervalList, List **replicatedShardIntervalList)
 		Oid relationId = RelationIdForShard(shardId);
 		if (ReferenceTableShardId(shardId))
 		{
-			*replicatedShardIntervalList =
-				lappend(*replicatedShardIntervalList, LoadShardInterval(shardId));
+			localList =
+				lappend(localList, LoadShardInterval(shardId));
 		}
 		else if (!SingleReplicatedTable(relationId))
 		{
-			*replicatedShardIntervalList =
-				lappend(*replicatedShardIntervalList, LoadShardInterval(shardId));
+			localList =
+				lappend(localList, LoadShardInterval(shardId));
 		}
 	}
 
-	return list_length(*replicatedShardIntervalList) > 0;
+    if (replicatedShardIntervalList != NULL)
+    {
+        *replicatedShardIntervalList = localList;
+    }
+
+	return list_length(localList) > 0;
 }
 
 


### PR DESCRIPTION
DESCRIPTION: Fixes a potential dangling pointer issue

Need to backport to 11.0 & 11.1 since we might want to release packages for debian/bookworm based on those branches in future.