### PR TITLE
Address the issues/comments from the original PR# 6315

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_get_node_clock/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_get_node_clock/11.2-1.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.citus_get_node_clock()
     RETURNS pg_catalog.cluster_clock
-    LANGUAGE C STABLE PARALLEL SAFE STRICT
+    LANGUAGE C VOLATILE PARALLEL UNSAFE STRICT
     AS 'MODULE_PATHNAME',$$citus_get_node_clock$$;
 COMMENT ON FUNCTION pg_catalog.citus_get_node_clock()
     IS 'Returns monotonically increasing timestamp with logical clock value as close to epoch value (in milli seconds) as possible, and a counter for ticks(maximum of 4 million) within the logical clock';

--- a/src/backend/distributed/sql/udfs/citus_get_node_clock/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_get_node_clock/latest.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.citus_get_node_clock()
     RETURNS pg_catalog.cluster_clock
-    LANGUAGE C STABLE PARALLEL SAFE STRICT
+    LANGUAGE C VOLATILE PARALLEL UNSAFE STRICT
     AS 'MODULE_PATHNAME',$$citus_get_node_clock$$;
 COMMENT ON FUNCTION pg_catalog.citus_get_node_clock()
     IS 'Returns monotonically increasing timestamp with logical clock value as close to epoch value (in milli seconds) as possible, and a counter for ticks(maximum of 4 million) within the logical clock';

--- a/src/backend/distributed/sql/udfs/citus_get_transaction_clock/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_get_transaction_clock/11.2-1.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.citus_get_transaction_clock()
     RETURNS pg_catalog.cluster_clock
-    LANGUAGE C STABLE PARALLEL SAFE STRICT
+    LANGUAGE C VOLATILE PARALLEL UNSAFE STRICT
     AS 'MODULE_PATHNAME',$$citus_get_transaction_clock$$;
 COMMENT ON FUNCTION pg_catalog.citus_get_transaction_clock()
     IS 'Returns a transaction timestamp logical clock';

--- a/src/backend/distributed/sql/udfs/citus_get_transaction_clock/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_get_transaction_clock/latest.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION pg_catalog.citus_get_transaction_clock()
     RETURNS pg_catalog.cluster_clock
-    LANGUAGE C STABLE PARALLEL SAFE STRICT
+    LANGUAGE C VOLATILE PARALLEL UNSAFE STRICT
     AS 'MODULE_PATHNAME',$$citus_get_transaction_clock$$;
 COMMENT ON FUNCTION pg_catalog.citus_get_transaction_clock()
     IS 'Returns a transaction timestamp logical clock';

--- a/src/test/regress/expected/clock.out
+++ b/src/test/regress/expected/clock.out
@@ -328,9 +328,51 @@ WARNING:  GUC enable_cluster_clock is off
 (1 row)
 
 END;
+SET citus.enable_cluster_clock to ON;
+-- Test if the clock UDFs are volatile, result should never be the same
+SELECT citus_get_node_clock() = citus_get_node_clock();
+ ?column?
+---------------------------------------------------------------------
+ f
+(1 row)
+
+select citus_get_transaction_clock() = citus_get_transaction_clock();
+DEBUG:  node xxxx transaction clock xxxxxx
+DEBUG:  final global transaction clock xxxxxx
+DEBUG:  node xxxx transaction clock xxxxxx
+DEBUG:  final global transaction clock xxxxxx
+ ?column?
+---------------------------------------------------------------------
+ f
+(1 row)
+
+-- Test if the clock UDFs are usable by non-superusers
+CREATE ROLE non_super_user_clock;
+SET ROLE non_super_user_clock;
+SELECT citus_get_node_clock();
+ citus_get_node_clock
+---------------------------------------------------------------------
+ (xxxxxxxxxxxxx,x)
+(1 row)
+
+BEGIN;
+SELECT citus_get_transaction_clock();
+DEBUG:  node xxxx transaction clock xxxxxx
+DEBUG:  final global transaction clock xxxxxx
+ citus_get_transaction_clock
+---------------------------------------------------------------------
+ (xxxxxxxxxxxxx,x)
+(1 row)
+
+COMMIT;
+-- Test setting the persisted clock value (it must fail)
+SELECT setval('pg_dist_clock_logical_seq', 100, true);
+ERROR:  permission denied for sequence pg_dist_clock_logical_seq
+\c
 RESET client_min_messages;
 RESET citus.enable_cluster_clock;
+DROP ROLE non_super_user_clock;
 DROP SCHEMA clock CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to table clock_test
-drop cascades to table cluster_clock_type
+DETAIL:  drop cascades to table clock.clock_test
+drop cascades to table clock.cluster_clock_type


### PR DESCRIPTION
1) Regular users fail to use clock UDFs with permissions issue.
2) Clock functions were declared as STABLE, whereas by definition they are VOLATILE. By design, any clock/time functions will 
    return different results for each call even within a single SQL statement.

Note: UDF citus_get_transaction_clock() is a misnomer as it internally calls the clock tick which always returns different results for every invocation in the same transaction.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
