### PR TITLE
When a domain or type is used in a distribution column, the drop type/domain operation is not allowed

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2370,7 +2370,7 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 					if(CheckCitusDropStmt(domainoid))
 					{
 						ereport(ERROR,
-							(errmsg("columnar storage parameters specified on non-columnar table")));
+							(errmsg("This domain cannot be deleted when it is used in a distribution column.")));
 					}
 				}
 			}

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2367,10 +2367,26 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 					typename = castNode(TypeName, object);
 					domainoid = typenameTypeId(NULL, typename);
 
-					if(CheckCitusDropStmt(domainoid))
+					if(CheckCitusDropDomainOrTypeStmt(domainoid))
 					{
 						ereport(ERROR,
 							(errmsg("This domain cannot be deleted when it is used in a distribution column.")));
+					}
+				}
+			}
+			else if(dropStmt->removeType == OBJECT_TYPE)
+			{
+				ListCell *objectCell = NULL;
+
+				foreach(objectCell, dropStmt->objects)
+				{
+					TypeName *typeName = castNode(TypeName, lfirst(objectCell));
+					Oid typeOid = LookupTypeNameOid(NULL, typeName, false);
+					
+					if(CheckCitusDropDomainOrTypeStmt(typeOid))
+					{
+						ereport(ERROR,
+							(errmsg("This type cannot be deleted when it is used in a distribution column.")));
 					}
 				}
 			}

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -5659,7 +5659,13 @@ poolinfo_valid(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(poolinfoValid);
 }
 
-bool CheckCitusDropStmt(Oid domainoid)
+/*
+ * CheckCitusDropStmt determines whether the domain in the current drop operation 
+ * is used in the distribution column of a distribution table, 
+ * and if so, returns true for subsequent error reporting.
+ */
+bool 
+CheckCitusDropStmt(Oid domainoid)
 {
 	bool result = false;
 	ScanKeyData scanKey[1];
@@ -5682,11 +5688,8 @@ bool CheckCitusDropStmt(Oid domainoid)
 		Datum datumArray[Natts_pg_dist_partition];
 		heap_deform_tuple(heapTuple, tupleDescriptor, datumArray, isNullArray);
 
-		// Datum relationIdDatum = datumArray[Anum_pg_dist_partition_logicalrelid - 1];
 		Datum partitionKeyDatum = datumArray[Anum_pg_dist_partition_partkey - 1];
 		char *partitionKeyString = TextDatumGetCString(partitionKeyDatum);
-
-		// Oid relationId = DatumGetObjectId(relationIdDatum);
 
 		if (strstr(partitionKeyString, domainoidStr) != NULL)
 		{

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -5660,18 +5660,18 @@ poolinfo_valid(PG_FUNCTION_ARGS)
 }
 
 /*
- * CheckCitusDropStmt determines whether the domain in the current drop operation 
+ * CheckCitusDropDomainOrTypeStmt determines whether the domain/type in the current drop operation 
  * is used in the distribution column of a distribution table, 
  * and if so, returns true for subsequent error reporting.
  */
 bool 
-CheckCitusDropStmt(Oid domainoid)
+CheckCitusDropDomainOrTypeStmt(Oid oid)
 {
 	bool result = false;
 	ScanKeyData scanKey[1];
 	int scanKeyCount = 0;
-	char domainoidStr[16] = {0};
-	sprintf(domainoidStr, "%d", domainoid);
+	char oidStr[16] = {0};
+	sprintf(oidStr, "%d", oid);
 
 	Relation pgDistPartition = table_open(DistPartitionRelationId(), AccessShareLock);
 
@@ -5691,7 +5691,7 @@ CheckCitusDropStmt(Oid domainoid)
 		Datum partitionKeyDatum = datumArray[Anum_pg_dist_partition_partkey - 1];
 		char *partitionKeyString = TextDatumGetCString(partitionKeyDatum);
 
-		if (strstr(partitionKeyString, domainoidStr) != NULL)
+		if (strstr(partitionKeyString, oidStr) != NULL)
 		{
 			result = true;
 			break;

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -211,6 +211,7 @@ extern bool RelationExists(Oid relationId);
 extern ShardInterval * TupleToShardInterval(HeapTuple heapTuple,
 											TupleDesc tupleDescriptor, Oid intervalTypeId,
 											int32 intervalTypeMod);
+extern bool CheckCitusDropStmt(Oid domainoid);
 
 /* access WorkerNodeHash */
 extern bool HasAnyNodes(void);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -211,7 +211,7 @@ extern bool RelationExists(Oid relationId);
 extern ShardInterval * TupleToShardInterval(HeapTuple heapTuple,
 											TupleDesc tupleDescriptor, Oid intervalTypeId,
 											int32 intervalTypeMod);
-extern bool CheckCitusDropStmt(Oid domainoid);
+extern bool CheckCitusDropDomainOrTypeStmt(Oid oid);
 
 /* access WorkerNodeHash */
 extern bool HasAnyNodes(void);


### PR DESCRIPTION
hello：

# The environment
Ubuntu 22.04 LTS + PostgreSQL15.0 + main

set citus.shard_count = 2;
set citus.override_table_visibility to off;
set citus.log_remote_commands = on;

# The problem
## one
create domain posint as integer check (value > 0);
-- SELECT run_command_on_workers('create domain posint as integer check (value > 0)');
create table t1(id posint);
select create_distributed_table('t1', 'id');
drop domain if exists posint cascade;

## second
create type mytype as (id int,name varchar(16));
create table t2(value mytype);
select create_distributed_table('t2', 'value');
drop type mytype cascade;

-- here
drop table t1; // error cache
drop table t2;

# The note
I obtained DropStmt from Utility hook for judgment, mainly using pg_type and pg_dist_partition system table contents. If you have any better ideas, I'm happy to share them with you. Thank you