### PR TITLE
Fix flakyness in multi_metadata_access

### DIFF
--- a/src/test/regress/sql/multi_metadata_access.sql
+++ b/src/test/regress/sql/multi_metadata_access.sql
@@ -18,7 +18,8 @@ WHERE
     AND classid ='pg_class'::regclass
     AND ext.extname = 'citus'
     AND nsp.nspname = 'pg_catalog'
-    AND NOT has_table_privilege(pg_class.oid, 'select');
+    AND NOT has_table_privilege(pg_class.oid, 'select')
+ORDER BY 1;
 
 
 RESET role;


### PR DESCRIPTION
Sometimes multi_metadata_access failed like this in CI:
```diff
     AND ext.extname = 'citus'
     AND nsp.nspname = 'pg_catalog'
     AND NOT has_table_privilege(pg_class.oid, 'select');
             oid
 ---------------------------
- pg_dist_authinfo
  pg_dist_clock_logical_seq
+ pg_dist_authinfo
 (2 rows)
```

Source: https://app.circleci.com/pipelines/github/citusdata/citus/28784/workflows/e462f118-eb64-4a3f-941a-e04115334f9b/jobs/883443

This fixes that by ordering the column.