### PR TITLE
Simplify columnar perf example

### DIFF
--- a/src/backend/columnar/README.md
+++ b/src/backend/columnar/README.md
@@ -234,16 +234,14 @@ CREATE TABLE perf_columnar(LIKE perf_row) USING COLUMNAR;
 ## Data
 
 ```sql
-CREATE OR REPLACE FUNCTION random_words(n INT4) RETURNS TEXT LANGUAGE plpython2u AS $$
-import random
-t = ''
-words = ['zero','one','two','three','four','five','six','seven','eight','nine','ten']
-for i in xrange(0,n):
-  if (i != 0):
-    t += ' '
-  r = random.randint(0,len(words)-1)
-  t += words[r]
-return t
+CREATE OR REPLACE FUNCTION random_words(n INT4) RETURNS TEXT LANGUAGE sql AS $$
+  WITH words(w) AS (
+    SELECT ARRAY['zero','one','two','three','four','five','six','seven','eight','nine','ten']
+  ),
+  random (word) AS (
+    SELECT w[(random()*array_length(w, 1))::int] FROM generate_series(1, $1) AS i, words
+  )
+  SELECT string_agg(word, ' ') FROM random;
 $$;
 ```
 


### PR DESCRIPTION
Rewrite the plpython function to generate random words in SQL to simplify the usage and run the example.
