### PR TITLE
Fix misleading GUC description

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2178,7 +2178,7 @@ RegisterCitusConfigVariables(void)
 		"citus.skip_advisory_lock_permission_checks",
 		gettext_noop("Postgres would normally enforce some "
 					 "ownership checks while acquiring locks. "
-					 "When this setting is 'off', Citus skips"
+					 "When this setting is 'on', Citus skips"
 					 "ownership checks on internal advisory "
 					 "locks."),
 		NULL,


### PR DESCRIPTION
citus.skip_advisory_lock_permission_checks skips checks when it is set to 'on', not 'off'