### PR TITLE
Push coverage to codeclimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
@@ -287,6 +288,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
@@ -380,6 +382,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
@@ -474,6 +477,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
@@ -549,6 +553,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ jobs:
           command: |
             lcov --directory . --capture --output-file lcov.info
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
+            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |
@@ -263,6 +264,7 @@ jobs:
           command: |
             lcov --directory . --capture --output-file lcov.info
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
+            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy logfiles'
           command: |
@@ -360,6 +362,7 @@ jobs:
           command: |
             lcov --directory . --capture --output-file lcov.info
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
+            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |
@@ -428,6 +431,7 @@ jobs:
           command: |
             lcov --directory . --capture --output-file lcov.info
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
+            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Regressions'
           command: |
@@ -524,6 +528,7 @@ jobs:
           command: |
             lcov --directory . --capture --output-file lcov.info
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
+            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,8 +167,8 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |
@@ -263,8 +263,8 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy logfiles'
           command: |
@@ -361,8 +361,8 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |
@@ -430,8 +430,8 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Regressions'
           command: |
@@ -527,8 +527,8 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
             codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-            sed "s/^SF:$PWD//g" -i codeclimate/$CIRCLE_JOB.json
       - run:
           name: 'Copy coredumps'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-v9372c09'
+    default: '-dev-13377e3'
   pg13_version:
     type: string
     default: '13.9'
@@ -164,6 +164,11 @@ jobs:
             fi
           when: on_fail
       - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -191,6 +196,10 @@ jobs:
           path: /tmp/pg_upgrade_newData_logs
       - codecov/upload:
           flags: 'test_<< parameters.old_pg_major >>_<< parameters.new_pg_major >>,upgrade'
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/*.json
 
   test-arbitrary-configs:
     description: Runs tests on arbitrary configs
@@ -250,6 +259,11 @@ jobs:
 
           when: on_fail
       - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+      - run:
           name: 'Copy logfiles'
           command: |
             mkdir src/test/regress/tmp_citus_test/logfiles
@@ -272,6 +286,10 @@ jobs:
           path: src/test/regress/tmp_citus_test/logfiles
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,upgrade'
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/*.json
 
   test-citus-upgrade:
     description: Runs citus upgrade tests
@@ -338,6 +356,11 @@ jobs:
             fi
           when: on_fail
       - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -354,6 +377,10 @@ jobs:
           path: /tmp/core_dumps
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,upgrade'
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/*.json
 
   test-citus:
     description: Runs the common tests of citus
@@ -397,6 +424,11 @@ jobs:
             gosu circleci make -C src/test/regress << parameters.make >>
           no_output_timeout: 2m
       - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+      - run:
           name: 'Regressions'
           command: |
             if [ -f "src/test/regress/regression.diffs" ]; then
@@ -437,6 +469,10 @@ jobs:
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,<< parameters.make >>'
           when: always
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/*.json
 
   tap-test-citus:
     description: Runs tap tests for citus
@@ -484,6 +520,11 @@ jobs:
             gosu circleci make -C src/test/<< parameters.suite >> << parameters.make >>
           no_output_timeout: 2m
       - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -501,6 +542,10 @@ jobs:
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,tap_<< parameters.suite >>_<< parameters.make >>'
           when: always
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/*.json
 
   check-merge-to-enterprise:
     docker:
@@ -631,6 +676,33 @@ jobs:
       - store_artifacts:
           name: 'Save worker2 log'
           path: src/test/regress/tmp_check/worker.57638/log
+  install-codeclimate:
+    docker:
+      - image: 'citus/extbuilder:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - run:
+          name:  Download cc-test-reporter
+          command: |
+            mkdir -p codeclimate/
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter
+            chmod +x ./codeclimate/test-reporter
+      - persist_to_workspace:
+          root: .
+          paths:
+            - codeclimate/test-reporter
+  upload-coverage:
+    docker:
+      - image: 'citus/extbuilder:latest'
+    working_directory: /home/circleci/project
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            ./codeclimate/test-reporter sum-coverage codeclimate/*.json -o total.json
+            ./codeclimate/test-reporter upload-coverage -i total.json
 
 workflows:
   version: 2
@@ -669,394 +741,460 @@ workflows:
 
       - check-style
       - check-sql-snapshots
+      - install-codeclimate
 
       - test-citus:
           name: 'test-13_check-multi'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-multi-1'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi-1
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-mx'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi-mx
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-vanilla'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-vanilla
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-isolation
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-operations'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-operations
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-follower-cluster'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-follower-cluster
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-columnar'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-columnar
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-columnar-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-columnar-isolation
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - tap-test-citus:
           name: 'test-13_tap-recovery'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           suite: recovery
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - tap-test-citus:
           name: 'test-13_tap-columnar-freezing'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           suite: columnar_freezing
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-failure'
           pg_major: 13
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-failure
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
 
       - test-citus:
           name: 'test-13_check-enterprise'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-1'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-2'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-3'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-enterprise-failure'
           pg_major: 13
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-failure
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-citus:
           name: 'test-13_check-split'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-split
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
 
       - test-citus:
           name: 'test-14_check-split'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-split
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-1'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-2'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-3'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-enterprise-failure'
           pg_major: 14
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-failure
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-multi'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-multi-1'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi-1
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-mx'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi-mx
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-vanilla'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-vanilla
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-isolation
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-operations'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-operations
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-follower-cluster'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-follower-cluster
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-columnar'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-columnar
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-columnar-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-columnar-isolation
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - tap-test-citus:
           name: 'test-14_tap-recovery'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           suite: recovery
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - tap-test-citus:
           name: 'test-14_tap-columnar-freezing'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           suite: columnar_freezing
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-citus:
           name: 'test-14_check-failure'
           pg_major: 14
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-failure
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
 
       - test-citus:
           name: 'test-15_check-split'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-split
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-1'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-2'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-3'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-enterprise-failure'
           pg_major: 15
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-failure
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-multi'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-multi-1'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi-1
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-mx'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi-mx
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-vanilla'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-vanilla
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-isolation
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-operations'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-operations
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-follower-cluster'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-follower-cluster
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-columnar'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-columnar
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-columnar-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-columnar-isolation
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - tap-test-citus:
           name: 'test-15_tap-recovery'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           suite: recovery
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - tap-test-citus:
           name: 'test-15_tap-columnar-freezing'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           suite: columnar_freezing
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
       - test-citus:
           name: 'test-15_check-failure'
           pg_major: 15
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-failure
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
 
       - test-arbitrary-configs:
           name: 'test-13_check-arbitrary-configs'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
       - test-arbitrary-configs:
           name: 'test-14_check-arbitrary-configs'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
-          requires: [build-14]
+          requires: [install-codeclimate, build-14]
       - test-arbitrary-configs:
           name: 'test-15_check-arbitrary-configs'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
-          requires: [build-15]
+          requires: [install-codeclimate, build-15]
 
       - test-pg-upgrade:
           name: 'test-13-14_check-pg-upgrade'
           old_pg_major: 13
           new_pg_major: 14
           image_tag: '<< pipeline.parameters.upgrade_pg_versions >>'
-          requires: [build-13, build-14]
+          requires: [install-codeclimate, build-13, build-14]
 
       - test-pg-upgrade:
           name: 'test-14-15_check-pg-upgrade'
           old_pg_major: 14
           new_pg_major: 15
           image_tag: '<< pipeline.parameters.upgrade_pg_versions >>'
-          requires: [build-14, build-15]
+          requires: [install-codeclimate, build-14, build-15]
 
       - test-citus-upgrade:
           name: test-13_check-citus-upgrade
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
-          requires: [build-13]
+          requires: [install-codeclimate, build-13]
+
+      - upload-coverage:
+          requires:
+            - test-13_check-multi
+            - test-13_check-multi-1
+            - test-13_check-mx
+            - test-13_check-vanilla
+            - test-13_check-isolation
+            - test-13_check-operations
+            - test-13_check-follower-cluster
+            - test-13_check-columnar
+            - test-13_check-columnar-isolation
+            - test-13_tap-recovery
+            - test-13_tap-columnar-freezing
+            - test-13_check-failure
+            - test-13_check-enterprise
+            - test-13_check-enterprise-isolation
+            - test-13_check-enterprise-isolation-logicalrep-1
+            - test-13_check-enterprise-isolation-logicalrep-2
+            - test-13_check-enterprise-isolation-logicalrep-3
+            - test-13_check-enterprise-failure
+            - test-13_check-split
+            - test-14_check-multi
+            - test-14_check-multi-1
+            - test-14_check-mx
+            - test-14_check-vanilla
+            - test-14_check-isolation
+            - test-14_check-operations
+            - test-14_check-follower-cluster
+            - test-14_check-columnar
+            - test-14_check-columnar-isolation
+            - test-14_tap-recovery
+            - test-14_tap-columnar-freezing
+            - test-14_check-failure
+            - test-14_check-enterprise
+            - test-14_check-enterprise-isolation
+            - test-14_check-enterprise-isolation-logicalrep-1
+            - test-14_check-enterprise-isolation-logicalrep-2
+            - test-14_check-enterprise-isolation-logicalrep-3
+            - test-14_check-enterprise-failure
+            - test-14_check-split
+            - test-14_check-arbitrary-configs
+            - test-15_check-multi
+            - test-15_check-multi-1
+            - test-15_check-mx
+            - test-15_check-vanilla
+            - test-15_check-isolation
+            - test-15_check-operations
+            - test-15_check-follower-cluster
+            - test-15_check-columnar
+            - test-15_check-columnar-isolation
+            - test-15_tap-recovery
+            - test-15_tap-columnar-freezing
+            - test-15_check-failure
+            - test-15_check-enterprise
+            - test-15_check-enterprise-isolation
+            - test-15_check-enterprise-isolation-logicalrep-1
+            - test-15_check-enterprise-isolation-logicalrep-2
+            - test-15_check-enterprise-isolation-logicalrep-3
+            - test-15_check-enterprise-failure
+            - test-15_check-split
+            - test-15_check-arbitrary-configs
+            - test-13-14_check-pg-upgrade
+            - test-14-15_check-pg-upgrade
+
 
       - ch_benchmark:
           requires: [build-13]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -199,7 +199,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/*.json
+            - codeclimate/<< parameters.name >>.json
 
   test-arbitrary-configs:
     description: Runs tests on arbitrary configs
@@ -262,7 +262,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
       - run:
           name: 'Copy logfiles'
           command: |
@@ -289,7 +289,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/*.json
+            - codeclimate/<< parameters.name >>.json
 
   test-citus-upgrade:
     description: Runs citus upgrade tests
@@ -359,7 +359,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -380,7 +380,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/*.json
+            - codeclimate/<< parameters.name >>.json
 
   test-citus:
     description: Runs the common tests of citus
@@ -427,7 +427,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
       - run:
           name: 'Regressions'
           command: |
@@ -472,7 +472,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/*.json
+            - codeclimate/<< parameters.name >>.json
 
   tap-test-citus:
     description: Runs tap tests for citus
@@ -523,7 +523,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$(openssl rand -hex 30).json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -545,7 +545,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/*.json
+            - codeclimate/<< parameters.name >>.json
 
   check-merge-to-enterprise:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,12 +164,6 @@ jobs:
             fi
           when: on_fail
       - run:
-          name: 'Create codeclimate coverage'
-          command: |
-            lcov --directory . --capture --output-file lcov.info
-            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -197,10 +191,17 @@ jobs:
           path: /tmp/pg_upgrade_newData_logs
       - codecov/upload:
           flags: 'test_<< parameters.old_pg_major >>_<< parameters.new_pg_major >>,upgrade'
+      - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+            mkdir -p /tmp/codeclimate
+            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
-          root: .
+          root: /tmp
           paths:
-            - codeclimate/$CIRCLE_JOB.json
+            - codeclimate/*.json
 
   test-arbitrary-configs:
     description: Runs tests on arbitrary configs
@@ -260,12 +261,6 @@ jobs:
 
           when: on_fail
       - run:
-          name: 'Create codeclimate coverage'
-          command: |
-            lcov --directory . --capture --output-file lcov.info
-            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-      - run:
           name: 'Copy logfiles'
           command: |
             mkdir src/test/regress/tmp_citus_test/logfiles
@@ -288,10 +283,17 @@ jobs:
           path: src/test/regress/tmp_citus_test/logfiles
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,upgrade'
+      - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+            mkdir -p /tmp/codeclimate
+            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
-          root: .
+          root: /tmp
           paths:
-            - codeclimate/$CIRCLE_JOB.json
+            - codeclimate/*.json
 
   test-citus-upgrade:
     description: Runs citus upgrade tests
@@ -358,12 +360,6 @@ jobs:
             fi
           when: on_fail
       - run:
-          name: 'Create codeclimate coverage'
-          command: |
-            lcov --directory . --capture --output-file lcov.info
-            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -380,10 +376,17 @@ jobs:
           path: /tmp/core_dumps
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,upgrade'
+      - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+            mkdir -p /tmp/codeclimate
+            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
-          root: .
+          root: /tmp
           paths:
-            - codeclimate/$CIRCLE_JOB.json
+            - codeclimate/*.json
 
   test-citus:
     description: Runs the common tests of citus
@@ -427,12 +430,6 @@ jobs:
             gosu circleci make -C src/test/regress << parameters.make >>
           no_output_timeout: 2m
       - run:
-          name: 'Create codeclimate coverage'
-          command: |
-            lcov --directory . --capture --output-file lcov.info
-            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-      - run:
           name: 'Regressions'
           command: |
             if [ -f "src/test/regress/regression.diffs" ]; then
@@ -473,10 +470,17 @@ jobs:
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,<< parameters.make >>'
           when: always
+      - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+            mkdir -p /tmp/codeclimate
+            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
-          root: .
+          root: /tmp
           paths:
-            - codeclimate/$CIRCLE_JOB.json
+            - codeclimate/*.json
 
   tap-test-citus:
     description: Runs tap tests for citus
@@ -524,12 +528,6 @@ jobs:
             gosu circleci make -C src/test/<< parameters.suite >> << parameters.make >>
           no_output_timeout: 2m
       - run:
-          name: 'Create codeclimate coverage'
-          command: |
-            lcov --directory . --capture --output-file lcov.info
-            sed "s=^SF:$PWD=SF:=g" -i lcov.info # relative pats are required by codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
-      - run:
           name: 'Copy coredumps'
           command: |
             mkdir -p /tmp/core_dumps
@@ -547,10 +545,17 @@ jobs:
       - codecov/upload:
           flags: 'test_<< parameters.pg_major >>,tap_<< parameters.suite >>_<< parameters.make >>'
           when: always
+      - run:
+          name: 'Create codeclimate coverage'
+          command: |
+            lcov --directory . --capture --output-file lcov.info
+            sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+            mkdir -p /tmp/codeclimate
+            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
-          root: .
+          root: /tmp
           paths:
-            - codeclimate/$CIRCLE_JOB.json
+            - codeclimate/*.json
 
   check-merge-to-enterprise:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,6 +1151,7 @@ workflows:
             - test-13_check-enterprise-isolation-logicalrep-3
             - test-13_check-enterprise-failure
             - test-13_check-split
+            - test-13_check-arbitrary-configs
             - test-14_check-multi
             - test-14_check-multi-1
             - test-14_check-mx
@@ -1193,6 +1194,7 @@ workflows:
             - test-15_check-arbitrary-configs
             - test-13-14_check-pg-upgrade
             - test-14-15_check-pg-upgrade
+            - test-13_check-citus-upgrade
 
 
       - ch_benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-d45e616'
+    default: '-vcbba174'
   pg13_version:
     type: string
     default: '13.9'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-13377e3'
+    default: '-dev-d45e616'
   pg13_version:
     type: string
     default: '13.9'
@@ -198,7 +198,7 @@ jobs:
             lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
+            cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -291,7 +291,7 @@ jobs:
             lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
+            cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -385,7 +385,7 @@ jobs:
             lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
+            cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -480,7 +480,7 @@ jobs:
             lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
+            cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -556,7 +556,7 @@ jobs:
             lcov --remove lcov.info -o lcov.info '/usr/*'
             sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
             mkdir -p /tmp/codeclimate
-            codeclimate/test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
+            cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -691,21 +691,6 @@ jobs:
       - store_artifacts:
           name: 'Save worker2 log'
           path: src/test/regress/tmp_check/worker.57638/log
-  install-codeclimate:
-    docker:
-      - image: 'citus/extbuilder:latest'
-    working_directory: /home/circleci/project
-    steps:
-      - run:
-          name:  Download cc-test-reporter
-          command: |
-            mkdir -p codeclimate/
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter
-            chmod +x ./codeclimate/test-reporter
-      - persist_to_workspace:
-          root: .
-          paths:
-            - codeclimate/test-reporter
   upload-coverage:
     docker:
       - image: 'citus/extbuilder:latest'
@@ -716,8 +701,8 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            ./codeclimate/test-reporter sum-coverage codeclimate/*.json -o total.json
-            ./codeclimate/test-reporter upload-coverage -i total.json
+            cc-test-reporter sum-coverage codeclimate/*.json -o total.json
+            cc-test-reporter upload-coverage -i total.json
 
 workflows:
   version: 2
@@ -756,395 +741,394 @@ workflows:
 
       - check-style
       - check-sql-snapshots
-      - install-codeclimate
 
       - test-citus:
           name: 'test-13_check-multi'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-multi-1'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi-1
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-mx'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-multi-mx
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-vanilla'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-vanilla
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-isolation
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-operations'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-operations
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-follower-cluster'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-follower-cluster
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-columnar'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-columnar
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-columnar-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-columnar-isolation
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - tap-test-citus:
           name: 'test-13_tap-recovery'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           suite: recovery
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - tap-test-citus:
           name: 'test-13_tap-columnar-freezing'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           suite: columnar_freezing
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-failure'
           pg_major: 13
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-failure
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
 
       - test-citus:
           name: 'test-13_check-enterprise'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-1'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-2'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-enterprise-isolation-logicalrep-3'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-enterprise-failure'
           pg_major: 13
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-enterprise-failure
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-citus:
           name: 'test-13_check-split'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
           make: check-split
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
 
       - test-citus:
           name: 'test-14_check-split'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-split
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-1'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-2'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise-isolation-logicalrep-3'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-enterprise-failure'
           pg_major: 14
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-enterprise-failure
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-multi'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-multi-1'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi-1
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-mx'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-multi-mx
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-vanilla'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-vanilla
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-isolation
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-operations'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-operations
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-follower-cluster'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-follower-cluster
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-columnar'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-columnar
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-columnar-isolation'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-columnar-isolation
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - tap-test-citus:
           name: 'test-14_tap-recovery'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           suite: recovery
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - tap-test-citus:
           name: 'test-14_tap-columnar-freezing'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
           suite: columnar_freezing
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-citus:
           name: 'test-14_check-failure'
           pg_major: 14
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg14_version >>'
           make: check-failure
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
 
       - test-citus:
           name: 'test-15_check-split'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-split
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-1'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-1
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-2'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-2
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise-isolation-logicalrep-3'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-isolation-logicalrep-3
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-enterprise-failure'
           pg_major: 15
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-enterprise-failure
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-multi'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-multi-1'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi-1
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-mx'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-multi-mx
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-vanilla'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-vanilla
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-isolation
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-operations'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-operations
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-follower-cluster'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-follower-cluster
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-columnar'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-columnar
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-columnar-isolation'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-columnar-isolation
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - tap-test-citus:
           name: 'test-15_tap-recovery'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           suite: recovery
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - tap-test-citus:
           name: 'test-15_tap-columnar-freezing'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
           suite: columnar_freezing
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
       - test-citus:
           name: 'test-15_check-failure'
           pg_major: 15
           image: citus/failtester
           image_tag: '<< pipeline.parameters.pg15_version >>'
           make: check-failure
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
 
       - test-arbitrary-configs:
           name: 'test-13_check-arbitrary-configs'
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
       - test-arbitrary-configs:
           name: 'test-14_check-arbitrary-configs'
           pg_major: 14
           image_tag: '<< pipeline.parameters.pg14_version >>'
-          requires: [install-codeclimate, build-14]
+          requires: [build-14]
       - test-arbitrary-configs:
           name: 'test-15_check-arbitrary-configs'
           pg_major: 15
           image_tag: '<< pipeline.parameters.pg15_version >>'
-          requires: [install-codeclimate, build-15]
+          requires: [build-15]
 
       - test-pg-upgrade:
           name: 'test-13-14_check-pg-upgrade'
           old_pg_major: 13
           new_pg_major: 14
           image_tag: '<< pipeline.parameters.upgrade_pg_versions >>'
-          requires: [install-codeclimate, build-13, build-14]
+          requires: [build-13, build-14]
 
       - test-pg-upgrade:
           name: 'test-14-15_check-pg-upgrade'
           old_pg_major: 14
           new_pg_major: 15
           image_tag: '<< pipeline.parameters.upgrade_pg_versions >>'
-          requires: [install-codeclimate, build-14, build-15]
+          requires: [build-14, build-15]
 
       - test-citus-upgrade:
           name: test-13_check-citus-upgrade
           pg_major: 13
           image_tag: '<< pipeline.parameters.pg13_version >>'
-          requires: [install-codeclimate, build-13]
+          requires: [build-13]
 
       - upload-coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -199,7 +199,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/<< parameters.name >>.json
+            - codeclimate/$CIRCLE_JOB.json
 
   test-arbitrary-configs:
     description: Runs tests on arbitrary configs
@@ -262,7 +262,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
       - run:
           name: 'Copy logfiles'
           command: |
@@ -289,7 +289,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/<< parameters.name >>.json
+            - codeclimate/$CIRCLE_JOB.json
 
   test-citus-upgrade:
     description: Runs citus upgrade tests
@@ -359,7 +359,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -380,7 +380,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/<< parameters.name >>.json
+            - codeclimate/$CIRCLE_JOB.json
 
   test-citus:
     description: Runs the common tests of citus
@@ -427,7 +427,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
       - run:
           name: 'Regressions'
           command: |
@@ -472,7 +472,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/<< parameters.name >>.json
+            - codeclimate/$CIRCLE_JOB.json
 
   tap-test-citus:
     description: Runs tap tests for citus
@@ -523,7 +523,7 @@ jobs:
           name: 'Create codeclimate coverage'
           command: |
             lcov --directory . --capture --output-file lcov.info
-            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/<< parameters.name >>.json lcov.info
+            codeclimate/test-reporter format-coverage -t lcov -o codeclimate/$CIRCLE_JOB.json lcov.info
       - run:
           name: 'Copy coredumps'
           command: |
@@ -545,7 +545,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - codeclimate/<< parameters.name >>.json
+            - codeclimate/$CIRCLE_JOB.json
 
   check-merge-to-enterprise:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,7 +693,7 @@ jobs:
           path: src/test/regress/tmp_check/worker.57638/log
   upload-coverage:
     docker:
-      - image: 'citus/extbuilder:latest'
+      - image: 'citus/exttester:<< pipeline.parameters.pg15_version >><< pipeline.parameters.image_suffix >>'
     working_directory: /home/circleci/project
     steps:
       - attach_workspace:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+exclude_patterns:
+  - "src/backend/distributed/utils/citus_outfuncs.c"
+  - "src/backend/distributed/deparser/ruleutils_*.c"
+  - "src/include/distributed/citus_nodes.h"
+  - "src/backend/distributed/safeclib"
+  - "**/vendor/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,4 +3,5 @@ exclude_patterns:
   - "src/backend/distributed/deparser/ruleutils_*.c"
   - "src/include/distributed/citus_nodes.h"
   - "src/backend/distributed/safeclib"
+  - "src/backend/columnar/safeclib"
   - "**/vendor/"


### PR DESCRIPTION
In addition to pushing coverage results to codecov, this now also pushes them to codeclimate. This is meant so we can evaluate codeclimate. 
