### PR TITLE
Remove IF EXISTS from cleanup on failure test for subscription object

### DIFF
--- a/src/test/regress/expected/failure_online_move_shard_placement.out
+++ b/src/test/regress/expected/failure_online_move_shard_placement.out
@@ -317,13 +317,13 @@ SELECT citus.mitmproxy('conn.allow()');
 
 -- first, manually drop the subscsription object. But the record for it will remain on pg_dist_cleanup
 -- we expect the drop query will succeed on only one node
-SELECT COUNT(*)=1 AS success_on_one_node
+SELECT COUNT(*)
     FROM run_command_on_workers(
         $$DROP SUBSCRIPTION citus_shard_move_subscription_xxxxxxx_xxxxxxx$$)
     WHERE success AND result = 'DROP SUBSCRIPTION';
- success_on_one_node
+ count
 ---------------------------------------------------------------------
- t
+     1
 (1 row)
 
 -- cleanup leftovers

--- a/src/test/regress/expected/failure_online_move_shard_placement.out
+++ b/src/test/regress/expected/failure_online_move_shard_placement.out
@@ -316,15 +316,18 @@ SELECT citus.mitmproxy('conn.allow()');
 (1 row)
 
 -- first, manually drop the subscsription object. But the record for it will remain on pg_dist_cleanup
-SELECT run_command_on_workers($$DROP SUBSCRIPTION IF EXISTS citus_shard_move_subscription_xxxxxxx_xxxxxxx$$);
-         run_command_on_workers
+-- we expect the drop query will succeed on only one node
+SELECT COUNT(*)=1 AS success_on_one_node
+    FROM run_command_on_workers(
+        $$DROP SUBSCRIPTION citus_shard_move_subscription_xxxxxxx_xxxxxxx$$)
+    WHERE success AND result = 'DROP SUBSCRIPTION';
+ success_on_one_node
 ---------------------------------------------------------------------
- (localhost,9060,t,"DROP SUBSCRIPTION")
- (localhost,57637,t,"DROP SUBSCRIPTION")
-(2 rows)
+ t
+(1 row)
 
 -- cleanup leftovers
--- verify we don't see any error for already dropped subscription
+-- then, verify we don't see any error for already dropped subscription
 SET client_min_messages TO WARNING;
 CALL citus_cleanup_orphaned_resources();
 RESET client_min_messages;

--- a/src/test/regress/sql/failure_online_move_shard_placement.sql
+++ b/src/test/regress/sql/failure_online_move_shard_placement.sql
@@ -132,7 +132,7 @@ SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost'
 SELECT citus.mitmproxy('conn.allow()');
 -- first, manually drop the subscsription object. But the record for it will remain on pg_dist_cleanup
 -- we expect the drop query will succeed on only one node
-SELECT COUNT(*)=1 AS success_on_one_node
+SELECT COUNT(*)
     FROM run_command_on_workers(
         $$DROP SUBSCRIPTION citus_shard_move_subscription_10_15$$)
     WHERE success AND result = 'DROP SUBSCRIPTION';

--- a/src/test/regress/sql/failure_online_move_shard_placement.sql
+++ b/src/test/regress/sql/failure_online_move_shard_placement.sql
@@ -131,9 +131,14 @@ SELECT master_move_shard_placement(101, 'localhost', :worker_1_port, 'localhost'
 
 SELECT citus.mitmproxy('conn.allow()');
 -- first, manually drop the subscsription object. But the record for it will remain on pg_dist_cleanup
-SELECT run_command_on_workers($$DROP SUBSCRIPTION IF EXISTS citus_shard_move_subscription_10_15$$);
+-- we expect the drop query will succeed on only one node
+SELECT COUNT(*)=1 AS success_on_one_node
+    FROM run_command_on_workers(
+        $$DROP SUBSCRIPTION citus_shard_move_subscription_10_15$$)
+    WHERE success AND result = 'DROP SUBSCRIPTION';
+
 -- cleanup leftovers
--- verify we don't see any error for already dropped subscription
+-- then, verify we don't see any error for already dropped subscription
 SET client_min_messages TO WARNING;
 CALL citus_cleanup_orphaned_resources();
 RESET client_min_messages;


### PR DESCRIPTION
Nothing critical. Just improving a DROP SUBSCRIPTION test for a cleanup after failure scenario.