### PR TITLE
fix vanilla test status on CI

### DIFF
--- a/src/backend/distributed/test/citus_depended_object.c
+++ b/src/backend/distributed/test/citus_depended_object.c
@@ -11,6 +11,8 @@
 
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_am.h"
+#include "catalog/pg_amop.h"
+#include "catalog/pg_amproc.h"
 #include "catalog/pg_attribute.h"
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_constraint.h"
@@ -20,6 +22,9 @@
 #include "catalog/pg_event_trigger.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_operator.h"
+#include "catalog/pg_opclass.h"
+#include "catalog/pg_opfamily.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_rewrite.h"
 #include "catalog/pg_sequence.h"
@@ -77,6 +82,11 @@ is_citus_depended_object(PG_FUNCTION_ARGS)
 		case AccessMethodRelationId:
 		case EventTriggerRelationId:
 		case TriggerRelationId:
+		case OperatorRelationId:
+		case OperatorClassRelationId:
+		case OperatorFamilyRelationId:
+		case AccessMethodOperatorRelationId:
+		case AccessMethodProcedureRelationId:
 		case TSConfigRelationId:
 		case TSTemplateRelationId:
 		case TSDictionaryRelationId:

--- a/src/backend/distributed/utils/citus_depended_object.c
+++ b/src/backend/distributed/utils/citus_depended_object.c
@@ -12,6 +12,8 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_am.h"
+#include "catalog/pg_amop.h"
+#include "catalog/pg_amproc.h"
 #include "catalog/pg_attribute.h"
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_constraint.h"
@@ -21,6 +23,9 @@
 #include "catalog/pg_event_trigger.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_operator.h"
+#include "catalog/pg_opclass.h"
+#include "catalog/pg_opfamily.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_rewrite.h"
 #include "catalog/pg_sequence.h"
@@ -204,6 +209,21 @@ HideCitusDependentObjectsOnQueriesOfPgMetaTables(Node *node, void *context)
 
 					/* pg_index */
 					case IndexRelationId:
+
+					/* pg_operator */
+					case OperatorRelationId:
+
+					/* pg_opclass */
+					case OperatorClassRelationId:
+
+					/* pg_opfamily */
+					case OperatorFamilyRelationId:
+
+					/* pg_amop */
+					case AccessMethodOperatorRelationId:
+
+					/* pg_amproc */
+					case AccessMethodProcedureRelationId:
 
 					/* pg_aggregate */
 					case AggregateRelationId:

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -202,7 +202,7 @@ check-isolation-base: all  $(isolation_test_files)
 
 # ci takes regression.diffs output from another location, so copy diffs file at the end.
 check-vanilla: all
-	$(pg_regress_multi_check) --vanillatest || (cp $(vanilla_diffs_file) $(citus_abs_srcdir)/regression.diffs)
+	$(pg_regress_multi_check) --vanillatest || (cp $(vanilla_diffs_file) $(citus_abs_srcdir)/regression.diffs && false)
 
 check-multi-mx: all
 	$(pg_regress_multi_check) --load-extension=citus \

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -1075,14 +1075,19 @@ sub RunVanillaTests
                     '-c', $citus_depended_object_def)) == 0
                 or die "Could not create FUNCTION is_citus_depended_object on master";
 
-    my $pgregressdir="";
+    # we need to set regress path to find test input files(sqls and schedule)
+    # we need to add regress.so path to dlpath because some tests need to find that lib
+    my $pgregressInputdir="";
+    my $dlpath="";
     if (-f "$vanillaSchedule")
 	{
-	    $pgregressdir=catfile(dirname("$pgxsdir"), "regress");
+	    $pgregressInputdir=catfile(dirname("$pgxsdir"), "regress");
+        $dlpath=dirname("$pgxsdir")
 	}
 	else
 	{
-	    $pgregressdir=catfile("$postgresSrcdir", "src", "test", "regress");
+	    $pgregressInputdir=catfile("$postgresSrcdir", "src", "test", "regress");
+        $dlpath=$pgregressInputdir
 	}
 
     # output dir
@@ -1098,13 +1103,11 @@ sub RunVanillaTests
     system("mkdir", ("-p", "$pgregressOutputdir/sql")) == 0
             or die "Could not create vanilla sql dir.";
 
-    # we need to add regress.so path to dlpath because some tests need to find that lib
-    my $regresslibdir = $pgregressdir;
     $exitcode = system("$plainRegress",
-                        ("--dlpath", $regresslibdir),
-                        ("--inputdir",  $pgregressdir),
+                        ("--dlpath", $dlpath),
+                        ("--inputdir",  $pgregressInputdir),
                         ("--outputdir",  $pgregressOutputdir),
-                        ("--schedule",  catfile("$pgregressdir", "parallel_schedule")),
+                        ("--schedule",  catfile("$pgregressInputdir", "parallel_schedule")),
                         ("--use-existing"),
                         ("--host","$host"),
                         ("--port","$masterPort"),


### PR DESCRIPTION
Fixes vanilla test status on CI.

- Because of the make command used for vanilla tests, test status is always shown as success on CI. As a fix, I added `&& false` at the end of the copying diff file to make the command fail when check-vanilla fails.
```make
check-vanilla: all
	$(pg_regress_multi_check) --vanillatest || (cp $(vanilla_diffs_file) $(citus_abs_srcdir)/regression.diffs && false)
```

- I also fixed some vanilla tests that fails due to recently added clock related operators shown up at some queries.