### PR TITLE
Use test name parameter in flakiness detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,8 +684,8 @@ jobs:
             tests_array=($tests)
             for test in "${tests_array[@]}"
             do
-                echo $test
-                gosu circleci src/test/regress/citus_tests/run_test.py --path $test --repeat << parameters.runs >> --use-base-schedule --use-whole-schedule-line
+                test_name=$(echo "$test" | sed -r "s/.+\/(.+)\..+/\1/")
+                gosu circleci src/test/regress/citus_tests/run_test.py $test_name --repeat << parameters.runs >> --use-base-schedule --use-whole-schedule-line
             done
           no_output_timeout: 2m
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ parameters:
   flaky_test:
     type: string
     default: ''
-  flaky_test_runs:
+  flaky_test_runs_per_job:
     type: integer
-    default: 1600
+    default: 50
   skip_flaky_tests:
     type: boolean
     default: false
@@ -625,7 +625,7 @@ jobs:
       runs:
         description: 'number of times that the test should be run in total'
         type: integer
-        default: 256
+        default: 8
       skip:
         description: 'A flag to bypass flaky test detection.'
         type: boolean
@@ -756,7 +756,7 @@ workflows:
           image_tag: '<< pipeline.parameters.pg15_version >>'
           requires: [build-flaky-15]
           test: '<< pipeline.parameters.flaky_test >>'
-          runs: << pipeline.parameters.flaky_test_runs >>
+          runs: << pipeline.parameters.flaky_test_runs_per_job >>
 
   build_and_test:
     when:


### PR DESCRIPTION
This PR changes test-flakyness CI job to pass the test name instead of the file path to `run_test.py` script.