### PR TITLE
add prepare and finish pg upgrade functions to 11.2-1

### DIFF
--- a/src/backend/distributed/sql/citus--11.1-1--11.2-1.sql
+++ b/src/backend/distributed/sql/citus--11.1-1--11.2-1.sql
@@ -11,3 +11,5 @@ DROP FUNCTION pg_catalog.worker_append_table_to_shard(text, text, text, integer)
 #include "udfs/citus_internal_adjust_local_clock_to_remote/11.2-1.sql"
 #include "udfs/worker_split_shard_replication_setup/11.2-1.sql"
 #include "udfs/citus_task_wait/11.2-1.sql"
+#include "udfs/citus_prepare_pg_upgrade/11.2-1.sql"
+#include "udfs/citus_finish_pg_upgrade/11.2-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--11.2-1--11.1-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.2-1--11.1-1.sql
@@ -23,5 +23,5 @@ COMMENT ON FUNCTION pg_catalog.worker_append_table_to_shard(text, text, text, in
 
 #include "../udfs/worker_split_shard_replication_setup/11.1-1.sql"
 DROP FUNCTION pg_catalog.citus_task_wait(bigint, pg_catalog.citus_task_status);
-#include "udfs/citus_prepare_pg_upgrade/11.1-1.sql"
-#include "udfs/citus_finish_pg_upgrade/11.2-1.sql"
+#include "../udfs/citus_prepare_pg_upgrade/11.1-1.sql"
+#include "../udfs/citus_finish_pg_upgrade/11.1-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--11.2-1--11.1-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--11.2-1--11.1-1.sql
@@ -23,3 +23,5 @@ COMMENT ON FUNCTION pg_catalog.worker_append_table_to_shard(text, text, text, in
 
 #include "../udfs/worker_split_shard_replication_setup/11.1-1.sql"
 DROP FUNCTION pg_catalog.citus_task_wait(bigint, pg_catalog.citus_task_status);
+#include "udfs/citus_prepare_pg_upgrade/11.1-1.sql"
+#include "udfs/citus_finish_pg_upgrade/11.2-1.sql"

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.2-1.sql
@@ -103,7 +103,7 @@ BEGIN
     PERFORM setval('pg_catalog.pg_dist_colocationid_seq', (SELECT MAX(colocationid)+1 AS max_colocation_id FROM pg_dist_colocation), false);
     PERFORM setval('pg_catalog.pg_dist_operationid_seq', (SELECT MAX(operation_id)+1 AS max_operation_id FROM pg_dist_cleanup), false);
     PERFORM setval('pg_catalog.pg_dist_cleanup_recordid_seq', (SELECT MAX(record_id)+1 AS max_record_id FROM pg_dist_cleanup), false);
-    PERFORM setval('pg_catalog.pg_dist_clock_logical_seq', (SELECT last_val FROM public.pg_dist_clock_logical_seq), false);
+    PERFORM setval('pg_catalog.pg_dist_clock_logical_seq', (SELECT last_value FROM public.pg_dist_clock_logical_seq), false);
     DROP TABLE public.pg_dist_clock_logical_seq;
 
 

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -103,7 +103,7 @@ BEGIN
     PERFORM setval('pg_catalog.pg_dist_colocationid_seq', (SELECT MAX(colocationid)+1 AS max_colocation_id FROM pg_dist_colocation), false);
     PERFORM setval('pg_catalog.pg_dist_operationid_seq', (SELECT MAX(operation_id)+1 AS max_operation_id FROM pg_dist_cleanup), false);
     PERFORM setval('pg_catalog.pg_dist_cleanup_recordid_seq', (SELECT MAX(record_id)+1 AS max_record_id FROM pg_dist_cleanup), false);
-    PERFORM setval('pg_catalog.pg_dist_clock_logical_seq', (SELECT last_val FROM public.pg_dist_clock_logical_seq), false);
+    PERFORM setval('pg_catalog.pg_dist_clock_logical_seq', (SELECT last_value FROM public.pg_dist_clock_logical_seq), false);
     DROP TABLE public.pg_dist_clock_logical_seq;
 
 

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/11.2-1.sql
@@ -51,7 +51,7 @@ BEGIN
     CREATE TABLE public.pg_dist_authinfo AS SELECT * FROM pg_catalog.pg_dist_authinfo;
     CREATE TABLE public.pg_dist_poolinfo AS SELECT * FROM pg_catalog.pg_dist_poolinfo;
     -- sequences
-    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT last_val FROM pg_catalog.pg_dist_clock_logical_seq;
+    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT nextval('pg_catalog.pg_dist_clock_logical_seq') AS last_val;
     CREATE TABLE public.pg_dist_rebalance_strategy AS SELECT
         name,
         default_strategy,

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/11.2-1.sql
@@ -51,7 +51,7 @@ BEGIN
     CREATE TABLE public.pg_dist_authinfo AS SELECT * FROM pg_catalog.pg_dist_authinfo;
     CREATE TABLE public.pg_dist_poolinfo AS SELECT * FROM pg_catalog.pg_dist_poolinfo;
     -- sequences
-    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT nextval('pg_catalog.pg_dist_clock_logical_seq') AS last_val;
+    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT last_value FROM pg_catalog.pg_dist_clock_logical_seq;
     CREATE TABLE public.pg_dist_rebalance_strategy AS SELECT
         name,
         default_strategy,

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
@@ -51,7 +51,7 @@ BEGIN
     CREATE TABLE public.pg_dist_authinfo AS SELECT * FROM pg_catalog.pg_dist_authinfo;
     CREATE TABLE public.pg_dist_poolinfo AS SELECT * FROM pg_catalog.pg_dist_poolinfo;
     -- sequences
-    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT last_val FROM pg_catalog.pg_dist_clock_logical_seq;
+    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT nextval('pg_catalog.pg_dist_clock_logical_seq') AS last_val;
     CREATE TABLE public.pg_dist_rebalance_strategy AS SELECT
         name,
         default_strategy,

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
@@ -51,7 +51,7 @@ BEGIN
     CREATE TABLE public.pg_dist_authinfo AS SELECT * FROM pg_catalog.pg_dist_authinfo;
     CREATE TABLE public.pg_dist_poolinfo AS SELECT * FROM pg_catalog.pg_dist_poolinfo;
     -- sequences
-    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT nextval('pg_catalog.pg_dist_clock_logical_seq') AS last_val;
+    CREATE TABLE public.pg_dist_clock_logical_seq AS SELECT last_value FROM pg_catalog.pg_dist_clock_logical_seq;
     CREATE TABLE public.pg_dist_rebalance_strategy AS SELECT
         name,
         default_strategy,


### PR DESCRIPTION
Fixes a missed include in #6315.

While adding the cluster clock we have added some extra steps to `citus_prepare_pg_upgrade` and `citus_finish_pg_upgrade`. These changes were not added to the citus upgrade and downgrade scripts, this allowed for a syntax error to slip in.

This PR adds the new versions of both UDF's to the upgrade script while adding the old version to the downgrade script. This exposed the syntax error which is also solved.