### PR TITLE
remove unused boundary type

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -316,11 +316,6 @@ BuildJobTree(MultiTreeRoot *multiTree)
 				boundaryNodeJobType = JOIN_MAP_MERGE_JOB;
 			}
 		}
-		else if (currentNodeType == T_MultiPartition &&
-				 parentNodeType == T_MultiExtendedOp)
-		{
-			boundaryNodeJobType = SUBQUERY_MAP_MERGE_JOB;
-		}
 		else if (currentNodeType == T_MultiCollect &&
 				 parentNodeType != T_MultiPartition)
 		{
@@ -1954,10 +1949,7 @@ BuildMapMergeJob(Query *jobQuery, List *dependentJobList, Var *partitionKey,
 	Var *partitionColumn = copyObject(partitionKey);
 
 	/* update the logical partition key's table and column identifiers */
-	if (boundaryNodeJobType != SUBQUERY_MAP_MERGE_JOB)
-	{
-		UpdateColumnAttributes(partitionColumn, rangeTableList, dependentJobList);
-	}
+	UpdateColumnAttributes(partitionColumn, rangeTableList, dependentJobList);
 
 	MapMergeJob *mapMergeJob = CitusMakeNode(MapMergeJob);
 	mapMergeJob->job.jobId = UniqueJobId();

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -95,8 +95,7 @@ typedef enum
 {
 	JOB_INVALID_FIRST = 0,
 	JOIN_MAP_MERGE_JOB = 1,
-	SUBQUERY_MAP_MERGE_JOB = 2,
-	TOP_LEVEL_WORKER_JOB = 3
+	TOP_LEVEL_WORKER_JOB = 2
 } BoundaryNodeJobType;
 
 


### PR DESCRIPTION
Removes unused job boundary tag `SUBQUERY_MAP_MERGE_JOB`.

Only usage is at `BuildMapMergeJob`, which is only called when the boundary = `JOIN_MAP_MERGE_JOB`. Hence, it should be safe to remove.
