### PR TITLE
fix typo in ci style file

### DIFF
--- a/ci/fix_style.sh
+++ b/ci/fix_style.sh
@@ -16,4 +16,4 @@ ci/disallow_hash_comments_in_spec_files.sh
 ci/disallow_long_changelog_entries.sh
 ci/normalize_expected.sh
 ci/fix_gitignore.sh
-ci/printstack_trace.sh
+ci/print_stack_trace.sh


### PR DESCRIPTION
Fixes typo in `ci/fix_style.sh`.