### PR TITLE
Use Citus version comparison in upgrade tests, not equality

### DIFF
--- a/src/test/regress/expected/upgrade_partition_constraints_after.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_after.out
@@ -1,15 +1,14 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  t
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_partition_constraints_after_0.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_after_0.out
@@ -1,14 +1,13 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  f
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q

--- a/src/test/regress/expected/upgrade_partition_constraints_before.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_before.out
@@ -1,15 +1,14 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  t
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_partition_constraints_before_0.out
+++ b/src/test/regress/expected/upgrade_partition_constraints_before_0.out
@@ -1,14 +1,13 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  f
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
@@ -1,15 +1,14 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  t
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after.out
@@ -40,7 +40,6 @@ SELECT i.* FROM pg_catalog.pg_dist_object, pg_identify_object_as_address(classid
 ---------------------------------------------------------------------
   collation                 | {post_11_upgrade,german_phonebook_unpropagated}          | {}
   database                  | {postgres}                                               | {}
-  extension                 | {isn}                                                    | {}
   extension                 | {plpgsql}                                                | {}
   function                  | {post_11_upgrade,func_in_transaction_def}                | {}
   role                      | {postgres}                                               | {}
@@ -48,12 +47,16 @@ SELECT i.* FROM pg_catalog.pg_dist_object, pg_identify_object_as_address(classid
   schema                    | {new_schema}                                             | {}
   schema                    | {post_11_upgrade}                                        | {}
   schema                    | {public}                                                 | {}
+  sequence                  | {post_11_upgrade,SC1}                                    | {}
+  sequence                  | {post_11_upgrade,seq_bigint}                             | {}
+  sequence                  | {post_11_upgrade,unrelated_sequence}                     | {}
   table                     | {fooschema,footable}                                     | {}
   table                     | {new_schema,another_dist_table}                          | {}
   table                     | {post_11_upgrade,colocated_dist_table}                   | {}
   table                     | {post_11_upgrade,colocated_partitioned_table}            | {}
   table                     | {post_11_upgrade,colocated_partitioned_table_2020_01_01} | {}
   table                     | {post_11_upgrade,dist}                                   | {}
+  table                     | {post_11_upgrade,employees}                              | {}
   table                     | {post_11_upgrade,index_backed_rep_identity}              | {}
   table                     | {post_11_upgrade,part_table}                             | {}
   table                     | {post_11_upgrade,part_table_p202008}                     | {}
@@ -65,11 +68,23 @@ SELECT i.* FROM pg_catalog.pg_dist_object, pg_identify_object_as_address(classid
   table                     | {post_11_upgrade,sensors_old}                            | {}
   table                     | {post_11_upgrade,sensors_parser}                         | {}
   table                     | {post_11_upgrade,sensors_parser_a_partition}             | {}
+  table                     | {post_11_upgrade,test}                                   | {}
   table                     | {post_11_upgrade,test_propagate_collate}                 | {}
   table                     | {public,dist_table}                                      | {}
-  table                     | {public,isn_dist_table}                                  | {}
   text search configuration | {post_11_upgrade,partial_index_test_config}              | {}
   type                      | {fooschema.footype}                                      | {}
   type                      | {post_11_upgrade.my_type}                                | {}
- (33 rows)
+  type                      | {post_11_upgrade.my_type_for_view}                       | {}
+  view                      | {post_11_upgrade,depends_on_citus}                       | {}
+  view                      | {post_11_upgrade,depends_on_nothing_1}                   | {}
+  view                      | {post_11_upgrade,depends_on_nothing_2}                   | {}
+  view                      | {post_11_upgrade,depends_on_pg}                          | {}
+  view                      | {post_11_upgrade,depends_on_seq}                         | {}
+  view                      | {post_11_upgrade,non_dist_upgrade_multiple_dist_view}    | {}
+  view                      | {post_11_upgrade,non_dist_upgrade_ref_view}              | {}
+  view                      | {post_11_upgrade,non_dist_upgrade_ref_view_2}            | {}
+  view                      | {post_11_upgrade,reporting_line}                         | {}
+  view                      | {post_11_upgrade,view_for_upgrade_test}                  | {}
+  view                      | {post_11_upgrade,view_for_upgrade_test_my_type}          | {}
+ (48 rows)
 

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after_0.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after_0.out
@@ -1,14 +1,13 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  f
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after_1.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after_1.out
@@ -1,15 +1,14 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  t
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_after_1.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_after_1.out
@@ -39,7 +39,6 @@ SELECT i.* FROM pg_catalog.pg_dist_object, pg_identify_object_as_address(classid
       type      | object_names | object_args
 ---------------------------------------------------------------------
   database                  | {postgres}                                               | {}
-  extension                 | {isn}                                                    | {}
   role                      | {postgres}                                               | {}
   schema                    | {fooschema}                                              | {}
   schema                    | {new_schema}                                             | {}
@@ -47,7 +46,6 @@ SELECT i.* FROM pg_catalog.pg_dist_object, pg_identify_object_as_address(classid
   table                     | {fooschema,footable}                                     | {}
   table                     | {new_schema,another_dist_table}                          | {}
   table                     | {public,dist_table}                                      | {}
-  table                     | {public,isn_dist_table}                                  | {}
   type                      | {fooschema.footype}                                      | {}
- (11 rows)
+ (9 rows)
 

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
@@ -12,34 +12,6 @@ AS upgrade_test_old_citus_version_lt_10_0;
 \else
 \q
 \endif
--- create some objects that we just included into distributed object
--- infrastructure in 9.1 versions but not included in 9.0.2
--- extension propagation --
--- create an extension on all nodes and a table that depends on it
-CREATE EXTENSION isn;
-SELECT run_command_on_workers($$CREATE EXTENSION isn;$$);
-         run_command_on_workers
----------------------------------------------------------------------
- (localhost,57636,t,"CREATE EXTENSION")
- (localhost,57637,t,"CREATE EXTENSION")
-(2 rows)
-
-CREATE TABLE isn_dist_table (key int, value issn);
-SELECT create_reference_table('isn_dist_table');
- create_reference_table
----------------------------------------------------------------------
-
-(1 row)
-
--- create an extension on all nodes, but do not create a table depending on it
-CREATE EXTENSION seg;
-SELECT run_command_on_workers($$CREATE EXTENSION seg;$$);
-         run_command_on_workers
----------------------------------------------------------------------
- (localhost,57636,t,"CREATE EXTENSION")
- (localhost,57637,t,"CREATE EXTENSION")
-(2 rows)
-
 -- schema propagation --
 -- public schema
 CREATE TABLE dist_table (a int);

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before.out
@@ -1,15 +1,14 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  t
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_pg_dist_object_test_before_0.out
+++ b/src/test/regress/expected/upgrade_pg_dist_object_test_before_0.out
@@ -1,14 +1,13 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
- upgrade_test_old_citus_version_e_9_0
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
+ upgrade_test_old_citus_version_lt_10_0
 ---------------------------------------------------------------------
  f
 (1 row)
 
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q

--- a/src/test/regress/sql/upgrade_partition_constraints_after.sql
+++ b/src/test/regress/sql/upgrade_partition_constraints_after.sql
@@ -1,10 +1,9 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/sql/upgrade_partition_constraints_before.sql
+++ b/src/test/regress/sql/upgrade_partition_constraints_before.sql
@@ -1,10 +1,9 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_after.sql
@@ -1,10 +1,9 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
@@ -1,10 +1,9 @@
--- run this test only when old citus version is 9.0
+-- run this test only when old citus version is earlier than 10.0
 \set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int = 9 AND
-       substring(:'upgrade_test_old_citus_version', 'v\d+\.(\d+)\.\d+')::int = 0
-AS upgrade_test_old_citus_version_e_9_0;
+SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 10
+AS upgrade_test_old_citus_version_lt_10_0;
 \gset
-\if :upgrade_test_old_citus_version_e_9_0
+\if :upgrade_test_old_citus_version_lt_10_0
 \else
 \q
 \endif

--- a/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
+++ b/src/test/regress/sql/upgrade_pg_dist_object_test_before.sql
@@ -8,22 +8,6 @@ AS upgrade_test_old_citus_version_lt_10_0;
 \q
 \endif
 
--- create some objects that we just included into distributed object
--- infrastructure in 9.1 versions but not included in 9.0.2
-
--- extension propagation --
-
--- create an extension on all nodes and a table that depends on it
-CREATE EXTENSION isn;
-SELECT run_command_on_workers($$CREATE EXTENSION isn;$$);
-
-CREATE TABLE isn_dist_table (key int, value issn);
-SELECT create_reference_table('isn_dist_table');
-
--- create an extension on all nodes, but do not create a table depending on it
-CREATE EXTENSION seg;
-SELECT run_command_on_workers($$CREATE EXTENSION seg;$$);
-
 -- schema propagation --
 
 -- public schema


### PR DESCRIPTION
We have several version checks in our Citus upgrade tests. However, as
we drop support for PG versions, we need to update the Citus versions
used in our CI images. Therefore we must compare Citus versions in our
tests instead of using equality checks so that the queries are ran in
all the associated Citus versions.

For example, we have many conditionals where we early exit if the Citus
version is not equal to 9.0. However, as of today we never use version
9.0 and thus we always early exit in those tests.