### PR TITLE
Remove duplicate split entry in run_test.py

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -90,8 +90,6 @@ elif "mx" in test_schedule:
         test_schedule = 'mx_minimal_schedule'
 elif "operations" in test_schedule:
     test_schedule = 'minimal_schedule'
-elif "split" in test_schedule:
-    test_schedule = 'minimal_schedule'
 elif test_schedule in config.ARBITRARY_SCHEDULE_NAMES:
     print(f"WARNING: Arbitrary config schedule ({test_schedule}) is not supported.")
     sys.exit(0)


### PR DESCRIPTION
Nothing important. Removing the duplicate `"split" in test_schedule` check