### PR TITLE
Make GPIDs work with pg_dist_poolinfo

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -158,7 +158,12 @@ static int ReplicationModel = REPLICATION_MODEL_STREAMING;
 
 /* we override the application_name assign_hook and keep a pointer to the old one */
 static GucStringAssignHook OldApplicationNameAssignHook = NULL;
-static bool RanStartupCitusBackend = false;
+
+/*
+ * Flag to indicate when ApplicationNameAssignHook becomes responsible for
+ * updating the global pid.
+ */
+static bool FinishedStartupCitusBackend = false;
 
 static object_access_hook_type PrevObjectAccessHook = NULL;
 
@@ -682,7 +687,7 @@ StartupCitusBackend(void)
 
 	SetBackendDataDatabaseId();
 	RegisterConnectionCleanup();
-	RanStartupCitusBackend = true;
+	FinishedStartupCitusBackend = true;
 }
 
 
@@ -2600,7 +2605,26 @@ ApplicationNameAssignHook(const char *newval, void *extra)
 {
 	ResetHideShardsDecision();
 	DetermineCitusBackendType(newval);
-	if (RanStartupCitusBackend)
+
+	/*
+	 * AssignGlobalPID might read from catalog tables to get the the local
+	 * nodeid. But ApplicationNameAssignHook might be called before catalog
+	 * access is available to the backend (such as in early stages of
+	 * authentication). We use StartupCitusBackend to initialize the global pid
+	 * after catalogs are available. After that happens this hook becomes
+	 * responsible to update the global pid on later application_name changes.
+	 * So we set the FinishedStartupCitusBackend flag in StartupCitusBackend to
+	 * indicate when this responsibility handoff has happened.
+	 *
+	 * Another solution to the catalog table acccess problem would be to update
+	 * global pid lazily, like we do for HideShards. But that's not possible
+	 * for the global pid, since it is stored in shared memory instead of in a
+	 * process-local global variable. So other processes might want to read it
+	 * before this process has updated it. So instead we try to set it as early
+	 * as reasonably possible, which is also why we extract global pids in the
+	 * AuthHook already (extracting doesn't require catalog access).
+	 */
+	if (FinishedStartupCitusBackend)
 	{
 		AssignGlobalPID(newval);
 	}

--- a/src/backend/distributed/test/global_pid.c
+++ b/src/backend/distributed/test/global_pid.c
@@ -27,7 +27,7 @@ test_assign_global_pid(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 
-	AssignGlobalPID();
+	AssignGlobalPID(application_name);
 
 	PG_RETURN_VOID();
 }

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -878,55 +878,52 @@ AssignDistributedTransactionId(void)
 
 
 /*
- * AssignGlobalPID assigns a global process id for the current backend.
- * If this is a Citus initiated backend, which means it is distributed part of a distributed
- * query, then this function assigns the global pid extracted from the application name.
- * If not, this function assigns a new generated global pid.
+ * AssignGlobalPID assigns a global process id for the current backend based on
+ * the given applicationName. If this is a Citus initiated backend, which means
+ * it is distributed part of a distributed query, then this function assigns
+ * the global pid extracted from the application name. If not, this function
+ * assigns a new generated global pid.
  *
- * If a global PID is already assigned to this backend, then this function is a
- * no-op. In most scenarios this would already be the case, because a newly
- * assigned global PID would be the same as a proviously assigned one. But
- * there's two important cases where the newly assigned  global PID would be
- * different from the previous one:
- * 1. The current backend is an internal backend and in the meantime the
- *    application_name was changed to one without a gpid, e.g.
- *    citus_rebalancer. In this case we don't want to throw away the original
- *    gpid of the query originator, because that would mess up distributed
- *    deadlock detection involving this backend.
- * 2. The current backend is an external backend and the node id of the current
- *    node changed. Updating the gpid to match the nodeid might actually seem
- *    like a desirable property, but that's not the case. Updating the gpid
- *    with the new nodeid would mess up distributed deadlock and originator
- *    detection of queries too. Because if this backend already opened
- *    connections to other nodes, then those backends will still have the old
- *    gpid.
+ * There's one special case where we don't want to assign a new pid and keep
+ * the old pid on purpose: The current backend is an external backend and the
+ * node id of the current node changed. Updating the gpid to match the nodeid
+ * might seem like a desirable property, but that's not the case. Updating the
+ * gpid with the new nodeid would mess up distributed deadlock and originator
+ * detection of queries too. Because if this backend already opened connections
+ * to other nodes, then those backends will still have the old gpid.
+ *
+ * NOTE: This function can be called arbitrary amount of times for the same
+ * backend, due to being called by StartupCitusBackend.
  */
 void
-AssignGlobalPID(void)
+AssignGlobalPID(const char *applicationName)
 {
-	if (GetGlobalPID() != INVALID_CITUS_INTERNAL_BACKEND_GPID)
-	{
-		return;
-	}
-
 	uint64 globalPID = INVALID_CITUS_INTERNAL_BACKEND_GPID;
-	bool distributedCommandOriginator = false;
+	bool distributedCommandOriginator = IsExternalClientBackend();
 
-	if (!IsCitusInternalBackend())
+	if (distributedCommandOriginator)
 	{
 		globalPID = GenerateGlobalPID();
-		distributedCommandOriginator = IsExternalClientBackend();
 	}
 	else
 	{
-		globalPID = ExtractGlobalPID(application_name);
+		globalPID = ExtractGlobalPID(applicationName);
 	}
 
 	SpinLockAcquire(&MyBackendData->mutex);
 
-	MyBackendData->globalPID = globalPID;
-	MyBackendData->distributedCommandOriginator = distributedCommandOriginator;
-
+	/*
+	 * Skip updating globalpid when we were a command originator and still are
+	 * and we already have a valid global pid assigned.
+	 * See function comment for detailed explanation.
+	 */
+	if (!MyBackendData->distributedCommandOriginator ||
+		!distributedCommandOriginator ||
+		MyBackendData->globalPID == INVALID_CITUS_INTERNAL_BACKEND_GPID)
+	{
+		MyBackendData->globalPID = globalPID;
+		MyBackendData->distributedCommandOriginator = distributedCommandOriginator;
+	}
 	SpinLockRelease(&MyBackendData->mutex);
 }
 
@@ -948,19 +945,21 @@ SetBackendDataDatabaseId(void)
 
 
 /*
- * SetBackendDataDistributedCommandOriginator is used to set the distributedCommandOriginator
- * field on MyBackendData.
+ * SetBackendDataGlobalPID is used to set the gpid field on MyBackendData.
+ *
+ * IMPORTANT: This should not be used for normal operations. It's a very hacky
+ * way of setting the gpid function that is only used. The main problem is
+ * that it does not set distributedCommandOriginator to the correct value.
  */
 void
-SetBackendDataDistributedCommandOriginator(bool distributedCommandOriginator)
+SetBackendDataGlobalPID(uint64 gpid)
 {
 	if (!MyBackendData)
 	{
 		return;
 	}
 	SpinLockAcquire(&MyBackendData->mutex);
-	MyBackendData->distributedCommandOriginator =
-		distributedCommandOriginator;
+	MyBackendData->globalPID = gpid;
 	SpinLockRelease(&MyBackendData->mutex);
 }
 
@@ -1386,16 +1385,6 @@ void
 DecrementExternalClientBackendCounter(void)
 {
 	pg_atomic_sub_fetch_u32(&backendManagementShmemData->externalClientBackendCounter, 1);
-}
-
-
-/*
- * ResetCitusBackendType resets the backend type cache.
- */
-void
-ResetCitusBackendType(void)
-{
-	CurrentBackendType = CITUS_BACKEND_NOT_ASSIGNED;
 }
 
 

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -56,12 +56,10 @@ extern void UnSetDistributedTransactionId(void);
 extern void UnSetGlobalPID(void);
 extern void SetActiveMyBackend(bool value);
 extern void AssignDistributedTransactionId(void);
-extern void AssignGlobalPID(void);
-extern void SetBackendDataGlobalPID(uint64 globalPID);
+extern void AssignGlobalPID(const char *applicationName);
 extern uint64 GetGlobalPID(void);
 extern void SetBackendDataDatabaseId(void);
-extern void SetBackendDataDistributedCommandOriginator(bool
-													   distributedCommandOriginator);
+extern void SetBackendDataGlobalPID(uint64 gpid);
 extern uint64 ExtractGlobalPID(const char *applicationName);
 extern int ExtractNodeIdFromGlobalPID(uint64 globalPID, bool missingOk);
 extern int ExtractProcessIdFromGlobalPID(uint64 globalPID);
@@ -79,7 +77,6 @@ extern bool IsCitusInternalBackend(void);
 extern bool IsRebalancerInternalBackend(void);
 extern bool IsCitusRunCommandBackend(void);
 extern bool IsExternalClientBackend(void);
-extern void ResetCitusBackendType(void);
 
 #define INVALID_CITUS_INTERNAL_BACKEND_GPID 0
 #define GLOBAL_PID_NODE_ID_FOR_NODES_NOT_IN_METADATA 99999999

--- a/src/test/regress/spec/isolation_mx_common.include.spec
+++ b/src/test/regress/spec/isolation_mx_common.include.spec
@@ -8,12 +8,12 @@ setup
         LANGUAGE C STRICT VOLATILE
         AS 'citus', $$start_session_level_connection_to_node$$;
 
-    CREATE OR REPLACE FUNCTION override_backend_data_command_originator(bool)
+    CREATE OR REPLACE FUNCTION override_backend_data_gpid(bigint)
         RETURNS void
         LANGUAGE C STRICT IMMUTABLE
-        AS 'citus', $$override_backend_data_command_originator$$;
+        AS 'citus', $$override_backend_data_gpid$$;
 
-    SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off;CREATE OR REPLACE FUNCTION override_backend_data_command_originator(bool)
+    SELECT run_command_on_workers($$SET citus.enable_metadata_sync TO off;CREATE OR REPLACE FUNCTION override_backend_data_gpid(bigint)
         RETURNS void
         LANGUAGE C STRICT IMMUTABLE
         AS 'citus'$$);


### PR DESCRIPTION
The original implementation of GPIDs didn't work correctly when using `pg_dist_poolinfo` together with PgBouncer. The reason is that it assumed that once a connection was made to a worker, the originating GPID should stay the same for ever. But when pg_dist_poolinfo is used this isn't the case, because the same connection on the worker might be used by different backends of the coordinator.

This fixes that issue by updating the GPID whenever a new application name is set on a connection. This is the only thing that's needed, because PgBouncer already sets the application name correctly on the server connection whenever a client is updated.
