### PR TITLE
Fix crash when trying to replicate a ref table that is actually dropped

### DIFF
--- a/src/backend/distributed/operations/shard_transfer.c
+++ b/src/backend/distributed/operations/shard_transfer.c
@@ -1611,6 +1611,15 @@ EnsureShardCanBeCopied(int64 shardId, const char *sourceNodeName, int32 sourceNo
 							"shard " INT64_FORMAT " already exists in the target node",
 							shardId)));
 	}
+
+	/*
+	 * Make sure the relation exists. In some cases the relation is actually dropped but
+	 * the metadata remains, such as dropping table while citus.enable_ddl_propagation
+	 * is set to off.
+	 */
+	ShardInterval *shardInterval = LoadShardInterval(shardId);
+	Oid distributedTableId = shardInterval->relationId;
+	EnsureRelationExists(distributedTableId);
 }
 
 

--- a/src/test/regress/expected/issue_6592.out
+++ b/src/test/regress/expected/issue_6592.out
@@ -1,0 +1,53 @@
+-- https://github.com/citusdata/citus/issues/6592
+SET citus.next_shard_id TO 180000;
+CREATE TABLE ref_table_to_be_dropped_6592 (key int);
+SELECT create_reference_table('ref_table_to_be_dropped_6592');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE ref_table_oid AS SELECT oid FROM pg_class WHERE relname = 'ref_table_to_be_dropped_6592';
+SET citus.enable_ddl_propagation TO OFF;
+DROP TABLE ref_table_to_be_dropped_6592 CASCADE; -- citus_drop_all_shards doesn't drop shards and metadata
+-- ensure that coordinator is added to pg_dist_node
+SET client_min_messages to ERROR;
+SELECT 1 FROM master_add_node('localhost', :master_port, groupId => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+RESET client_min_messages;
+-- error out for the dropped reference table
+CREATE TABLE citus_local_table(id int, other_column int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+ERROR:  relation with OID XXXX does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+RESET citus.enable_ddl_propagation;
+DROP TABLE citus_local_table;
+\c - - - :worker_1_port
+SET citus.enable_ddl_propagation TO OFF;
+DELETE FROM pg_dist_partition WHERE logicalrelid = 'ref_table_to_be_dropped_6592'::regclass;
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592_180000;
+\c - - - :worker_2_port
+SET citus.enable_ddl_propagation TO OFF;
+DELETE FROM pg_dist_partition WHERE logicalrelid = 'ref_table_to_be_dropped_6592'::regclass;
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592_180000;
+\c - - - :master_port
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DELETE FROM pg_dist_partition WHERE logicalrelid IN (SELECT oid FROM ref_table_oid);
+DROP TABLE ref_table_oid;
+SELECT 1 FROM citus_remove_node('localhost', :master_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+

--- a/src/test/regress/multi_mx_schedule
+++ b/src/test/regress/multi_mx_schedule
@@ -67,6 +67,8 @@ test: distributed_locks
 test: local_shard_execution_dropped_column
 test: metadata_sync_helpers
 
+test: issue_6592
+
 # test that no tests leaked intermediate results. This should always be last
 test: ensure_no_intermediate_data_leak
 test: check_mx

--- a/src/test/regress/sql/issue_6592.sql
+++ b/src/test/regress/sql/issue_6592.sql
@@ -1,0 +1,39 @@
+-- https://github.com/citusdata/citus/issues/6592
+SET citus.next_shard_id TO 180000;
+CREATE TABLE ref_table_to_be_dropped_6592 (key int);
+SELECT create_reference_table('ref_table_to_be_dropped_6592');
+CREATE TABLE ref_table_oid AS SELECT oid FROM pg_class WHERE relname = 'ref_table_to_be_dropped_6592';
+SET citus.enable_ddl_propagation TO OFF;
+DROP TABLE ref_table_to_be_dropped_6592 CASCADE; -- citus_drop_all_shards doesn't drop shards and metadata
+
+-- ensure that coordinator is added to pg_dist_node
+SET client_min_messages to ERROR;
+SELECT 1 FROM master_add_node('localhost', :master_port, groupId => 0);
+RESET client_min_messages;
+
+-- error out for the dropped reference table
+CREATE TABLE citus_local_table(id int, other_column int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+RESET citus.enable_ddl_propagation;
+DROP TABLE citus_local_table;
+
+\c - - - :worker_1_port
+SET citus.enable_ddl_propagation TO OFF;
+DELETE FROM pg_dist_partition WHERE logicalrelid = 'ref_table_to_be_dropped_6592'::regclass;
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592_180000;
+\c - - - :worker_2_port
+SET citus.enable_ddl_propagation TO OFF;
+DELETE FROM pg_dist_partition WHERE logicalrelid = 'ref_table_to_be_dropped_6592'::regclass;
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592;
+DROP TABLE IF EXISTS ref_table_to_be_dropped_6592_180000;
+\c - - - :master_port
+DELETE FROM pg_dist_placement WHERE shardid = 180000;
+DELETE FROM pg_dist_shard WHERE shardid = 180000;
+DELETE FROM pg_dist_partition WHERE logicalrelid IN (SELECT oid FROM ref_table_oid);
+DROP TABLE ref_table_oid;
+SELECT 1 FROM citus_remove_node('localhost', :master_port);


### PR DESCRIPTION
DESCRIPTION: Fix crash when trying to replicate a ref table that is actually dropped

see #6592 
We should have a real solution for it.

Adding the test file into `test_files_to_skip` in `run_test.py`, because we are not able to create reference tables when this case happens. The dropped reference table leaves its metadata behind, and it prevents us from running this test file again.