### PR TITLE
Use the executor to sync objects during node activation

### DIFF
--- a/src/test/regress/expected/failure_add_disable_node.out
+++ b/src/test/regress/expected/failure_add_disable_node.out
@@ -105,9 +105,7 @@ SELECT citus.mitmproxy('conn.onQuery(query="CREATE SCHEMA").kill()');
 (1 row)
 
 SELECT master_activate_node('localhost', :worker_2_proxy_port);
-WARNING:  connection not open
-CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  failure on connection marked as essential: localhost:xxxxx
+ERROR:  connection to the remote node localhost:xxxxx failed with the following error: connection not open
 -- verify node is not activated
 SELECT * FROM master_get_active_worker_nodes()
 ORDER BY 1, 2;

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -210,9 +210,8 @@ SELECT run_command_on_workers($$SELECT extversion FROM pg_extension WHERE extnam
 
 -- adding the second node will fail as the text search template needs to be created manually
 SELECT 1 from master_add_node('localhost', :worker_2_port);
-WARNING:  text search template "public.intdict_template" does not exist
+ERROR:  text search template "public.intdict_template" does not exist
 CONTEXT:  while executing command on localhost:xxxxx
-ERROR:  failure on connection marked as essential: localhost:xxxxx
 -- create the text search template manually on the worker
 \c - - - :worker_2_port
 SET citus.enable_metadata_sync TO false;


### PR DESCRIPTION
DESCRIPTION: Reduce memory usage of metadata syncing during node activation

We previously started batching commands together to minimize round trips and overall duration of metadata sync. However, for large metadata syncs this leads to a large number of large memory allocations (e.g. in StringJoin, libpq), which can cause a large metadata sync to fail. In general, it's preferable to use the executor for complex interactions with the worker nodes since it's more heavily tuned, so this PR changes SyncDistributedObjectsToNodeList to use the executor.