### PR TITLE
Fix failures in mx_base_schedule

### DIFF
--- a/src/test/regress/mx_base_schedule
+++ b/src/test/regress/mx_base_schedule
@@ -1,8 +1,9 @@
 # ----------
 # Only run few basic tests to set up a testing environment
 # ----------
-test: multi_cluster_management
 test: multi_test_helpers multi_test_helpers_superuser
+test: multi_cluster_management
+test: multi_mx_function_table_reference
 test: multi_test_catalog_views
 
 # the following test has to be run sequentially


### PR DESCRIPTION
Apparently no-one actually ran the mx_base_schedule, because the tests
in schedule itself were already failing. This updates it to be in line
with multi_mx_schedule again to make the tests pass again. Notably it
doesn't contain multi_mx_node_metadata and multi_extension. Because
those tests take long to run and the were not necessary to make
multi_mx_create_table pass again.
