### PR TITLE
Use %u instead of %i for naming subscriptions & roles

### DIFF
--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -1231,7 +1231,7 @@ ReplicationSlotNameForNodeAndOwnerForOperation(LogicalRepType type, uint32_t nod
 char *
 SubscriptionName(LogicalRepType type, Oid ownerId)
 {
-	return psprintf("%s%i_%lu", subscriptionPrefix[type],
+	return psprintf("%s%u_%lu", subscriptionPrefix[type],
 					ownerId, CurrentOperationId);
 }
 
@@ -1243,7 +1243,7 @@ SubscriptionName(LogicalRepType type, Oid ownerId)
 char *
 SubscriptionRoleName(LogicalRepType type, Oid ownerId)
 {
-	return psprintf("%s%i_%lu", subscriptionRolePrefix[type], ownerId,
+	return psprintf("%s%u_%lu", subscriptionRolePrefix[type], ownerId,
 					CurrentOperationId);
 }
 


### PR DESCRIPTION
DESCRIPTION: Fix the modifier for subscription and role creation

fixes: #6598 
Reported by @ivyazmitinov
