### PR TITLE
Only run package builds on pull requests

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -1,8 +1,6 @@
 name: Build tests in packaging images
 
 on:
-  push:
-    branches: "**"
   pull_request:
     types: [opened, reopened,synchronize]
 


### PR DESCRIPTION
Recently a package test build pipeline was introduced, to build citus on
all OS that we build packages for. However, every pull request would run
each build twice. This fixes that by only running it for the pull
request event, not for the push event.

Example of duplicate run:
![image](https://user-images.githubusercontent.com/1162278/211028723-8c0e8aa0-e267-4665-811c-6cecd4286621.png)
