### PR TITLE
Fall-back to seq-scan when accessing columnar metadata if the index doesn't exist

### DIFF
--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -55,6 +55,89 @@ SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_table_1_
  t
 (1 row)
 
+BEGIN;
+  INSERT INTO columnar_table_1 VALUES (2);
+ROLLBACK;
+INSERT INTO columnar_table_1 VALUES (3),(4);
+INSERT INTO columnar_table_1 VALUES (5),(6);
+INSERT INTO columnar_table_1 VALUES (7),(8);
+-- Test whether columnar metadata accessors are still fine even
+-- when the metadata indexes are not available to them.
+BEGIN;
+  ALTER INDEX columnar_internal.stripe_first_row_number_idx RENAME TO new_index_name;
+  ALTER INDEX columnar_internal.chunk_pkey RENAME TO new_index_name_1;
+  ALTER INDEX columnar_internal.stripe_pkey RENAME TO new_index_name_2;
+  ALTER INDEX columnar_internal.chunk_group_pkey RENAME TO new_index_name_3;
+  CREATE INDEX columnar_table_1_idx ON columnar_table_1(a);
+WARNING:  Metadata index stripe_first_row_number_idx is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+WARNING:  Metadata index stripe_first_row_number_idx is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+WARNING:  Metadata index chunk_pkey is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+WARNING:  Metadata index chunk_group_pkey is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+  -- make sure that we test index scan
+  SET LOCAL columnar.enable_custom_scan TO 'off';
+  SET LOCAL enable_seqscan TO off;
+  SET LOCAL seq_page_cost TO 10000000;
+  SELECT * FROM columnar_table_1 WHERE a = 6;
+WARNING:  Metadata index stripe_first_row_number_idx is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+ a
+---------------------------------------------------------------------
+ 6
+(1 row)
+
+  SELECT * FROM columnar_table_1 WHERE a = 5;
+ a
+---------------------------------------------------------------------
+ 5
+(1 row)
+
+  SELECT * FROM columnar_table_1 WHERE a = 7;
+ a
+---------------------------------------------------------------------
+ 7
+(1 row)
+
+  SELECT * FROM columnar_table_1 WHERE a = 3;
+ a
+---------------------------------------------------------------------
+ 3
+(1 row)
+
+  DROP INDEX columnar_table_1_idx;
+  -- Re-shuffle some metadata records to test whether we can
+  -- rely on sequential metadata scan when the metadata records
+  -- are not ordered by their "first_row_number"s.
+  WITH cte AS (
+      DELETE FROM columnar_internal.stripe
+      WHERE storage_id = columnar.get_storage_id('columnar_table_1')
+      RETURNING *
+  )
+  INSERT INTO columnar_internal.stripe SELECT * FROM cte ORDER BY first_row_number DESC;
+  SELECT SUM(a) FROM columnar_table_1;
+ sum
+---------------------------------------------------------------------
+  34
+(1 row)
+
+  SELECT * FROM columnar_table_1 WHERE a = 6;
+ a
+---------------------------------------------------------------------
+ 6
+(1 row)
+
+  -- Run a SELECT query after the INSERT command to force flushing the
+  -- data within the xact block.
+  INSERT INTO columnar_table_1 VALUES (20);
+  SELECT COUNT(*) FROM columnar_table_1;
+WARNING:  Metadata index stripe_pkey is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+ count
+---------------------------------------------------------------------
+     8
+(1 row)
+
+  DROP TABLE columnar_table_1 CASCADE;
+NOTICE:  drop cascades to materialized view columnar_table_1_mv
+WARNING:  Metadata index on a columnar metadata table is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+ROLLBACK;
 -- test dropping columnar table
 DROP TABLE columnar_table_1 CASCADE;
 NOTICE:  drop cascades to materialized view columnar_table_1_mv

--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -1,24 +1,50 @@
 --
 -- Test the CREATE statements related to columnar.
 --
--- Create uncompressed table
-CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
-	percentile FLOAT, country CHAR(3), achievements TEXT[])
-	USING columnar;
-ALTER TABLE contestant SET (columnar.compression = none);
-CREATE INDEX contestant_idx on contestant(handle);
--- Create zstd compressed table
-CREATE TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,
-	percentile FLOAT, country CHAR(3), achievements TEXT[])
-	USING columnar;
--- Test that querying an empty table works
-ANALYZE contestant;
+-- We cannot create below tables within columnar_create because columnar_create
+-- is dropped at the end of this test but unfortunately some other tests depend
+-- those tables too.
+--
+-- However, this file has to be runnable multiple times for flaky test detection;
+-- so we create them below --outside columnar_create-- idempotantly.
+DO
+$$
+BEGIN
+IF NOT EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE relname = 'contestant' AND
+          relnamespace = (
+            SELECT oid FROM pg_namespace WHERE nspname = 'public'
+          )
+   )
+THEN
+    -- Create uncompressed table
+    CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
+        percentile FLOAT, country CHAR(3), achievements TEXT[])
+        USING columnar;
+    ALTER TABLE contestant SET (columnar.compression = none);
+
+    CREATE INDEX contestant_idx on contestant(handle);
+
+    -- Create zstd compressed table
+    CREATE TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,
+        percentile FLOAT, country CHAR(3), achievements TEXT[])
+        USING columnar;
+
+    -- Test that querying an empty table works
+    ANALYZE contestant;
+END IF;
+END
+$$
+LANGUAGE plpgsql;
 SELECT count(*) FROM contestant;
  count
 ---------------------------------------------------------------------
      0
 (1 row)
 
+CREATE SCHEMA columnar_create;
+SET search_path TO columnar_create;
 -- Should fail: unlogged tables not supported
 CREATE UNLOGGED TABLE columnar_unlogged(i int) USING columnar;
 ERROR:  unlogged columnar tables are not supported
@@ -156,6 +182,7 @@ SELECT columnar.get_storage_id(oid) AS columnar_temp_storage_id
 FROM pg_class WHERE relname='columnar_temp' \gset
 SELECT pg_backend_pid() AS val INTO old_backend_pid;
 \c - - - :master_port
+SET search_path TO columnar_create;
 -- wait until old backend to expire to make sure that temp table cleanup is complete
 SELECT columnar_test_helpers.pg_waitpid(val) FROM old_backend_pid;
  pg_waitpid
@@ -265,3 +292,5 @@ SELECT columnar_test_helpers.columnar_metadata_has_storage_id(:columnar_temp_sto
 
 -- make sure citus_columnar can be loaded
 LOAD 'citus_columnar';
+SET client_min_messages TO WARNING;
+DROP SCHEMA columnar_create CASCADE;

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -257,6 +257,32 @@ SELECT SUM(a)=48000 FROM columnar_table WHERE a = 16000 OR a = 32000;
  t
 (1 row)
 
+BEGIN;
+  ALTER INDEX columnar_internal.stripe_first_row_number_idx RENAME TO new_index_name;
+  ALTER INDEX columnar_internal.chunk_pkey RENAME TO new_index_name_1;
+  -- same queries but this time some metadata indexes are not available
+  SELECT SUM(a)=312487500 FROM columnar_table WHERE a < 25000;
+WARNING:  Metadata index stripe_first_row_number_idx is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+WARNING:  Metadata index stripe_first_row_number_idx is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+WARNING:  Metadata index chunk_pkey is not available, this might mean slower read/writes on columnar tables. This is expected during Postgres upgrades and not expected otherwise.
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+  SELECT SUM(a)=167000 FROM columnar_table WHERE a = 16000 OR a = 151000;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+  SELECT SUM(a)=48000 FROM columnar_table WHERE a = 16000 OR a = 32000;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
 TRUNCATE columnar_table;
 ALTER TABLE columnar_table DROP CONSTRAINT columnar_table_pkey;
 -- hash --

--- a/src/test/regress/expected/upgrade_columnar_before.out
+++ b/src/test/regress/expected/upgrade_columnar_before.out
@@ -371,3 +371,6 @@ select count(DISTINCT value) from text_data;
     11
 (1 row)
 
+-- test using a columnar partition
+CREATE TABLE foo (d DATE NOT NULL) PARTITION BY RANGE (d);
+CREATE TABLE foo3 PARTITION OF foo FOR VALUES FROM ('2009-02-01') TO ('2009-03-01') USING COLUMNAR;

--- a/src/test/regress/sql/columnar_indexes.sql
+++ b/src/test/regress/sql/columnar_indexes.sql
@@ -167,6 +167,16 @@ SELECT SUM(a)=312487500 FROM columnar_table WHERE a < 25000;
 SELECT SUM(a)=167000 FROM columnar_table WHERE a = 16000 OR a = 151000;
 SELECT SUM(a)=48000 FROM columnar_table WHERE a = 16000 OR a = 32000;
 
+BEGIN;
+  ALTER INDEX columnar_internal.stripe_first_row_number_idx RENAME TO new_index_name;
+  ALTER INDEX columnar_internal.chunk_pkey RENAME TO new_index_name_1;
+
+  -- same queries but this time some metadata indexes are not available
+  SELECT SUM(a)=312487500 FROM columnar_table WHERE a < 25000;
+  SELECT SUM(a)=167000 FROM columnar_table WHERE a = 16000 OR a = 151000;
+  SELECT SUM(a)=48000 FROM columnar_table WHERE a = 16000 OR a = 32000;
+ROLLBACK;
+
 TRUNCATE columnar_table;
 ALTER TABLE columnar_table DROP CONSTRAINT columnar_table_pkey;
 

--- a/src/test/regress/sql/upgrade_columnar_before.sql
+++ b/src/test/regress/sql/upgrade_columnar_before.sql
@@ -276,3 +276,7 @@ $$ LANGUAGE plpgsql;
 CREATE TABLE text_data (id SERIAL, value TEXT) USING COLUMNAR;
 INSERT INTO text_data (value) SELECT generate_random_string(1024 * 10) FROM generate_series(0,10);
 select count(DISTINCT value) from text_data;
+
+-- test using a columnar partition
+CREATE TABLE foo (d DATE NOT NULL) PARTITION BY RANGE (d);
+CREATE TABLE foo3 PARTITION OF foo FOR VALUES FROM ('2009-02-01') TO ('2009-03-01') USING COLUMNAR;


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that breaks pg upgrades if the user has a columnar table

Fixes #6570.

In the past, having columnar tables in the cluster was causing pg
upgrades to fail when attempting to access columnar metadata. This is
because, pg_dump doesn't see objects that we use for columnar-am related
booking as the dependencies of the tables using columnar-am.
To fix that; in #5456, we inserted some "normal dependency" edges (from
those objects to columnar-am) into pg_depend.

This helped us ensuring the existency of a class of metadata objects
--such as columnar.storageid_seq-- and helped fixing #5437.

However, the normal-dependency edges that we added for indexes on
columnar metadata tables --such columnar.stripe_pkey-- didn't help at
all because they were indeed causing dependency loops (#5510) and
pg_dump was not able to take those dependency edges into the account.

For this reason, this commit allows columnar metadata accessors to
fall-back to sequential scan if the index is not available, which can
only be the case during pg upgrades.