### PR TITLE
Move tablespace directory creation to pg_regress_multi.pl

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -56,19 +56,11 @@ ISOLATION_BUILDDIR=build/specs
 # ex: make print-generated_isolation_files
 print-%  : ; @echo $* = $($*)
 
-.PHONY: create-symbolic-link create-tablespaces
+.PHONY: create-symbolic-link
 
 create-symbolic-link:
 	mkdir -p $(citus_abs_srcdir)/build
 	ln -fsn $(citus_abs_srcdir)/expected $(citus_abs_srcdir)/build/
-
-create-tablespaces:
-	rm -rf $(citus_abs_srcdir)/tmp_check/ts1
-	mkdir -p $(citus_abs_srcdir)/tmp_check/ts1
-	rm -rf $(citus_abs_srcdir)/tmp_check/ts0
-	mkdir -p $(citus_abs_srcdir)/tmp_check/ts0
-	rm -rf $(citus_abs_srcdir)/tmp_check/ts2
-	mkdir -p $(citus_abs_srcdir)/tmp_check/ts2
 
 # How this target works:
 # cpp is used before running isolation tests to preprocess spec files.
@@ -107,7 +99,7 @@ check-base: all
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/base_schedule $(EXTRA_TESTS)
 
 # check-minimal only sets up the cluster
-check-minimal: all create-tablespaces
+check-minimal: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/minimal_schedule $(EXTRA_TESTS)
 
@@ -285,4 +277,3 @@ clean distclean maintainer-clean:
 	rm -rf tmp_check/
 	rm -rf tmp_citus_test/
 
-all: create-tablespaces

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -624,6 +624,17 @@ for my $port (@followerWorkerPorts)
 	}
 }
 
+for my $tablespace ("ts0", "ts1", "ts2")
+{
+	if (-e catfile($TMP_CHECKDIR, $tablespace))
+	{
+	    remove_tree(catfile($TMP_CHECKDIR, $tablespace)) or die "Could not remove tablespace directory";
+	}
+    system("mkdir", ("-p", catfile($TMP_CHECKDIR, $tablespace))) == 0
+            or die "Could not create vanilla testtablespace dir.";
+}
+
+
 # Prepare directory in which 'psql' has some helpful variables for locating the workers
 make_path(catfile($TMP_CHECKDIR, $TMP_BINDIR)) or die "Could not create $TMP_BINDIR directory $!\n";
 


### PR DESCRIPTION
Multiple `check-xxx` targets create tablespaces. If you run
two of these at the same time you would get an error like:

```diff
CREATE TABLESPACE test_tablespace LOCATION :'test_tablespace';
+ERROR:  directory "/home/rajesh/citus/citus/src/test/regress/tmp_check/ts0/PG_14_202107181" already in use as a tablespace
```

This fixes that by moving creation of table space directory creation and
removal to pg_regress_multi.pl instead of being in the Makefile.
