### PR TITLE
Refactor shard transfers

### DIFF
--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -310,8 +310,6 @@ extern ShardPlacement * SearchShardPlacementInList(List *shardPlacementList,
 extern ShardPlacement * SearchShardPlacementInListOrError(List *shardPlacementList,
 														  const char *nodeName,
 														  uint32 nodePort);
-extern void ErrorIfTargetNodeIsNotSafeToMove(const char *targetNodeName, int
-											 targetNodePort);
 extern char LookupShardTransferMode(Oid shardReplicationModeOid);
 extern void BlockWritesToShardList(List *shardList);
 extern List * WorkerApplyShardDDLCommandList(List *ddlCommandList, int64 shardId);

--- a/src/include/distributed/shard_transfer.h
+++ b/src/include/distributed/shard_transfer.h
@@ -19,12 +19,10 @@ typedef enum
 	SHARD_TRANSFER_COPY = 2
 } ShardTransferType;
 
-extern void citus_move_shard_placement_internal(int64 shardId, char *sourceNodeName,
-												int32 sourceNodePort,
-												char *targetNodeName,
-												int32 targetNodePort,
-												char shardReplicationMode,
-												ShardTransferType transferType);
+extern void TransferShards(int64 shardId,
+						   char *sourceNodeName, int32 sourceNodePort,
+						   char *targetNodeName, int32 targetNodePort,
+						   char shardReplicationMode, ShardTransferType transferType);
 extern uint64 ShardListSizeInBytes(List *colocatedShardList,
 								   char *workerNodeName, uint32 workerNodePort);
 extern void ErrorIfMoveUnsupportedTableType(Oid relationId);

--- a/src/include/distributed/shard_transfer.h
+++ b/src/include/distributed/shard_transfer.h
@@ -12,11 +12,19 @@
 #include "distributed/shard_rebalancer.h"
 #include "nodes/pg_list.h"
 
+typedef enum
+{
+	SHARD_TRANSFER_INVALID_FIRST = 0,
+	SHARD_TRANSFER_MOVE = 1,
+	SHARD_TRANSFER_COPY = 2
+} ShardTransferType;
+
 extern void citus_move_shard_placement_internal(int64 shardId, char *sourceNodeName,
 												int32 sourceNodePort,
 												char *targetNodeName,
 												int32 targetNodePort,
-												Oid shardReplicationModeOid);
+												char shardReplicationMode,
+												ShardTransferType transferType);
 extern uint64 ShardListSizeInBytes(List *colocatedShardList,
 								   char *workerNodeName, uint32 workerNodePort);
 extern void ErrorIfMoveUnsupportedTableType(Oid relationId);


### PR DESCRIPTION
DESCRIPTION: Refactor and unify shard move and copy functions

Shard move and copy functions share a lot of code in common. This PR unifies these functions into one, along with some helper functions. To preserve the current behavior, we'll introduce and use an enum parameter, and hardcoded strings for producing error/warning messages.