### PR TITLE
Use correct guc value to disable statistics collection

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -561,7 +561,7 @@ if($isolationtester)
    # maintenance daemon.
    push(@pgOptions, "citus.distributed_deadlock_detection_factor=-1");
    push(@pgOptions, "citus.recover_2pc_interval=-1");
-   push(@pgOptions, "citus.enable_statistics_collection=-1");
+   push(@pgOptions, "citus.enable_statistics_collection=false");
    push(@pgOptions, "citus.defer_shard_delete_interval=-1");
    push(@pgOptions, "citus.stat_statements_purge_interval=-1");
    push(@pgOptions, "citus.background_task_queue_interval=-1");


### PR DESCRIPTION
The `citus.enable_statistics_collection` is a boolean GUC not an integer
one. Setting it to `-1` showed errors in the logs.
