### PR TITLE
Fix ADD {PRIMARY KEY/UNIQUE} USING INDEX command

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1270,8 +1270,8 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 				}
 			}
 			/*
-			 * When constraint->indexname is not NULL we are handling an add constraint USING INDEX command. In this case
-			 * we do not have to create a name. If both are NULL then we create a constraint name.
+			 * When constraint->indexname is not NULL we are handling an ADD {PRIMARY KEY, UNIQUE} USING INDEX command. In this case
+			 * we do not have to create a name and change the command. The index name will be used by the postgres.
 			 */
 			else if (constraint->conname == NULL && constraint->indexname == NULL)
 			{

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -1269,7 +1269,11 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 															 constraint);
 				}
 			}
-			else if (constraint->conname == NULL)
+			/*
+			 * When constraint->indexname is not NULL we are handling an add constraint USING INDEX command. In this case
+			 * we do not have to create a name. If both are NULL then we create a constraint name.
+			 */
+			else if (constraint->conname == NULL && constraint->indexname == NULL)
 			{
 				if (ConstrTypeCitusCanDefaultName(constraint->contype))
 				{

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -3336,8 +3336,6 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 			case AT_AddConstraint:
 			{
-				Constraint *constraint = (Constraint *) command->def;
-
 				/* we only allow constraints if they are only subcommand */
 				if (commandList->length > 1)
 				{

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -180,7 +180,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 						constraint->contype != CONSTR_CHECK)
 					{
 						/*
-						 * constraint->conname could be empty in the case of add constraint USING INDEX.
+						 * constraint->conname could be empty in the case of ADD {PRIMARY KEY, UNIQUE} USING INDEX.
 						 * In this case, already extended index name will be used by postgres.
 						 */
 						if (constraint->conname != NULL)

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -150,7 +150,6 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 				if (command->subtype == AT_AddConstraint)
 				{
 					Constraint *constraint = (Constraint *) command->def;
-
 					char **constraintName = &(constraint->conname);
 					const bool missingOk = false;
 					relationId = RangeVarGetRelid(alterTableStmt->relation,
@@ -180,7 +179,8 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 						constraint->contype != CONSTR_CHECK)
 					{
 						/*
-						 * constraint->conname could be empty in the case of ADD {PRIMARY KEY, UNIQUE} USING INDEX.
+						 * constraint->conname could be empty in the case of
+						 * ADD {PRIMARY KEY, UNIQUE} USING INDEX.
 						 * In this case, already extended index name will be used by postgres.
 						 */
 						if (constraint->conname != NULL)

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -150,6 +150,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 				if (command->subtype == AT_AddConstraint)
 				{
 					Constraint *constraint = (Constraint *) command->def;
+
 					char **constraintName = &(constraint->conname);
 					const bool missingOk = false;
 					relationId = RangeVarGetRelid(alterTableStmt->relation,
@@ -178,7 +179,14 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 					if (!PartitionedTable(relationId) ||
 						constraint->contype != CONSTR_CHECK)
 					{
-						AppendShardIdToName(constraintName, shardId);
+						/*
+						 * constraint->conname could be empty in the case of add constraint USING INDEX.
+						 * In this case, already extended index name will be used by postgres.
+						 */
+						if (constraint->conname != NULL)
+						{
+							AppendShardIdToName(constraintName, shardId);
+						}
 					}
 				}
 				else if (command->subtype == AT_DropConstraint ||

--- a/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
@@ -44,6 +44,27 @@ SELECT con.conname
 
 \c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.products DROP CONSTRAINT products_pkey;
+-- Check "ADD PRIMARY KEY USING INDEX ..."
+CREATE TABLE  AT_AddConstNoName.tbl(col1 int, col2 int);
+SELECT create_distributed_table('AT_AddConstNoName.tbl', 'col1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE UNIQUE INDEX my_index ON AT_AddConstNoName.tbl(col1);
+ALTER TABLE AT_AddConstNoName.tbl ADD PRIMARY KEY USING INDEX my_index;
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'tbl';
+ conname
+---------------------------------------------------------------------
+ my_index
+(1 row)
+
+ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 -- Check "ADD PRIMARY KEY DEFERRABLE"
 ALTER TABLE AT_AddConstNoName.products ADD PRIMARY KEY(product_no) DEFERRABLE;
 \c - - :public_worker_1_host :worker_1_port
@@ -429,10 +450,10 @@ SELECT con.conname
 		WHERE rel.relname LIKE 'very%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410006
- verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410007
- verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410008
- verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410009
+ verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410010
+ verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410011
+ verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410012
+ verylonglonglonglonglonglonglonglonglonglonglo_559ab79d_5410013
  verylonglonglonglonglonglonglonglonglonglonglonglonglonglo_pkey
 (5 rows)
 
@@ -472,10 +493,10 @@ SELECT con.conname
                 WHERE rel.relname LIKE 'very%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410006
- verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410007
- verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410008
- verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410009
+ verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410010
+ verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410011
+ verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410012
+ verylonglonglonglonglonglonglonglonglonglonglo_cd61b0cf_5410013
  verylonglonglonglonglonglonglonglonglonglonglong_product_no_key
 (5 rows)
 
@@ -515,10 +536,10 @@ SELECT con.conname
                 WHERE rel.relname LIKE 'very%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410006
- verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410007
- verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410008
- verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410009
+ verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410010
+ verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410011
+ verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410012
+ verylonglonglonglonglonglonglonglonglonglonglo_057ed027_5410013
  verylonglonglonglonglonglonglonglonglonglonglon_product_no_excl
 (5 rows)
 
@@ -558,10 +579,10 @@ SELECT con.conname
                 WHERE rel.relname LIKE 'very%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410006
- verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410007
- verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410008
- verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410009
+ verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410010
+ verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410011
+ verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410012
+ verylonglonglonglonglonglonglonglonglonglonglo_d943e063_5410013
  verylonglonglonglonglonglonglonglonglonglonglonglonglongl_check
 (5 rows)
 
@@ -618,10 +639,10 @@ SELECT con.conname
           WHERE rel.relname LIKE 'longlonglonglonglonglonglonglonglong%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410014
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410015
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410016
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410017
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410018
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410019
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410020
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410021
  longlonglonglonglonglonglonglonglonglonglonglonglonglonglo_pkey
 (5 rows)
 
@@ -664,10 +685,10 @@ SELECT con.conname
           WHERE rel.relname LIKE 'longlonglonglonglonglonglonglonglong%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410014
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410015
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410016
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410017
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410018
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410019
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410020
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410021
  longlonglonglonglonglonglonglonglonglonglongl_partition_col_key
 (5 rows)
 
@@ -820,7 +841,7 @@ SELECT con.conname
             conname
 ---------------------------------------------------------------------
  citus_local_table_pkey
- citus_local_table_pkey_5410022
+ citus_local_table_pkey_5410026
 (2 rows)
 
 SELECT create_distributed_table('AT_AddConstNoName.citus_local_table','id');
@@ -848,10 +869,10 @@ SELECT con.conname
             conname
 ---------------------------------------------------------------------
  citus_local_table_pkey
- citus_local_table_pkey_5410023
- citus_local_table_pkey_5410024
- citus_local_table_pkey_5410025
- citus_local_table_pkey_5410026
+ citus_local_table_pkey_5410027
+ citus_local_table_pkey_5410028
+ citus_local_table_pkey_5410029
+ citus_local_table_pkey_5410030
 (5 rows)
 
 \c - - :master_host :master_port
@@ -879,10 +900,10 @@ SELECT con.conname
              conname
 ---------------------------------------------------------------------
  citus_local_table_id_key
- citus_local_table_id_key_5410023
- citus_local_table_id_key_5410024
- citus_local_table_id_key_5410025
- citus_local_table_id_key_5410026
+ citus_local_table_id_key_5410027
+ citus_local_table_id_key_5410028
+ citus_local_table_id_key_5410029
+ citus_local_table_id_key_5410030
 (5 rows)
 
 \c - - :master_host :master_port
@@ -920,10 +941,10 @@ SELECT con.conname
               conname
 ---------------------------------------------------------------------
  citus_local_table_id_excl
- citus_local_table_id_excl_5410023
- citus_local_table_id_excl_5410024
- citus_local_table_id_excl_5410025
- citus_local_table_id_excl_5410026
+ citus_local_table_id_excl_5410027
+ citus_local_table_id_excl_5410028
+ citus_local_table_id_excl_5410029
+ citus_local_table_id_excl_5410030
 (5 rows)
 
 \c - - :master_host :master_port
@@ -961,10 +982,10 @@ SELECT con.conname
              conname
 ---------------------------------------------------------------------
  citus_local_table_check
- citus_local_table_check_5410023
- citus_local_table_check_5410024
- citus_local_table_check_5410025
- citus_local_table_check_5410026
+ citus_local_table_check_5410027
+ citus_local_table_check_5410028
+ citus_local_table_check_5410029
+ citus_local_table_check_5410030
 (5 rows)
 
 \c - - :master_host :master_port
@@ -1014,10 +1035,10 @@ SELECT con.conname
           WHERE rel.relname LIKE 'longlonglonglonglonglonglonglonglong%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410034
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410035
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410036
- longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410037
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410038
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410039
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410040
+ longlonglonglonglonglonglonglonglonglonglonglo_9e4e3069_5410041
  longlonglonglonglonglonglonglonglonglonglonglonglonglonglo_pkey
 (5 rows)
 
@@ -1051,10 +1072,10 @@ SELECT con.conname
           WHERE rel.relname LIKE 'longlonglonglonglonglonglonglonglong%' ORDER BY con.conname ASC;
                              conname
 ---------------------------------------------------------------------
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410034
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410035
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410036
- longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410037
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410038
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410039
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410040
+ longlonglonglonglonglonglonglonglonglonglongl__d794d9f1_5410041
  longlonglonglonglonglonglonglonglonglonglongl_partition_col_key
 (5 rows)
 
@@ -1144,10 +1165,10 @@ SELECT con.conname
         conname
 ---------------------------------------------------------------------
  2nd table_pkey
- 2nd table_pkey_5410042
- 2nd table_pkey_5410043
- 2nd table_pkey_5410044
- 2nd table_pkey_5410045
+ 2nd table_pkey_5410046
+ 2nd table_pkey_5410047
+ 2nd table_pkey_5410048
+ 2nd table_pkey_5410049
 (5 rows)
 
 \c - - :master_host :master_port
@@ -1174,10 +1195,10 @@ SELECT con.conname
                conname
 ---------------------------------------------------------------------
  2nd table_2nd id_3rd id_key
- 2nd table_2nd id_3rd id_key_5410042
- 2nd table_2nd id_3rd id_key_5410043
- 2nd table_2nd id_3rd id_key_5410044
- 2nd table_2nd id_3rd id_key_5410045
+ 2nd table_2nd id_3rd id_key_5410046
+ 2nd table_2nd id_3rd id_key_5410047
+ 2nd table_2nd id_3rd id_key_5410048
+ 2nd table_2nd id_3rd id_key_5410049
 (5 rows)
 
 \c - - :master_host :master_port
@@ -1204,10 +1225,10 @@ SELECT con.conname
             conname
 ---------------------------------------------------------------------
  2nd table_2nd id_excl
- 2nd table_2nd id_excl_5410042
- 2nd table_2nd id_excl_5410043
- 2nd table_2nd id_excl_5410044
- 2nd table_2nd id_excl_5410045
+ 2nd table_2nd id_excl_5410046
+ 2nd table_2nd id_excl_5410047
+ 2nd table_2nd id_excl_5410048
+ 2nd table_2nd id_excl_5410049
 (5 rows)
 
 \c - - :master_host :master_port
@@ -1234,20 +1255,21 @@ SELECT con.conname
          conname
 ---------------------------------------------------------------------
  2nd table_check
- 2nd table_check_5410042
- 2nd table_check_5410043
- 2nd table_check_5410044
- 2nd table_check_5410045
+ 2nd table_check_5410046
+ 2nd table_check_5410047
+ 2nd table_check_5410048
+ 2nd table_check_5410049
 (5 rows)
 
 \c - - :master_host :master_port
 ALTER TABLE  AT_AddConstNoName."2nd table" DROP CONSTRAINT "2nd table_check";
 DROP EXTENSION btree_gist;
 DROP SCHEMA AT_AddConstNoName CASCADE;
-NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to table at_addconstnoname.products_ref_2
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table at_addconstnoname.tbl
+drop cascades to table at_addconstnoname.products_ref_2
 drop cascades to table at_addconstnoname.products_ref_3
 drop cascades to table at_addconstnoname.verylonglonglonglonglonglonglonglonglonglonglonglonglonglonglon
-drop cascades to table at_addconstnoname.products_ref_3_5410005
+drop cascades to table at_addconstnoname.products_ref_3_5410009
 drop cascades to table at_addconstnoname.citus_local_partitioned_table
 drop cascades to table at_addconstnoname."2nd table"

--- a/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
@@ -64,6 +64,22 @@ SELECT con.conname
  my_index
 (1 row)
 
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+                WHERE rel.relname LIKE 'tbl%' ORDER BY con.conname ASC;
+     conname
+---------------------------------------------------------------------
+ my_index
+ my_index_5410004
+ my_index_5410005
+ my_index_5410006
+ my_index_5410007
+(5 rows)
+
+\c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 -- Check "ADD UNIQUE USING INDEX ..."
 CREATE UNIQUE INDEX my_index ON AT_AddConstNoName.tbl(col1);
@@ -78,6 +94,22 @@ SELECT con.conname
  my_index
 (1 row)
 
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+                WHERE rel.relname LIKE 'tbl%'ORDER BY con.conname ASC;
+     conname
+---------------------------------------------------------------------
+ my_index
+ my_index_5410004
+ my_index_5410005
+ my_index_5410006
+ my_index_5410007
+(5 rows)
+
+\c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 -- Check "ADD PRIMARY KEY DEFERRABLE"
 ALTER TABLE AT_AddConstNoName.products ADD PRIMARY KEY(product_no) DEFERRABLE;

--- a/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
@@ -65,6 +65,20 @@ SELECT con.conname
 (1 row)
 
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
+-- Check "ADD UNIQUE USING INDEX ..."
+CREATE UNIQUE INDEX my_index ON AT_AddConstNoName.tbl(col1);
+ALTER TABLE AT_AddConstNoName.tbl ADD UNIQUE USING INDEX my_index;
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'tbl';
+ conname
+---------------------------------------------------------------------
+ my_index
+(1 row)
+
+ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 -- Check "ADD PRIMARY KEY DEFERRABLE"
 ALTER TABLE AT_AddConstNoName.products ADD PRIMARY KEY(product_no) DEFERRABLE;
 \c - - :public_worker_1_host :worker_1_port

--- a/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
@@ -49,6 +49,14 @@ SELECT con.conname
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
               WHERE rel.relname = 'tbl';
 
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+                WHERE rel.relname LIKE 'tbl%' ORDER BY con.conname ASC;
+
+\c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 
 -- Check "ADD UNIQUE USING INDEX ..."
@@ -61,6 +69,14 @@ SELECT con.conname
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
               WHERE rel.relname = 'tbl';
 
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+                WHERE rel.relname LIKE 'tbl%'ORDER BY con.conname ASC;
+
+\c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 
 -- Check "ADD PRIMARY KEY DEFERRABLE"

--- a/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
@@ -36,6 +36,20 @@ SELECT con.conname
 
 \c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.products DROP CONSTRAINT products_pkey;
+-- Check "ADD PRIMARY KEY USING INDEX ..."
+
+CREATE TABLE  AT_AddConstNoName.tbl(col1 int, col2 int);
+SELECT create_distributed_table('AT_AddConstNoName.tbl', 'col1');
+CREATE UNIQUE INDEX my_index ON AT_AddConstNoName.tbl(col1);
+ALTER TABLE AT_AddConstNoName.tbl ADD PRIMARY KEY USING INDEX my_index;
+
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'tbl';
+
+ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 
 -- Check "ADD PRIMARY KEY DEFERRABLE"
 ALTER TABLE AT_AddConstNoName.products ADD PRIMARY KEY(product_no) DEFERRABLE;

--- a/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
@@ -51,6 +51,18 @@ SELECT con.conname
 
 ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
 
+-- Check "ADD UNIQUE USING INDEX ..."
+CREATE UNIQUE INDEX my_index ON AT_AddConstNoName.tbl(col1);
+ALTER TABLE AT_AddConstNoName.tbl ADD UNIQUE USING INDEX my_index;
+
+SELECT con.conname
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'tbl';
+
+ALTER TABLE AT_AddConstNoName.tbl DROP CONSTRAINT my_index;
+
 -- Check "ADD PRIMARY KEY DEFERRABLE"
 ALTER TABLE AT_AddConstNoName.products ADD PRIMARY KEY(product_no) DEFERRABLE;
 \c - - :public_worker_1_host :worker_1_port


### PR DESCRIPTION
This change allows creating a constraint without a name using an index. The index name will be used as the constraint name the same way postgres handles it.

I am not adding a description since this is a pre-release PR and should not be in changelog.

Fixes #6644 
