### PR TITLE
Add "NOT VALID" option to deparser for FOREIGN KEY and CHECK constraints

### DIFF
--- a/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
@@ -268,7 +268,7 @@ SELECT con.conname, con.connoinherit
 (1 row)
 
 \c - - :public_worker_1_host :worker_1_port
-SELECT con.conname, connoinherit
+SELECT con.conname, con.connoinherit
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
@@ -276,6 +276,31 @@ SELECT con.conname, connoinherit
         conname         | connoinherit
 ---------------------------------------------------------------------
  products_check_5410000 | t
+(1 row)
+
+\c - - :master_host :master_port
+ALTER TABLE AT_AddConstNoName.products DROP CONSTRAINT products_check;
+-- Check "ADD CHECK ... NOT VALID"
+ALTER TABLE AT_AddConstNoName.products ADD CHECK (product_no > 0 AND price > 0) NOT VALID;
+SELECT con.conname, con.convalidated
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'products';
+    conname     | convalidated
+---------------------------------------------------------------------
+ products_check | f
+(1 row)
+
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname, con.convalidated
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'products_5410000';
+        conname         | convalidated
+---------------------------------------------------------------------
+ products_check_5410000 | f
 (1 row)
 
 \c - - :master_host :master_port

--- a/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
@@ -251,6 +251,34 @@ SELECT con.conname, con.confupdtype, con.confdeltype, con.confmatchtype
 \c - - :master_host :master_port
 SET SEARCH_PATH = at_add_fk;
 ALTER TABLE  referencing_table DROP CONSTRAINT referencing_table_ref_id_fkey;
+-- test NOT VALID
+ALTER TABLE referencing_table ADD FOREIGN KEY(ref_id) REFERENCES referenced_table(id) NOT VALID;
+SELECT  con.conname, con.convalidated
+  FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'referencing_table';
+            conname            | convalidated
+---------------------------------------------------------------------
+ referencing_table_ref_id_fkey | f
+(1 row)
+
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname, con.convalidated
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
+                conname                | convalidated
+---------------------------------------------------------------------
+ referencing_table_ref_id_fkey         | f
+ referencing_table_ref_id_fkey_1770041 | f
+ referencing_table_ref_id_fkey_1770043 | f
+(3 rows)
+
+\c - - :master_host :master_port
+SET SEARCH_PATH = at_add_fk;
+ALTER TABLE  referencing_table DROP CONSTRAINT referencing_table_ref_id_fkey;
 -- test ON DELETE NO ACTION + DEFERABLE + INITIALLY DEFERRED
 ALTER TABLE referencing_table ADD FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED;
 SELECT  con.conname, con.confupdtype, con.confdeltype, con.confmatchtype

--- a/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
@@ -212,7 +212,26 @@ SELECT con.conname, con.connoinherit
               WHERE rel.relname = 'products';
 
 \c - - :public_worker_1_host :worker_1_port
-SELECT con.conname, connoinherit
+SELECT con.conname, con.connoinherit
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'products_5410000';
+
+\c - - :master_host :master_port
+ALTER TABLE AT_AddConstNoName.products DROP CONSTRAINT products_check;
+
+-- Check "ADD CHECK ... NOT VALID"
+ALTER TABLE AT_AddConstNoName.products ADD CHECK (product_no > 0 AND price > 0) NOT VALID;
+
+SELECT con.conname, con.convalidated
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'products';
+
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname, con.convalidated
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace

--- a/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
@@ -154,6 +154,25 @@ SET SEARCH_PATH = at_add_fk;
 
 ALTER TABLE  referencing_table DROP CONSTRAINT referencing_table_ref_id_fkey;
 
+-- test NOT VALID
+ALTER TABLE referencing_table ADD FOREIGN KEY(ref_id) REFERENCES referenced_table(id) NOT VALID;
+SELECT  con.conname, con.convalidated
+  FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname = 'referencing_table';
+
+\c - - :public_worker_1_host :worker_1_port
+SELECT con.conname, con.convalidated
+    FROM pg_catalog.pg_constraint con
+      INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+      INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
+
+\c - - :master_host :master_port
+SET SEARCH_PATH = at_add_fk;
+ALTER TABLE  referencing_table DROP CONSTRAINT referencing_table_ref_id_fkey;
+
 -- test ON DELETE NO ACTION + DEFERABLE + INITIALLY DEFERRED
 ALTER TABLE referencing_table ADD FOREIGN KEY(ref_id) REFERENCES referenced_table(id) ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED;
 


### PR DESCRIPTION
Add NOT VALID option to deparser. When wee need to deparse 

  ALTER TABLE ADD FOREIGN KEY ... NOT VALID

  ALTER TABLE ADD CHECK ... NOT VALID

"NOT VALID" option should be propagated to workers.

No description. This is a pre-release bug.

Fixes #6646.