### PR TITLE
Allow empty lines in arbitrary config schedules

### DIFF
--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -125,7 +125,11 @@ def copy_test_files(config):
         with open(scheduleName) as file:
             lines = file.readlines()
             for line in lines:
-                colon_index = line.index(":")
+                colon_index = line.find(":")
+                # skip empty lines
+                if colon_index == -1:
+                    continue
+
                 line = line[colon_index + 1 :].strip()
                 test_names = line.split(" ")
                 copy_test_files_with_names(test_names, sql_dir_path, expected_dir_path, config)


### PR DESCRIPTION
This change is a precursor to attempts to add more editorconfig rules in our codebase. It is a good idea to comply with POSIX standards and have an empty newline at the end of text files. However, once we have such a rule, arbitrary configs scripts used to fail before this change.

Related: #5981 