### PR TITLE
Fix uninit mem acceess in UpdateFunctionDistributionInfo

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -752,6 +752,8 @@ UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 							   distAddress->objectId, distAddress->objectSubId)));
 	}
 
+	memset(values, 0, sizeof(values));
+	memset(isnull, 0, sizeof(isnull));
 	memset(replace, 0, sizeof(replace));
 
 	replace[Anum_pg_dist_object_distribution_argument_index - 1] = true;


### PR DESCRIPTION
Fixes #6655.

heap_modify_tuple() fetches values[i] if replace[i] is set true, regardless of the fact that whether isnull[i] is true or false. So similar to replace[], let's init values[] & isnull[] too.

DESCRIPTION: Fixes an uninitialized memory access in create_distributed_function()
