### PR TITLE
Add valgrind output check to diff script

### DIFF
--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -47,7 +47,12 @@ then
 	sed -Ef "$normalize_file" < "$file1" > "$file1.modified"
 	sed -Ef "$normalize_file" < "$file2" > "$file2.modified"
 	"$DIFF" -w $args "$file1.modified" "$file2.modified" | LC_CTYPE=C.UTF-8 diff-filter "$BASEDIR/normalize.sed"
-	exit ${PIPESTATUS[0]}
+	diff_status=${PIPESTATUS[0]}
+	if [ -s "$BASEDIR/../citus_valgrind_test_log.txt" ]; then
+		cat "$BASEDIR/../citus_valgrind_test_log.txt"
+		exit 1
+	fi
+	exit $diff_status
 else
 	exec "$DIFF" -w $args "$file1" "$file2"
 fi

--- a/src/test/regress/bin/diff
+++ b/src/test/regress/bin/diff
@@ -49,8 +49,12 @@ then
 	"$DIFF" -w $args "$file1.modified" "$file2.modified" | LC_CTYPE=C.UTF-8 diff-filter "$BASEDIR/normalize.sed"
 	diff_status=${PIPESTATUS[0]}
 	if [ -s "$BASEDIR/../citus_valgrind_test_log.txt" ]; then
-		cat "$BASEDIR/../citus_valgrind_test_log.txt"
-		exit 1
+		if grep -q citus "$BASEDIR/../citus_valgrind_test_log.txt"; then
+			cat "$BASEDIR/../citus_valgrind_test_log.txt"
+			exit 1
+		fi
+		# if the file doesn't contain "citus", it's probably reported because of a pg issue
+		# we are currently not interested in such reports
 	fi
 	exit $diff_status
 else


### PR DESCRIPTION
Valgrind outputs do not tell which test causes the failure. With this change we'll be able to see the (first) test that fails and debug that.