### PR TITLE
Fix flaky multi_reference_table test

### DIFF
--- a/src/test/regress/expected/multi_reference_table.out
+++ b/src/test/regress/expected/multi_reference_table.out
@@ -1020,7 +1020,8 @@ SELECT
 FROM
 	reference_table_test, colocated_table_test
 WHERE
-	colocated_table_test.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_1
 ---------------------------------------------------------------------
@@ -1033,7 +1034,8 @@ SELECT
 FROM
 	reference_table_test, colocated_table_test
 WHERE
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2
 ---------------------------------------------------------------------
@@ -1046,7 +1048,8 @@ SELECT
 FROM
 	colocated_table_test, reference_table_test
 WHERE
-	reference_table_test.value_1 = colocated_table_test.value_1;
+	reference_table_test.value_1 = colocated_table_test.value_1
+ORDER BY 1;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2
 ---------------------------------------------------------------------
@@ -1150,6 +1153,7 @@ FROM
 	colocated_table_test_2, reference_table_test
 WHERE
 	colocated_table_test_2.value_4 = reference_table_test.value_4
+ORDER BY 1
 RETURNING value_1, value_2;
  value_1 | value_2
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/multi_reference_table.sql
+++ b/src/test/regress/sql/multi_reference_table.sql
@@ -643,21 +643,24 @@ SELECT
 FROM
 	reference_table_test, colocated_table_test
 WHERE
-	colocated_table_test.value_1 = reference_table_test.value_1;
+	colocated_table_test.value_1 = reference_table_test.value_1
+ORDER BY 1;
 
 SELECT
 	colocated_table_test.value_2
 FROM
 	reference_table_test, colocated_table_test
 WHERE
-	colocated_table_test.value_2 = reference_table_test.value_2;
+	colocated_table_test.value_2 = reference_table_test.value_2
+ORDER BY 1;
 
 SELECT
 	colocated_table_test.value_2
 FROM
 	colocated_table_test, reference_table_test
 WHERE
-	reference_table_test.value_1 = colocated_table_test.value_1;
+	reference_table_test.value_1 = colocated_table_test.value_1
+ORDER BY 1;
 
 SET citus.enable_repartition_joins = on;
 SELECT
@@ -730,6 +733,7 @@ FROM
 	colocated_table_test_2, reference_table_test
 WHERE
 	colocated_table_test_2.value_4 = reference_table_test.value_4
+ORDER BY 1
 RETURNING value_1, value_2;
 
 -- similar query with the above, this time partition key but without equality


### PR DESCRIPTION
Sometimes in CI our multi_reference_table test fails like this:
```diff
 WHERE
 	colocated_table_test.value_2 = reference_table_test.value_2;
 LOG:  join order: [ "colocated_table_test" ][ reference join "reference_table_test" ]
  value_2
 ---------
-       1
        2
+       1
 (2 rows)
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/30223/workflows/ce3ab5db-310f-4e30-ba0b-c3b31927d9b6/jobs/970041

We forgot an ORDER BY in this test.
