### PR TITLE
Fix flaky isolation_non_blocking_shard_split test

### DIFF
--- a/src/test/regress/expected/isolation_non_blocking_shard_split.out
+++ b/src/test/regress/expected/isolation_non_blocking_shard_split.out
@@ -774,7 +774,7 @@ id|value
 (0 rows)
 
 
-starting permutation: s1-load-cache s1-start-connection s1-lock-to-split-shard s2-print-locks s2-non-blocking-shard-split s2-print-locks s2-show-pg_dist_cleanup s1-stop-connection
+starting permutation: s1-load-cache s1-start-connection s1-lock-to-split-shard s2-print-locks s2-non-blocking-shard-split s2-print-locks s2-show-pg_dist_cleanup-shards s1-stop-connection
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -842,8 +842,9 @@ node_name|node_port|success|result
 localhost|    57637|t      |to_split_table_1500001-relation-AccessShareLock
 (1 row)
 
-step s2-show-pg_dist_cleanup:
- SELECT object_name, object_type, policy_type FROM pg_dist_cleanup;
+step s2-show-pg_dist_cleanup-shards:
+ SELECT object_name, object_type, policy_type FROM pg_dist_cleanup
+ WHERE object_type = 1;
 
 object_name                  |object_type|policy_type
 ---------------------------------------------------------------------
@@ -859,7 +860,7 @@ stop_session_level_connection_to_node
 (1 row)
 
 
-starting permutation: s1-start-connection s1-lock-to-split-shard s2-print-locks s2-non-blocking-shard-split s2-print-cluster s2-show-pg_dist_cleanup s1-stop-connection
+starting permutation: s1-start-connection s1-lock-to-split-shard s2-print-locks s2-non-blocking-shard-split s2-print-cluster s2-show-pg_dist_cleanup-shards s1-stop-connection
 create_distributed_table
 ---------------------------------------------------------------------
 
@@ -929,8 +930,9 @@ id|value
 ---------------------------------------------------------------------
 (0 rows)
 
-step s2-show-pg_dist_cleanup:
- SELECT object_name, object_type, policy_type FROM pg_dist_cleanup;
+step s2-show-pg_dist_cleanup-shards:
+ SELECT object_name, object_type, policy_type FROM pg_dist_cleanup
+ WHERE object_type = 1;
 
 object_name                  |object_type|policy_type
 ---------------------------------------------------------------------

--- a/src/test/regress/spec/isolation_non_blocking_shard_split.spec
+++ b/src/test/regress/spec/isolation_non_blocking_shard_split.spec
@@ -155,6 +155,12 @@ step "s2-show-pg_dist_cleanup"
 	SELECT object_name, object_type, policy_type FROM pg_dist_cleanup;
 }
 
+step "s2-show-pg_dist_cleanup-shards"
+{
+	SELECT object_name, object_type, policy_type FROM pg_dist_cleanup
+	WHERE object_type = 1;
+}
+
 step "s2-print-cluster"
 {
 	-- row count per shard
@@ -233,9 +239,9 @@ permutation "s2-insert" "s2-print-cluster" "s3-acquire-advisory-lock" "s1-begin"
 
 
 // With Deferred drop, AccessShareLock (acquired by SELECTS) do not block split from completion.
-permutation "s1-load-cache" "s1-start-connection"  "s1-lock-to-split-shard" "s2-print-locks" "s2-non-blocking-shard-split" "s2-print-locks" "s2-show-pg_dist_cleanup" "s1-stop-connection"
+permutation "s1-load-cache" "s1-start-connection"  "s1-lock-to-split-shard" "s2-print-locks" "s2-non-blocking-shard-split" "s2-print-locks" "s2-show-pg_dist_cleanup-shards" "s1-stop-connection"
 // The same test above without loading the cache at first
-permutation "s1-start-connection"  "s1-lock-to-split-shard" "s2-print-locks" "s2-non-blocking-shard-split" "s2-print-cluster" "s2-show-pg_dist_cleanup" "s1-stop-connection"
+permutation "s1-start-connection"  "s1-lock-to-split-shard" "s2-print-locks" "s2-non-blocking-shard-split" "s2-print-cluster" "s2-show-pg_dist_cleanup-shards" "s1-stop-connection"
 
 // When a split operation is running, cleaner cannot clean its resources.
 permutation "s1-load-cache" "s1-acquire-split-advisory-lock" "s2-non-blocking-shard-split" "s1-run-cleaner" "s1-show-pg_dist_cleanup" "s1-release-split-advisory-lock" "s1-run-cleaner" "s2-show-pg_dist_cleanup"


### PR DESCRIPTION
Sometimes isolation_non_blocking_shard_split would fail like this:
```diff
 step s2-show-pg_dist_cleanup:
  SELECT object_name, object_type, policy_type FROM pg_dist_cleanup;

 object_name                   |object_type|policy_type
 ------------------------------+-----------+-----------
+citus_shard_split_slot_2_10_39|          3|          0
 public.to_split_table_1500001 |          1|          2
-(1 row)
+(2 rows)
```
Source: https://app.circleci.com/pipelines/github/citusdata/citus/30237/workflows/edcf34b7-d7d3-4d10-8293-b6f59b00cdf2/jobs/970960

The reason is that replication slots have now become part of
pg_dist_cleanup too, and sometimes they cannot be cleaned up right away.
This is harmless as they will be cleaned up eventually. So this simply
filters out the replication slots for those tests.
