### PR TITLE
Add valgrind support to run_test.py

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -128,6 +128,22 @@ check-isolation-custom-schedule: all  $(isolation_test_files)
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
 	-- $(MULTI_REGRESS_OPTS) --inputdir=$(citus_abs_srcdir)/build --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
 
+check-custom-schedule-vg: all
+	$(pg_regress_multi_check) --load-extension=citus \
+	--valgrind --pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
+
+check-failure-custom-schedule-vg: all
+	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
+	--valgrind --pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
+
+check-isolation-custom-schedule-vg: all  $(isolation_test_files)
+	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
+	--valgrind --pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
+	-- $(MULTI_REGRESS_OPTS) --inputdir=$(citus_abs_srcdir)/build --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
+
+
 check-empty: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) $(EXTRA_TESTS)

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -17,6 +17,7 @@ args.add_argument("-p", "--path", required=False, help="Relative path for test f
 args.add_argument("-r", "--repeat", help="Number of test to run", type=int, default=1)
 args.add_argument("-b", "--use-base-schedule", required=False, help="Choose base-schedules rather than minimal-schedules", action='store_true')
 args.add_argument("-w", "--use-whole-schedule-line", required=False, help="Use the whole line found in related schedule", action='store_true')
+args.add_argument("--valgrind", required=False, help="Run the test with valgrind enabled", action='store_true')
 
 args = vars(args.parse_args())
 
@@ -119,6 +120,9 @@ elif "failure" in test_schedule:
     make_recipe = 'check-failure-custom-schedule'
 else:
     make_recipe = 'check-custom-schedule'
+
+if args['valgrind']:
+    make_recipe += '-vg'
 
 # prepare command to run tests
 test_command = f"make -C {regress_dir} {make_recipe} SCHEDULE='{pathlib.Path(tmp_schedule_path).stem}'"


### PR DESCRIPTION
Running tests with valgrind was not possible with our run_test.py script
yet. This adds that support.
