### PR TITLE
Mark RowModifyLevel for Merge command accurately

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -4628,7 +4628,8 @@ RowModifyLevelForQuery(Query *query)
 	}
 
 	if (commandType == CMD_UPDATE ||
-		commandType == CMD_DELETE)
+		commandType == CMD_DELETE ||
+		commandType == CMD_MERGE /* PG15+ */)
 	{
 		return ROW_MODIFY_NONCOMMUTATIVE;
 	}


### PR DESCRIPTION
It seems like an oversight from earlier commits. Accurate RowModifyLevel helps the executor acquire proper locks on RowModifyLevelForQuery.

