### PR TITLE
Remove dependencies on placement caches from DROP

### DIFF
--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1466,7 +1466,7 @@ ActiveShardPlacementListOnGroup(uint64 shardId, int32 groupId)
 
 /*
  * ActiveShardPlacementList finds shard placements for the given shardId from
- * system catalogs, chooses placements that are in active state, and returns
+ * metadata cache, chooses placements that are in active state, and returns
  * these shard placements in a new list.
  */
 List *

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -373,7 +373,7 @@ DropTaskList(Oid relationId, char *schemaName, char *relationName,
 		task->dependentTaskList = NULL;
 		task->replicationModel = REPLICATION_MODEL_INVALID;
 		task->anchorShardId = shardId;
-		task->taskPlacementList = ShardPlacementList(shardId);
+		task->taskPlacementList = ShardPlacementListViaCatalog(shardId);
 
 		taskList = lappend(taskList, task);
 	}

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -175,6 +175,7 @@ extern int32 GetLocalNodeId(void);
 extern void CitusTableCacheFlushInvalidatedEntries(void);
 extern Oid LookupShardRelationFromCatalog(int64 shardId, bool missing_ok);
 extern List * ShardPlacementList(uint64 shardId);
+extern List * ShardPlacementListViaCatalog(uint64 shardId);
 extern void CitusInvalidateRelcacheByRelid(Oid relationId);
 extern void CitusInvalidateRelcacheByShardId(int64 shardId);
 extern void InvalidateForeignKeyGraph(void);

--- a/src/test/regress/expected/distributed_types.out
+++ b/src/test/regress/expected/distributed_types.out
@@ -578,6 +578,22 @@ DETAIL:  "type temp_type" will be created only locally
 CREATE TYPE pg_temp.temp_enum AS ENUM ('one', 'two', 'three');
 WARNING:  "type temp_enum" has dependency on unsupported object "schema pg_temp_xxx"
 DETAIL:  "type temp_enum" will be created only locally
+-- check that dropping a schema that has a type used in a distribution column does not fail
+CREATE SCHEMA schema_with_custom_distribution_type;
+SET search_path TO schema_with_custom_distribution_type;
+CREATE TYPE my_type AS (int_field int);
+CREATE TABLE tbl (a schema_with_custom_distribution_type.my_type);
+SELECT create_distributed_table('tbl', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+drop schema schema_with_custom_distribution_type cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to type my_type
+drop cascades to table tbl
+SET search_path TO type_tests;
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;

--- a/src/test/regress/sql/distributed_types.sql
+++ b/src/test/regress/sql/distributed_types.sql
@@ -350,6 +350,19 @@ SELECT create_distributed_table('table_text_local_def','id');
 CREATE TYPE pg_temp.temp_type AS (int_field int);
 CREATE TYPE pg_temp.temp_enum AS ENUM ('one', 'two', 'three');
 
+-- check that dropping a schema that has a type used in a distribution column does not fail
+
+CREATE SCHEMA schema_with_custom_distribution_type;
+SET search_path TO schema_with_custom_distribution_type;
+
+CREATE TYPE my_type AS (int_field int);
+CREATE TABLE tbl (a schema_with_custom_distribution_type.my_type);
+SELECT create_distributed_table('tbl', 'a');
+
+drop schema schema_with_custom_distribution_type cascade;
+
+SET search_path TO type_tests;
+
 -- clear objects
 SET client_min_messages TO error; -- suppress cascading objects dropping
 DROP SCHEMA type_tests CASCADE;


### PR DESCRIPTION
When dropping objects, citus_drop_trigger should not depend on the validity of the caches for placements as it causes may cause error messages from time to time. With this commit we remove the depencency on the validity on caches for shard placements.

Fixes: #5780

DESCRIPTION: Fixes an issue with dropping schemas with custom types used in distribution columns.
