### PR TITLE
Stop background daemon before dropping the database

### DIFF
--- a/src/test/regress/expected/drop_database.out
+++ b/src/test/regress/expected/drop_database.out
@@ -1,0 +1,21 @@
+CREATE SCHEMA drop_database;
+SET search_path TO drop_database;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 35137400;
+CREATE DATABASE citus_created;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DETAIL:  Citus does not propagate CREATE DATABASE command to workers
+HINT:  You can manually create a database and its extensions on workers.
+\c citus_created
+CREATE EXTENSION citus;
+CREATE DATABASE citus_not_created;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DETAIL:  Citus does not propagate CREATE DATABASE command to workers
+HINT:  You can manually create a database and its extensions on workers.
+\c citus_not_created
+DROP DATABASE citus_created;
+\c regression
+DROP DATABASE citus_not_created;
+SET client_min_messages TO WARNING;
+DROP SCHEMA drop_database CASCADE;

--- a/src/test/regress/expected/drop_database.out
+++ b/src/test/regress/expected/drop_database.out
@@ -1,3 +1,4 @@
+-- coordinator
 CREATE SCHEMA drop_database;
 SET search_path TO drop_database;
 SET citus.shard_count TO 4;
@@ -17,5 +18,26 @@ HINT:  You can manually create a database and its extensions on workers.
 DROP DATABASE citus_created;
 \c regression
 DROP DATABASE citus_not_created;
+-- worker1
+\c - - - :worker_1_port
+SET search_path TO drop_database;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 35137400;
+CREATE DATABASE citus_created;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DETAIL:  Citus does not propagate CREATE DATABASE command to workers
+HINT:  You can manually create a database and its extensions on workers.
+\c citus_created
+CREATE EXTENSION citus;
+CREATE DATABASE citus_not_created;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DETAIL:  Citus does not propagate CREATE DATABASE command to workers
+HINT:  You can manually create a database and its extensions on workers.
+\c citus_not_created
+DROP DATABASE citus_created;
+\c regression
+DROP DATABASE citus_not_created;
+\c - - - :master_port
 SET client_min_messages TO WARNING;
 DROP SCHEMA drop_database CASCADE;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -121,3 +121,4 @@ test: ensure_no_shared_connection_leak
 test: check_mx
 
 test: generated_identity
+test: drop_database

--- a/src/test/regress/sql/drop_database.sql
+++ b/src/test/regress/sql/drop_database.sql
@@ -1,0 +1,21 @@
+CREATE SCHEMA drop_database;
+SET search_path TO drop_database;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 35137400;
+
+CREATE DATABASE citus_created;
+
+\c citus_created
+CREATE EXTENSION citus;
+
+CREATE DATABASE citus_not_created;
+
+\c citus_not_created
+DROP DATABASE citus_created;
+
+\c regression
+DROP DATABASE citus_not_created;
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA drop_database CASCADE;

--- a/src/test/regress/sql/drop_database.sql
+++ b/src/test/regress/sql/drop_database.sql
@@ -1,3 +1,4 @@
+-- coordinator
 CREATE SCHEMA drop_database;
 SET search_path TO drop_database;
 SET citus.shard_count TO 4;
@@ -16,6 +17,29 @@ DROP DATABASE citus_created;
 
 \c regression
 DROP DATABASE citus_not_created;
+
+-- worker1
+\c - - - :worker_1_port
+
+SET search_path TO drop_database;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 35137400;
+
+CREATE DATABASE citus_created;
+
+\c citus_created
+CREATE EXTENSION citus;
+
+CREATE DATABASE citus_not_created;
+
+\c citus_not_created
+DROP DATABASE citus_created;
+
+\c regression
+DROP DATABASE citus_not_created;
+
+\c - - - :master_port
 
 SET client_min_messages TO WARNING;
 DROP SCHEMA drop_database CASCADE;


### PR DESCRIPTION
DESCRIPTION: Stop maintenance daemon when dropping a database even without Citus extension

Fixes #6670.
Fixes #5297.