### PR TITLE
prevent memory leak during ConvertTable with a lot of partitions

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -800,15 +800,30 @@ ConvertTable(TableConversionState *con)
 		ExecuteQueryViaSPI(tableConstructionSQL, SPI_OK_UTILITY);
 	}
 
+	/*
+	 * when there are many partitions, each call to ProcessUtilityParseTree
+	 * accumulates used memory. Free context after each call.
+	 */
+	MemoryContext citusPerPartitionContext =
+		AllocSetContextCreate(CurrentMemoryContext,
+							  "citus_per_partition_context",
+							  ALLOCSET_DEFAULT_SIZES);
+	MemoryContext oldContext = MemoryContextSwitchTo(citusPerPartitionContext);
+
 	char *attachPartitionCommand = NULL;
 	foreach_ptr(attachPartitionCommand, attachPartitionCommands)
 	{
+		MemoryContextReset(citusPerPartitionContext);
+
 		Node *parseTree = ParseTreeNode(attachPartitionCommand);
 
 		ProcessUtilityParseTree(parseTree, attachPartitionCommand,
 								PROCESS_UTILITY_QUERY,
 								NULL, None_Receiver, NULL);
 	}
+
+	MemoryContextSwitchTo(oldContext);
+	MemoryContextDelete(citusPerPartitionContext);
 
 	if (isPartitionTable)
 	{


### PR DESCRIPTION
Prevents memory leak during ConvertTable call for a table with a lot of partitions.

DESCRIPTION: Fixes memory leak during undistribution and alteration of a table with a lot of partitions.

You can reproduce memory leak by undistributing the table created in issue #6572. Note that we also get out of memory error during distribution of that table with so many partitions. It will be addressed in different PR.