### PR TITLE
This implements MERGE phase-III

### DIFF
--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -54,8 +54,6 @@
 bool EnableFastPathRouterPlanner = true;
 
 static bool ColumnAppearsMultipleTimes(Node *quals, Var *distributionKey);
-static bool ConjunctionContainsColumnFilter(Node *node, Var *column,
-											Node **distributionKeyValue);
 static bool DistKeyInSimpleOpExpression(Expr *clause, Var *distColumn,
 										Node **distributionKeyValue);
 
@@ -294,7 +292,7 @@ ColumnAppearsMultipleTimes(Node *quals, Var *distributionKey)
  *
  * If the conjuction contains column filter which is const, distributionKeyValue is set.
  */
-static bool
+bool
 ConjunctionContainsColumnFilter(Node *node, Var *column, Node **distributionKeyValue)
 {
 	if (node == NULL)

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -56,6 +56,9 @@ bool EnableFastPathRouterPlanner = true;
 static bool ColumnAppearsMultipleTimes(Node *quals, Var *distributionKey);
 static bool DistKeyInSimpleOpExpression(Expr *clause, Var *distColumn,
 										Node **distributionKeyValue);
+static bool ConjunctionContainsColumnFilter(Node *node,
+											Var *column,
+											Node **distributionKeyValue);
 
 
 /*
@@ -292,7 +295,7 @@ ColumnAppearsMultipleTimes(Node *quals, Var *distributionKey)
  *
  * If the conjuction contains column filter which is const, distributionKeyValue is set.
  */
-bool
+static bool
 ConjunctionContainsColumnFilter(Node *node, Var *column, Node **distributionKeyValue)
 {
 	if (node == NULL)

--- a/src/backend/distributed/planner/merge_planner.c
+++ b/src/backend/distributed/planner/merge_planner.c
@@ -1,0 +1,701 @@
+/*-------------------------------------------------------------------------
+ *
+ * merge_planner.c
+ *
+ * This file contains functions to help plan MERGE queries.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include <stddef.h>
+
+#include "postgres.h"
+#include "nodes/makefuncs.h"
+#include "optimizer/optimizer.h"
+#include "parser/parsetree.h"
+#include "utils/lsyscache.h"
+
+#include "distributed/citus_clauses.h"
+#include "distributed/listutils.h"
+#include "distributed/merge_planner.h"
+#include "distributed/multi_logical_optimizer.h"
+#include "distributed/multi_router_planner.h"
+#include "distributed/pg_version_constants.h"
+#include "distributed/query_pushdown_planning.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_15
+
+static DeferredErrorMessage * CheckIfRTETypeIsUnsupported(Query *parse,
+														  RangeTblEntry *rangeTableEntry);
+static DeferredErrorMessage * ErrorIfDistTablesNotColocated(Query *parse,
+															List *
+															distTablesList,
+															PlannerRestrictionContext
+															*
+															plannerRestrictionContext);
+static DeferredErrorMessage * ErrorIfMergeHasUnsupportedTables(Query *parse,
+															   List *rangeTableList,
+															   PlannerRestrictionContext *
+															   restrictionContext);
+static bool IsDistributionColumnInMergeSource(Expr *columnExpression, Query *query, bool
+											  skipOuterVars);
+static DeferredErrorMessage * InsertDistributionColumnMatchesSource(Query *query,
+																	RangeTblEntry *
+																	resultRte);
+
+static DeferredErrorMessage * MergeQualAndTargetListFunctionsSupported(Oid
+																	   resultRelationId,
+																	   FromExpr *joinTree,
+																	   Node *quals,
+																	   List *targetList,
+																	   CmdType commandType);
+#endif
+
+
+/*
+ * MergeQuerySupported does check for a MERGE command in the query, if it finds
+ * one, it will verify the below criteria
+ * - Supported tables and combinations in ErrorIfMergeHasUnsupportedTables
+ * - Distributed tables requirements in ErrorIfDistTablesNotColocated
+ * - Checks target-lists and functions-in-quals in TargetlistAndFunctionsSupported
+ */
+DeferredErrorMessage *
+MergeQuerySupported(Query *originalQuery, bool multiShardQuery,
+					PlannerRestrictionContext *plannerRestrictionContext)
+{
+	/* function is void for pre-15 versions of Postgres */
+	#if PG_VERSION_NUM < PG_VERSION_15
+
+	return NULL;
+
+	#else
+
+	/* For non-MERGE commands it's a no-op */
+	if (!IsMergeQuery(originalQuery))
+	{
+		return NULL;
+	}
+
+	/*
+	 * TODO: For now, we are adding an exception where any volatile or stable
+	 * functions are not allowed in the MERGE query, but this will become too
+	 * restrictive as this will prevent many useful and simple cases, such as,
+	 * INSERT VALUES(ts::timestamp), bigserial column inserts etc. But without
+	 * this restriction, we have a potential danger of some of the function(s)
+	 * getting executed at the worker which will result in incorrect behavior.
+	 */
+	if (contain_mutable_functions((Node *) originalQuery))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "non-IMMUTABLE functions are not yet supported "
+							 "in MERGE sql with distributed tables ",
+							 NULL, NULL);
+	}
+
+	List *rangeTableList = ExtractRangeTableEntryList(originalQuery);
+	RangeTblEntry *resultRte = ExtractResultRelationRTE(originalQuery);
+
+	/*
+	 * Fast path queries cannot have merge command, and we prevent the remaining here.
+	 * In Citus we have limited support for MERGE, it's allowed only if all
+	 * the tables(target, source or any CTE) tables are are local i.e. a
+	 * combination of Citus local and Non-Citus tables (regular Postgres tables)
+	 * or distributed tables with some restrictions, please see header of routine
+	 * ErrorIfDistTablesNotColocated for details.
+	 */
+	DeferredErrorMessage *deferredError =
+		ErrorIfMergeHasUnsupportedTables(originalQuery,
+										 rangeTableList,
+										 plannerRestrictionContext);
+	if (deferredError)
+	{
+		/* MERGE's unsupported combination, raise the exception */
+		RaiseDeferredError(deferredError, ERROR);
+	}
+
+	Oid resultRelationId = resultRte->relid;
+	deferredError = MergeQualAndTargetListFunctionsSupported(resultRelationId,
+															 originalQuery->jointree,
+															 originalQuery->jointree->
+															 quals,
+															 originalQuery->targetList,
+															 originalQuery->commandType);
+	if (deferredError)
+	{
+		return deferredError;
+	}
+
+	/*
+	 * MERGE is a special case where we have multiple modify statements
+	 * within itself. Check each INSERT/UPDATE/DELETE individually.
+	 */
+	MergeAction *action = NULL;
+	foreach_ptr(action, originalQuery->mergeActionList)
+	{
+		Assert(originalQuery->returningList == NULL);
+		deferredError = MergeQualAndTargetListFunctionsSupported(resultRelationId,
+																 originalQuery->jointree,
+																 action->qual,
+																 action->targetList,
+																 action->commandType);
+		if (deferredError)
+		{
+			/* MERGE's unsupported scenario, raise the exception */
+			RaiseDeferredError(deferredError, ERROR);
+		}
+	}
+
+	deferredError =
+		InsertDistributionColumnMatchesSource(originalQuery, resultRte);
+	if (deferredError)
+	{
+		/* MERGE's unsupported scenario, raise the exception */
+		RaiseDeferredError(deferredError, ERROR);
+	}
+
+	if (multiShardQuery)
+	{
+		deferredError =
+			DeferErrorIfUnsupportedSubqueryPushdown(originalQuery,
+													plannerRestrictionContext);
+		if (deferredError)
+		{
+			return deferredError;
+		}
+	}
+
+	if (HasDangerousJoinUsing(originalQuery->rtable, (Node *) originalQuery->jointree))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "a join with USING causes an internal naming "
+							 "conflict, use ON instead", NULL, NULL);
+	}
+
+	return NULL;
+
+	#endif
+}
+
+
+/*
+ * IsMergeAllowedOnRelation takes a relation entry and checks if MERGE command is
+ * permitted on special relations, such as materialized view, returns true only if
+ * it's a "source" relation.
+ */
+bool
+IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte)
+{
+	if (!IsMergeQuery(parse))
+	{
+		return false;
+	}
+
+	/* Fetch the MERGE target relation */
+	RangeTblEntry *targetRte = rt_fetch(parse->resultRelation, parse->rtable);
+
+	/* Is it a target relation? */
+	if (targetRte->relid == rte->relid)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+#if PG_VERSION_NUM >= PG_VERSION_15
+
+/*
+ * ErrorIfDistTablesNotColocated Checks to see if
+ *
+ *   - There are a minimum of two distributed tables (source and a target).
+ *   - All the distributed tables are indeed colocated.
+ *
+ * If any of the conditions are not met, it raises an exception.
+ */
+static DeferredErrorMessage *
+ErrorIfDistTablesNotColocated(Query *parse, List *distTablesList,
+							  PlannerRestrictionContext *
+							  plannerRestrictionContext)
+{
+	/* All MERGE tables must be distributed */
+	if (list_length(distTablesList) < 2)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "For MERGE command, both the source and target "
+							 "must be distributed", NULL, NULL);
+	}
+
+	/* All distributed tables must be colocated */
+	if (!AllRelationsInRTEListColocated(distTablesList))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "For MERGE command, all the distributed tables "
+							 "must be colocated", NULL, NULL);
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ErrorIfRTETypeIsUnsupported Checks for types of tables that are not supported, such
+ * as, reference tables, append-distributed tables and materialized view as target relation.
+ * Routine returns NULL for the supported types, error message for everything else.
+ */
+static DeferredErrorMessage *
+CheckIfRTETypeIsUnsupported(Query *parse, RangeTblEntry *rangeTableEntry)
+{
+	if (rangeTableEntry->relkind == RELKIND_MATVIEW ||
+		rangeTableEntry->relkind == RELKIND_FOREIGN_TABLE)
+	{
+		/* Materialized view or Foreign table as target is not allowed */
+		if (IsMergeAllowedOnRelation(parse, rangeTableEntry))
+		{
+			/* Non target relation is ok */
+			return NULL;
+		}
+		else
+		{
+			/* Usually we don't reach this exception as the Postgres parser catches it */
+			StringInfo errorMessage = makeStringInfo();
+			appendStringInfo(errorMessage, "MERGE command is not allowed on "
+										   "relation type(relkind:%c)",
+							 rangeTableEntry->relkind);
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 errorMessage->data, NULL, NULL);
+		}
+	}
+
+	if (rangeTableEntry->relkind != RELKIND_RELATION &&
+		rangeTableEntry->relkind != RELKIND_PARTITIONED_TABLE)
+	{
+		StringInfo errorMessage = makeStringInfo();
+		appendStringInfo(errorMessage, "Unexpected table type(relkind:%c) "
+									   "in MERGE command", rangeTableEntry->relkind);
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 errorMessage->data, NULL, NULL);
+	}
+
+	Assert(rangeTableEntry->relid != 0);
+
+	/* Reference tables are not supported yet */
+	if (IsCitusTableType(rangeTableEntry->relid, REFERENCE_TABLE))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "MERGE command is not supported on reference "
+							 "tables yet", NULL, NULL);
+	}
+
+	/* Append/Range tables are not supported */
+	if (IsCitusTableType(rangeTableEntry->relid, APPEND_DISTRIBUTED) ||
+		IsCitusTableType(rangeTableEntry->relid, RANGE_DISTRIBUTED))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "For MERGE command, all the distributed tables "
+							 "must be colocated, for append/range distribution, "
+							 "colocation is not supported", NULL,
+							 "Consider using hash distribution instead");
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ErrorIfMergeHasUnsupportedTables checks if all the tables(target, source or any CTE
+ * present) in the MERGE command are local i.e. a combination of Citus local and Non-Citus
+ * tables (regular Postgres tables), or distributed tables with some restrictions, please
+ * see header of routine ErrorIfDistTablesNotColocated for details, raises an exception
+ * for all other combinations.
+ */
+static DeferredErrorMessage *
+ErrorIfMergeHasUnsupportedTables(Query *parse, List *rangeTableList,
+								 PlannerRestrictionContext *restrictionContext)
+{
+	List *distTablesList = NIL;
+	bool foundLocalTables = false;
+
+	RangeTblEntry *rangeTableEntry = NULL;
+	foreach_ptr(rangeTableEntry, rangeTableList)
+	{
+		Oid relationId = rangeTableEntry->relid;
+
+		switch (rangeTableEntry->rtekind)
+		{
+			case RTE_RELATION:
+			{
+				/* Check the relation type */
+				break;
+			}
+
+			case RTE_SUBQUERY:
+			case RTE_FUNCTION:
+			case RTE_TABLEFUNC:
+			case RTE_VALUES:
+			case RTE_JOIN:
+			case RTE_CTE:
+			{
+				/* Skip them as base table(s) will be checked */
+				continue;
+			}
+
+			/*
+			 * RTE_NAMEDTUPLESTORE is typically used in ephmeral named relations,
+			 * such as, trigger data; until we find a genuine use case, raise an
+			 * exception.
+			 * RTE_RESULT is a node added by the planner and we shouldn't
+			 * encounter it in the parse tree.
+			 */
+			case RTE_NAMEDTUPLESTORE:
+			case RTE_RESULT:
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "MERGE command is not supported with "
+									 "Tuplestores and results",
+									 NULL, NULL);
+			}
+
+			default:
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "MERGE command: Unrecognized range table entry.",
+									 NULL, NULL);
+			}
+		}
+
+		/* RTE Relation can be of various types, check them now */
+
+		/* skip the regular views as they are replaced with subqueries */
+		if (rangeTableEntry->relkind == RELKIND_VIEW)
+		{
+			continue;
+		}
+
+		DeferredErrorMessage *errorMessage =
+			CheckIfRTETypeIsUnsupported(parse, rangeTableEntry);
+		if (errorMessage)
+		{
+			return errorMessage;
+		}
+
+		/*
+		 * For now, save all distributed tables, later (below) we will
+		 * check for supported combination(s).
+		 */
+		if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
+		{
+			distTablesList = lappend(distTablesList, rangeTableEntry);
+			continue;
+		}
+
+		/* Regular Postgres tables and Citus local tables are allowed */
+		if (!IsCitusTable(relationId) ||
+			IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
+		{
+			foundLocalTables = true;
+			continue;
+		}
+
+		/* Any other Citus table type missing ? */
+	}
+
+	/* Ensure all tables are indeed local */
+	if (foundLocalTables && list_length(distTablesList) == 0)
+	{
+		/* All the tables are local, supported */
+		return NULL;
+	}
+	else if (foundLocalTables && list_length(distTablesList) > 0)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "MERGE command is not supported with "
+							 "combination of distributed/local tables yet",
+							 NULL, NULL);
+	}
+
+	/* Ensure all distributed tables are indeed co-located */
+	return ErrorIfDistTablesNotColocated(parse,
+										 distTablesList,
+										 restrictionContext);
+}
+
+
+/*
+ * IsPartitionColumnInMerge returns true if the given column is a partition column.
+ * The function uses FindReferencedTableColumn to find the original relation
+ * id and column that the column expression refers to. It then checks whether
+ * that column is a partition column of the relation.
+ *
+ * Also, the function returns always false for reference tables given that
+ * reference tables do not have partition column.
+ *
+ * If skipOuterVars is true, then it doesn't process the outervars.
+ */
+bool
+IsDistributionColumnInMergeSource(Expr *columnExpression, Query *query, bool
+								  skipOuterVars)
+{
+	bool isDistributionColumn = false;
+	Var *column = NULL;
+	RangeTblEntry *relationRTE = NULL;
+
+	/* ParentQueryList is same as the original query for MERGE */
+	FindReferencedTableColumn(columnExpression, list_make1(query), query, &column,
+							  &relationRTE,
+							  skipOuterVars);
+	Oid relationId = relationRTE ? relationRTE->relid : InvalidOid;
+	if (relationId != InvalidOid && column != NULL)
+	{
+		Var *distributionColumn = DistPartitionKey(relationId);
+
+		/* not all distributed tables have partition column */
+		if (distributionColumn != NULL && column->varattno ==
+			distributionColumn->varattno)
+		{
+			isDistributionColumn = true;
+		}
+	}
+
+	return isDistributionColumn;
+}
+
+
+/*
+ * InsertDistributionColumnMatchesSource check to see if MERGE is inserting a
+ * value into the target which is not from the source table, if so, it
+ * raises an exception.
+ * Note: Inserting random values other than the joined column values will
+ * result in unexpected behaviour of rows ending up in incorrect shards, to
+ * prevent such mishaps, we disallow such inserts here.
+ */
+static DeferredErrorMessage *
+InsertDistributionColumnMatchesSource(Query *query, RangeTblEntry *resultRte)
+{
+	Assert(IsMergeQuery(query));
+
+	if (!IsCitusTableType(resultRte->relid, DISTRIBUTED_TABLE))
+	{
+		return NULL;
+	}
+
+	bool foundDistributionColumn = false;
+	MergeAction *action = NULL;
+	foreach_ptr(action, query->mergeActionList)
+	{
+		/* Skip MATCHED clause as INSERTS are not allowed in it*/
+		if (action->matched)
+		{
+			continue;
+		}
+
+		/* NOT MATCHED can have either INSERT or DO NOTHING */
+		if (action->commandType == CMD_NOTHING)
+		{
+			return NULL;
+		}
+
+		if (action->targetList == NIL)
+		{
+			/* INSERT DEFAULT VALUES is not allowed */
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "cannot perform MERGE INSERT with DEFAULTS",
+								 NULL, NULL);
+		}
+
+		Assert(action->commandType == CMD_INSERT);
+		Var *targetKey = PartitionColumn(resultRte->relid, 1);
+
+		TargetEntry *targetEntry = NULL;
+		foreach_ptr(targetEntry, action->targetList)
+		{
+			AttrNumber originalAttrNo = targetEntry->resno;
+
+			/* skip processing of target table non-partition columns */
+			if (originalAttrNo != targetKey->varattno)
+			{
+				continue;
+			}
+
+			foundDistributionColumn = true;
+
+			if (IsA(targetEntry->expr, Var))
+			{
+				if (IsDistributionColumnInMergeSource(targetEntry->expr, query, true))
+				{
+					return NULL;
+				}
+				else
+				{
+					return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+										 "MERGE INSERT must use the source table "
+										 "distribution column value",
+										 NULL, NULL);
+				}
+			}
+			else
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "MERGE INSERT must refer a source column "
+									 "for distribution column ",
+									 NULL, NULL);
+			}
+		}
+
+		if (!foundDistributionColumn)
+		{
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "MERGE INSERT must have distribution column as value",
+								 NULL, NULL);
+		}
+	}
+
+	return NULL;
+}
+
+
+/*
+ * MergeQualAndTargetListFunctionsSupported Checks WHEN/ON clause actions to see what functions
+ * are allowed, if we are updating distribution column, etc.
+ */
+static DeferredErrorMessage *
+MergeQualAndTargetListFunctionsSupported(Oid resultRelationId, FromExpr *joinTree,
+										 Node *quals,
+										 List *targetList, CmdType commandType)
+{
+	uint32 rangeTableId = 1;
+	Var *distributionColumn = NULL;
+	if (IsCitusTable(resultRelationId) && HasDistributionKey(resultRelationId))
+	{
+		distributionColumn = PartitionColumn(resultRelationId, rangeTableId);
+	}
+
+	ListCell *targetEntryCell = NULL;
+	bool hasVarArgument = false; /* A STABLE function is passed a Var argument */
+	bool hasBadCoalesce = false; /* CASE/COALESCE passed a mutable function */
+	foreach(targetEntryCell, targetList)
+	{
+		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
+
+		/* skip resjunk entries: UPDATE adds some for ctid, etc. */
+		if (targetEntry->resjunk)
+		{
+			continue;
+		}
+
+		bool targetEntryDistributionColumn = false;
+		AttrNumber targetColumnAttrNumber = InvalidAttrNumber;
+
+		if (distributionColumn)
+		{
+			if (commandType == CMD_UPDATE)
+			{
+				/*
+				 * Note that it is not possible to give an alias to
+				 * UPDATE table SET ...
+				 */
+				if (targetEntry->resname)
+				{
+					targetColumnAttrNumber = get_attnum(resultRelationId,
+														targetEntry->resname);
+					if (targetColumnAttrNumber == distributionColumn->varattno)
+					{
+						targetEntryDistributionColumn = true;
+					}
+				}
+			}
+		}
+
+		if (targetEntryDistributionColumn &&
+			TargetEntryChangesValue(targetEntry, distributionColumn, joinTree))
+		{
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "updating the distribution column is not "
+								 "allowed in MERGE actions",
+								 NULL, NULL);
+		}
+
+		if (FindNodeMatchingCheckFunction((Node *) targetEntry->expr,
+										  CitusIsVolatileFunction))
+		{
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "functions used in MERGE actions on distributed "
+								 "tables must not be VOLATILE",
+								 NULL, NULL);
+		}
+
+		if (MasterIrreducibleExpression((Node *) targetEntry->expr,
+										&hasVarArgument, &hasBadCoalesce))
+		{
+			Assert(hasVarArgument || hasBadCoalesce);
+		}
+
+		if (FindNodeMatchingCheckFunction((Node *) targetEntry->expr,
+										  NodeIsFieldStore))
+		{
+			/* DELETE cannot do field indirection already */
+			Assert(commandType == CMD_UPDATE || commandType == CMD_INSERT);
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "inserting or modifying composite type fields is not "
+								 "supported", NULL,
+								 "Use the column name to insert or update the composite "
+								 "type as a single value");
+		}
+	}
+
+
+	/*
+	 * Check the condition, convert list of expressions into expression tree for further processing
+	 */
+	if (quals)
+	{
+		if (IsA(quals, List))
+		{
+			quals = (Node *) make_ands_explicit((List *) quals);
+		}
+
+		if (FindNodeMatchingCheckFunction((Node *) quals, CitusIsVolatileFunction))
+		{
+			StringInfo errorMessage = makeStringInfo();
+			appendStringInfo(errorMessage, "functions used in the %s clause of MERGE "
+										   "queries on distributed tables must not be VOLATILE",
+							 (commandType == CMD_MERGE) ? "ON" : "WHEN");
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 errorMessage->data, NULL, NULL);
+		}
+		else if (MasterIrreducibleExpression(quals, &hasVarArgument, &hasBadCoalesce))
+		{
+			Assert(hasVarArgument || hasBadCoalesce);
+		}
+	}
+
+	if (hasVarArgument)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "STABLE functions used in MERGE queries "
+							 "cannot be called with column references",
+							 NULL, NULL);
+	}
+
+	if (hasBadCoalesce)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "non-IMMUTABLE functions are not allowed in CASE or "
+							 "COALESCE statements",
+							 NULL, NULL);
+	}
+
+	if (quals != NULL && nodeTag(quals) == T_CurrentOfExpr)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "cannot run MERGE actions with cursors",
+							 NULL, NULL);
+	}
+
+	return NULL;
+}
+
+
+#endif

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2225,17 +2225,14 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		}
 
 		/*
-		 * For left joins we don't care about the shards pruned for
-		 * the right hand side. If the right hand side would prune
-		 * to a smaller set we should still send it to all tables
-		 * of the left hand side. However if the right hand side is
-		 * bigger than the left hand side we don't have to send the
-		 * query to any shard that is not matching anything on the
-		 * left hand side.
+		 * For left joins we don't care about the shards pruned for the right hand side.
+		 * If the right hand side would prune to a smaller set we should still send it to
+		 * all tables of the left hand side. However if the right hand side is bigger than
+		 * the left hand side we don't have to send the query to any shard that is not
+		 * matching anything on the left hand side.
 		 *
-		 * Instead we will simply skip any RelationRestriction if it
-		 * is an OUTER join and the table is part of the non-outer
-		 * side of the join.
+		 * Instead we will simply skip any RelationRestriction if it is an OUTER join and
+		 * the table is part of the non-outer side of the join.
 		 */
 		if (IsInnerTableOfOuterJoin(relationRestriction))
 		{

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2225,14 +2225,17 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		}
 
 		/*
-		 * For left joins we don't care about the shards pruned for the right hand side.
-		 * If the right hand side would prune to a smaller set we should still send it to
-		 * all tables of the left hand side. However if the right hand side is bigger than
-		 * the left hand side we don't have to send the query to any shard that is not
-		 * matching anything on the left hand side.
+		 * For left joins we don't care about the shards pruned for
+		 * the right hand side. If the right hand side would prune
+		 * to a smaller set we should still send it to all tables
+		 * of the left hand side. However if the right hand side is
+		 * bigger than the left hand side we don't have to send the
+		 * query to any shard that is not matching anything on the
+		 * left hand side.
 		 *
-		 * Instead we will simply skip any RelationRestriction if it is an OUTER join and
-		 * the table is part of the non-outer side of the join.
+		 * Instead we will simply skip any RelationRestriction if it
+		 * is an OUTER join and the table is part of the non-outer
+		 * side of the join.
 		 */
 		if (IsInnerTableOfOuterJoin(relationRestriction))
 		{

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -185,7 +185,6 @@ static DeferredErrorMessage * TargetlistAndFunctionsSupported(Oid resultRelation
 															  List *targetList,
 															  CmdType commandType,
 															  List *returningList);
-
 /*
  * CreateRouterPlan attempts to create a router executor plan for the given
  * SELECT statement. ->planningError is set if planning fails.
@@ -906,6 +905,85 @@ NodeIsFieldStore(Node *node)
 
 
 /*
+ * MergeQuerySupported does check for a MERGE command in the query, if it finds
+ * one, it will verify the below criteria
+ * - Supported tables and combinations in ErrorIfMergeHasUnsupportedTables
+ * - Distributed tables requirements in ErrorIfDistTablesNotColocated
+ * - Checks target-lists and functions-in-quals in TargetlistAndFunctionsSupported
+ */
+static DeferredErrorMessage *
+MergeQuerySupported(Query *originalQuery,
+					PlannerRestrictionContext *plannerRestrictionContext)
+{
+	/* For non-MERGE commands it's a no-op */
+	if (!QueryHasMergeCommand(originalQuery))
+	{
+		return NULL;
+	}
+
+	List *rangeTableList = ExtractRangeTableEntryList(originalQuery);
+	RangeTblEntry *resultRte = ExtractResultRelationRTE(originalQuery);
+
+	/*
+	 * Fast path queries cannot have merge command, and we prevent the remaining here.
+	 * In Citus we have limited support for MERGE, it's allowed only if all
+	 * the tables(target, source or any CTE) tables are are local i.e. a
+	 * combination of Citus local and Non-Citus tables (regular Postgres tables)
+	 * or distributed tables with some restrictions, please see header of routine
+	 * ErrorIfDistTablesNotColocated for details.
+	 */
+	DeferredErrorMessage *deferredError =
+		ErrorIfMergeHasUnsupportedTables(originalQuery,
+										 rangeTableList,
+										 plannerRestrictionContext);
+	if (deferredError)
+	{
+		return deferredError;
+	}
+
+	Oid resultRelationId = resultRte->relid;
+	deferredError =
+		TargetlistAndFunctionsSupported(resultRelationId,
+										originalQuery->jointree,
+										originalQuery->jointree->quals,
+										originalQuery->targetList,
+										originalQuery->commandType,
+										originalQuery->returningList);
+	if (deferredError)
+	{
+		return deferredError;
+	}
+
+	#if PG_VERSION_NUM >= PG_VERSION_15
+
+	/*
+	 * MERGE is a special case where we have multiple modify statements
+	 * within itself. Check each INSERT/UPDATE/DELETE individually.
+	 */
+	MergeAction *action = NULL;
+	foreach_ptr(action, originalQuery->mergeActionList)
+	{
+		Assert(originalQuery->returningList == NULL);
+		deferredError =
+			TargetlistAndFunctionsSupported(resultRelationId,
+											originalQuery->jointree,
+											action->qual,
+											action->targetList,
+											action->commandType,
+											originalQuery->returningList);
+		if (deferredError)
+		{
+			return deferredError;
+		}
+	}
+
+	#endif
+
+	return NULL;
+}
+
+
+/*
  * ModifyQuerySupported returns NULL if the query only contains supported
  * features, otherwise it returns an error description.
  * Note that we need both the original query and the modified one because
@@ -920,8 +998,17 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 					 PlannerRestrictionContext *plannerRestrictionContext)
 {
 	Oid distributedTableId = InvalidOid;
-	DeferredErrorMessage *error = ModifyPartialQuerySupported(queryTree, multiShardQuery,
-															  &distributedTableId);
+	DeferredErrorMessage *error = MergeQuerySupported(originalQuery,
+													  plannerRestrictionContext);
+	if (error)
+	{
+		/*
+		 * For MERGE, we do not do recursive plannning, simply bail out.
+		 */
+		RaiseDeferredError(error, ERROR);
+	}
+
+	error = ModifyPartialQuerySupported(queryTree, multiShardQuery, &distributedTableId);
 	if (error)
 	{
 		return error;
@@ -3968,4 +4055,264 @@ CompareInsertValuesByShardId(const void *leftElement, const void *rightElement)
 			return 0;
 		}
 	}
+}
+
+
+/*
+ * IsMergeAllowedOnRelation takes a relation entry and checks if MERGE command is
+ * permitted on special relations, such as materialized view, returns true only if
+ * it's a "source" relation.
+ */
+bool
+IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte)
+{
+	if (!IsMergeQuery(parse))
+	{
+		return false;
+	}
+
+	RangeTblEntry *targetRte = rt_fetch(parse->resultRelation, parse->rtable);
+
+	/* Is it a target relation? */
+	if (targetRte->relid == rte->relid)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * ErrorIfDistTablesNotColocated Checks to see if
+ *
+ *   - There are a minimum of two distributed tables (source and a target).
+ *   - All the distributed tables are indeed colocated.
+ *   - MERGE relations are joined on the distribution column
+ *          MERGE .. USING .. ON target.dist_key = source.dist_key
+ *
+ * If any of the conditions are not met, it raises an exception.
+ */
+static DeferredErrorMessage *
+ErrorIfDistTablesNotColocated(Query *parse, List *distTablesList,
+							  PlannerRestrictionContext *plannerRestrictionContext)
+{
+	/* All MERGE tables must be distributed */
+	if (list_length(distTablesList) < 2)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "For MERGE command, both the source and target "
+							 "must be distributed", NULL, NULL);
+	}
+
+	/* All distributed tables must be colocated */
+	if (!AllRelationsInListColocated(distTablesList, RANGETABLE_ENTRY))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "For MERGE command, all the distributed tables "
+							 "must be colocated", NULL, NULL);
+	}
+
+	/* Are source and target tables joined on distribution column? */
+	if (!RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "MERGE command is only supported when distributed "
+							 "tables are joined on their distribution column",
+							 NULL, NULL);
+	}
+
+	return NULL;
+}
+
+
+/*
+ * ErrorIfMergeHasUnsupportedTables checks if all the tables(target, source or any CTE
+ * present) in the MERGE command are local i.e. a combination of Citus local and Non-Citus
+ * tables (regular Postgres tables), or distributed tables with some restrictions, please
+ * see header of routine ErrorIfDistTablesNotColocated for details, raises an exception
+ * for all other combinations.
+ */
+static DeferredErrorMessage *
+ErrorIfMergeHasUnsupportedTables(Query *parse, List *rangeTableList,
+								 PlannerRestrictionContext *restrictionContext)
+{
+	List *distTablesList = NIL;
+	bool foundLocalTables = false;
+
+	RangeTblEntry *rangeTableEntry = NULL;
+	foreach_ptr(rangeTableEntry, rangeTableList)
+	{
+		Oid relationId = rangeTableEntry->relid;
+
+		switch (rangeTableEntry->rtekind)
+		{
+			case RTE_RELATION:
+			{
+				/* Check the relation type */
+				break;
+			}
+
+			case RTE_SUBQUERY:
+			case RTE_FUNCTION:
+			case RTE_TABLEFUNC:
+			case RTE_VALUES:
+			case RTE_JOIN:
+			case RTE_CTE:
+			{
+				/* Skip them as base table(s) will be checked */
+				continue;
+			}
+
+			/*
+			 * RTE_NAMEDTUPLESTORE is typically used in ephmeral named relations,
+			 * such as, trigger data; until we find a genuine use case, raise an
+			 * exception.
+			 * RTE_RESULT is a node added by the planner and we shouldn't
+			 * encounter it in the parse tree.
+			 */
+			case RTE_NAMEDTUPLESTORE:
+			case RTE_RESULT:
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "MERGE command is not supported with "
+									 "Tuplestores and results",
+									 NULL, NULL);
+			}
+
+			default:
+			{
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+									 "MERGE command: Unrecognized range table entry.",
+									 NULL, NULL);
+			}
+		}
+
+		/* RTE Relation can be of various types, check them now */
+
+		/* skip the regular views as they are replaced with subqueries */
+		if (rangeTableEntry->relkind == RELKIND_VIEW)
+		{
+			continue;
+		}
+
+		if (rangeTableEntry->relkind == RELKIND_MATVIEW ||
+			rangeTableEntry->relkind == RELKIND_FOREIGN_TABLE)
+		{
+			/* Materialized view or Foreign table as target is not allowed */
+			if (IsMergeAllowedOnRelation(parse, rangeTableEntry))
+			{
+				/* Non target relation is ok */
+				continue;
+			}
+			else
+			{
+				/* Usually we don't reach this exception as the Postgres parser catches it */
+				StringInfo errorMessage = makeStringInfo();
+				appendStringInfo(errorMessage,
+								 "MERGE command is not allowed on "
+								 "relation type(relkind:%c)", rangeTableEntry->relkind);
+				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED, errorMessage->data,
+									 NULL, NULL);
+			}
+		}
+
+		if (rangeTableEntry->relkind != RELKIND_RELATION &&
+			rangeTableEntry->relkind != RELKIND_PARTITIONED_TABLE)
+		{
+			StringInfo errorMessage = makeStringInfo();
+			appendStringInfo(errorMessage, "Unexpected table type(relkind:%c) "
+										   "in MERGE command", rangeTableEntry->relkind);
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED, errorMessage->data,
+								 NULL, NULL);
+		}
+
+		Assert(rangeTableEntry->relid != 0);
+
+		/* Reference tables are not supported yet */
+		if (IsCitusTableType(relationId, REFERENCE_TABLE))
+		{
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "MERGE command is not supported on reference "
+								 "tables yet", NULL, NULL);
+		}
+
+		/* Append/Range tables are not supported */
+		if (IsCitusTableType(relationId, APPEND_DISTRIBUTED) ||
+			IsCitusTableType(relationId, RANGE_DISTRIBUTED))
+		{
+			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+								 "For MERGE command, all the distributed tables "
+								 "must be colocated, for append/range distribution, "
+								 "colocation is not supported", NULL,
+								 "Consider using hash distribution instead");
+		}
+
+		/*
+		 * For now, save all distributed tables, later (below) we will
+		 * check for supported combination(s).
+		 */
+		if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
+		{
+			distTablesList = lappend(distTablesList, rangeTableEntry);
+			continue;
+		}
+
+		/* Regular Postgres tables and Citus local tables are allowed */
+		if (!IsCitusTable(relationId) ||
+			IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
+		{
+			foundLocalTables = true;
+			continue;
+		}
+
+		/* Any other Citus table type missing ? */
+	}
+
+	/* Ensure all tables are indeed local */
+	if (foundLocalTables && list_length(distTablesList) == 0)
+	{
+		/* All the tables are local, supported */
+		return NULL;
+	}
+	else if (foundLocalTables && list_length(distTablesList) > 0)
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "MERGE command is not supported with "
+							 "combination of distributed/local tables yet",
+							 NULL, NULL);
+	}
+
+	/* Ensure all distributed tables are indeed co-located */
+	return ErrorIfDistTablesNotColocated(parse, distTablesList, restrictionContext);
+}
+
+
+/*
+ * QueryHasMergeCommand walks over the query tree and returns false if there
+ * is no Merge command (e.g., CMD_MERGE), true otherwise.
+ */
+static bool
+QueryHasMergeCommand(Query *queryTree)
+{
+	/* function is void for pre-15 versions of Postgres */
+	#if PG_VERSION_NUM < PG_VERSION_15
+	return false;
+	#else
+
+	/*
+	 * Postgres currently doesn't support Merge queries inside subqueries and
+	 * ctes, but lets be defensive and do query tree walk anyway.
+	 *
+	 * We do not call this path for fast-path queries to avoid this additional
+	 * overhead.
+	 */
+	if (!ContainsMergeCommandWalker((Node *) queryTree))
+	{
+		/* No MERGE found */
+		return false;
+	}
+
+	return true;
+	#endif
 }

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -33,6 +33,7 @@
 #include "distributed/intermediate_result_pruning.h"
 #include "distributed/metadata_utility.h"
 #include "distributed/coordinator_protocol.h"
+#include "distributed/merge_planner.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/multi_executor.h"
 #include "distributed/multi_join_order.h"
@@ -125,21 +126,15 @@ static bool IsTidColumn(Node *node);
 static DeferredErrorMessage * ModifyPartialQuerySupported(Query *queryTree, bool
 														  multiShardQuery,
 														  Oid *distributedTableId);
-static bool NodeIsFieldStore(Node *node);
-static DeferredErrorMessage * MultiShardUpdateDeleteMergeSupported(Query *originalQuery,
-																   PlannerRestrictionContext
-																   *
-																   plannerRestrictionContext);
+static DeferredErrorMessage * MultiShardUpdateDeleteSupported(Query *originalQuery,
+															  PlannerRestrictionContext
+															  *
+															  plannerRestrictionContext);
 static DeferredErrorMessage * SingleShardUpdateDeleteSupported(Query *originalQuery,
 															   PlannerRestrictionContext *
 															   plannerRestrictionContext);
-static bool HasDangerousJoinUsing(List *rtableList, Node *jtnode);
-static bool MasterIrreducibleExpression(Node *expression, bool *varArgument,
-										bool *badCoalesce);
 static bool MasterIrreducibleExpressionWalker(Node *expression, WalkerState *state);
 static bool MasterIrreducibleExpressionFunctionChecker(Oid func_id, void *context);
-static bool TargetEntryChangesValue(TargetEntry *targetEntry, Var *column,
-									FromExpr *joinTree);
 static Job * RouterInsertJob(Query *originalQuery);
 static void ErrorIfNoShardsExist(CitusTableCacheEntry *cacheEntry);
 static DeferredErrorMessage * DeferErrorIfModifyView(Query *queryTree);
@@ -179,12 +174,8 @@ static void ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 static bool ModifiesLocalTableWithRemoteCitusLocalTable(List *rangeTableList);
 static DeferredErrorMessage * DeferErrorIfUnsupportedLocalTableJoin(List *rangeTableList);
 static bool IsLocallyAccessibleCitusLocalTable(Oid relationId);
-static DeferredErrorMessage * TargetlistAndFunctionsSupported(Oid resultRelationId,
-															  FromExpr *joinTree,
-															  Node *quals,
-															  List *targetList,
-															  CmdType commandType,
-															  List *returningList);
+
+
 /*
  * CreateRouterPlan attempts to create a router executor plan for the given
  * SELECT statement. ->planningError is set if planning fails.
@@ -521,7 +512,7 @@ IsTidColumn(Node *node)
  * updating distribution column, etc.
  * Note: This subset of checks are repeated for each MERGE modify action.
  */
-static DeferredErrorMessage *
+DeferredErrorMessage *
 TargetlistAndFunctionsSupported(Oid resultRelationId, FromExpr *joinTree, Node *quals,
 								List *targetList,
 								CmdType commandType, List *returningList)
@@ -897,89 +888,10 @@ IsLocallyAccessibleCitusLocalTable(Oid relationId)
 /*
  * NodeIsFieldStore returns true if given Node is a FieldStore object.
  */
-static bool
+bool
 NodeIsFieldStore(Node *node)
 {
 	return node && IsA(node, FieldStore);
-}
-
-
-/*
- * MergeQuerySupported does check for a MERGE command in the query, if it finds
- * one, it will verify the below criteria
- * - Supported tables and combinations in ErrorIfMergeHasUnsupportedTables
- * - Distributed tables requirements in ErrorIfDistTablesNotColocated
- * - Checks target-lists and functions-in-quals in TargetlistAndFunctionsSupported
- */
-static DeferredErrorMessage *
-MergeQuerySupported(Query *originalQuery,
-					PlannerRestrictionContext *plannerRestrictionContext)
-{
-	/* For non-MERGE commands it's a no-op */
-	if (!QueryHasMergeCommand(originalQuery))
-	{
-		return NULL;
-	}
-
-	List *rangeTableList = ExtractRangeTableEntryList(originalQuery);
-	RangeTblEntry *resultRte = ExtractResultRelationRTE(originalQuery);
-
-	/*
-	 * Fast path queries cannot have merge command, and we prevent the remaining here.
-	 * In Citus we have limited support for MERGE, it's allowed only if all
-	 * the tables(target, source or any CTE) tables are are local i.e. a
-	 * combination of Citus local and Non-Citus tables (regular Postgres tables)
-	 * or distributed tables with some restrictions, please see header of routine
-	 * ErrorIfDistTablesNotColocated for details.
-	 */
-	DeferredErrorMessage *deferredError =
-		ErrorIfMergeHasUnsupportedTables(originalQuery,
-										 rangeTableList,
-										 plannerRestrictionContext);
-	if (deferredError)
-	{
-		return deferredError;
-	}
-
-	Oid resultRelationId = resultRte->relid;
-	deferredError =
-		TargetlistAndFunctionsSupported(resultRelationId,
-										originalQuery->jointree,
-										originalQuery->jointree->quals,
-										originalQuery->targetList,
-										originalQuery->commandType,
-										originalQuery->returningList);
-	if (deferredError)
-	{
-		return deferredError;
-	}
-
-	#if PG_VERSION_NUM >= PG_VERSION_15
-
-	/*
-	 * MERGE is a special case where we have multiple modify statements
-	 * within itself. Check each INSERT/UPDATE/DELETE individually.
-	 */
-	MergeAction *action = NULL;
-	foreach_ptr(action, originalQuery->mergeActionList)
-	{
-		Assert(originalQuery->returningList == NULL);
-		deferredError =
-			TargetlistAndFunctionsSupported(resultRelationId,
-											originalQuery->jointree,
-											action->qual,
-											action->targetList,
-											action->commandType,
-											originalQuery->returningList);
-		if (deferredError)
-		{
-			return deferredError;
-		}
-	}
-
-	#endif
-
-	return NULL;
 }
 
 
@@ -998,14 +910,11 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 					 PlannerRestrictionContext *plannerRestrictionContext)
 {
 	Oid distributedTableId = InvalidOid;
-	DeferredErrorMessage *error = MergeQuerySupported(originalQuery,
+	DeferredErrorMessage *error = MergeQuerySupported(originalQuery, multiShardQuery,
 													  plannerRestrictionContext);
 	if (error)
 	{
-		/*
-		 * For MERGE, we do not do recursive plannning, simply bail out.
-		 */
-		RaiseDeferredError(error, ERROR);
+		return error;
 	}
 
 	error = ModifyPartialQuerySupported(queryTree, multiShardQuery, &distributedTableId);
@@ -1178,13 +1087,13 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 		}
 	}
 
-	if (commandType != CMD_INSERT)
+	if (commandType != CMD_INSERT && commandType != CMD_MERGE)
 	{
 		DeferredErrorMessage *errorMessage = NULL;
 
 		if (multiShardQuery)
 		{
-			errorMessage = MultiShardUpdateDeleteMergeSupported(
+			errorMessage = MultiShardUpdateDeleteSupported(
 				originalQuery,
 				plannerRestrictionContext);
 		}
@@ -1365,12 +1274,12 @@ ErrorIfOnConflictNotSupported(Query *queryTree)
 
 
 /*
- * MultiShardUpdateDeleteMergeSupported returns the error message if the update/delete is
+ * MultiShardUpdateDeleteSupported returns the error message if the update/delete is
  * not pushdownable, otherwise it returns NULL.
  */
 static DeferredErrorMessage *
-MultiShardUpdateDeleteMergeSupported(Query *originalQuery,
-									 PlannerRestrictionContext *plannerRestrictionContext)
+MultiShardUpdateDeleteSupported(Query *originalQuery,
+								PlannerRestrictionContext *plannerRestrictionContext)
 {
 	DeferredErrorMessage *errorMessage = NULL;
 	RangeTblEntry *resultRangeTable = ExtractResultRelationRTE(originalQuery);
@@ -1401,8 +1310,9 @@ MultiShardUpdateDeleteMergeSupported(Query *originalQuery,
 	}
 	else
 	{
-		errorMessage = DeferErrorIfUnsupportedSubqueryPushdown(originalQuery,
-															   plannerRestrictionContext);
+		errorMessage = DeferErrorIfUnsupportedSubqueryPushdown(
+			originalQuery,
+			plannerRestrictionContext);
 	}
 
 	return errorMessage;
@@ -1442,7 +1352,7 @@ SingleShardUpdateDeleteSupported(Query *originalQuery,
  * HasDangerousJoinUsing search jointree for unnamed JOIN USING. Check the
  * implementation of has_dangerous_join_using in ruleutils.
  */
-static bool
+bool
 HasDangerousJoinUsing(List *rtableList, Node *joinTreeNode)
 {
 	if (IsA(joinTreeNode, RangeTblRef))
@@ -1546,7 +1456,7 @@ IsMergeQuery(Query *query)
  * which do, but for now we just error out. That makes both the code and user-education
  * easier.
  */
-static bool
+bool
 MasterIrreducibleExpression(Node *expression, bool *varArgument, bool *badCoalesce)
 {
 	WalkerState data;
@@ -1694,7 +1604,7 @@ MasterIrreducibleExpressionFunctionChecker(Oid func_id, void *context)
  * expression is a value that is implied by the qualifiers of the join
  * tree, or the target entry sets a different column.
  */
-static bool
+bool
 TargetEntryChangesValue(TargetEntry *targetEntry, Var *column, FromExpr *joinTree)
 {
 	bool isColumnValueChanged = true;
@@ -1965,8 +1875,8 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 	if (*planningError)
 	{
 		/*
-		 * For MERGE, we do _not_ plan anything other than Router job, let's
-		 * not continue further down the lane in distributed planning, simply
+		 * For MERGE, we do _not_ plan any other router job than the MERGE job itself,
+		 * let's not continue further down the lane in distributed planning, simply
 		 * bail out.
 		 */
 		if (IsMergeQuery(originalQuery))
@@ -4055,264 +3965,4 @@ CompareInsertValuesByShardId(const void *leftElement, const void *rightElement)
 			return 0;
 		}
 	}
-}
-
-
-/*
- * IsMergeAllowedOnRelation takes a relation entry and checks if MERGE command is
- * permitted on special relations, such as materialized view, returns true only if
- * it's a "source" relation.
- */
-bool
-IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte)
-{
-	if (!IsMergeQuery(parse))
-	{
-		return false;
-	}
-
-	RangeTblEntry *targetRte = rt_fetch(parse->resultRelation, parse->rtable);
-
-	/* Is it a target relation? */
-	if (targetRte->relid == rte->relid)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-
-/*
- * ErrorIfDistTablesNotColocated Checks to see if
- *
- *   - There are a minimum of two distributed tables (source and a target).
- *   - All the distributed tables are indeed colocated.
- *   - MERGE relations are joined on the distribution column
- *          MERGE .. USING .. ON target.dist_key = source.dist_key
- *
- * If any of the conditions are not met, it raises an exception.
- */
-static DeferredErrorMessage *
-ErrorIfDistTablesNotColocated(Query *parse, List *distTablesList,
-							  PlannerRestrictionContext *plannerRestrictionContext)
-{
-	/* All MERGE tables must be distributed */
-	if (list_length(distTablesList) < 2)
-	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "For MERGE command, both the source and target "
-							 "must be distributed", NULL, NULL);
-	}
-
-	/* All distributed tables must be colocated */
-	if (!AllRelationsInListColocated(distTablesList, RANGETABLE_ENTRY))
-	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "For MERGE command, all the distributed tables "
-							 "must be colocated", NULL, NULL);
-	}
-
-	/* Are source and target tables joined on distribution column? */
-	if (!RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext))
-	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "MERGE command is only supported when distributed "
-							 "tables are joined on their distribution column",
-							 NULL, NULL);
-	}
-
-	return NULL;
-}
-
-
-/*
- * ErrorIfMergeHasUnsupportedTables checks if all the tables(target, source or any CTE
- * present) in the MERGE command are local i.e. a combination of Citus local and Non-Citus
- * tables (regular Postgres tables), or distributed tables with some restrictions, please
- * see header of routine ErrorIfDistTablesNotColocated for details, raises an exception
- * for all other combinations.
- */
-static DeferredErrorMessage *
-ErrorIfMergeHasUnsupportedTables(Query *parse, List *rangeTableList,
-								 PlannerRestrictionContext *restrictionContext)
-{
-	List *distTablesList = NIL;
-	bool foundLocalTables = false;
-
-	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
-	{
-		Oid relationId = rangeTableEntry->relid;
-
-		switch (rangeTableEntry->rtekind)
-		{
-			case RTE_RELATION:
-			{
-				/* Check the relation type */
-				break;
-			}
-
-			case RTE_SUBQUERY:
-			case RTE_FUNCTION:
-			case RTE_TABLEFUNC:
-			case RTE_VALUES:
-			case RTE_JOIN:
-			case RTE_CTE:
-			{
-				/* Skip them as base table(s) will be checked */
-				continue;
-			}
-
-			/*
-			 * RTE_NAMEDTUPLESTORE is typically used in ephmeral named relations,
-			 * such as, trigger data; until we find a genuine use case, raise an
-			 * exception.
-			 * RTE_RESULT is a node added by the planner and we shouldn't
-			 * encounter it in the parse tree.
-			 */
-			case RTE_NAMEDTUPLESTORE:
-			case RTE_RESULT:
-			{
-				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-									 "MERGE command is not supported with "
-									 "Tuplestores and results",
-									 NULL, NULL);
-			}
-
-			default:
-			{
-				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-									 "MERGE command: Unrecognized range table entry.",
-									 NULL, NULL);
-			}
-		}
-
-		/* RTE Relation can be of various types, check them now */
-
-		/* skip the regular views as they are replaced with subqueries */
-		if (rangeTableEntry->relkind == RELKIND_VIEW)
-		{
-			continue;
-		}
-
-		if (rangeTableEntry->relkind == RELKIND_MATVIEW ||
-			rangeTableEntry->relkind == RELKIND_FOREIGN_TABLE)
-		{
-			/* Materialized view or Foreign table as target is not allowed */
-			if (IsMergeAllowedOnRelation(parse, rangeTableEntry))
-			{
-				/* Non target relation is ok */
-				continue;
-			}
-			else
-			{
-				/* Usually we don't reach this exception as the Postgres parser catches it */
-				StringInfo errorMessage = makeStringInfo();
-				appendStringInfo(errorMessage,
-								 "MERGE command is not allowed on "
-								 "relation type(relkind:%c)", rangeTableEntry->relkind);
-				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED, errorMessage->data,
-									 NULL, NULL);
-			}
-		}
-
-		if (rangeTableEntry->relkind != RELKIND_RELATION &&
-			rangeTableEntry->relkind != RELKIND_PARTITIONED_TABLE)
-		{
-			StringInfo errorMessage = makeStringInfo();
-			appendStringInfo(errorMessage, "Unexpected table type(relkind:%c) "
-										   "in MERGE command", rangeTableEntry->relkind);
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED, errorMessage->data,
-								 NULL, NULL);
-		}
-
-		Assert(rangeTableEntry->relid != 0);
-
-		/* Reference tables are not supported yet */
-		if (IsCitusTableType(relationId, REFERENCE_TABLE))
-		{
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-								 "MERGE command is not supported on reference "
-								 "tables yet", NULL, NULL);
-		}
-
-		/* Append/Range tables are not supported */
-		if (IsCitusTableType(relationId, APPEND_DISTRIBUTED) ||
-			IsCitusTableType(relationId, RANGE_DISTRIBUTED))
-		{
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-								 "For MERGE command, all the distributed tables "
-								 "must be colocated, for append/range distribution, "
-								 "colocation is not supported", NULL,
-								 "Consider using hash distribution instead");
-		}
-
-		/*
-		 * For now, save all distributed tables, later (below) we will
-		 * check for supported combination(s).
-		 */
-		if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
-		{
-			distTablesList = lappend(distTablesList, rangeTableEntry);
-			continue;
-		}
-
-		/* Regular Postgres tables and Citus local tables are allowed */
-		if (!IsCitusTable(relationId) ||
-			IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
-		{
-			foundLocalTables = true;
-			continue;
-		}
-
-		/* Any other Citus table type missing ? */
-	}
-
-	/* Ensure all tables are indeed local */
-	if (foundLocalTables && list_length(distTablesList) == 0)
-	{
-		/* All the tables are local, supported */
-		return NULL;
-	}
-	else if (foundLocalTables && list_length(distTablesList) > 0)
-	{
-		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "MERGE command is not supported with "
-							 "combination of distributed/local tables yet",
-							 NULL, NULL);
-	}
-
-	/* Ensure all distributed tables are indeed co-located */
-	return ErrorIfDistTablesNotColocated(parse, distTablesList, restrictionContext);
-}
-
-
-/*
- * QueryHasMergeCommand walks over the query tree and returns false if there
- * is no Merge command (e.g., CMD_MERGE), true otherwise.
- */
-static bool
-QueryHasMergeCommand(Query *queryTree)
-{
-	/* function is void for pre-15 versions of Postgres */
-	#if PG_VERSION_NUM < PG_VERSION_15
-	return false;
-	#else
-
-	/*
-	 * Postgres currently doesn't support Merge queries inside subqueries and
-	 * ctes, but lets be defensive and do query tree walk anyway.
-	 *
-	 * We do not call this path for fast-path queries to avoid this additional
-	 * overhead.
-	 */
-	if (!ContainsMergeCommandWalker((Node *) queryTree))
-	{
-		/* No MERGE found */
-		return false;
-	}
-
-	return true;
-	#endif
 }

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -591,10 +591,16 @@ DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 	}
 	else if (!RestrictionEquivalenceForPartitionKeys(plannerRestrictionContext))
 	{
+		StringInfo errorMessage = makeStringInfo();
+		bool isMergeCmd = IsMergeQuery(originalQuery);
+		appendStringInfo(errorMessage,
+						 "%s"
+						 "only supported when all distributed tables are "
+						 "co-located and joined on their distribution columns",
+						 isMergeCmd ? "MERGE command is " : "complex joins are ");
+
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-							 "complex joins are only supported when all distributed tables are "
-							 "co-located and joined on their distribution columns",
-							 NULL, NULL);
+							 errorMessage->data, NULL, NULL);
 	}
 
 	/* we shouldn't allow reference tables in the FROM clause when the query has sublinks */

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -151,8 +151,6 @@ static void ListConcatUniqueAttributeClassMemberLists(AttributeEquivalenceClass 
 													  secondClass);
 static Var * PartitionKeyForRTEIdentityInQuery(Query *query, int targetRTEIndex,
 											   Index *partitionKeyIndex);
-static bool AllRelationsInRestrictionContextColocated(RelationRestrictionContext *
-													  restrictionContext);
 static bool IsNotSafeRestrictionToRecursivelyPlan(Node *node);
 static JoinRestrictionContext * FilterJoinRestrictionContext(
 	JoinRestrictionContext *joinRestrictionContext, Relids
@@ -383,7 +381,8 @@ SafeToPushdownUnionSubquery(Query *originalQuery,
 		return false;
 	}
 
-	if (!AllRelationsInRestrictionContextColocated(restrictionContext))
+	if (!AllRelationsInListColocated(restrictionContext->relationRestrictionList,
+									 RESTRICTION_CONTEXT))
 	{
 		/* distribution columns are equal, but tables are not co-located */
 		return false;
@@ -1919,19 +1918,33 @@ FindQueryContainingRTEIdentityInternal(Node *node,
 
 
 /*
- * AllRelationsInRestrictionContextColocated determines whether all of the relations in the
- * given relation restrictions list are co-located.
+ * AllRelationsInListColocated determines whether all of the relations in the
+ * given list are co-located.
+ * Note: The list can be of dofferent types, which is specified by ListEntryType
  */
-static bool
-AllRelationsInRestrictionContextColocated(RelationRestrictionContext *restrictionContext)
+bool
+AllRelationsInListColocated(List *relationList, ListEntryType entryType)
 {
+	void *varPtr = NULL;
+	RangeTblEntry *rangeTableEntry = NULL;
 	RelationRestriction *relationRestriction = NULL;
 	int initialColocationId = INVALID_COLOCATION_ID;
 
 	/* check whether all relations exists in the main restriction list */
-	foreach_ptr(relationRestriction, restrictionContext->relationRestrictionList)
+	foreach_ptr(varPtr, relationList)
 	{
-		Oid relationId = relationRestriction->relationId;
+		Oid relationId = InvalidOid;
+
+		if (entryType == RANGETABLE_ENTRY)
+		{
+			rangeTableEntry = (RangeTblEntry *) varPtr;
+			relationId = rangeTableEntry->relid;
+		}
+		else if (entryType == RESTRICTION_CONTEXT)
+		{
+			relationRestriction = (RelationRestriction *) varPtr;
+			relationId = relationRestriction->relationId;
+		}
 
 		if (IsCitusTable(relationId) && !HasDistributionKey(relationId))
 		{

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -256,5 +256,9 @@ extern struct DistributedPlan * CreateDistributedPlan(uint64 planId,
 													  plannerRestrictionContext);
 
 extern bool IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte);
+extern bool ConjunctionContainsColumnFilter(Node *node,
+											Var *column,
+											Node **distributionKeyValue);
+extern bool ContainsMergeCommandWalker(Node *node);
 
 #endif /* DISTRIBUTED_PLANNER_H */

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -255,10 +255,4 @@ extern struct DistributedPlan * CreateDistributedPlan(uint64 planId,
 													  PlannerRestrictionContext *
 													  plannerRestrictionContext);
 
-extern bool IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte);
-extern bool ConjunctionContainsColumnFilter(Node *node,
-											Var *column,
-											Node **distributionKeyValue);
-extern bool ContainsMergeCommandWalker(Node *node);
-
 #endif /* DISTRIBUTED_PLANNER_H */

--- a/src/include/distributed/merge_planner.h
+++ b/src/include/distributed/merge_planner.h
@@ -1,0 +1,26 @@
+/*-------------------------------------------------------------------------
+ *
+ * merge_planner.h
+ *
+ * Declarations for public functions and types related to router planning.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef MERGE_PLANNER_H
+#define MERGE_PLANNER_H
+
+#include "c.h"
+
+#include "nodes/parsenodes.h"
+#include "distributed/distributed_planner.h"
+#include "distributed/errormessage.h"
+
+extern bool IsMergeAllowedOnRelation(Query *parse, RangeTblEntry *rte);
+extern DeferredErrorMessage * MergeQuerySupported(Query *originalQuery,
+												  bool multiShardQuery,
+												  PlannerRestrictionContext *
+												  plannerRestrictionContext);
+#endif /* MERGE_PLANNER_H */

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -100,6 +100,17 @@ extern PlannedStmt * FastPathPlanner(Query *originalQuery, Query *parse, ParamLi
 extern bool FastPathRouterQuery(Query *query, Node **distributionKeyValue);
 extern bool JoinConditionIsOnFalse(List *relOptInfo);
 extern Oid ResultRelationOidForQuery(Query *query);
-
+extern DeferredErrorMessage * TargetlistAndFunctionsSupported(Oid resultRelationId,
+															  FromExpr *joinTree,
+															  Node *quals,
+															  List *targetList,
+															  CmdType commandType,
+															  List *returningList);
+extern bool NodeIsFieldStore(Node *node);
+extern bool TargetEntryChangesValue(TargetEntry *targetEntry, Var *column,
+									FromExpr *joinTree);
+extern bool MasterIrreducibleExpression(Node *expression, bool *varArgument,
+										bool *badCoalesce);
+extern bool HasDangerousJoinUsing(List *rtableList, Node *jtnode);
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -17,6 +17,15 @@
 
 #define SINGLE_RTE_INDEX 1
 
+/*
+ * Represents the pointer type that's being passed in the list.
+ */
+typedef enum ListEntryType
+{
+	RANGETABLE_ENTRY, /* RangeTblEntry */
+	RESTRICTION_CONTEXT /* RelationRestriction */
+} ListEntryType;
+
 extern bool AllDistributionKeysInQueryAreEqual(Query *originalQuery,
 											   PlannerRestrictionContext *
 											   plannerRestrictionContext);
@@ -54,4 +63,6 @@ extern RelationRestrictionContext * FilterRelationRestrictionContext(
 	RelationRestrictionContext *relationRestrictionContext,
 	Relids
 	queryRteIdentities);
+extern bool AllRelationsInListColocated(List *relationList, ListEntryType entryType);
+
 #endif /* RELATION_RESTRICTION_EQUIVALENCE_H */

--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -17,15 +17,6 @@
 
 #define SINGLE_RTE_INDEX 1
 
-/*
- * Represents the pointer type that's being passed in the list.
- */
-typedef enum ListEntryType
-{
-	RANGETABLE_ENTRY, /* RangeTblEntry */
-	RESTRICTION_CONTEXT /* RelationRestriction */
-} ListEntryType;
-
 extern bool AllDistributionKeysInQueryAreEqual(Query *originalQuery,
 											   PlannerRestrictionContext *
 											   plannerRestrictionContext);
@@ -63,6 +54,5 @@ extern RelationRestrictionContext * FilterRelationRestrictionContext(
 	RelationRestrictionContext *relationRestrictionContext,
 	Relids
 	queryRteIdentities);
-extern bool AllRelationsInListColocated(List *relationList, ListEntryType entryType);
-
+extern bool AllRelationsInRTEListColocated(List *rangeTableEntryList);
 #endif /* RELATION_RESTRICTION_EQUIVALENCE_H */

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -28,6 +28,10 @@ s/\(ref_id\)=\([0-9]+\)/(ref_id)=(X)/g
 # shard table names for multi_subtransactions
 s/"t2_[0-9]+"/"t2_xxxxxxx"/g
 
+# shard table names for MERGE tests
+s/merge_schema\.([_a-z0-9]+)_40[0-9]+ /merge_schema.\1_xxxxxxx /g
+s/pgmerge_schema\.([_a-z0-9]+)_40[0-9]+ /pgmerge_schema.\1_xxxxxxx /g
+
 # shard table names for multi_subquery
 s/ keyval(1|2|ref)_[0-9]+ / keyval\1_xxxxxxx /g
 

--- a/src/test/regress/create_schedule
+++ b/src/test/regress/create_schedule
@@ -13,3 +13,4 @@ test: arbitrary_configs_truncate_create
 test: arbitrary_configs_truncate_cascade_create
 test: arbitrary_configs_truncate_partition_create
 test: arbitrary_configs_alter_table_add_constraint_without_name_create
+test: merge_arbitrary_create

--- a/src/test/regress/expected/merge.out
+++ b/src/test/regress/expected/merge.out
@@ -18,6 +18,7 @@ SET search_path TO merge_schema;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 4000000;
 SET citus.explain_all_tasks to true;
+SET citus.shard_replication_factor TO 1;
 SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
 NOTICE:  localhost:xxxxx is the coordinator and already contains metadata, skipping syncing the metadata
  ?column?
@@ -214,9 +215,45 @@ HINT:  To remove the local data, run: SELECT truncate_local_data_after_distribut
 
 (1 row)
 
+-- Updates one of the row with customer_id  = 30002
+SELECT * from target t WHERE t.customer_id  = 30002;
+ customer_id | last_order_id | order_center | order_count |        last_order
+---------------------------------------------------------------------
+       30002 |           103 | AX           |          -1 | Sun Jan 17 19:53:00 2021
+(1 row)
+
+-- Turn on notice to print tasks sent to nodes
+SET citus.log_remote_commands to true;
 MERGE INTO target t
    USING source s
-   ON (t.customer_id = s.customer_id)
+   ON (t.customer_id = s.customer_id) AND t.customer_id = 30002
+   WHEN MATCHED AND t.order_center = 'XX' THEN
+       DELETE
+   WHEN MATCHED THEN
+       UPDATE SET     -- Existing customer, update the order count and last_order_id
+           order_count = t.order_count + 1,
+           last_order_id = s.order_id
+   WHEN NOT MATCHED THEN
+       DO NOTHING;
+NOTICE:  issuing MERGE INTO merge_schema.target_xxxxxxx t USING merge_schema.source_xxxxxxx s ON ((t.customer_id OPERATOR(pg_catalog.=) s.customer_id) AND (t.customer_id OPERATOR(pg_catalog.=) 30002)) WHEN MATCHED AND ((t.order_center COLLATE "default") OPERATOR(pg_catalog.=) 'XX'::text) THEN DELETE WHEN MATCHED THEN UPDATE SET last_order_id = s.order_id, order_count = (t.order_count OPERATOR(pg_catalog.+) 1) WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT * from target t WHERE t.customer_id  = 30002;
+ customer_id | last_order_id | order_center | order_count |        last_order
+---------------------------------------------------------------------
+       30002 |           103 | AX           |           0 | Sun Jan 17 19:53:00 2021
+(1 row)
+
+-- Deletes one of the row with customer_id  = 30004
+SELECT * from target t WHERE t.customer_id  = 30004;
+ customer_id | last_order_id | order_center | order_count |        last_order
+---------------------------------------------------------------------
+       30004 |            99 | XX           |          -1 | Fri Sep 11 03:23:00 2020
+(1 row)
+
+MERGE INTO target t
+   USING source s
+   ON (t.customer_id = s.customer_id) AND t.customer_id = 30004
    WHEN MATCHED AND t.order_center = 'XX' THEN
        DELETE
    WHEN MATCHED THEN
@@ -226,7 +263,11 @@ MERGE INTO target t
    WHEN NOT MATCHED THEN       -- New entry, record it.
        INSERT (customer_id, last_order_id, order_center, order_count, last_order)
            VALUES (customer_id, s.order_id, s.order_center, 123, s.order_time);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+SELECT * from target t WHERE t.customer_id  = 30004;
+ customer_id | last_order_id | order_center | order_count | last_order
+---------------------------------------------------------------------
+(0 rows)
+
 --
 -- Test MERGE with CTE as source
 --
@@ -386,18 +427,61 @@ HINT:  To remove the local data, run: SELECT truncate_local_data_after_distribut
 
 (1 row)
 
+SELECT * FROM t1 order by id;
+ id | val
+---------------------------------------------------------------------
+  1 |   0
+  2 |   0
+  5 |   0
+(3 rows)
+
+SET citus.log_remote_commands to true;
 WITH s1_res AS (
 	SELECT * FROM s1
 )
 MERGE INTO t1
-	USING s1_res ON (s1_res.id = t1.id)
+	USING s1_res ON (s1_res.id = t1.id) AND t1.id = 6
 	WHEN MATCHED AND s1_res.val = 0 THEN
 		DELETE
 	WHEN MATCHED THEN
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH s1_res AS (SELECT s1.id, s1.val FROM merge_schema.s1_xxxxxxx s1) MERGE INTO merge_schema.t1_xxxxxxx t1 USING s1_res ON ((s1_res.id OPERATOR(pg_catalog.=) t1.id) AND (t1.id OPERATOR(pg_catalog.=) 6)) WHEN MATCHED AND (s1_res.val OPERATOR(pg_catalog.=) 0) THEN DELETE WHEN MATCHED THEN UPDATE SET val = (t1.val OPERATOR(pg_catalog.+) 1) WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s1_res.id, s1_res.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH s1_res AS (SELECT s1.id, s1.val FROM merge_schema.s1_xxxxxxx s1) MERGE INTO merge_schema.t1_xxxxxxx t1 USING s1_res ON ((s1_res.id OPERATOR(pg_catalog.=) t1.id) AND (t1.id OPERATOR(pg_catalog.=) 6)) WHEN MATCHED AND (s1_res.val OPERATOR(pg_catalog.=) 0) THEN DELETE WHEN MATCHED THEN UPDATE SET val = (t1.val OPERATOR(pg_catalog.+) 1) WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s1_res.id, s1_res.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH s1_res AS (SELECT s1.id, s1.val FROM merge_schema.s1_xxxxxxx s1) MERGE INTO merge_schema.t1_xxxxxxx t1 USING s1_res ON ((s1_res.id OPERATOR(pg_catalog.=) t1.id) AND (t1.id OPERATOR(pg_catalog.=) 6)) WHEN MATCHED AND (s1_res.val OPERATOR(pg_catalog.=) 0) THEN DELETE WHEN MATCHED THEN UPDATE SET val = (t1.val OPERATOR(pg_catalog.+) 1) WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s1_res.id, s1_res.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH s1_res AS (SELECT s1.id, s1.val FROM merge_schema.s1_xxxxxxx s1) MERGE INTO merge_schema.t1_xxxxxxx t1 USING s1_res ON ((s1_res.id OPERATOR(pg_catalog.=) t1.id) AND (t1.id OPERATOR(pg_catalog.=) 6)) WHEN MATCHED AND (s1_res.val OPERATOR(pg_catalog.=) 0) THEN DELETE WHEN MATCHED THEN UPDATE SET val = (t1.val OPERATOR(pg_catalog.+) 1) WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s1_res.id, s1_res.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing PREPARE TRANSACTION 'citus_xx_xx_xx_xx'
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing PREPARE TRANSACTION 'citus_xx_xx_xx_xx'
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT PREPARED 'citus_xx_xx_xx_xx'
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing COMMIT PREPARED 'citus_xx_xx_xx_xx'
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+-- Other than id 6 everything else is a NO match, and should appear in target
+SELECT * FROM t1 order by 1, 2;
+ id | val
+---------------------------------------------------------------------
+  1 |   0
+  1 |   0
+  2 |   0
+  2 |   1
+  3 |   1
+  4 |   1
+  5 |   0
+  6 |   1
+(8 rows)
+
 --
 -- Test with multiple join conditions
 --
@@ -553,16 +637,38 @@ HINT:  To remove the local data, run: SELECT truncate_local_data_after_distribut
 
 (1 row)
 
+SELECT * FROM t2 ORDER BY 1;
+ id | val |  src
+---------------------------------------------------------------------
+  1 |   0 | target
+  2 |   0 | target
+  3 |   1 | match
+  4 |   0 | match
+(4 rows)
+
+SET citus.log_remote_commands to true;
 MERGE INTO t2
 USING s2
-ON t2.id = s2.id AND t2.src = s2.src
+ON t2.id = s2.id AND t2.src = s2.src AND t2.id = 4
 	WHEN MATCHED AND t2.val = 1 THEN
 		UPDATE SET val = s2.val + 10
 	WHEN MATCHED THEN
 		DELETE
 	WHEN NOT MATCHED THEN
-		INSERT (id, val, src) VALUES (s2.id, s2.val, s2.src);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+		DO NOTHING;
+NOTICE:  issuing MERGE INTO merge_schema.t2_xxxxxxx t2 USING merge_schema.s2_xxxxxxx s2 ON ((t2.id OPERATOR(pg_catalog.=) s2.id) AND (t2.src OPERATOR(pg_catalog.=) s2.src) AND (t2.id OPERATOR(pg_catalog.=) 4)) WHEN MATCHED AND (t2.val OPERATOR(pg_catalog.=) 1) THEN UPDATE SET val = (s2.val OPERATOR(pg_catalog.+) 10) WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+-- Row with id = 4 is a match for delete clause, row should be deleted
+-- Row with id = 3 is a NO match, row from source will be inserted
+SELECT * FROM t2 ORDER BY 1;
+ id | val |  src
+---------------------------------------------------------------------
+  1 |   0 | target
+  2 |   0 | target
+  3 |   1 | match
+(3 rows)
+
 --
 -- With sub-query as the MERGE source
 --
@@ -943,7 +1049,7 @@ WHEN MATCHED THEN
 UPDATE SET value = vl_source.value, id = vl_target.id + 1
 WHEN NOT MATCHED THEN
 INSERT VALUES(vl_source.ID, vl_source.value);
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.vl_target_4000036 vl_target USING (SELECT vl.id, vl.value FROM (VALUES (100,'source1'::text), (200,'source2'::text)) vl(id, value)) vl_source ON (vl_source.id OPERATOR(pg_catalog.=) vl_target.id) WHEN MATCHED THEN UPDATE SET id = (vl_target.id OPERATOR(pg_catalog.+) 1), value = (vl_source.value COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, value) VALUES (vl_source.id, (vl_source.value COLLATE "default"))>
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.vl_target_xxxxxxx vl_target USING (SELECT vl.id, vl.value FROM (VALUES (100,'source1'::text), (200,'source2'::text)) vl(id, value)) vl_source ON (vl_source.id OPERATOR(pg_catalog.=) vl_target.id) WHEN MATCHED THEN UPDATE SET id = (vl_target.id OPERATOR(pg_catalog.+) 1), value = (vl_source.value COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, value) VALUES (vl_source.id, (vl_source.value COLLATE "default"))>
 RESET client_min_messages;
 SELECT * INTO vl_local FROM vl_target ORDER BY 1 ;
 -- Should be equal
@@ -996,7 +1102,7 @@ WHEN MATCHED THEN
 DO NOTHING
 WHEN NOT MATCHED THEN
 INSERT VALUES(rs_source.id);
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.rs_target_4000037 rs_target USING (SELECT id.id FROM merge_schema.f_immutable(99) id(id) WHERE (id.id OPERATOR(pg_catalog.=) ANY (SELECT 99))) rs_source ON (rs_source.id OPERATOR(pg_catalog.=) rs_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id) VALUES (rs_source.id)>
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.rs_target_xxxxxxx rs_target USING (SELECT id.id FROM merge_schema.f_immutable(99) id(id) WHERE (id.id OPERATOR(pg_catalog.=) ANY (SELECT 99))) rs_source ON (rs_source.id OPERATOR(pg_catalog.=) rs_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id) VALUES (rs_source.id)>
 RESET client_min_messages;
 SELECT * INTO rs_local FROM rs_target ORDER BY 1 ;
 -- Should be equal
@@ -1132,7 +1238,7 @@ DEBUG:  function does not have co-located tables
 DEBUG:  generating subplan XXX_1 for subquery SELECT id, source FROM merge_schema.f_dist() f(id integer, source character varying)
 DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
 DEBUG:  Plan XXX query after replacing subqueries and CTEs: MERGE INTO merge_schema.fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target_4000040 fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target_xxxxxxx fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
 RESET client_min_messages;
 SELECT * INTO fn_local FROM fn_target ORDER BY 1 ;
 -- Should be equal
@@ -1204,7 +1310,7 @@ MERGE INTO ft_target
 		DELETE
 	WHEN NOT MATCHED THEN
 		INSERT (id, user_val) VALUES (foreign_table.id, foreign_table.user_val);
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.ft_target USING merge_schema.foreign_table_4000046 foreign_table ON (foreign_table.id OPERATOR(pg_catalog.=) ft_target.id) WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, user_val) VALUES (foreign_table.id, (foreign_table.user_val COLLATE "default"))>
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.ft_target USING merge_schema.foreign_table_xxxxxxx foreign_table ON (foreign_table.id OPERATOR(pg_catalog.=) ft_target.id) WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, user_val) VALUES (foreign_table.id, (foreign_table.user_val COLLATE "default"))>
 RESET client_min_messages;
 SELECT * FROM ft_target;
  id | user_val
@@ -1214,8 +1320,865 @@ SELECT * FROM ft_target;
 (2 rows)
 
 --
+-- complex joins on the source side
+--
+-- source(join of two relations) relation is an unaliased join
+CREATE TABLE target_cj(tid int, src text, val int);
+CREATE TABLE source_cj1(sid1 int, src1 text, val1 int);
+CREATE TABLE source_cj2(sid2 int, src2 text, val2 int);
+INSERT INTO target_cj VALUES (1, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (3, 'target', 0);
+INSERT INTO source_cj1 VALUES (2, 'source-1', 10);
+INSERT INTO source_cj2 VALUES (2, 'source-2', 20);
+BEGIN;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+-- Gold result to compare against
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-2 |   0
+   2 | source-2 |   0
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET tid = sid2, src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+-- Gold result to compare against
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-1 |  20
+   2 | source-1 |  20
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+-- Test the same scenarios with distributed tables
+SELECT create_distributed_table('target_cj', 'tid');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.target_cj$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('source_cj1', 'sid1');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.source_cj1$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('source_cj2', 'sid2');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.source_cj2$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.target_cj_xxxxxxx t USING (merge_schema.source_cj1_xxxxxxx s1 JOIN merge_schema.source_cj2_xxxxxxx s2 ON ((s1.sid1 OPERATOR(pg_catalog.=) s2.sid2))) ON ((t.tid OPERATOR(pg_catalog.=) s1.sid1) AND (t.tid OPERATOR(pg_catalog.=) 2)) WHEN MATCHED THEN UPDATE SET src = s2.src2 WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-2 |   0
+   2 | source-2 |   0
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-1 |  20
+   2 | source-1 |  20
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+-- sub-query as a source
+BEGIN;
+MERGE INTO target_cj t
+USING (SELECT * FROM source_cj1 WHERE sid1 = 2) sub
+ON t.tid = sub.sid1 AND t.tid = 2
+WHEN MATCHED THEN
+	UPDATE SET src = sub.src1, val = val1
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-1 |  10
+   2 | source-1 |  10
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+-- Test self-join
+BEGIN;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |  src   | val
+---------------------------------------------------------------------
+   1 | target |   0
+   2 | target |   0
+   2 | target |   0
+   3 | target |   0
+(4 rows)
+
+set citus.log_remote_commands to true;
+MERGE INTO target_cj t1
+USING (SELECT * FROM target_cj) sub
+ON t1.tid = sub.tid AND t1.tid = 3
+WHEN MATCHED THEN
+	UPDATE SET src = sub.src, val = sub.val + 100
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+NOTICE:  issuing MERGE INTO merge_schema.target_cj_xxxxxxx t1 USING (SELECT target_cj.tid, target_cj.src, target_cj.val FROM merge_schema.target_cj_xxxxxxx target_cj) sub ON ((t1.tid OPERATOR(pg_catalog.=) sub.tid) AND (t1.tid OPERATOR(pg_catalog.=) 3)) WHEN MATCHED THEN UPDATE SET src = sub.src, val = (sub.val OPERATOR(pg_catalog.+) 100) WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+set citus.log_remote_commands to false;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |  src   | val
+---------------------------------------------------------------------
+   1 | target |   0
+   2 | target |   0
+   2 | target |   0
+   3 | target | 100
+(4 rows)
+
+ROLLBACK;
+-- Test PREPARE
+PREPARE foo(int) AS
+MERGE INTO target_cj target
+USING (SELECT * FROM source_cj1) sub
+ON target.tid = sub.sid1 AND target.tid = $1
+WHEN MATCHED THEN
+        UPDATE SET val = sub.val1
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |  src   | val
+---------------------------------------------------------------------
+   1 | target |   0
+   2 | target |   0
+   2 | target |   0
+   3 | target |   0
+(4 rows)
+
+BEGIN;
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+SELECT * FROM target_cj ORDER BY 1;
+ tid |  src   | val
+---------------------------------------------------------------------
+   1 | target |   0
+   2 | target |  10
+   2 | target |  10
+   3 | target |   0
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+SET citus.log_remote_commands to true;
+SET client_min_messages TO DEBUG1;
+EXECUTE foo(2);
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING >
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING >
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING >
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING >
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING >
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+RESET client_min_messages;
+EXECUTE foo(2);
+NOTICE:  issuing MERGE INTO merge_schema.target_cj_xxxxxxx target USING (SELECT source_cj1.sid1, source_cj1.src1, source_cj1.val1 FROM merge_schema.source_cj1_xxxxxxx source_cj1) sub ON ((target.tid OPERATOR(pg_catalog.=) sub.sid1) AND (target.tid OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = sub.val1 WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |  src   | val
+---------------------------------------------------------------------
+   1 | target |   0
+   2 | target |  10
+   2 | target |  10
+   3 | target |   0
+(4 rows)
+
+ROLLBACK;
+-- Test distributed tables, must be co-located and joined on distribution column.
+--
+-- We create two sets of source and target tables, one set is Postgres and the other
+-- is Citus distributed. Run the _exact_ MERGE SQL on both the sets and compare the
+-- final results of target tables of Postgres and Citus, the result should match.
+-- This is repeated for various MERGE SQL combinations
+--
+CREATE TABLE pg_target(id int, val varchar);
+CREATE TABLE pg_source(id int, val varchar);
+CREATE TABLE citus_target(id int, val varchar);
+CREATE TABLE citus_source(id int, val varchar);
+-- Half of the source rows do not match
+INSERT INTO pg_target SELECT i, 'target' FROM generate_series(250, 500) i;
+INSERT INTO pg_source SELECT i, 'source' FROM generate_series(1, 500) i;
+INSERT INTO citus_target SELECT i, 'target' FROM generate_series(250, 500) i;
+INSERT INTO citus_source SELECT i, 'source' FROM generate_series(1, 500) i;
+SELECT create_distributed_table('citus_target', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.citus_target$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('citus_source', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.citus_source$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+--
+-- This routine compares the target tables of Postgres and Citus and
+-- returns true if they match, false if the results do not match.
+--
+CREATE OR REPLACE FUNCTION compare_tables() RETURNS BOOLEAN AS $$
+DECLARE ret BOOL;
+BEGIN
+SELECT count(1) = 0 INTO ret
+    FROM pg_target
+    FULL OUTER JOIN citus_target
+        USING (id, val)
+    WHERE pg_target.id IS NULL
+        OR citus_target.id IS NULL;
+RETURN ret;
+END
+$$ LANGUAGE PLPGSQL;
+-- Make sure we start with exact data in Postgres and Citus
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- Run the MERGE on both Postgres and Citus, and compare the final target tables
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+--
+-- ON clause filter on source
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+--
+-- ON clause filter on target
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND t.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND t.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (t.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (t.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (t.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (t.id OPERATOR(pg_catalog.<) 100)) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 400) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+--
+-- NOT MATCHED clause filter on source
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id
+WHEN MATCHED THEN
+	DO NOTHING
+WHEN NOT MATCHED AND s.id < 100 THEN
+        INSERT VALUES(s.id, s.val);
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN MATCHED THEN
+	DO NOTHING
+WHEN NOT MATCHED AND s.id < 100 THEN
+        INSERT VALUES(s.id, s.val);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED AND (s.id OPERATOR(pg_catalog.<) 100) THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED AND (s.id OPERATOR(pg_catalog.<) 100) THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED AND (s.id OPERATOR(pg_catalog.<) 100) THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON (t.id OPERATOR(pg_catalog.=) s.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED AND (s.id OPERATOR(pg_catalog.<) 100) THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+--
+-- Test constant filter in ON clause to check if shards are pruned
+-- with restriction information
+--
+--
+-- Though constant filter is present, this won't prune shards as
+-- NOT MATCHED clause is present
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.=) 250)) WHEN MATCHED THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.=) 250)) WHEN MATCHED THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.=) 250)) WHEN MATCHED THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.=) 250)) WHEN MATCHED THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- This will prune shards with restriction information as NOT MATCHED is void
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING merge_schema.citus_source_xxxxxxx s ON ((t.id OPERATOR(pg_catalog.=) s.id) AND (s.id OPERATOR(pg_catalog.=) 250)) WHEN MATCHED THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by Merge'::text) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- Test CTE with distributed tables
+CREATE VIEW pg_source_view AS SELECT * FROM pg_source WHERE id < 400;
+WARNING:  "view pg_source_view" has dependency to "table pg_source" that is not in Citus' metadata
+DETAIL:  "view pg_source_view" will be created only locally
+HINT:  Distribute "table pg_source" first to distribute "view pg_source_view"
+CREATE VIEW citus_source_view AS SELECT * FROM citus_source WHERE id < 400;
+BEGIN;
+SEt citus.log_remote_commands to true;
+WITH cte AS (
+        SELECT * FROM pg_source_view
+)
+MERGE INTO pg_target t
+USING cte
+ON cte.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by CTE'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (cte.id, cte.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+WITH cte AS (
+        SELECT * FROM citus_source_view
+)
+MERGE INTO citus_target t
+USING cte
+ON cte.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by CTE'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (cte.id, cte.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH cte AS (SELECT citus_source_view.id, citus_source_view.val FROM (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source WHERE (citus_source.id OPERATOR(pg_catalog.<) 400)) citus_source_view) MERGE INTO merge_schema.citus_target_xxxxxxx t USING cte ON (cte.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by CTE'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (cte.id, cte.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH cte AS (SELECT citus_source_view.id, citus_source_view.val FROM (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source WHERE (citus_source.id OPERATOR(pg_catalog.<) 400)) citus_source_view) MERGE INTO merge_schema.citus_target_xxxxxxx t USING cte ON (cte.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by CTE'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (cte.id, cte.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH cte AS (SELECT citus_source_view.id, citus_source_view.val FROM (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source WHERE (citus_source.id OPERATOR(pg_catalog.<) 400)) citus_source_view) MERGE INTO merge_schema.citus_target_xxxxxxx t USING cte ON (cte.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by CTE'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (cte.id, cte.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing WITH cte AS (SELECT citus_source_view.id, citus_source_view.val FROM (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source WHERE (citus_source.id OPERATOR(pg_catalog.<) 400)) citus_source_view) MERGE INTO merge_schema.citus_target_xxxxxxx t USING cte ON (cte.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by CTE'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (cte.id, cte.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- Test sub-query with distributed tables
+BEGIN;
+SEt citus.log_remote_commands to true;
+MERGE INTO pg_target t
+USING (SELECT * FROM pg_source) subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by subquery'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, subq.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+MERGE INTO citus_target t
+USING (SELECT * FROM citus_source) subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by subquery'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, subq.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) subq ON (subq.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by subquery'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (subq.id, subq.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) subq ON (subq.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by subquery'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (subq.id, subq.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) subq ON (subq.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by subquery'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (subq.id, subq.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx t USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) subq ON (subq.id OPERATOR(pg_catalog.=) t.id) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.>) 350) THEN UPDATE SET val = (((t.val COLLATE "default") OPERATOR(pg_catalog.||) 'Updated by subquery'::text) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (subq.id, subq.val) WHEN MATCHED AND (t.id OPERATOR(pg_catalog.<) 350) THEN DELETE
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- Test PREPARE
+PREPARE pg_prep(int) AS
+MERGE INTO pg_target
+USING (SELECT * FROM pg_source) sub
+ON pg_target.id = sub.id AND pg_target.id = $1
+WHEN MATCHED THEN
+        UPDATE SET val = 'Updated by prepare using ' || sub.val
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+PREPARE citus_prep(int) AS
+MERGE INTO citus_target
+USING (SELECT * FROM citus_source) sub
+ON citus_target.id = sub.id AND citus_target.id = $1
+WHEN MATCHED THEN
+        UPDATE SET val = 'Updated by prepare using ' || sub.val
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+BEGIN;
+SET citus.log_remote_commands to true;
+SELECT * FROM pg_target WHERE id = 500; -- before merge
+ id  |  val
+---------------------------------------------------------------------
+ 500 | target
+(1 row)
+
+EXECUTE pg_prep(500);
+SELECT * FROM pg_target WHERE id = 500; -- non-cached
+ id  |               val
+---------------------------------------------------------------------
+ 500 | Updated by prepare using source
+(1 row)
+
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+SELECT * FROM pg_target WHERE id = 500; -- cached
+ id  |               val
+---------------------------------------------------------------------
+ 500 | Updated by prepare using source
+(1 row)
+
+SELECT * FROM citus_target WHERE id = 500; -- before merge
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ id  |  val
+---------------------------------------------------------------------
+ 500 | target
+(1 row)
+
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SELECT * FROM citus_target WHERE id = 500; -- non-cached
+NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ id  |               val
+---------------------------------------------------------------------
+ 500 | Updated by prepare using source
+(1 row)
+
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+EXECUTE citus_prep(500);
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SELECT * FROM citus_target WHERE id = 500; -- cached
+NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ id  |               val
+---------------------------------------------------------------------
+ 500 | Updated by prepare using source
+(1 row)
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- Test partitions + distributed tables
+CREATE TABLE pg_pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE citus_pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE part1 PARTITION OF pg_pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 PARTITION OF pg_pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 PARTITION OF pg_pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 PARTITION OF pg_pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part5 PARTITION OF citus_pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part6 PARTITION OF citus_pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part7 PARTITION OF citus_pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part8 PARTITION OF citus_pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+CREATE TABLE pg_pa_source (sid integer, delta float);
+CREATE TABLE citus_pa_source (sid integer, delta float);
+-- insert many rows to the source table
+INSERT INTO pg_pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+INSERT INTO citus_pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pg_pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+INSERT INTO citus_pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+SELECT create_distributed_table('citus_pa_target', 'tid');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.part5$$)
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.part6$$)
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.part7$$)
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.part8$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('citus_pa_source', 'sid');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.citus_pa_source$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE OR REPLACE FUNCTION pa_compare_tables() RETURNS BOOLEAN AS $$
+DECLARE ret BOOL;
+BEGIN
+SELECT count(1) = 0 INTO ret
+    FROM pg_pa_target
+    FULL OUTER JOIN citus_pa_target
+        USING (tid, balance, val)
+    WHERE pg_pa_target.tid IS NULL
+        OR citus_pa_target.tid IS NULL;
+RETURN ret;
+END
+$$ LANGUAGE PLPGSQL;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pg_pa_target t
+  USING pg_pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+MERGE INTO citus_pa_target t
+  USING citus_pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT pa_compare_tables();
+ pa_compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+-- same with a constant qual
+BEGIN;
+MERGE INTO pg_pa_target t
+  USING pg_pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+MERGE INTO citus_pa_target t
+  USING citus_pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT pa_compare_tables();
+ pa_compare_tables
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+--
 -- Error and Unsupported scenarios
 --
+-- try updating the distribution key column
+BEGIN;
+MERGE INTO target_cj t
+  USING source_cj1 s
+  ON t.tid = s.sid1 AND t.tid = 2
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 9, src = src || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid1, 'inserted by merge', val1);
+ERROR:  modifying the partition value of rows is not allowed
+ROLLBACK;
 -- Foreign table as target
 MERGE INTO foreign_table
 	USING ft_target ON (foreign_table.id = ft_target.id)
@@ -1274,7 +2237,54 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1.id, s1.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
+-- Now both s1 and t1 are distributed tables
+SELECT undistribute_table('t1');
+NOTICE:  creating a new table for merge_schema.t1
+NOTICE:  moving the data of merge_schema.t1
+NOTICE:  dropping the old merge_schema.t1
+NOTICE:  renaming the new table to merge_schema.t1
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('t1', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.t1$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- We have a potential pitfall where a function can be invoked in
+-- the MERGE conditions which can insert/update to a random shard
+CREATE OR REPLACE function merge_when_and_write() RETURNS BOOLEAN
+LANGUAGE PLPGSQL AS
+$$
+BEGIN
+        INSERT INTO t1 VALUES (100, 100);
+        RETURN TRUE;
+END;
+$$;
+-- Test preventing "ON" join condition from writing to the database
+BEGIN;
+MERGE INTO t1
+USING s1 ON t1.id = s1.id AND t1.id = 2 AND (merge_when_and_write())
+WHEN MATCHED THEN
+        UPDATE SET val = t1.val + s1.val;
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ROLLBACK;
+-- Test preventing WHEN clause(s) from writing to the database
+BEGIN;
+MERGE INTO t1
+USING s1 ON t1.id = s1.id AND t1.id = 2
+WHEN MATCHED AND (merge_when_and_write()) THEN
+        UPDATE SET val = t1.val + s1.val;
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ROLLBACK;
 -- Joining on partition columns with sub-query
 MERGE INTO t1
 	USING (SELECT * FROM s1) sub ON (sub.val = t1.id) -- sub.val is not a distribution column
@@ -1284,7 +2294,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (sub.id, sub.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- Joining on partition columns with CTE
 WITH s1_res AS (
 	SELECT * FROM s1
@@ -1297,7 +2307,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- Constant Join condition
 WITH s1_res AS (
 	SELECT * FROM s1
@@ -1310,7 +2320,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- With a single WHEN clause, which causes a non-left join
 WITH s1_res AS (
      SELECT * FROM s1
@@ -1319,7 +2329,7 @@ WITH s1_res AS (
  WHEN MATCHED THEN DELETE
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 --
 -- Reference tables
 --
@@ -1371,7 +2381,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1.id, s1.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported on reference tables yet
 --
 -- Postgres + Citus-Distributed table
 --
@@ -1413,7 +2423,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1.id, s1.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
 MERGE INTO t1
 	USING (SELECT * FROM s1) sub ON (sub.id = t1.id)
 	WHEN MATCHED AND sub.val = 0 THEN
@@ -1422,7 +2432,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (sub.id, sub.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
 CREATE TABLE pg(val int);
 SELECT create_distributed_table('s1', 'id');
 NOTICE:  Copying data from local table...
@@ -1443,7 +2453,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (sub.id, sub.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
 -- Mix Postgres table in CTE
 WITH pg_res AS (
 	SELECT * FROM pg
@@ -1456,7 +2466,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (sub.id, sub.val);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
 -- Match more than one source row should fail same as Postgres behavior
 SELECT undistribute_table('t1');
 NOTICE:  creating a new table for merge_schema.t1
@@ -1511,6 +2521,234 @@ WHEN NOT MATCHED THEN
     INSERT VALUES(mv_source.id, mv_source.val);
 ERROR:  cannot execute MERGE on relation "mv_source"
 DETAIL:  This operation is not supported for materialized views.
+-- Distributed tables *must* be colocated
+CREATE TABLE dist_target(id int, val varchar);
+SELECT create_distributed_table('dist_target', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE dist_source(id int, val varchar);
+SELECT create_distributed_table('dist_source', 'id', colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+ERROR:  For MERGE command, all the distributed tables must be colocated
+-- Distributed tables *must* be joined on distribution column
+CREATE TABLE dist_colocated(id int, val int);
+SELECT create_distributed_table('dist_colocated', 'id', colocate_with => 'dist_target');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+MERGE INTO dist_target
+USING dist_colocated
+ON dist_target.id = dist_colocated.val -- val is not the distribution column
+WHEN MATCHED THEN
+UPDATE SET val = dist_colocated.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_colocated.id, dist_colocated.val);
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+-- Both the source and target must be distributed
+MERGE INTO dist_target
+USING (SELECT 100 id) AS source
+ON dist_target.id = source.id AND dist_target.val = 'const'
+WHEN MATCHED THEN
+UPDATE SET val = 'source'
+WHEN NOT MATCHED THEN
+INSERT VALUES(source.id, 'source');
+ERROR:  For MERGE command, both the source and target must be distributed
+-- Non-hash distributed tables (append/range).
+CREATE VIEW show_tables AS
+SELECT logicalrelid, partmethod
+FROM pg_dist_partition
+WHERE (logicalrelid = 'dist_target'::regclass) OR (logicalrelid = 'dist_source'::regclass)
+ORDER BY 1;
+SELECT undistribute_table('dist_source');
+NOTICE:  creating a new table for merge_schema.dist_source
+NOTICE:  moving the data of merge_schema.dist_source
+NOTICE:  dropping the old merge_schema.dist_source
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_source CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_source
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_source', 'id', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM show_tables;
+ logicalrelid | partmethod
+---------------------------------------------------------------------
+ dist_target  | h
+ dist_source  | a
+(2 rows)
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+ERROR:  For MERGE command, all the distributed tables must be colocated, for append/range distribution, colocation is not supported
+HINT:  Consider using hash distribution instead
+SELECT undistribute_table('dist_source');
+NOTICE:  creating a new table for merge_schema.dist_source
+NOTICE:  moving the data of merge_schema.dist_source
+NOTICE:  dropping the old merge_schema.dist_source
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_source CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_source
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_source', 'id', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM show_tables;
+ logicalrelid | partmethod
+---------------------------------------------------------------------
+ dist_target  | h
+ dist_source  | r
+(2 rows)
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+ERROR:  For MERGE command, all the distributed tables must be colocated, for append/range distribution, colocation is not supported
+HINT:  Consider using hash distribution instead
+-- Both are append tables
+SELECT undistribute_table('dist_target');
+NOTICE:  creating a new table for merge_schema.dist_target
+NOTICE:  moving the data of merge_schema.dist_target
+NOTICE:  dropping the old merge_schema.dist_target
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_target CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_target
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT undistribute_table('dist_source');
+NOTICE:  creating a new table for merge_schema.dist_source
+NOTICE:  moving the data of merge_schema.dist_source
+NOTICE:  dropping the old merge_schema.dist_source
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_source CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_source
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_target', 'id', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_source', 'id', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM show_tables;
+ logicalrelid | partmethod
+---------------------------------------------------------------------
+ dist_target  | a
+ dist_source  | a
+(2 rows)
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+ERROR:  For MERGE command, all the distributed tables must be colocated, for append/range distribution, colocation is not supported
+HINT:  Consider using hash distribution instead
+-- Both are range tables
+SELECT undistribute_table('dist_target');
+NOTICE:  creating a new table for merge_schema.dist_target
+NOTICE:  moving the data of merge_schema.dist_target
+NOTICE:  dropping the old merge_schema.dist_target
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_target CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_target
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT undistribute_table('dist_source');
+NOTICE:  creating a new table for merge_schema.dist_source
+NOTICE:  moving the data of merge_schema.dist_source
+NOTICE:  dropping the old merge_schema.dist_source
+NOTICE:  drop cascades to view show_tables
+CONTEXT:  SQL statement "DROP TABLE merge_schema.dist_source CASCADE"
+NOTICE:  renaming the new table to merge_schema.dist_source
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_target', 'id', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('dist_source', 'id', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM show_tables;
+ logicalrelid | partmethod
+---------------------------------------------------------------------
+ dist_target  | r
+ dist_source  | r
+(2 rows)
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+ERROR:  For MERGE command, all the distributed tables must be colocated, for append/range distribution, colocation is not supported
+HINT:  Consider using hash distribution instead
 DROP SERVER foreign_server CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to user mapping for postgres on server foreign_server
@@ -1519,8 +2757,9 @@ drop cascades to foreign table foreign_table
 NOTICE:  foreign table "foreign_table_4000046" does not exist, skipping
 CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
+DROP FUNCTION merge_when_and_write();
 DROP SCHEMA merge_schema CASCADE;
-NOTICE:  drop cascades to 56 other objects
+NOTICE:  drop cascades to 75 other objects
 DETAIL:  drop cascades to function insert_data()
 drop cascades to table pg_result
 drop cascades to table local_local
@@ -1572,11 +2811,30 @@ drop cascades to table ft_target
 drop cascades to table ft_source_4000045
 drop cascades to table ft_source
 drop cascades to extension postgres_fdw
+drop cascades to table target_cj
+drop cascades to table source_cj1
+drop cascades to table source_cj2
+drop cascades to table pg_target
+drop cascades to table pg_source
+drop cascades to table citus_target
+drop cascades to table citus_source
+drop cascades to function compare_tables()
+drop cascades to view pg_source_view
+drop cascades to view citus_source_view
+drop cascades to table pg_pa_target
+drop cascades to table citus_pa_target
+drop cascades to table pg_pa_source
+drop cascades to table citus_pa_source
+drop cascades to function pa_compare_tables()
 drop cascades to table pg
-drop cascades to table t1_4000062
-drop cascades to table s1_4000063
+drop cascades to table t1_4000110
+drop cascades to table s1_4000111
 drop cascades to table t1
 drop cascades to table s1
+drop cascades to table dist_colocated
+drop cascades to table dist_target
+drop cascades to table dist_source
+drop cascades to view show_tables
 SELECT 1 FROM master_remove_node('localhost', :master_port);
  ?column?
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/merge.out
+++ b/src/test/regress/expected/merge.out
@@ -17,8 +17,9 @@ CREATE SCHEMA merge_schema;
 SET search_path TO merge_schema;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 4000000;
-SET citus.explain_all_tasks to true;
+SET citus.explain_all_tasks TO true;
 SET citus.shard_replication_factor TO 1;
+SET citus.max_adaptive_executor_pool_size TO 1;
 SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
 NOTICE:  localhost:xxxxx is the coordinator and already contains metadata, skipping syncing the metadata
  ?column?
@@ -268,6 +269,29 @@ SELECT * from target t WHERE t.customer_id  = 30004;
 ---------------------------------------------------------------------
 (0 rows)
 
+-- Updating distribution column is allowed if the operation is a no-op
+SELECT * from target t WHERE t.customer_id  = 30000;
+ customer_id | last_order_id | order_center | order_count |        last_order
+---------------------------------------------------------------------
+       30000 |           101 | WX           |         123 | Sat Jan 01 00:00:00 2022
+(1 row)
+
+MERGE INTO target t
+USING SOURCE s
+ON (t.customer_id = s.customer_id AND t.customer_id = 30000)
+WHEN MATCHED THEN
+	UPDATE SET customer_id = 30000;
+MERGE INTO target t
+USING SOURCE s
+ON (t.customer_id = s.customer_id AND t.customer_id = 30000)
+WHEN MATCHED THEN
+	UPDATE SET customer_id = t.customer_id;
+SELECT * from target t WHERE t.customer_id  = 30000;
+ customer_id | last_order_id | order_center | order_count |        last_order
+---------------------------------------------------------------------
+       30000 |           101 | WX           |         123 | Sat Jan 01 00:00:00 2022
+(1 row)
+
 --
 -- Test MERGE with CTE as source
 --
@@ -310,7 +334,6 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (pg_res.id, pg_res.val);
--- Two rows with id 2 and val incremented, id 3, and id 1 is deleted
 SELECT * FROM t1 order by id;
  id | val
 ---------------------------------------------------------------------
@@ -1200,7 +1223,8 @@ END;
 $$ language plpgsql volatile;
 CREATE TABLE fn_target(id int, data varchar);
 MERGE INTO fn_target
-USING (SELECT * FROM f_dist() f(id integer, source varchar)) as fn_source
+--USING (SELECT * FROM f_dist() f(id integer, source varchar)) as fn_source
+USING (SELECT id, source FROM dist_table) as fn_source
 ON fn_source.id = fn_target.id
 WHEN MATCHED THEN
 DO NOTHING
@@ -1216,29 +1240,22 @@ SELECT citus_add_local_table_to_metadata('fn_target');
 
 (1 row)
 
-SELECT create_distributed_table('dist_table', 'id');
-NOTICE:  Copying data from local table...
-NOTICE:  copying the data has completed
-DETAIL:  The local data in the table is no longer visible, but is still on disk.
-HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.dist_table$$)
- create_distributed_table
+SELECT citus_add_local_table_to_metadata('dist_table');
+ citus_add_local_table_to_metadata
 ---------------------------------------------------------------------
 
 (1 row)
 
 SET client_min_messages TO DEBUG1;
 MERGE INTO fn_target
-USING (SELECT * FROM f_dist() f(id integer, source varchar)) as fn_source
+--USING (SELECT * FROM f_dist() f(id integer, source varchar)) as fn_source
+USING (SELECT id, source FROM dist_table) as fn_source
 ON fn_source.id = fn_target.id
 WHEN MATCHED THEN
 DO NOTHING
 WHEN NOT MATCHED THEN
 INSERT VALUES(fn_source.id, fn_source.source);
-DEBUG:  function does not have co-located tables
-DEBUG:  generating subplan XXX_1 for subquery SELECT id, source FROM merge_schema.f_dist() f(id integer, source character varying)
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: MERGE INTO merge_schema.fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)
-DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target_xxxxxxx fn_target USING (SELECT intermediate_result.id, intermediate_result.source FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, source character varying)) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
+DEBUG:  <Deparsed MERGE query: MERGE INTO merge_schema.fn_target_xxxxxxx fn_target USING (SELECT dist_table.id, dist_table.source FROM merge_schema.dist_table_xxxxxxx dist_table) fn_source ON (fn_source.id OPERATOR(pg_catalog.=) fn_target.id) WHEN MATCHED THEN DO NOTHING  WHEN NOT MATCHED THEN INSERT (id, data) VALUES (fn_source.id, fn_source.source)>
 RESET client_min_messages;
 SELECT * INTO fn_local FROM fn_target ORDER BY 1 ;
 -- Should be equal
@@ -1959,7 +1976,7 @@ ON pg_target.id = sub.id AND pg_target.id = $1
 WHEN MATCHED THEN
         UPDATE SET val = 'Updated by prepare using ' || sub.val
 WHEN NOT MATCHED THEN
-        DO NOTHING;
+        INSERT VALUES (sub.id, sub.val);
 PREPARE citus_prep(int) AS
 MERGE INTO citus_target
 USING (SELECT * FROM citus_source) sub
@@ -1967,13 +1984,18 @@ ON citus_target.id = sub.id AND citus_target.id = $1
 WHEN MATCHED THEN
         UPDATE SET val = 'Updated by prepare using ' || sub.val
 WHEN NOT MATCHED THEN
-        DO NOTHING;
+        INSERT VALUES (sub.id, sub.val);
 BEGIN;
-SET citus.log_remote_commands to true;
 SELECT * FROM pg_target WHERE id = 500; -- before merge
  id  |  val
 ---------------------------------------------------------------------
  500 | target
+(1 row)
+
+SELECT count(*) FROM pg_target; -- before merge
+ count
+---------------------------------------------------------------------
+   251
 (1 row)
 
 EXECUTE pg_prep(500);
@@ -1994,18 +2016,33 @@ SELECT * FROM pg_target WHERE id = 500; -- cached
  500 | Updated by prepare using source
 (1 row)
 
+SELECT count(*) FROM pg_target; -- cached
+ count
+---------------------------------------------------------------------
+  3245
+(1 row)
+
 SELECT * FROM citus_target WHERE id = 500; -- before merge
-NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
  id  |  val
 ---------------------------------------------------------------------
  500 | target
 (1 row)
 
+SELECT count(*) FROM citus_target; -- before merge
+ count
+---------------------------------------------------------------------
+   251
+(1 row)
+
+SET citus.log_remote_commands to true;
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 SELECT * FROM citus_target WHERE id = 500; -- non-cached
 NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
@@ -2016,29 +2053,63 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 (1 row)
 
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 EXECUTE citus_prep(500);
-NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN DO NOTHING
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
 DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing MERGE INTO merge_schema.citus_target_xxxxxxx citus_target USING (SELECT citus_source.id, citus_source.val FROM merge_schema.citus_source_xxxxxxx citus_source) sub ON ((citus_target.id OPERATOR(pg_catalog.=) sub.id) AND (citus_target.id OPERATOR(pg_catalog.=) $1)) WHEN MATCHED THEN UPDATE SET val = (('Updated by prepare using '::text OPERATOR(pg_catalog.||) (sub.val COLLATE "default")) COLLATE "default") WHEN NOT MATCHED THEN INSERT (id, val) VALUES (sub.id, sub.val)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands to false;
 SELECT * FROM citus_target WHERE id = 500; -- cached
-NOTICE:  issuing SELECT id, val FROM merge_schema.citus_target_xxxxxxx citus_target WHERE (id OPERATOR(pg_catalog.=) 500)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
  id  |               val
 ---------------------------------------------------------------------
  500 | Updated by prepare using source
 (1 row)
 
-SET citus.log_remote_commands to false;
+SELECT count(*) FROM citus_target; -- cached
+ count
+---------------------------------------------------------------------
+  3245
+(1 row)
+
 SELECT compare_tables();
  compare_tables
 ---------------------------------------------------------------------
@@ -2165,9 +2236,263 @@ SELECT pa_compare_tables();
 (1 row)
 
 ROLLBACK;
+CREATE TABLE source_json( id   integer, z int, d jsonb);
+CREATE TABLE target_json( id   integer, z int, d jsonb);
+INSERT INTO source_json SELECT i,i FROM generate_series(0,5)i;
+SELECT create_distributed_table('target_json','id'), create_distributed_table('source_json', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.source_json$$)
+ create_distributed_table | create_distributed_table
+---------------------------------------------------------------------
+                          |
+(1 row)
+
+-- single shard query given source_json is filtered and Postgres is smart to pushdown
+-- filter to the target_json as well
+SELECT public.coordinator_plan($Q$
+EXPLAIN (ANALYZE ON, TIMING OFF) MERGE INTO target_json sda
+USING (SELECT * FROM source_json WHERE id = 1) sdn
+ON sda.id = sdn.id
+WHEN NOT matched THEN
+	INSERT (id, z) VALUES (sdn.id, 5);
+$Q$);
+                                    coordinator_plan
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0) (actual rows=0 loops=1)
+   Task Count: 1
+(2 rows)
+
+SELECT * FROM target_json ORDER BY 1;
+ id | z | d
+---------------------------------------------------------------------
+  1 | 5 |
+(1 row)
+
+-- zero shard query as filters do not match
+--SELECT public.coordinator_plan($Q$
+--EXPLAIN (ANALYZE ON, TIMING OFF) MERGE INTO target_json sda
+--USING (SELECT * FROM source_json WHERE id = 1) sdn
+--ON sda.id = sdn.id AND sda.id = 2
+--WHEN NOT matched THEN
+--	INSERT (id, z) VALUES (sdn.id, 5);
+--$Q$);
+--SELECT * FROM target_json ORDER BY 1;
+-- join for source_json is happening at a different place
+SELECT public.coordinator_plan($Q$
+EXPLAIN (ANALYZE ON, TIMING OFF) MERGE INTO target_json sda
+USING source_json s1 LEFT JOIN (SELECT * FROM source_json) s2 USING(z)
+ON sda.id = s1.id AND s1.id = s2.id
+WHEN NOT matched THEN
+	INSERT (id, z) VALUES (s2.id, 5);
+$Q$);
+                                    coordinator_plan
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0) (actual rows=0 loops=1)
+   Task Count: 4
+(2 rows)
+
+SELECT * FROM target_json ORDER BY 1;
+ id | z | d
+---------------------------------------------------------------------
+  0 | 5 |
+  1 | 5 |
+  2 | 5 |
+  3 | 5 |
+  4 | 5 |
+  5 | 5 |
+(6 rows)
+
+-- update JSON column
+SELECT public.coordinator_plan($Q$
+EXPLAIN (ANALYZE ON, TIMING OFF) MERGE INTO target_json sda
+USING source_json sdn
+ON sda.id = sdn.id
+WHEN matched THEN
+	UPDATE SET d = '{"a" : 5}';
+$Q$);
+                                    coordinator_plan
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0) (actual rows=0 loops=1)
+   Task Count: 4
+(2 rows)
+
+SELECT * FROM target_json ORDER BY 1;
+ id | z |    d
+---------------------------------------------------------------------
+  0 | 5 | {"a": 5}
+  1 | 5 | {"a": 5}
+  2 | 5 | {"a": 5}
+  3 | 5 | {"a": 5}
+  4 | 5 | {"a": 5}
+  5 | 5 | {"a": 5}
+(6 rows)
+
+CREATE FUNCTION immutable_hash(int) RETURNS int
+AS 'SELECT hashtext( ($1 + $1)::text);'
+LANGUAGE SQL
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+MERGE INTO target_json sda
+USING source_json sdn
+ON sda.id = sdn.id
+WHEN matched THEN
+	UPDATE SET z = immutable_hash(sdn.z);
+-- Test bigserial
+CREATE TABLE source_serial (id integer, z int, d bigserial);
+CREATE TABLE target_serial (id integer, z int, d bigserial);
+INSERT INTO source_serial SELECT i,i FROM generate_series(0,100)i;
+SELECT create_distributed_table('source_serial', 'id'),
+       create_distributed_table('target_serial', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$merge_schema.source_serial$$)
+ create_distributed_table | create_distributed_table
+---------------------------------------------------------------------
+                          |
+(1 row)
+
+MERGE INTO target_serial sda
+USING source_serial sdn
+ON sda.id = sdn.id
+WHEN NOT matched THEN
+       INSERT (id, z) VALUES (id, z);
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
+SELECT count(*) from source_serial;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+SELECT count(*) from target_serial;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT count(distinct d) from source_serial;
+ count
+---------------------------------------------------------------------
+   101
+(1 row)
+
+SELECT count(distinct d) from target_serial;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Test set operations
+CREATE TABLE target_set(t1 int, t2 int);
+CREATE TABLE source_set(s1 int, s2 int);
+SELECT create_distributed_table('target_set', 't1'),
+       create_distributed_table('source_set', 's1');
+ create_distributed_table | create_distributed_table
+---------------------------------------------------------------------
+                          |
+(1 row)
+
+INSERT INTO target_set VALUES(1, 0);
+INSERT INTO source_set VALUES(1, 1);
+INSERT INTO source_set VALUES(2, 2);
+MERGE INTO target_set
+USING (SELECT * FROM source_set UNION SELECT * FROM source_set) AS foo ON target_set.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 100
+WHEN NOT MATCHED THEN
+	INSERT VALUES(foo.s1);
+SELECT * FROM target_set ORDER BY 1, 2;
+ t1 | t2
+---------------------------------------------------------------------
+  1 | 100
+  2 |
+(2 rows)
+
 --
 -- Error and Unsupported scenarios
 --
+MERGE INTO target_set
+USING (SELECT s1,s2 FROM source_set UNION SELECT s2,s1 FROM source_set) AS foo ON target_set.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 1;
+ERROR:  cannot pushdown the subquery since not all subqueries in the UNION have the partition column in the same position
+DETAIL:  Each leaf query of the UNION should return the partition column in the same position and all joins must be on the partition column
+MERGE INTO target_set
+USING (SELECT 2 as s3, source_set.* FROM (SELECT * FROM source_set LIMIT 1) as foo LEFT JOIN source_set USING( s1)) AS foo
+ON target_set.t1 = foo.s1
+WHEN MATCHED THEN UPDATE SET t2 = t2 + 1
+WHEN NOT MATCHED THEN INSERT VALUES(s1, s3);
+ERROR:  cannot push down this subquery
+DETAIL:  Limit clause is currently unsupported when a subquery references a column from another query
+-- modifying CTE not supported
+EXPLAIN
+WITH cte_1 AS (DELETE FROM target_json)
+MERGE INTO target_json sda
+USING source_json sdn
+ON sda.id = sdn.id
+WHEN NOT matched THEN
+	INSERT (id, z) VALUES (sdn.id, 5);
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
+-- Grouping sets not supported
+MERGE INTO citus_target t
+USING (SELECT count(*), id FROM citus_source GROUP BY GROUPING SETS (id, val)) subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, 99)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+ERROR:  cannot push down this subquery
+DETAIL:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+WITH subq AS
+(
+SELECT count(*), id FROM citus_source GROUP BY GROUPING SETS (id, val)
+)
+MERGE INTO citus_target t
+USING subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, 99)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+ERROR:  cannot push down this subquery
+DETAIL:  could not run distributed query with GROUPING SETS, CUBE, or ROLLUP
+-- try inserting unmatched distribution column value
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN NOT MATCHED THEN
+  INSERT DEFAULT VALUES;
+ERROR:  cannot perform MERGE INSERT with DEFAULTS
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN NOT MATCHED THEN
+  INSERT VALUES(10000);
+ERROR:  MERGE INSERT must refer a source column for distribution column
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN NOT MATCHED THEN
+  INSERT (id) VALUES(1000);
+ERROR:  MERGE INSERT must refer a source column for distribution column
+MERGE INTO t1 t
+USING s1 s
+ON t.id = s.id
+WHEN NOT MATCHED THEN
+  INSERT (id) VALUES(s.val);
+ERROR:  MERGE INSERT must use the source table distribution column value
+MERGE INTO t1 t
+USING s1 s
+ON t.id = s.id
+WHEN NOT MATCHED THEN
+  INSERT (val) VALUES(s.val);
+ERROR:  MERGE INSERT must have distribution column as value
 -- try updating the distribution key column
 BEGIN;
 MERGE INTO target_cj t
@@ -2177,7 +2502,7 @@ MERGE INTO target_cj t
     UPDATE SET tid = tid + 9, src = src || ' updated by merge'
   WHEN NOT MATCHED THEN
     INSERT VALUES (sid1, 'inserted by merge', val1);
-ERROR:  modifying the partition value of rows is not allowed
+ERROR:  updating the distribution column is not allowed in MERGE actions
 ROLLBACK;
 -- Foreign table as target
 MERGE INTO foreign_table
@@ -2269,13 +2594,31 @@ BEGIN
         RETURN TRUE;
 END;
 $$;
+-- Test functions executing in MERGE statement. This is to prevent the functions from
+-- doing a random sql, which may be executed in a remote node or modifying the target
+-- relation which will have unexpected/suprising results.
+MERGE INTO t1 USING (SELECT * FROM s1 WHERE true) s1 ON
+  t1.id = s1.id AND s1.id = 2
+   WHEN matched THEN
+ UPDATE SET id = s1.id, val = random();
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
+-- Test STABLE function
+CREATE FUNCTION add_s(integer, integer) RETURNS integer
+AS 'select $1 + $2;'
+LANGUAGE SQL
+STABLE RETURNS NULL ON NULL INPUT;
+MERGE INTO t1
+USING s1 ON t1.id = s1.id
+WHEN NOT MATCHED THEN
+	INSERT VALUES(s1.id, add_s(s1.val, 2));
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
 -- Test preventing "ON" join condition from writing to the database
 BEGIN;
 MERGE INTO t1
 USING s1 ON t1.id = s1.id AND t1.id = 2 AND (merge_when_and_write())
 WHEN MATCHED THEN
         UPDATE SET val = t1.val + s1.val;
-ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
 ROLLBACK;
 -- Test preventing WHEN clause(s) from writing to the database
 BEGIN;
@@ -2283,7 +2626,7 @@ MERGE INTO t1
 USING s1 ON t1.id = s1.id AND t1.id = 2
 WHEN MATCHED AND (merge_when_and_write()) THEN
         UPDATE SET val = t1.val + s1.val;
-ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
 ROLLBACK;
 -- Joining on partition columns with sub-query
 MERGE INTO t1
@@ -2294,7 +2637,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (sub.id, sub.val);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 -- Joining on partition columns with CTE
 WITH s1_res AS (
 	SELECT * FROM s1
@@ -2307,7 +2650,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 -- Constant Join condition
 WITH s1_res AS (
 	SELECT * FROM s1
@@ -2320,7 +2663,7 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 -- With a single WHEN clause, which causes a non-left join
 WITH s1_res AS (
      SELECT * FROM s1
@@ -2329,7 +2672,7 @@ WITH s1_res AS (
  WHEN MATCHED THEN DELETE
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 --
 -- Reference tables
 --
@@ -2559,7 +2902,7 @@ WHEN MATCHED THEN
 UPDATE SET val = dist_colocated.val
 WHEN NOT MATCHED THEN
 INSERT VALUES(dist_colocated.id, dist_colocated.val);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 -- Both the source and target must be distributed
 MERGE INTO dist_target
 USING (SELECT 100 id) AS source
@@ -2752,14 +3095,14 @@ HINT:  Consider using hash distribution instead
 DROP SERVER foreign_server CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to user mapping for postgres on server foreign_server
-drop cascades to foreign table foreign_table_4000046
+drop cascades to foreign table foreign_table_4000043
 drop cascades to foreign table foreign_table
-NOTICE:  foreign table "foreign_table_4000046" does not exist, skipping
+NOTICE:  foreign table "foreign_table_4000043" does not exist, skipping
 CONTEXT:  SQL statement "SELECT citus_drop_all_shards(v_obj.objid, v_obj.schema_name, v_obj.object_name, drop_shards_metadata_only := false)"
 PL/pgSQL function citus_drop_trigger() line XX at PERFORM
 DROP FUNCTION merge_when_and_write();
 DROP SCHEMA merge_schema CASCADE;
-NOTICE:  drop cascades to 75 other objects
+NOTICE:  drop cascades to 84 other objects
 DETAIL:  drop cascades to function insert_data()
 drop cascades to table pg_result
 drop cascades to table local_local
@@ -2801,14 +3144,15 @@ drop cascades to table mv_target
 drop cascades to table mv_source_table
 drop cascades to materialized view mv_source
 drop cascades to table mv_local
-drop cascades to table dist_table
+drop cascades to table dist_table_4000041
 drop cascades to function f_dist()
 drop cascades to table fn_target_4000040
 drop cascades to table fn_result
 drop cascades to table fn_target
+drop cascades to table dist_table
 drop cascades to table fn_local
 drop cascades to table ft_target
-drop cascades to table ft_source_4000045
+drop cascades to table ft_source_4000042
 drop cascades to table ft_source
 drop cascades to extension postgres_fdw
 drop cascades to table target_cj
@@ -2826,9 +3170,17 @@ drop cascades to table citus_pa_target
 drop cascades to table pg_pa_source
 drop cascades to table citus_pa_source
 drop cascades to function pa_compare_tables()
+drop cascades to table source_json
+drop cascades to table target_json
+drop cascades to function immutable_hash(integer)
+drop cascades to table source_serial
+drop cascades to table target_serial
+drop cascades to table target_set
+drop cascades to table source_set
+drop cascades to function add_s(integer,integer)
 drop cascades to table pg
-drop cascades to table t1_4000110
-drop cascades to table s1_4000111
+drop cascades to table t1_4000131
+drop cascades to table s1_4000132
 drop cascades to table t1
 drop cascades to table s1
 drop cascades to table dist_colocated

--- a/src/test/regress/expected/merge_arbitrary.out
+++ b/src/test/regress/expected/merge_arbitrary.out
@@ -1,0 +1,150 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+SET search_path TO merge_arbitrary_schema;
+INSERT INTO target_cj VALUES (1, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (3, 'target', 0);
+INSERT INTO source_cj1 VALUES (2, 'source-1', 10);
+INSERT INTO source_cj2 VALUES (2, 'source-2', 20);
+BEGIN;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-2 |   0
+   2 | source-2 |   0
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ tid |   src    | val
+---------------------------------------------------------------------
+   1 | target   |   0
+   2 | source-1 |  20
+   2 | source-1 |  20
+   3 | target   |   0
+(4 rows)
+
+ROLLBACK;
+-- Test PREPARE
+PREPARE insert(int, int, int) AS
+MERGE INTO prept
+USING (SELECT $2, s1, s2 FROM preps WHERE s2 > $3) as foo
+ON prept.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + $1
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s1, s2);
+PREPARE delete(int) AS
+MERGE INTO prept
+USING preps
+ON prept.t1 = preps.s1
+WHEN MATCHED AND prept.t2 = $1 THEN
+        DELETE
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 1;
+INSERT INTO prept VALUES(100, 0);
+INSERT INTO preps VALUES(100, 0);
+INSERT INTO preps VALUES(200, 0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+-- sixth time
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+-- Should have the counter as 14 (7 * 2)
+SELECT * FROM prept;
+ t1  | t2
+---------------------------------------------------------------------
+ 100 | 14
+(1 row)
+
+-- Test local tables
+INSERT INTO s1 VALUES(1, 0); -- Matches DELETE clause
+INSERT INTO s1 VALUES(2, 1); -- Matches UPDATE clause
+INSERT INTO s1 VALUES(3, 1); -- No Match INSERT clause
+INSERT INTO s1 VALUES(4, 1); -- No Match INSERT clause
+INSERT INTO s1 VALUES(6, 1); -- No Match INSERT clause
+INSERT INTO t1 VALUES(1, 0); -- Will be deleted
+INSERT INTO t1 VALUES(2, 0); -- Will be updated
+INSERT INTO t1 VALUES(5, 0); -- Will be intact
+PREPARE local(int, int) AS
+WITH s1_res AS (
+        SELECT * FROM s1
+)
+MERGE INTO t1
+        USING s1_res ON (s1_res.id = t1.id)
+        WHEN MATCHED AND s1_res.val = $1 THEN
+                DELETE
+        WHEN MATCHED THEN
+                UPDATE SET val = t1.val + $2
+        WHEN NOT MATCHED THEN
+                INSERT (id, val) VALUES (s1_res.id, s1_res.val);
+BEGIN;
+EXECUTE local(0, 1);
+SELECT * FROM t1 order by id;
+ id | val
+---------------------------------------------------------------------
+  2 |   1
+  3 |   1
+  4 |   1
+  5 |   0
+  6 |   1
+(5 rows)
+
+ROLLBACK;
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+-- sixth time
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+BEGIN;
+EXECUTE local(0, 1);
+SELECT * FROM t1 order by id;
+ id | val
+---------------------------------------------------------------------
+  2 |   1
+  3 |   1
+  4 |   1
+  5 |   0
+  6 |   1
+(5 rows)
+
+ROLLBACK;

--- a/src/test/regress/expected/merge_arbitrary_0.out
+++ b/src/test/regress/expected/merge_arbitrary_0.out
@@ -1,0 +1,6 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q

--- a/src/test/regress/expected/merge_arbitrary_create.out
+++ b/src/test/regress/expected/merge_arbitrary_create.out
@@ -1,0 +1,72 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+DROP SCHEMA IF EXISTS merge_arbitrary_schema CASCADE;
+CREATE SCHEMA merge_arbitrary_schema;
+SET search_path TO merge_arbitrary_schema;
+SET citus.shard_count TO 4;
+SET citus.next_shard_id TO 6000000;
+CREATE TABLE target_cj(tid int, src text, val int);
+CREATE TABLE source_cj1(sid1 int, src1 text, val1 int);
+CREATE TABLE source_cj2(sid2 int, src2 text, val2 int);
+SELECT create_distributed_table('target_cj', 'tid');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('source_cj1', 'sid1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('source_cj2', 'sid2');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE prept(t1 int, t2 int);
+CREATE TABLE preps(s1 int, s2 int);
+SELECT create_distributed_table('prept', 't1'), create_distributed_table('preps', 's1');
+ create_distributed_table | create_distributed_table
+---------------------------------------------------------------------
+                          |
+(1 row)
+
+PREPARE insert(int, int, int) AS
+MERGE INTO prept
+USING (SELECT $2, s1, s2 FROM preps WHERE s2 > $3) as foo
+ON prept.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + $1
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s1, s2);
+PREPARE delete(int) AS
+MERGE INTO prept
+USING preps
+ON prept.t1 = preps.s1
+WHEN MATCHED AND prept.t2 = $1 THEN
+        DELETE
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 1;
+-- Citus local tables
+CREATE TABLE t1(id int, val int);
+CREATE TABLE s1(id int, val int);
+SELECT citus_add_local_table_to_metadata('t1');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT citus_add_local_table_to_metadata('s1');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+

--- a/src/test/regress/expected/merge_arbitrary_create_0.out
+++ b/src/test/regress/expected/merge_arbitrary_create_0.out
@@ -1,0 +1,6 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q

--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -315,7 +315,7 @@ SELECT create_reference_table('tbl2');
 
 MERGE INTO tbl1 USING tbl2 ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported on reference tables yet
 -- now, both are reference, still not supported
 SELECT create_reference_table('tbl1');
  create_reference_table
@@ -325,7 +325,7 @@ SELECT create_reference_table('tbl1');
 
 MERGE INTO tbl1 USING tbl2 ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is not supported on reference tables yet
 -- now, both distributed, not works
 SELECT undistribute_table('tbl1');
 NOTICE:  creating a new table for pg15.tbl1
@@ -419,14 +419,14 @@ SELECT create_distributed_table('tbl2', 'x');
 
 MERGE INTO tbl1 USING tbl2 ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- also, not inside subqueries & ctes
 WITH targq AS (
     SELECT * FROM tbl2
 )
 MERGE INTO tbl1 USING targq ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- crashes on beta3, fixed on 15 stable
 --WITH foo AS (
 --  MERGE INTO tbl1 USING tbl2 ON (true)
@@ -441,7 +441,7 @@ USING tbl2
 ON (true)
 WHEN MATCHED THEN
     UPDATE SET x = (SELECT count(*) FROM tbl2);
-ERROR:  MERGE command is not supported on distributed/reference tables yet
+ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
 -- test numeric types with negative scale
 CREATE TABLE numeric_negative_scale(numeric_column numeric(3,-1), orig_value int);
 INSERT into numeric_negative_scale SELECT x,x FROM generate_series(111, 115) x;

--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -419,29 +419,36 @@ SELECT create_distributed_table('tbl2', 'x');
 
 MERGE INTO tbl1 USING tbl2 ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 -- also, not inside subqueries & ctes
 WITH targq AS (
     SELECT * FROM tbl2
 )
 MERGE INTO tbl1 USING targq ON (true)
 WHEN MATCHED THEN DELETE;
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
--- crashes on beta3, fixed on 15 stable
---WITH foo AS (
---  MERGE INTO tbl1 USING tbl2 ON (true)
---  WHEN MATCHED THEN DELETE
---) SELECT * FROM foo;
---COPY (
---  MERGE INTO tbl1 USING tbl2 ON (true)
---  WHEN MATCHED THEN DELETE
---) TO stdout;
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
+WITH foo AS (
+  MERGE INTO tbl1 USING tbl2 ON (true)
+  WHEN MATCHED THEN DELETE
+) SELECT * FROM foo;
+ERROR:  MERGE not supported in WITH query
+COPY (
+  MERGE INTO tbl1 USING tbl2 ON (true)
+  WHEN MATCHED THEN DELETE
+) TO stdout;
+ERROR:  MERGE not supported in COPY
+MERGE INTO tbl1 t
+USING tbl2
+ON (true)
+WHEN MATCHED THEN
+    DO NOTHING;
+ERROR:  MERGE command is only supported when all distributed tables are co-located and joined on their distribution columns
 MERGE INTO tbl1 t
 USING tbl2
 ON (true)
 WHEN MATCHED THEN
     UPDATE SET x = (SELECT count(*) FROM tbl2);
-ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
+ERROR:  updating the distribution column is not allowed in MERGE actions
 -- test numeric types with negative scale
 CREATE TABLE numeric_negative_scale(numeric_column numeric(3,-1), orig_value int);
 INSERT into numeric_negative_scale SELECT x,x FROM generate_series(111, 115) x;

--- a/src/test/regress/expected/pgmerge.out
+++ b/src/test/regress/expected/pgmerge.out
@@ -910,7 +910,7 @@ MERGE INTO wq_target t
 USING wq_source s ON t.tid = s.sid
 WHEN MATCHED AND (merge_when_and_write()) THEN
 	UPDATE SET balance = t.balance + s.balance;
-ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
 ROLLBACK;
 -- Test preventing ON condition from writing to the database
 BEGIN;
@@ -918,7 +918,7 @@ MERGE INTO wq_target t
 USING wq_source s ON t.tid = s.sid AND (merge_when_and_write())
 WHEN MATCHED THEN
 	UPDATE SET balance = t.balance + s.balance;
-ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  non-IMMUTABLE functions are not yet supported in MERGE sql with distributed tables
 ROLLBACK;
 drop function merge_when_and_write();
 DROP TABLE wq_target, wq_source;
@@ -1893,13 +1893,15 @@ INSERT INTO pa_target SELECT '2017-02-28', id, id * 100, 'initial' FROM generate
 SET client_min_messages TO DEBUG1;
 BEGIN;
 MERGE INTO pa_target t
-  USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
+  USING (SELECT * FROM pa_source WHERE sid < 10) s
+  --USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
   ON t.tid = s.sid
   WHEN MATCHED THEN
     UPDATE SET balance = balance + delta, val = val || ' updated by merge'
   WHEN NOT MATCHED THEN
-    INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
-DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.pa_target t USING (SELECT '2017-01-15'::text AS slogts, pa_source.sid, pa_source.delta FROM pgmerge_schema.pa_source_xxxxxxx pa_source WHERE (pa_source.sid OPERATOR(pg_catalog.<) 10)) s ON (t.tid OPERATOR(pg_catalog.=) s.sid) WHEN MATCHED THEN UPDATE SET balance = (t.balance OPERATOR(pg_catalog.+) s.delta), val = (t.val OPERATOR(pg_catalog.||) ' updated by merge'::text) WHEN NOT MATCHED THEN INSERT (logts, tid, balance, val) VALUES ((s.slogts)::timestamp without time zone, s.sid, s.delta, 'inserted by merge'::text)>
+    INSERT VALUES ('2017-01-15', sid, delta, 'inserted by merge');
+DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.pa_target t USING (SELECT pa_source.sid, pa_source.delta FROM pgmerge_schema.pa_source_xxxxxxx pa_source WHERE (pa_source.sid OPERATOR(pg_catalog.<) 10)) s ON (t.tid OPERATOR(pg_catalog.=) s.sid) WHEN MATCHED THEN UPDATE SET balance = (t.balance OPERATOR(pg_catalog.+) s.delta), val = (t.val OPERATOR(pg_catalog.||) ' updated by merge'::text) WHEN NOT MATCHED THEN INSERT (logts, tid, balance, val) VALUES ('Sun Jan 15 00:00:00 2017'::timestamp without time zone, s.sid, s.delta, 'inserted by merge'::text)>
+    --INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
 SELECT * FROM pa_target ORDER BY tid;
           logts           | tid | balance |           val
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/pgmerge.out
+++ b/src/test/regress/expected/pgmerge.out
@@ -910,7 +910,15 @@ MERGE INTO wq_target t
 USING wq_source s ON t.tid = s.sid
 WHEN MATCHED AND (merge_when_and_write()) THEN
 	UPDATE SET balance = t.balance + s.balance;
-ERROR:  functions used in UPDATE queries on distributed tables must not be VOLATILE
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+ROLLBACK;
+-- Test preventing ON condition from writing to the database
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid AND (merge_when_and_write())
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.balance;
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
 ROLLBACK;
 drop function merge_when_and_write();
 DROP TABLE wq_target, wq_source;
@@ -1891,7 +1899,7 @@ MERGE INTO pa_target t
     UPDATE SET balance = balance + delta, val = val || ' updated by merge'
   WHEN NOT MATCHED THEN
     INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
-DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.pa_target t USING (SELECT '2017-01-15'::text AS slogts, pa_source.sid, pa_source.delta FROM pgmerge_schema.pa_source_4001021 pa_source WHERE (pa_source.sid OPERATOR(pg_catalog.<) 10)) s ON (t.tid OPERATOR(pg_catalog.=) s.sid) WHEN MATCHED THEN UPDATE SET balance = (t.balance OPERATOR(pg_catalog.+) s.delta), val = (t.val OPERATOR(pg_catalog.||) ' updated by merge'::text) WHEN NOT MATCHED THEN INSERT (logts, tid, balance, val) VALUES ((s.slogts)::timestamp without time zone, s.sid, s.delta, 'inserted by merge'::text)>
+DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.pa_target t USING (SELECT '2017-01-15'::text AS slogts, pa_source.sid, pa_source.delta FROM pgmerge_schema.pa_source_xxxxxxx pa_source WHERE (pa_source.sid OPERATOR(pg_catalog.<) 10)) s ON (t.tid OPERATOR(pg_catalog.=) s.sid) WHEN MATCHED THEN UPDATE SET balance = (t.balance OPERATOR(pg_catalog.+) s.delta), val = (t.val OPERATOR(pg_catalog.||) ' updated by merge'::text) WHEN NOT MATCHED THEN INSERT (logts, tid, balance, val) VALUES ((s.slogts)::timestamp without time zone, s.sid, s.delta, 'inserted by merge'::text)>
 SELECT * FROM pa_target ORDER BY tid;
           logts           | tid | balance |           val
 ---------------------------------------------------------------------
@@ -2083,7 +2091,7 @@ WHEN MATCHED THEN UPDATE
 WHEN NOT MATCHED THEN INSERT
      (city_id, logdate, peaktemp, unitsales)
    VALUES (city_id, logdate, peaktemp, unitsales);
-DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.measurement m USING pgmerge_schema.new_measurement_4001026 nm ON ((m.city_id OPERATOR(pg_catalog.=) nm.city_id) AND (m.logdate OPERATOR(pg_catalog.=) nm.logdate)) WHEN MATCHED AND (nm.peaktemp IS NULL) THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = GREATEST(m.peaktemp, nm.peaktemp), unitsales = (m.unitsales OPERATOR(pg_catalog.+) COALESCE(nm.unitsales, 0)) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (nm.city_id, nm.logdate, nm.peaktemp, nm.unitsales)>
+DEBUG:  <Deparsed MERGE query: MERGE INTO pgmerge_schema.measurement m USING pgmerge_schema.new_measurement_xxxxxxx nm ON ((m.city_id OPERATOR(pg_catalog.=) nm.city_id) AND (m.logdate OPERATOR(pg_catalog.=) nm.logdate)) WHEN MATCHED AND (nm.peaktemp IS NULL) THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = GREATEST(m.peaktemp, nm.peaktemp), unitsales = (m.unitsales OPERATOR(pg_catalog.+) COALESCE(nm.unitsales, 0)) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (nm.city_id, nm.logdate, nm.peaktemp, nm.unitsales)>
 RESET client_min_messages;
 SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
        tableoid       | city_id |  logdate   | peaktemp | unitsales

--- a/src/test/regress/sql/merge.sql
+++ b/src/test/regress/sql/merge.sql
@@ -19,6 +19,7 @@ SET search_path TO merge_schema;
 SET citus.shard_count TO 4;
 SET citus.next_shard_id TO 4000000;
 SET citus.explain_all_tasks to true;
+SET citus.shard_replication_factor TO 1;
 SELECT 1 FROM master_add_node('localhost', :master_port, groupid => 0);
 
 CREATE TABLE source
@@ -143,9 +144,33 @@ SELECT undistribute_table('source');
 SELECT create_distributed_table('target', 'customer_id');
 SELECT create_distributed_table('source', 'customer_id');
 
+-- Updates one of the row with customer_id  = 30002
+SELECT * from target t WHERE t.customer_id  = 30002;
+-- Turn on notice to print tasks sent to nodes
+SET citus.log_remote_commands to true;
 MERGE INTO target t
    USING source s
-   ON (t.customer_id = s.customer_id)
+   ON (t.customer_id = s.customer_id) AND t.customer_id = 30002
+
+   WHEN MATCHED AND t.order_center = 'XX' THEN
+       DELETE
+
+   WHEN MATCHED THEN
+       UPDATE SET     -- Existing customer, update the order count and last_order_id
+           order_count = t.order_count + 1,
+           last_order_id = s.order_id
+
+   WHEN NOT MATCHED THEN
+       DO NOTHING;
+
+SET citus.log_remote_commands to false;
+SELECT * from target t WHERE t.customer_id  = 30002;
+
+-- Deletes one of the row with customer_id  = 30004
+SELECT * from target t WHERE t.customer_id  = 30004;
+MERGE INTO target t
+   USING source s
+   ON (t.customer_id = s.customer_id) AND t.customer_id = 30004
 
    WHEN MATCHED AND t.order_center = 'XX' THEN
        DELETE
@@ -158,6 +183,7 @@ MERGE INTO target t
    WHEN NOT MATCHED THEN       -- New entry, record it.
        INSERT (customer_id, last_order_id, order_center, order_count, last_order)
            VALUES (customer_id, s.order_id, s.order_center, 123, s.order_time);
+SELECT * from target t WHERE t.customer_id  = 30004;
 
 --
 -- Test MERGE with CTE as source
@@ -243,11 +269,13 @@ SELECT create_distributed_table('t1', 'id');
 SELECT create_distributed_table('s1', 'id');
 
 
+SELECT * FROM t1 order by id;
+SET citus.log_remote_commands to true;
 WITH s1_res AS (
 	SELECT * FROM s1
 )
 MERGE INTO t1
-	USING s1_res ON (s1_res.id = t1.id)
+	USING s1_res ON (s1_res.id = t1.id) AND t1.id = 6
 
 	WHEN MATCHED AND s1_res.val = 0 THEN
 		DELETE
@@ -255,6 +283,9 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1_res.id, s1_res.val);
+SET citus.log_remote_commands to false;
+-- Other than id 6 everything else is a NO match, and should appear in target
+SELECT * FROM t1 order by 1, 2;
 
 --
 -- Test with multiple join conditions
@@ -325,15 +356,21 @@ SELECT undistribute_table('s2');
 SELECT create_distributed_table('t2', 'id');
 SELECT create_distributed_table('s2', 'id');
 
+SELECT * FROM t2 ORDER BY 1;
+SET citus.log_remote_commands to true;
 MERGE INTO t2
 USING s2
-ON t2.id = s2.id AND t2.src = s2.src
+ON t2.id = s2.id AND t2.src = s2.src AND t2.id = 4
 	WHEN MATCHED AND t2.val = 1 THEN
 		UPDATE SET val = s2.val + 10
 	WHEN MATCHED THEN
 		DELETE
 	WHEN NOT MATCHED THEN
-		INSERT (id, val, src) VALUES (s2.id, s2.val, s2.src);
+		DO NOTHING;
+SET citus.log_remote_commands to false;
+-- Row with id = 4 is a match for delete clause, row should be deleted
+-- Row with id = 3 is a NO match, row from source will be inserted
+SELECT * FROM t2 ORDER BY 1;
 
 --
 -- With sub-query as the MERGE source
@@ -825,8 +862,575 @@ RESET client_min_messages;
 SELECT * FROM ft_target;
 
 --
+-- complex joins on the source side
+--
+
+-- source(join of two relations) relation is an unaliased join
+
+CREATE TABLE target_cj(tid int, src text, val int);
+CREATE TABLE source_cj1(sid1 int, src1 text, val1 int);
+CREATE TABLE source_cj2(sid2 int, src2 text, val2 int);
+
+INSERT INTO target_cj VALUES (1, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (3, 'target', 0);
+
+INSERT INTO source_cj1 VALUES (2, 'source-1', 10);
+INSERT INTO source_cj2 VALUES (2, 'source-2', 20);
+
+BEGIN;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+-- Gold result to compare against
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET tid = sid2, src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+-- Gold result to compare against
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+-- Test the same scenarios with distributed tables
+
+SELECT create_distributed_table('target_cj', 'tid');
+SELECT create_distributed_table('source_cj1', 'sid1');
+SELECT create_distributed_table('source_cj2', 'sid2');
+
+BEGIN;
+SET citus.log_remote_commands to true;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SET citus.log_remote_commands to false;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+-- sub-query as a source
+BEGIN;
+MERGE INTO target_cj t
+USING (SELECT * FROM source_cj1 WHERE sid1 = 2) sub
+ON t.tid = sub.sid1 AND t.tid = 2
+WHEN MATCHED THEN
+	UPDATE SET src = sub.src1, val = val1
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+-- Test self-join
+BEGIN;
+SELECT * FROM target_cj ORDER BY 1;
+set citus.log_remote_commands to true;
+MERGE INTO target_cj t1
+USING (SELECT * FROM target_cj) sub
+ON t1.tid = sub.tid AND t1.tid = 3
+WHEN MATCHED THEN
+	UPDATE SET src = sub.src, val = sub.val + 100
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+set citus.log_remote_commands to false;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+
+-- Test PREPARE
+PREPARE foo(int) AS
+MERGE INTO target_cj target
+USING (SELECT * FROM source_cj1) sub
+ON target.tid = sub.sid1 AND target.tid = $1
+WHEN MATCHED THEN
+        UPDATE SET val = sub.val1
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+
+SELECT * FROM target_cj ORDER BY 1;
+
+BEGIN;
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+EXECUTE foo(2);
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+BEGIN;
+
+SET citus.log_remote_commands to true;
+SET client_min_messages TO DEBUG1;
+EXECUTE foo(2);
+RESET client_min_messages;
+
+EXECUTE foo(2);
+SET citus.log_remote_commands to false;
+
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+-- Test distributed tables, must be co-located and joined on distribution column.
+
+--
+-- We create two sets of source and target tables, one set is Postgres and the other
+-- is Citus distributed. Run the _exact_ MERGE SQL on both the sets and compare the
+-- final results of target tables of Postgres and Citus, the result should match.
+-- This is repeated for various MERGE SQL combinations
+--
+CREATE TABLE pg_target(id int, val varchar);
+CREATE TABLE pg_source(id int, val varchar);
+CREATE TABLE citus_target(id int, val varchar);
+CREATE TABLE citus_source(id int, val varchar);
+
+-- Half of the source rows do not match
+INSERT INTO pg_target SELECT i, 'target' FROM generate_series(250, 500) i;
+INSERT INTO pg_source SELECT i, 'source' FROM generate_series(1, 500) i;
+
+INSERT INTO citus_target SELECT i, 'target' FROM generate_series(250, 500) i;
+INSERT INTO citus_source SELECT i, 'source' FROM generate_series(1, 500) i;
+
+SELECT create_distributed_table('citus_target', 'id');
+SELECT create_distributed_table('citus_source', 'id');
+
+--
+-- This routine compares the target tables of Postgres and Citus and
+-- returns true if they match, false if the results do not match.
+--
+CREATE OR REPLACE FUNCTION compare_tables() RETURNS BOOLEAN AS $$
+DECLARE ret BOOL;
+BEGIN
+SELECT count(1) = 0 INTO ret
+    FROM pg_target
+    FULL OUTER JOIN citus_target
+        USING (id, val)
+    WHERE pg_target.id IS NULL
+        OR citus_target.id IS NULL;
+RETURN ret;
+END
+$$ LANGUAGE PLPGSQL;
+
+-- Make sure we start with exact data in Postgres and Citus
+SELECT compare_tables();
+
+-- Run the MERGE on both Postgres and Citus, and compare the final target tables
+
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+--
+-- ON clause filter on source
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+--
+-- ON clause filter on target
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND t.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND t.id < 100
+WHEN MATCHED AND t.id > 400 THEN
+	UPDATE SET val = t.val || 'Updated by Merge'
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+--
+-- NOT MATCHED clause filter on source
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id
+WHEN MATCHED THEN
+	DO NOTHING
+WHEN NOT MATCHED AND s.id < 100 THEN
+        INSERT VALUES(s.id, s.val);
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id
+WHEN MATCHED THEN
+	DO NOTHING
+WHEN NOT MATCHED AND s.id < 100 THEN
+        INSERT VALUES(s.id, s.val);
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+--
+-- Test constant filter in ON clause to check if shards are pruned
+-- with restriction information
+--
+
+--
+-- Though constant filter is present, this won't prune shards as
+-- NOT MATCHED clause is present
+--
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s.id, s.val);
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+-- This will prune shards with restriction information as NOT MATCHED is void
+BEGIN;
+SET citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING pg_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+
+MERGE INTO citus_target t
+USING citus_source s
+ON t.id = s.id AND s.id = 250
+WHEN MATCHED THEN
+        UPDATE SET val = t.val || 'Updated by Merge'
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+-- Test CTE with distributed tables
+CREATE VIEW pg_source_view AS SELECT * FROM pg_source WHERE id < 400;
+CREATE VIEW citus_source_view AS SELECT * FROM citus_source WHERE id < 400;
+
+BEGIN;
+SEt citus.log_remote_commands to true;
+
+WITH cte AS (
+        SELECT * FROM pg_source_view
+)
+MERGE INTO pg_target t
+USING cte
+ON cte.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by CTE'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (cte.id, cte.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+
+WITH cte AS (
+        SELECT * FROM citus_source_view
+)
+MERGE INTO citus_target t
+USING cte
+ON cte.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by CTE'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (cte.id, cte.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+
+-- Test sub-query with distributed tables
+BEGIN;
+SEt citus.log_remote_commands to true;
+
+MERGE INTO pg_target t
+USING (SELECT * FROM pg_source) subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by subquery'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, subq.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+
+MERGE INTO citus_target t
+USING (SELECT * FROM citus_source) subq
+ON subq.id = t.id
+WHEN MATCHED AND t.id > 350 THEN
+    UPDATE SET val = t.val || 'Updated by subquery'
+WHEN NOT MATCHED THEN
+        INSERT VALUES (subq.id, subq.val)
+WHEN MATCHED AND t.id < 350 THEN
+        DELETE;
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+-- Test PREPARE
+PREPARE pg_prep(int) AS
+MERGE INTO pg_target
+USING (SELECT * FROM pg_source) sub
+ON pg_target.id = sub.id AND pg_target.id = $1
+WHEN MATCHED THEN
+        UPDATE SET val = 'Updated by prepare using ' || sub.val
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+
+PREPARE citus_prep(int) AS
+MERGE INTO citus_target
+USING (SELECT * FROM citus_source) sub
+ON citus_target.id = sub.id AND citus_target.id = $1
+WHEN MATCHED THEN
+        UPDATE SET val = 'Updated by prepare using ' || sub.val
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+
+BEGIN;
+SET citus.log_remote_commands to true;
+
+SELECT * FROM pg_target WHERE id = 500; -- before merge
+EXECUTE pg_prep(500);
+SELECT * FROM pg_target WHERE id = 500; -- non-cached
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+EXECUTE pg_prep(500);
+SELECT * FROM pg_target WHERE id = 500; -- cached
+
+SELECT * FROM citus_target WHERE id = 500; -- before merge
+EXECUTE citus_prep(500);
+SELECT * FROM citus_target WHERE id = 500; -- non-cached
+EXECUTE citus_prep(500);
+EXECUTE citus_prep(500);
+EXECUTE citus_prep(500);
+EXECUTE citus_prep(500);
+EXECUTE citus_prep(500);
+SELECT * FROM citus_target WHERE id = 500; -- cached
+
+SET citus.log_remote_commands to false;
+SELECT compare_tables();
+ROLLBACK;
+
+-- Test partitions + distributed tables
+
+CREATE TABLE pg_pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE citus_pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+
+CREATE TABLE part1 PARTITION OF pg_pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 PARTITION OF pg_pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 PARTITION OF pg_pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 PARTITION OF pg_pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part5 PARTITION OF citus_pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part6 PARTITION OF citus_pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part7 PARTITION OF citus_pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part8 PARTITION OF citus_pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+
+CREATE TABLE pg_pa_source (sid integer, delta float);
+CREATE TABLE citus_pa_source (sid integer, delta float);
+
+-- insert many rows to the source table
+INSERT INTO pg_pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+INSERT INTO citus_pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pg_pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+INSERT INTO citus_pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+
+SELECT create_distributed_table('citus_pa_target', 'tid');
+SELECT create_distributed_table('citus_pa_source', 'sid');
+
+CREATE OR REPLACE FUNCTION pa_compare_tables() RETURNS BOOLEAN AS $$
+DECLARE ret BOOL;
+BEGIN
+SELECT count(1) = 0 INTO ret
+    FROM pg_pa_target
+    FULL OUTER JOIN citus_pa_target
+        USING (tid, balance, val)
+    WHERE pg_pa_target.tid IS NULL
+        OR citus_pa_target.tid IS NULL;
+RETURN ret;
+END
+$$ LANGUAGE PLPGSQL;
+
+-- try simple MERGE
+BEGIN;
+MERGE INTO pg_pa_target t
+  USING pg_pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+
+MERGE INTO citus_pa_target t
+  USING citus_pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+
+SELECT pa_compare_tables();
+ROLLBACK;
+
+-- same with a constant qual
+BEGIN;
+MERGE INTO pg_pa_target t
+  USING pg_pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+
+MERGE INTO citus_pa_target t
+  USING citus_pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+
+SELECT pa_compare_tables();
+ROLLBACK;
+
+--
 -- Error and Unsupported scenarios
 --
+
+-- try updating the distribution key column
+BEGIN;
+MERGE INTO target_cj t
+  USING source_cj1 s
+  ON t.tid = s.sid1 AND t.tid = 2
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 9, src = src || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid1, 'inserted by merge', val1);
+ROLLBACK;
 
 -- Foreign table as target
 MERGE INTO foreign_table
@@ -853,6 +1457,38 @@ MERGE INTO t1
 		UPDATE SET val = t1.val + 1
 	WHEN NOT MATCHED THEN
 		INSERT (id, val) VALUES (s1.id, s1.val);
+
+-- Now both s1 and t1 are distributed tables
+SELECT undistribute_table('t1');
+SELECT create_distributed_table('t1', 'id');
+
+-- We have a potential pitfall where a function can be invoked in
+-- the MERGE conditions which can insert/update to a random shard
+CREATE OR REPLACE function merge_when_and_write() RETURNS BOOLEAN
+LANGUAGE PLPGSQL AS
+$$
+BEGIN
+        INSERT INTO t1 VALUES (100, 100);
+        RETURN TRUE;
+END;
+$$;
+
+-- Test preventing "ON" join condition from writing to the database
+BEGIN;
+MERGE INTO t1
+USING s1 ON t1.id = s1.id AND t1.id = 2 AND (merge_when_and_write())
+WHEN MATCHED THEN
+        UPDATE SET val = t1.val + s1.val;
+ROLLBACK;
+
+-- Test preventing WHEN clause(s) from writing to the database
+BEGIN;
+MERGE INTO t1
+USING s1 ON t1.id = s1.id AND t1.id = 2
+WHEN MATCHED AND (merge_when_and_write()) THEN
+        UPDATE SET val = t1.val + s1.val;
+ROLLBACK;
+
 
 -- Joining on partition columns with sub-query
 MERGE INTO t1
@@ -997,6 +1633,104 @@ WHEN MATCHED THEN
 WHEN NOT MATCHED THEN
     INSERT VALUES(mv_source.id, mv_source.val);
 
+-- Distributed tables *must* be colocated
+CREATE TABLE dist_target(id int, val varchar);
+SELECT create_distributed_table('dist_target', 'id');
+CREATE TABLE dist_source(id int, val varchar);
+SELECT create_distributed_table('dist_source', 'id', colocate_with => 'none');
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+
+-- Distributed tables *must* be joined on distribution column
+CREATE TABLE dist_colocated(id int, val int);
+SELECT create_distributed_table('dist_colocated', 'id', colocate_with => 'dist_target');
+
+MERGE INTO dist_target
+USING dist_colocated
+ON dist_target.id = dist_colocated.val -- val is not the distribution column
+WHEN MATCHED THEN
+UPDATE SET val = dist_colocated.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_colocated.id, dist_colocated.val);
+
+
+-- Both the source and target must be distributed
+MERGE INTO dist_target
+USING (SELECT 100 id) AS source
+ON dist_target.id = source.id AND dist_target.val = 'const'
+WHEN MATCHED THEN
+UPDATE SET val = 'source'
+WHEN NOT MATCHED THEN
+INSERT VALUES(source.id, 'source');
+
+-- Non-hash distributed tables (append/range).
+CREATE VIEW show_tables AS
+SELECT logicalrelid, partmethod
+FROM pg_dist_partition
+WHERE (logicalrelid = 'dist_target'::regclass) OR (logicalrelid = 'dist_source'::regclass)
+ORDER BY 1;
+
+SELECT undistribute_table('dist_source');
+SELECT create_distributed_table('dist_source', 'id', 'append');
+SELECT * FROM show_tables;
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+
+SELECT undistribute_table('dist_source');
+SELECT create_distributed_table('dist_source', 'id', 'range');
+SELECT * FROM show_tables;
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+
+-- Both are append tables
+SELECT undistribute_table('dist_target');
+SELECT undistribute_table('dist_source');
+SELECT create_distributed_table('dist_target', 'id', 'append');
+SELECT create_distributed_table('dist_source', 'id', 'append');
+SELECT * FROM show_tables;
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+
+-- Both are range tables
+SELECT undistribute_table('dist_target');
+SELECT undistribute_table('dist_source');
+SELECT create_distributed_table('dist_target', 'id', 'range');
+SELECT create_distributed_table('dist_source', 'id', 'range');
+SELECT * FROM show_tables;
+
+MERGE INTO dist_target
+USING dist_source
+ON dist_target.id = dist_source.id
+WHEN MATCHED THEN
+UPDATE SET val = dist_source.val
+WHEN NOT MATCHED THEN
+INSERT VALUES(dist_source.id, dist_source.val);
+
 DROP SERVER foreign_server CASCADE;
+DROP FUNCTION merge_when_and_write();
 DROP SCHEMA merge_schema CASCADE;
 SELECT 1 FROM master_remove_node('localhost', :master_port);

--- a/src/test/regress/sql/merge_arbitrary.sql
+++ b/src/test/regress/sql/merge_arbitrary.sql
@@ -1,0 +1,133 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+
+SET search_path TO merge_arbitrary_schema;
+INSERT INTO target_cj VALUES (1, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (2, 'target', 0);
+INSERT INTO target_cj VALUES (3, 'target', 0);
+
+INSERT INTO source_cj1 VALUES (2, 'source-1', 10);
+INSERT INTO source_cj2 VALUES (2, 'source-2', 20);
+
+BEGIN;
+MERGE INTO target_cj t
+USING source_cj1 s1 INNER JOIN source_cj2 s2 ON sid1 = sid2
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+BEGIN;
+-- try accessing columns from either side of the source join
+MERGE INTO target_cj t
+USING source_cj1 s2
+        INNER JOIN source_cj2 s1 ON sid1 = sid2 AND val1 = 10
+ON t.tid = sid1 AND t.tid = 2
+WHEN MATCHED THEN
+        UPDATE SET src = src1, val = val2
+WHEN NOT MATCHED THEN
+        DO NOTHING;
+SELECT * FROM target_cj ORDER BY 1;
+ROLLBACK;
+
+-- Test PREPARE
+PREPARE insert(int, int, int) AS
+MERGE INTO prept
+USING (SELECT $2, s1, s2 FROM preps WHERE s2 > $3) as foo
+ON prept.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + $1
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s1, s2);
+
+PREPARE delete(int) AS
+MERGE INTO prept
+USING preps
+ON prept.t1 = preps.s1
+WHEN MATCHED AND prept.t2 = $1 THEN
+        DELETE
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 1;
+
+INSERT INTO prept VALUES(100, 0);
+
+INSERT INTO preps VALUES(100, 0);
+INSERT INTO preps VALUES(200, 0);
+
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+
+-- sixth time
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+EXECUTE insert(1, 1, -1); EXECUTE delete(0);
+
+-- Should have the counter as 14 (7 * 2)
+SELECT * FROM prept;
+
+-- Test local tables
+INSERT INTO s1 VALUES(1, 0); -- Matches DELETE clause
+INSERT INTO s1 VALUES(2, 1); -- Matches UPDATE clause
+INSERT INTO s1 VALUES(3, 1); -- No Match INSERT clause
+INSERT INTO s1 VALUES(4, 1); -- No Match INSERT clause
+INSERT INTO s1 VALUES(6, 1); -- No Match INSERT clause
+
+INSERT INTO t1 VALUES(1, 0); -- Will be deleted
+INSERT INTO t1 VALUES(2, 0); -- Will be updated
+INSERT INTO t1 VALUES(5, 0); -- Will be intact
+
+PREPARE local(int, int) AS
+WITH s1_res AS (
+        SELECT * FROM s1
+)
+MERGE INTO t1
+        USING s1_res ON (s1_res.id = t1.id)
+
+        WHEN MATCHED AND s1_res.val = $1 THEN
+                DELETE
+        WHEN MATCHED THEN
+                UPDATE SET val = t1.val + $2
+        WHEN NOT MATCHED THEN
+                INSERT (id, val) VALUES (s1_res.id, s1_res.val);
+
+BEGIN;
+EXECUTE local(0, 1);
+SELECT * FROM t1 order by id;
+ROLLBACK;
+
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+
+-- sixth time
+BEGIN;
+EXECUTE local(0, 1);
+ROLLBACK;
+
+BEGIN;
+EXECUTE local(0, 1);
+SELECT * FROM t1 order by id;
+ROLLBACK;

--- a/src/test/regress/sql/merge_arbitrary_create.sql
+++ b/src/test/regress/sql/merge_arbitrary_create.sql
@@ -1,0 +1,50 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 15 AS server_version_ge_15
+\gset
+\if :server_version_ge_15
+\else
+\q
+\endif
+
+DROP SCHEMA IF EXISTS merge_arbitrary_schema CASCADE;
+CREATE SCHEMA merge_arbitrary_schema;
+SET search_path TO merge_arbitrary_schema;
+SET citus.shard_count TO 4;
+SET citus.next_shard_id TO 6000000;
+CREATE TABLE target_cj(tid int, src text, val int);
+CREATE TABLE source_cj1(sid1 int, src1 text, val1 int);
+CREATE TABLE source_cj2(sid2 int, src2 text, val2 int);
+
+SELECT create_distributed_table('target_cj', 'tid');
+SELECT create_distributed_table('source_cj1', 'sid1');
+SELECT create_distributed_table('source_cj2', 'sid2');
+
+CREATE TABLE prept(t1 int, t2 int);
+CREATE TABLE preps(s1 int, s2 int);
+
+SELECT create_distributed_table('prept', 't1'), create_distributed_table('preps', 's1');
+
+PREPARE insert(int, int, int) AS
+MERGE INTO prept
+USING (SELECT $2, s1, s2 FROM preps WHERE s2 > $3) as foo
+ON prept.t1 = foo.s1
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + $1
+WHEN NOT MATCHED THEN
+        INSERT VALUES(s1, s2);
+
+PREPARE delete(int) AS
+MERGE INTO prept
+USING preps
+ON prept.t1 = preps.s1
+WHEN MATCHED AND prept.t2 = $1 THEN
+        DELETE
+WHEN MATCHED THEN
+        UPDATE SET t2 = t2 + 1;
+
+-- Citus local tables
+CREATE TABLE t1(id int, val int);
+CREATE TABLE s1(id int, val int);
+
+SELECT citus_add_local_table_to_metadata('t1');
+SELECT citus_add_local_table_to_metadata('s1');

--- a/src/test/regress/sql/pg15.sql
+++ b/src/test/regress/sql/pg15.sql
@@ -269,16 +269,21 @@ WITH targq AS (
 MERGE INTO tbl1 USING targq ON (true)
 WHEN MATCHED THEN DELETE;
 
--- crashes on beta3, fixed on 15 stable
---WITH foo AS (
---  MERGE INTO tbl1 USING tbl2 ON (true)
---  WHEN MATCHED THEN DELETE
---) SELECT * FROM foo;
+WITH foo AS (
+  MERGE INTO tbl1 USING tbl2 ON (true)
+  WHEN MATCHED THEN DELETE
+) SELECT * FROM foo;
 
---COPY (
---  MERGE INTO tbl1 USING tbl2 ON (true)
---  WHEN MATCHED THEN DELETE
---) TO stdout;
+COPY (
+  MERGE INTO tbl1 USING tbl2 ON (true)
+  WHEN MATCHED THEN DELETE
+) TO stdout;
+
+MERGE INTO tbl1 t
+USING tbl2
+ON (true)
+WHEN MATCHED THEN
+    DO NOTHING;
 
 MERGE INTO tbl1 t
 USING tbl2

--- a/src/test/regress/sql/pgmerge.sql
+++ b/src/test/regress/sql/pgmerge.sql
@@ -608,6 +608,14 @@ USING wq_source s ON t.tid = s.sid
 WHEN MATCHED AND (merge_when_and_write()) THEN
 	UPDATE SET balance = t.balance + s.balance;
 ROLLBACK;
+
+-- Test preventing ON condition from writing to the database
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid AND (merge_when_and_write())
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.balance;
+ROLLBACK;
 drop function merge_when_and_write();
 
 DROP TABLE wq_target, wq_source;

--- a/src/test/regress/sql/pgmerge.sql
+++ b/src/test/regress/sql/pgmerge.sql
@@ -1172,12 +1172,14 @@ INSERT INTO pa_target SELECT '2017-02-28', id, id * 100, 'initial' FROM generate
 SET client_min_messages TO DEBUG1;
 BEGIN;
 MERGE INTO pa_target t
-  USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
+  USING (SELECT * FROM pa_source WHERE sid < 10) s
+  --USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
   ON t.tid = s.sid
   WHEN MATCHED THEN
     UPDATE SET balance = balance + delta, val = val || ' updated by merge'
   WHEN NOT MATCHED THEN
-    INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
+    INSERT VALUES ('2017-01-15', sid, delta, 'inserted by merge');
+    --INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
 SELECT * FROM pa_target ORDER BY tid;
 ROLLBACK;
 RESET client_min_messages;

--- a/src/test/regress/sql_schedule
+++ b/src/test/regress/sql_schedule
@@ -14,3 +14,4 @@ test: arbitrary_configs_truncate
 test: arbitrary_configs_truncate_cascade
 test: arbitrary_configs_truncate_partition
 test: arbitrary_configs_alter_table_add_constraint_without_name
+test: merge_arbitrary


### PR DESCRIPTION
This primarily has 3 commits.
44c387b978a51b0c0e87c7f9aec154cfc3041da1 --> Phase-II commit, which was reverted (This commit was already reviewed and pushed)
4fe2a48b6afcffdafb0e967e7c414895e22033f2 --> Phase-III commit to expand it to multi-shard
d12e429371783336a3a2d039010571db376cd6cd --> Fixes a bug 

Fixes: #6672 #6674 #6676 

Phase-III
Support pushdown query where all the tables in the merge-sql are Citus-distributed, co-located, and both
the source and target relations are joined on the distribution column. This will generate multiple tasks
which execute independently after pushdown.
```SQL
SELECT create_distributed_table('t1', 'id');
SELECT create_distributed_table('s1', 'id', colocate_with => ‘t1’);

MERGE INTO t1
USING s1
ON t1.id = s1.id
        WHEN MATCHED THEN
                UPDATE SET val = s1.val + 10
        WHEN MATCHED THEN
                DELETE
        WHEN NOT MATCHED THEN
                INSERT (id, val, src) VALUES (s1.id, s1.val, s1.src)
```
*The only exception for both the phases II and III is, UPDATEs and INSERTs must be done on the same shard-group
as the joined key; for example, below scenarios are NOT supported as the key-value to be inserted/updated is not
guaranteed to be on the same node as the id distribution-column.

```SQL
MERGE INTO target t
USING source s ON (t.customer_id = s.customer_id)
WHEN NOT MATCHED THEN - -
     INSERT(customer_id, …) VALUES (<non-local-constant-key-value>, ……);
```
OR this scenario where we update the distribution column itself
```SQL
MERGE INTO target t
USING source s On (t.customer_id = s.customer_id)
WHEN MATCHED THEN
     UPDATE SET customer_id = 100;
```

**Subquery/CTE support**: We have only very limited subquery/CTE support until we have recursive planner support for MERGE. Complex subqueries as source are not supported at this time, for example

```
EXPLAIN MERGE INTO target sda USING (SELECT * FROM SOURCE where z NOT IN (SELECT z FROM target WHERE id > 5 )) sdn ON
sda.id = sdn.id
WHEN NOT matched THEN
INSERT (id, z)
VALUES (sdn.id, 5);
ERROR:  MERGE command is only supported when distributed tables are joined on their distribution column
```
```
MERGE INTO target_set
USING (SELECT 2 as s3, source_set.* FROM (SELECT * FROM source_set LIMIT 1) as foo LEFT JOIN source_set USING( s1)) AS foo
ON target_set.t1 = foo.s1
WHEN MATCHED THEN UPDATE SET t2 = t2 + 1
WHEN NOT MATCHED THEN INSERT VALUES(s1, s3);
psql:sets:35: ERROR:  cannot push down this subquery
DETAIL:  Limit clause is currently unsupported when a subquery references a column from another query
```

