### PR TITLE
Fix dubious ownership error from git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,9 @@ commands:
           lcov --remove lcov.info -o lcov.info '/usr/*'
           sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
           mkdir -p /tmp/codeclimate
+          # We started getting permissions error. This fixes them and since
+          # weqre not on a multi-user system so this is safe to do.
+          git config --global --add safe.directory /home/circleci/project
           cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/$CIRCLE_JOB.json lcov.info
     - persist_to_workspace:
         root: /tmp


### PR DESCRIPTION
We started getting this error in CI:
```
Summary coverage rate:
  lines......: 43.4% (28347 of 65321 lines)
  functions..: 53.2% (2544 of 4786 functions)
  branches...: no data found
fatal: detected dubious ownership in repository at '/home/circleci/project'
To add an exception for this directory, call:

	git config --global --add safe.directory /home/circleci/project
Error: exit status 128
```

This fixes that by running the proposed command to command in CI. This error is
related to a CVE that does not apply to this case, since this is not a multiuser
system. 

Commit on git itself that fixed the CVE: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
