### PR TITLE
Fix flakyness in failure_create_distributed_table_non_empty

### DIFF
--- a/src/test/regress/expected/failure_create_distributed_table_non_empty.out
+++ b/src/test/regress/expected/failure_create_distributed_table_non_empty.out
@@ -35,21 +35,6 @@ SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_
      0
 (1 row)
 
--- in the first test, cancel the first connection we sent from the coordinator
-SELECT citus.mitmproxy('conn.cancel(' ||  pg_backend_pid() || ')');
- mitmproxy
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT create_distributed_table('test_table', 'id');
-ERROR:  canceling statement due to user request
-SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
- count
----------------------------------------------------------------------
-     0
-(1 row)
-
 -- kill as soon as the coordinator sends CREATE SCHEMA
 SELECT citus.mitmproxy('conn.onQuery(query="^CREATE SCHEMA").kill()');
  mitmproxy

--- a/src/test/regress/sql/failure_create_distributed_table_non_empty.sql
+++ b/src/test/regress/sql/failure_create_distributed_table_non_empty.sql
@@ -27,11 +27,6 @@ SELECT citus.mitmproxy('conn.kill()');
 SELECT create_distributed_table('test_table', 'id');
 SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
 
--- in the first test, cancel the first connection we sent from the coordinator
-SELECT citus.mitmproxy('conn.cancel(' ||  pg_backend_pid() || ')');
-SELECT create_distributed_table('test_table', 'id');
-SELECT count(*) FROM pg_dist_shard WHERE logicalrelid='create_distributed_table_non_empty_failure.test_table'::regclass;
-
 -- kill as soon as the coordinator sends CREATE SCHEMA
 SELECT citus.mitmproxy('conn.onQuery(query="^CREATE SCHEMA").kill()');
 SELECT create_distributed_table('test_table', 'id');


### PR DESCRIPTION
The failure_create_distributed_table_non_empty test would sometimes fail
like this:
```diff
 -- in the first test, cancel the first connection we sent from the coordinator
 SELECT citus.mitmproxy('conn.cancel(' ||  pg_backend_pid() || ')');
- mitmproxy
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  canceling statement due to user request
+CONTEXT:  COPY mitmproxy_result, line 0
+SQL statement "COPY mitmproxy_result FROM '/home/circleci/project/src/test/regress/tmp_check/mitmproxy.fifo'"
+PL/pgSQL function citus.mitmproxy(text) line 11 at EXECUTE
 SELECT create_distributed_table('test_table', 'id');
```

Source: https://app.circleci.com/pipelines/github/citusdata/citus/30474/workflows/be1c9f9d-22c9-465c-964a-dcdd1cb8c99c/jobs/985441

Because the cancel command had no filter it would actually sometimes
cancel the mitmproxy cancel command itself. This PR addresses that by
simply removing this test.

This is basically the exact same issue as #6217, only in a different
place in the file. It's fixed here by removing the test since there's
already many different similar tests.
