### PR TITLE
Support compilation and run tests on latest PG versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,19 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-v9a494cd'
+    default: '-vc4b1573'
   pg13_version:
     type: string
-    default: '13.9'
+    default: '13.10'
   pg14_version:
     type: string
-    default: '14.6'
+    default: '14.7'
   pg15_version:
     type: string
-    default: '15.1'
+    default: '15.2'
   upgrade_pg_versions:
     type: string
-    default: '13.9-14.6-15.1'
+    default: '13.10-14.7-15.2'
   style_checker_tools_version:
     type: string
     default: '0.8.18'

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -55,6 +55,14 @@ pg_strtoint64(char *s)
 }
 
 
+/*
+ * RelationGetSmgr got backported in 13.10 and 14.7 so redefining it for any
+ * version higher causes compilation errors due to redefining of the function.
+ * We want to use it in all versions. So we backport it ourselves in earlier
+ * versions, and rely on the Postgres provided version in the later versions.
+ */
+#if PG_VERSION_NUM >= PG_VERSION_13 && PG_VERSION_NUM < 130010 \
+	|| PG_VERSION_NUM >= PG_VERSION_14 && PG_VERSION_NUM < 140007
 static inline SMgrRelation
 RelationGetSmgr(Relation rel)
 {
@@ -64,6 +72,9 @@ RelationGetSmgr(Relation rel)
 	}
 	return rel->rd_smgr;
 }
+
+
+#endif
 
 
 #define CREATE_SEQUENCE_COMMAND \


### PR DESCRIPTION
Postgres got minor updates this starts using the images with the latest version for our tests.

These new Postgres versions caused a compilation issue in PG14 and PG13 due to some function being backported that we had already backported ourselves. Due this backport being a static inline function it doesn't matter who provides this and there will be no linkage errors when either running old Citus packages on new PG versions or the other way around.