### PR TITLE
fix single tuple result memory leak

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -4777,6 +4777,7 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 		TupleDesc tupleDescriptor = tupleDest->tupleDescForQuery(tupleDest, queryIndex);
 		if (tupleDescriptor == NULL)
 		{
+			PQclear(result);
 			continue;
 		}
 


### PR DESCRIPTION
We should not omit to free PGResult when we receive single tuple result from an internal backend.
Single tuple results are normally freed by our ReceiveResults for `tupleDescriptor != NULL` flow but not for those with `tupleDescriptor == NULL`. See https://github.com/citusdata/citus/pull/6722 for details.

DESCRIPTION: Fixes memory leak issue with query results that returns single row.
