### PR TITLE
Move common code to a new routine.

### DIFF
--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -99,6 +99,7 @@ extern PlannedStmt * FastPathPlanner(Query *originalQuery, Query *parse, ParamLi
 									 boundParams);
 extern bool FastPathRouterQuery(Query *query, Node **distributionKeyValue);
 extern bool JoinConditionIsOnFalse(List *relOptInfo);
+extern Oid ResultRelationOidForQuery(Query *query);
 
 
 #endif /* MULTI_ROUTER_PLANNER_H */

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -177,7 +177,7 @@ INSERT INTO limit_orders VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:50:
 INSERT INTO limit_orders VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 -- commands with mutable functions in their quals
 DELETE FROM limit_orders WHERE id = 246 AND bidder_id = (random() * 1000);
-ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
 -- commands with mutable but non-volatile functions(ie: stable func.) in their quals
 -- (the cast to timestamp is because the timestamp_eq_timestamptz operator is stable)
 DELETE FROM limit_orders WHERE id = 246 AND placed_at = current_timestamp::timestamp;

--- a/src/test/regress/expected/multi_mx_modifications.out
+++ b/src/test/regress/expected/multi_mx_modifications.out
@@ -95,7 +95,7 @@ INSERT INTO limit_orders_mx VALUES (random() * 100, 'ORCL', 152, '2011-08-25 11:
 INSERT INTO limit_orders_mx VALUES (2036, 'GOOG', 5634, now(), 'buy', random());
 -- commands with mutable functions in their quals
 DELETE FROM limit_orders_mx WHERE id = 246 AND bidder_id = (random() * 1000);
-ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
 -- commands with mutable but non-volatile functions(ie: stable func.) in their quals
 -- (the cast to timestamp is because the timestamp_eq_timestamptz operator is stable)
 DELETE FROM limit_orders_mx WHERE id = 246 AND placed_at = current_timestamp::timestamp;

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -674,7 +674,7 @@ UPDATE users_test_table
 SET    value_2 = 5
 FROM   events_test_table
 WHERE  users_test_table.user_id = events_test_table.user_id * random();
-ERROR:  functions used in the WHERE clause of modification queries on distributed tables must not be VOLATILE
+ERROR:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
 UPDATE users_test_table
 SET    value_2 = 5 * random()
 FROM   events_test_table


### PR DESCRIPTION
Rearrange the common code into a new function, `TargetlistAndFunctionsSupported()`,  to facilitate the multiple checks of the same conditions in a multi-modify MERGE statement.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
