### PR TITLE
Don't blanket ignore flake8 E402 error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 # E203 is ignored for black
-# E402 is ignored because of te way we do relative imports
-extend-ignore = E203, E402
+extend-ignore = E203
 # black will truncate to 88 characters usually, but long string literals it
 # might keep. That's fine in most cases unless it gets really excessive.
 max-line-length = 150

--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -12,23 +12,23 @@ Options:
     --seed=<seed>                   random number seed
     --base                          whether to use the base sql schedule or not
 """
+import concurrent.futures
+import multiprocessing
 import os
+import random
 import shutil
 import sys
+import time
+
+from docopt import docopt
 
 # https://stackoverflow.com/questions/14132789/relative-imports-for-the-billionth-time/14132912#14132912
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# ignore E402 because these imports require addition to path
+import common  # noqa: E402
 
-import concurrent.futures
-import multiprocessing
-import random
-import time
-
-import common
-from docopt import docopt
-
-import config as cfg
+import config as cfg  # noqa: E402
 
 testResults = {}
 parallel_thread_amount = 1

--- a/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/citus_upgrade_test.py
@@ -19,15 +19,17 @@ import re
 import subprocess
 import sys
 
+from docopt import docopt
+
 # https://stackoverflow.com/questions/14132789/relative-imports-for-the-billionth-time/14132912#14132912
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import common
-import utils
-from docopt import docopt
-from utils import USER
+# ignore E402 because these imports require addition to path
+import common  # noqa: E402
+import utils  # noqa: E402
+from utils import USER  # noqa: E402
 
-from config import (
+from config import (  # noqa: E402
     AFTER_CITUS_UPGRADE_COORD_SCHEDULE,
     BEFORE_CITUS_UPGRADE_COORD_SCHEDULE,
     CITUS_VERSION_SQL,

--- a/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
+++ b/src/test/regress/citus_tests/upgrade/pg_upgrade_test.py
@@ -10,21 +10,22 @@ Options:
     --pgxsdir=<pgxsdir>           	       Path to the PGXS directory(ex: ~/.pgenv/src/postgresql-11.3)
 """
 
+import atexit
 import os
+import subprocess
 import sys
+
+from docopt import docopt
 
 # https://stackoverflow.com/questions/14132789/relative-imports-for-the-billionth-time/14132912#14132912
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import atexit
-import subprocess
+# ignore E402 because these imports require addition to path
+import common  # noqa: E402
+import utils  # noqa: E402
+from utils import USER  # noqa: E402
 
-import common
-import utils
-from docopt import docopt
-from utils import USER
-
-from config import (
+from config import (  # noqa: E402
     AFTER_PG_UPGRADE_SCHEDULE,
     BEFORE_PG_UPGRADE_SCHEDULE,
     PGUpgradeConfig,


### PR DESCRIPTION
Instead this starts ignoring it in specific places only, because most files don't actually need it ignored.
