### PR TITLE
Fix run_test.py on python 3.9

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 from collections import OrderedDict
 from glob import glob
+from typing import Optional
 
 import common
 
@@ -57,7 +58,7 @@ use_whole_schedule_line = args["use_whole_schedule_line"]
 
 
 class TestDeps:
-    schedule: str | None
+    schedule: Optional[str]
     direct_extra_tests: list[str]
 
     def __init__(self, schedule, extra_tests=None, repeatable=True):


### PR DESCRIPTION
In #6718 I accidentally added Python type hint syntax that was only
supported on Python 3.10. Our CI uses 3.9, so this PR changes that to a
syntax that's supported on 3.9 too.
