### PR TITLE
Fixes bookworm packaging pipeline problem

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -155,8 +155,8 @@ jobs:
         run: |
           echo "Postgres version: ${POSTGRES_VERSION}"
 
-          sudo apt-get update -y
+          apt-get update -y
           ## Install required packages to execute packaging tools for deb based distros
-          sudo apt-get install python3-dev python3-pip -y
-          sudo apt-get purge -y python3-yaml
+          apt-get install python3-dev python3-pip -y
+          apt-get purge -y python3-yaml
           ./.github/packaging/validate_build_output.sh "deb"


### PR DESCRIPTION
Recently, I changed Python execution structure into virtual. Therefore, now there is no need change built in python for the images. Since Github is provisioning images with specific permissions, this issue  caused error. 
With this PR, I removed unnecessary installation of pip and setuptools in container docker image
Additionally,  removed some unnecessary sudos and used ap-get instead of apt in one place