### PR TITLE
Fix multiple output version arbitrary config tests

### DIFF
--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -56,9 +56,7 @@ def run_for_config(config, lock, sql_schedule_name):
     )
     if config.user == cfg.REGULAR_USER_NAME:
         common.create_role(
-            config.bindir,
-            config.node_name_to_ports.values(),
-            config.user,
+            config.bindir, config.node_name_to_ports.values(), config.user
         )
 
     copy_copy_modified_binary(config.datadir)
@@ -160,7 +158,9 @@ def copy_test_files_with_names(test_names, sql_dir_path, expected_dir_path, conf
             # might not be there yet, in that case, we don't want to error out
             # while copying the file.
             shutil.copy(output_name, expected_dir_path)
-            output_name = os.path.join("./expected", f"{test_name}_{alt_output_version_no}.out")
+            output_name = os.path.join(
+                "./expected", f"{test_name}_{alt_output_version_no}.out"
+            )
             alt_output_version_no += 1
 
 

--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -151,14 +151,17 @@ def copy_test_files_with_names(test_names, sql_dir_path, expected_dir_path, conf
             continue
 
         sql_name = os.path.join("./sql", test_name + ".sql")
-        output_name = os.path.join("./expected", test_name + ".out")
-
         shutil.copy(sql_name, sql_dir_path)
-        if os.path.isfile(output_name):
+
+        output_name = os.path.join("./expected", test_name + ".out")
+        alt_output_version_no = 0
+        while os.path.isfile(output_name):
             # it might be the first time we run this test and the expected file
             # might not be there yet, in that case, we don't want to error out
             # while copying the file.
             shutil.copy(output_name, expected_dir_path)
+            output_name = os.path.join("./expected", f"{test_name}_{alt_output_version_no}.out")
+            alt_output_version_no += 1
 
 
 def run_tests(configs, sql_schedule_name):

--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -56,7 +56,9 @@ def run_for_config(config, lock, sql_schedule_name):
     )
     if config.user == cfg.REGULAR_USER_NAME:
         common.create_role(
-            config.bindir, config.node_name_to_ports.values(), config.user
+            config.bindir,
+            config.node_name_to_ports.values(),
+            config.user,
         )
 
     copy_copy_modified_binary(config.datadir)
@@ -151,6 +153,11 @@ def copy_test_files_with_names(test_names, sql_dir_path, expected_dir_path, conf
         sql_name = os.path.join("./sql", test_name + ".sql")
         shutil.copy(sql_name, sql_dir_path)
 
+        # for a test named <t>, all files:
+        # <t>.out, <t>_0.out, <t>_1.out ...
+        # are considered as valid outputs for the test
+        # by the testing tool (pg_regress)
+        # so copy such files to the testing directory
         output_name = os.path.join("./expected", test_name + ".out")
         alt_output_version_no = 0
         while os.path.isfile(output_name):


### PR DESCRIPTION
With this small change, arbitrary config tests can have multiple acceptable correct outputs.

For an arbitrary config tests named `t`, now you can define `expected/t.out`, `expected/t_0.out`, `expected/t_1.out` etc and the test will succeed if the output of `sql/t.sql` is equal to any of the `t.out` or `t_{0, 1, ...}.out` files.