### PR TITLE
Add a simple variation of router planning for distributed insert .. select

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -366,8 +366,10 @@ AddPartitionKeyNotNullFilterToSelect(Query *subqery)
 		}
 	}
 
-	/* we should have found target partition column */
-	Assert(targetPartitionColumnVar != NULL);
+	if (targetPartitionColumnVar == NULL)
+	{
+		return;
+	}
 
 	/* create expression for partition_column IS NOT NULL */
 	NullTest *nullTest = makeNode(NullTest);


### PR DESCRIPTION
When deciding whether an insert .. select command is distributed, we can skip many checks performed in MultiTaskRouterSelectQuerySupported() if the select query is router plannable and the target relation is colocated with the anchor select relation.

On main, this is mostly useful when inserting into a local table from a reference table, or if we're targeting a single shard group of a colocated set of distributed tables.

Moreover, this could also help optimizing insert .. select between distributed tables that don't have a shard key.

**Opening as a draft PR so that we can spend more time on that if time permits / if we think that this is a usual query pattern that is worth to optimize.**