### PR TITLE
Clean up resources in background rebalance test

### DIFF
--- a/src/test/regress/expected/background_rebalance.out
+++ b/src/test/regress/expected/background_rebalance.out
@@ -291,6 +291,12 @@ SELECT state, details from citus_rebalance_status();
  finished | {"tasks": [], "task_state_counts": {"done": 2}}
 (1 row)
 
+SELECT public.wait_for_resource_cleanup();
+ wait_for_resource_cleanup
+---------------------------------------------------------------------
+
+(1 row)
+
 -- Remove coordinator again to allow rerunning of this test
 SELECT 1 FROM citus_remove_node('localhost', :master_port);
  ?column?

--- a/src/test/regress/sql/background_rebalance.sql
+++ b/src/test/regress/sql/background_rebalance.sql
@@ -104,6 +104,8 @@ SELECT 1 FROM citus_rebalance_start(shard_transfer_mode := 'force_logical');
 SELECT citus_rebalance_wait();
 SELECT state, details from citus_rebalance_status();
 
+SELECT public.wait_for_resource_cleanup();
+
 -- Remove coordinator again to allow rerunning of this test
 SELECT 1 FROM citus_remove_node('localhost', :master_port);
 SELECT public.wait_until_metadata_sync(30000);


### PR DESCRIPTION
This test would leave some clean up records around. Which caused issues
in the test that Emel tried to add after it.
