### PR TITLE
Revoke statistics permissions from public and grant them to pg_monitor

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_stats_tenants/11.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats_tenants/11.3-1.sql
@@ -71,4 +71,8 @@ FROM pg_catalog.citus_stats_tenants(FALSE);
 
 ALTER VIEW citus.citus_stats_tenants SET SCHEMA pg_catalog;
 
-GRANT SELECT ON pg_catalog.citus_stats_tenants TO PUBLIC;
+REVOKE ALL ON FUNCTION pg_catalog.citus_stats_tenants(BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_catalog.citus_stats_tenants(BOOLEAN) TO pg_monitor;
+
+REVOKE ALL ON pg_catalog.citus_stats_tenants FROM PUBLIC;
+GRANT SELECT ON pg_catalog.citus_stats_tenants TO pg_monitor;

--- a/src/backend/distributed/sql/udfs/citus_stats_tenants/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats_tenants/latest.sql
@@ -71,4 +71,8 @@ FROM pg_catalog.citus_stats_tenants(FALSE);
 
 ALTER VIEW citus.citus_stats_tenants SET SCHEMA pg_catalog;
 
-GRANT SELECT ON pg_catalog.citus_stats_tenants TO PUBLIC;
+REVOKE ALL ON FUNCTION pg_catalog.citus_stats_tenants(BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_catalog.citus_stats_tenants(BOOLEAN) TO pg_monitor;
+
+REVOKE ALL ON pg_catalog.citus_stats_tenants FROM PUBLIC;
+GRANT SELECT ON pg_catalog.citus_stats_tenants TO pg_monitor;

--- a/src/backend/distributed/sql/udfs/citus_stats_tenants_local/11.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats_tenants_local/11.3-1.sql
@@ -24,4 +24,9 @@ FROM pg_catalog.citus_stats_tenants_local()
 ORDER BY score DESC;
 
 ALTER VIEW citus.citus_stats_tenants_local SET SCHEMA pg_catalog;
-GRANT SELECT ON pg_catalog.citus_stats_tenants_local TO PUBLIC;
+
+REVOKE ALL ON FUNCTION pg_catalog.citus_stats_tenants_local(BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_catalog.citus_stats_tenants_local(BOOLEAN) TO pg_monitor;
+
+REVOKE ALL ON pg_catalog.citus_stats_tenants_local FROM PUBLIC;
+GRANT SELECT ON pg_catalog.citus_stats_tenants_local TO pg_monitor;

--- a/src/backend/distributed/sql/udfs/citus_stats_tenants_local/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats_tenants_local/latest.sql
@@ -24,4 +24,9 @@ FROM pg_catalog.citus_stats_tenants_local()
 ORDER BY score DESC;
 
 ALTER VIEW citus.citus_stats_tenants_local SET SCHEMA pg_catalog;
-GRANT SELECT ON pg_catalog.citus_stats_tenants_local TO PUBLIC;
+
+REVOKE ALL ON FUNCTION pg_catalog.citus_stats_tenants_local(BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_catalog.citus_stats_tenants_local(BOOLEAN) TO pg_monitor;
+
+REVOKE ALL ON pg_catalog.citus_stats_tenants_local FROM PUBLIC;
+GRANT SELECT ON pg_catalog.citus_stats_tenants_local TO pg_monitor;

--- a/src/test/regress/expected/citus_stats_tenants.out
+++ b/src/test/regress/expected/citus_stats_tenants.out
@@ -692,5 +692,45 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
  thisisaverylooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo |                         1 |                         0 |                          1 |                          0
 (1 row)
 
+-- test role permissions
+CREATE ROLE stats_non_superuser WITH LOGIN;
+SET ROLE stats_non_superuser;
+SELECT count(*)>=0 FROM citus_stats_tenants;
+ERROR:  permission denied for view citus_stats_tenants
+SELECT count(*)>=0 FROM citus_stats_tenants_local;
+ERROR:  permission denied for view citus_stats_tenants_local
+SELECT count(*)>=0 FROM citus_stats_tenants();
+ERROR:  permission denied for function citus_stats_tenants
+SELECT count(*)>=0 FROM citus_stats_tenants_local();
+ERROR:  permission denied for function citus_stats_tenants_local
+RESET ROLE;
+GRANT pg_monitor TO stats_non_superuser;
+SET ROLE stats_non_superuser;
+SELECT count(*)>=0 FROM citus_stats_tenants;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*)>=0 FROM citus_stats_tenants_local;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*)>=0 FROM citus_stats_tenants();
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*)>=0 FROM citus_stats_tenants_local();
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+RESET ROLE;
+DROP ROLE stats_non_superuser;
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stats_tenants CASCADE;

--- a/src/test/regress/expected/multi_metadata_access.out
+++ b/src/test/regress/expected/multi_metadata_access.out
@@ -21,7 +21,9 @@ ORDER BY 1;
 ---------------------------------------------------------------------
  pg_dist_authinfo
  pg_dist_clock_logical_seq
-(2 rows)
+ citus_stats_tenants_local
+ citus_stats_tenants
+(4 rows)
 
 RESET role;
 DROP USER no_access;

--- a/src/test/regress/sql/citus_stats_tenants.sql
+++ b/src/test/regress/sql/citus_stats_tenants.sql
@@ -213,5 +213,27 @@ SELECT result FROM run_command_on_all_nodes('SELECT clean_citus_stats_tenants()'
 SELECT count(*)>=0 FROM dist_tbl_text WHERE a = 'thisisaveryloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongname';
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stats_tenants ORDER BY tenant_attribute;
 
+-- test role permissions
+CREATE ROLE stats_non_superuser WITH LOGIN;
+SET ROLE stats_non_superuser;
+
+SELECT count(*)>=0 FROM citus_stats_tenants;
+SELECT count(*)>=0 FROM citus_stats_tenants_local;
+SELECT count(*)>=0 FROM citus_stats_tenants();
+SELECT count(*)>=0 FROM citus_stats_tenants_local();
+
+RESET ROLE;
+GRANT pg_monitor TO stats_non_superuser;
+
+SET ROLE stats_non_superuser;
+
+SELECT count(*)>=0 FROM citus_stats_tenants;
+SELECT count(*)>=0 FROM citus_stats_tenants_local;
+SELECT count(*)>=0 FROM citus_stats_tenants();
+SELECT count(*)>=0 FROM citus_stats_tenants_local();
+
+RESET ROLE;
+DROP ROLE stats_non_superuser;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stats_tenants CASCADE;


### PR DESCRIPTION
This PR revokes permissions from stats views and functions from the public role and grants `SELECT` and `EXECUTE` to pg_monitor. 