### PR TITLE
Make python-regress based tests runnable with run_test.py

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -360,6 +360,11 @@ def run(command, *args, check=True, shell=True, silent=False, **kwargs):
     return subprocess.run(command, *args, check=check, shell=shell, **kwargs)
 
 
+def capture(command, *args, **kwargs):
+    """runs the given command and returns its output as a string"""
+    return run(command, *args, stdout=subprocess.PIPE, text=True, **kwargs).stdout
+
+
 def sudo(command, *args, shell=True, **kwargs):
     """
     A version of run that prefixes the command with sudo when the process is


### PR DESCRIPTION
For some tests such as upgrade tests and arbitrary config tests we set
up the citus cluster using Python. This setup is slightly different from
the perl based setup script (`multi_regress.pl`). Most importantly it
uses replication factor 1 by default.

This changes our run_test.py script to be able to run a schedule using
python instead of `multi_regress.pl`, for the tests that require it.

For now arbitrary config tests are still not runnable with
`run_test.py`, but this brings us one step closer to being able to do
that.

Fixes #6804
