### PR TITLE
Fixes flakiness in multi_metadata_sync test

### DIFF
--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -497,7 +497,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
       5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f              | t
 (4 rows)
 
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
@@ -635,7 +635,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
       5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f              | t
 (4 rows)
 
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
@@ -872,7 +872,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -888,7 +888,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
         logicalrelid         | shardid | nodename  | nodeport
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
@@ -923,7 +923,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -939,7 +939,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
         logicalrelid         | shardid | nodename  | nodeport
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
@@ -1083,7 +1083,7 @@ FROM
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
-ORDER BY logicalrelid;
+ORDER BY logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10000
@@ -1105,7 +1105,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10001
@@ -1121,7 +1121,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10001

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -921,7 +921,9 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
-	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY
+	logicalrelid;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -1101,11 +1103,13 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
- mx_colocation_test_2 |        10001
  mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
 (2 rows)
 
 \c - - - :worker_1_port
@@ -1115,11 +1119,13 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
- mx_colocation_test_2 |        10001
  mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
 (2 rows)
 
 \c - - - :master_port

--- a/src/test/regress/expected/multi_metadata_sync_0.out
+++ b/src/test/regress/expected/multi_metadata_sync_0.out
@@ -497,7 +497,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
       5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f              | t
 (4 rows)
 
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
@@ -635,7 +635,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
       5 |       1 | localhost |     8889 | default  | f           | t        | secondary | second-cluster | f              | t
 (4 rows)
 
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
  mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
@@ -872,7 +872,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -888,7 +888,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
         logicalrelid         | shardid | nodename  | nodeport
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
@@ -923,7 +923,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -939,7 +939,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
         logicalrelid         | shardid | nodename  | nodeport
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | 1310020 | localhost |    57637
@@ -1083,7 +1083,7 @@ FROM
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
-ORDER BY logicalrelid;
+ORDER BY logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10000
@@ -1105,7 +1105,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10001
@@ -1121,7 +1121,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
  mx_colocation_test_1 |        10001

--- a/src/test/regress/expected/multi_metadata_sync_0.out
+++ b/src/test/regress/expected/multi_metadata_sync_0.out
@@ -921,7 +921,9 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
-	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY
+	logicalrelid;
         logicalrelid         | repmodel
 ---------------------------------------------------------------------
  mx_test_schema_1.mx_table_1 | s
@@ -1101,11 +1103,13 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
- mx_colocation_test_2 |        10001
  mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
 (2 rows)
 
 \c - - - :worker_1_port
@@ -1115,11 +1119,13 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
      logicalrelid     | colocationid
 ---------------------------------------------------------------------
- mx_colocation_test_2 |        10001
  mx_colocation_test_1 |        10001
+ mx_colocation_test_2 |        10001
 (2 rows)
 
 \c - - - :master_port

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -111,7 +111,7 @@ SELECT nodeid, hasmetadata FROM pg_dist_node WHERE nodename='localhost' AND node
 \c - - - :worker_1_port
 SELECT * FROM pg_dist_local_group;
 SELECT * FROM pg_dist_node ORDER BY nodeid;
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
 SELECT * FROM pg_dist_shard  WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;
 SELECT * FROM pg_dist_shard_placement WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid::text LIKE 'mx_testing_schema%') ORDER BY shardid, nodename, nodeport;
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='mx_testing_schema.mx_test_table'::regclass;
@@ -161,7 +161,7 @@ SELECT 1 FROM citus_activate_node('localhost', :worker_1_port);
 \c - - - :worker_1_port
 SELECT * FROM pg_dist_local_group;
 SELECT * FROM pg_dist_node ORDER BY nodeid;
-SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid;
+SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
 SELECT * FROM pg_dist_shard WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;
 SELECT * FROM pg_dist_shard_placement WHERE shardid IN (SELECT shardid FROM pg_dist_shard WHERE logicalrelid::text LIKE 'mx_testing_schema%') ORDER BY shardid, nodename, nodeport;
 SELECT "Column", "Type", "Modifiers" FROM table_desc WHERE relid='mx_testing_schema.mx_test_table'::regclass;
@@ -252,7 +252,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
 
 -- See the shards and placements of the mx tables
 SELECT
@@ -263,7 +263,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
 
 -- Check that metadata of MX tables exist on the metadata worker
 \c - - - :worker_1_port
@@ -280,7 +280,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
 
 -- Check that shard and placement data are created
 SELECT
@@ -291,7 +291,7 @@ WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
 ORDER BY
-	logicalrelid, shardid;
+	logicalrelid::text, shardid;
 
 -- Check that metadata of MX tables don't exist on the non-metadata worker
 \c - - - :worker_2_port
@@ -383,7 +383,7 @@ FROM
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
-ORDER BY logicalrelid;
+ORDER BY logicalrelid::text;
 
 -- Update colocation and see the changes on the master and the worker
 SELECT update_distributed_table_colocation('mx_colocation_test_1', colocate_with => 'mx_colocation_test_2');
@@ -395,7 +395,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
 \c - - - :worker_1_port
 SELECT
 	logicalrelid, colocationid
@@ -405,7 +405,7 @@ WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
 	OR logicalrelid = 'mx_colocation_test_2'::regclass
 ORDER BY
-	logicalrelid;
+	logicalrelid::text;
 
 \c - - - :master_port
 

--- a/src/test/regress/sql/multi_metadata_sync.sql
+++ b/src/test/regress/sql/multi_metadata_sync.sql
@@ -278,7 +278,9 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
-	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
+	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass
+ORDER BY
+	logicalrelid;
 
 -- Check that shard and placement data are created
 SELECT
@@ -391,7 +393,9 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
 \c - - - :worker_1_port
 SELECT
 	logicalrelid, colocationid
@@ -399,7 +403,9 @@ FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_colocation_test_1'::regclass
-	OR logicalrelid = 'mx_colocation_test_2'::regclass;
+	OR logicalrelid = 'mx_colocation_test_2'::regclass
+ORDER BY
+	logicalrelid;
 
 \c - - - :master_port
 


### PR DESCRIPTION
Fixes flakiness in multi_metadata_sync test

https://app.circleci.com/pipelines/github/citusdata/citus/31863/workflows/ea937480-a4cc-4646-815c-bb2634361d98/jobs/1074457
```diff
SELECT
 	logicalrelid, repmodel
 FROM
 	pg_dist_partition
 WHERE
 	logicalrelid = 'mx_test_schema_1.mx_table_1'::regclass
 	OR logicalrelid = 'mx_test_schema_2.mx_table_2'::regclass;
         logicalrelid         | repmodel 
 -----------------------------+----------
- mx_test_schema_1.mx_table_1 | s
  mx_test_schema_2.mx_table_2 | s
+ mx_test_schema_1.mx_table_1 | s
 (2 rows)
```
This is a simple issue of missing `ORDER BY` clauses. I went ahead and added some other missing ones in the same file as well. Also, I replaced existing `ORDER BY logicalrelid` with `ORDER BY logicalrelid::text`, in order to compare names, not OIDs.