### PR TITLE
Fixes flakiness in multi_cluster_management test

### DIFF
--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -83,7 +83,7 @@ SELECT citus_disable_node('localhost', :worker_2_port);
 
 (1 row)
 
-SELECT public.wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync(60000);
  wait_until_metadata_sync
 ---------------------------------------------------------------------
 
@@ -796,7 +796,7 @@ SELECT citus_disable_node('localhost', 9999);
 
 (1 row)
 
-SELECT public.wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync(60000);
  wait_until_metadata_sync
 ---------------------------------------------------------------------
 

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -35,7 +35,7 @@ SELECT master_get_active_worker_nodes();
 SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 
 SELECT citus_disable_node('localhost', :worker_2_port);
-SELECT public.wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync(60000);
 SELECT master_get_active_worker_nodes();
 
 -- add some shard placements to the cluster
@@ -323,7 +323,7 @@ SELECT 1 FROM master_add_inactive_node('localhost', 9996, groupid => :worker_2_g
 SELECT master_add_inactive_node('localhost', 9999, groupid => :worker_2_group, nodecluster => 'olap', noderole => 'secondary');
 SELECT master_activate_node('localhost', 9999);
 SELECT citus_disable_node('localhost', 9999);
-SELECT public.wait_until_metadata_sync();
+SELECT public.wait_until_metadata_sync(60000);
 SELECT master_remove_node('localhost', 9999);
 
 -- check that you can't manually add two primaries to a group


### PR DESCRIPTION
Fixes flakiness in multi_cluster_management test

https://app.circleci.com/pipelines/github/citusdata/citus/31816/workflows/2f455a30-1c0b-4b21-9831-f7cf2169df5a/jobs/1071444
```diff
SELECT public.wait_until_metadata_sync();
+WARNING:  waiting for metadata sync timed out
  wait_until_metadata_sync 
 --------------------------
  
 (1 row)
```
Default timeout value is 15000. I increased it to 60000.