### PR TITLE
Makefile changes to build CDC in builddir for pgoutput and wal2json.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-v087ecd7'
+    default: '-f104adb'
   pg13_version:
     type: string
     default: '13.10'
@@ -490,10 +490,6 @@ jobs:
           pg_major: << parameters.pg_major >>
       - configure
       - enable_core
-      - run:
-          name: 'Install DBI.pm'
-          command: |
-            apt-get update && apt-get install libdbi-perl && apt-get install libdbd-pg-perl postgresql-<< parameters.pg_major >>-wal2json
       - run:
           name: 'Run Test'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
       - run:
           name: 'Install DBI.pm'
           command: |
-            apt-get update && apt-get install libdbi-perl && apt-get install libdbd-pg-perl
+            apt-get update && apt-get install libdbi-perl && apt-get install libdbd-pg-perl postgresql-<< parameters.pg_major >>-wal2json
       - run:
           name: 'Run Test'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: 'dev-f104adb'
+    default: '-dev-f104adb'
   pg13_version:
     type: string
     default: '13.10'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-f104adb'
+    default: '-v3417e8d'
   pg13_version:
     type: string
     default: '13.10'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-f104adb'
+    default: 'dev-f104adb'
   pg13_version:
     type: string
     default: '13.10'

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -36,37 +36,8 @@ OBJS += \
 
 all: cdc
 
-setup_cdc_build_dir_copy_files:
-	mkdir -p $(DECODER_BUILD_DIR)
-	$(eval SRC_DIR = $(citus_abs_srcdir)/cdc)
-	$(eval DEST_DIR = $(DECODER_BUILD_DIR))
-	@for file in $(SRC_DIR)/*.c $(SRC_DIR)/*.h $(SRC_DIR)/Makefile; do \
-		if [ -f $$file ]; then \
-            if ! diff -q $$file $(DEST_DIR)/$$(basename $$file); then \
-                cp $$file $(DEST_DIR)/$$(basename $$file); \
-            fi \
-        fi \
-    done
-
-cdc_build_dir:
-	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
-	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
-	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		-C $(DECODER_BUILD_DIR)
-
-cdc_clean_dir:
-	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
-	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		-C $(DECODER_BUILD_DIR) clean
-
-cdc_install_dir:
-	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
-	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		-C $(DECODER_BUILD_DIR) install
-
 cdc:
-	$(MAKE) DECODER=pgoutput cdc_build_dir
-	$(MAKE) DECODER=wal2json cdc_build_dir
+	$(MAKE) -C cdc all
 
 NO_PGXS = 1
 
@@ -119,20 +90,16 @@ endif
 clean: clean-cdc
 
 clean-cdc:
-	$(MAKE) DECODER=pgoutput cdc_clean_dir
-	$(MAKE) DECODER=wal2json cdc_clean_dir
+	$(MAKE) -C cdc clean
 
 cleanup-before-install:
 	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/citus.control
 	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/citus--*
-	echo cleanup-before-install $(DESTDIR)$(datadir)/$(datamoduledir)/lib/citus_decoders/*.so
-	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/lib/citus_decoders/*.so
 
 install: cleanup-before-install install-cdc
 
 install-cdc:
-	$(MAKE) DECODER=pgoutput cdc_install_dir
-	$(MAKE) DECODER=wal2json cdc_install_dir
+	$(MAKE) -C cdc install
 
 # install and install-downgrades should be run sequentially
 install-all: install

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -36,9 +36,42 @@ OBJS += \
 
 all: cdc
 
+setup_cdc_build_dir_copy_files:
+	mkdir -p $(DECODER_BUILD_DIR)
+	$(eval SRC_DIR = $(citus_abs_srcdir)/cdc)
+	$(eval DEST_DIR = $(DECODER_BUILD_DIR))
+	@for file in $(SRC_DIR)/*.c $(SRC_DIR)/*.h $(SRC_DIR)/Makefile; do \
+		if [ -f $$file ]; then \
+            if ! diff -q $$file $(DEST_DIR)/$$(basename $$file); then \
+                cp $$file $(DEST_DIR)/$$(basename $$file); \
+            fi \
+        fi \
+    done
+
+cdc_build_dir:
+	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
+	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
+	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
+		citus_subdir=$(DECODER_BUILD_DIR) \
+		-C $(DECODER_BUILD_DIR)
+
+cdc_clean_dir:
+	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
+	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
+	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
+		citus_subdir=$(DECODER_BUILD_DIR) \
+		-C $(DECODER_BUILD_DIR) clean
+
+cdc_install_dir:
+	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
+	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
+	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
+		citus_subdir=$(DECODER_BUILD_DIR) \
+		-C $(DECODER_BUILD_DIR) install
+
 cdc:
-	echo "running cdc make"
-	$(MAKE) DECODER=pgoutput -C cdc all
+	$(MAKE) DECODER=pgoutput cdc_build_dir
+	$(MAKE) DECODER=wal2json cdc_build_dir
 
 NO_PGXS = 1
 
@@ -85,21 +118,26 @@ ifneq (,$(SQL_Po_files))
 include $(SQL_Po_files)
 endif
 
-.PHONY: clean-full install install-downgrades install-all
+
+.PHONY: clean-full install install-downgrades install-all install-cdc clean-cdc
 
 clean: clean-cdc
 
 clean-cdc:
-	$(MAKE) DECODER=pgoutput -C cdc clean
+	$(MAKE) DECODER=pgoutput cdc_clean_dir
+	$(MAKE) DECODER=wal2json cdc_clean_dir
 
 cleanup-before-install:
 	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/citus.control
 	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/citus--*
+	echo cleanup-before-install $(DESTDIR)$(datadir)/$(datamoduledir)/lib/citus_decoders/*.so
+	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/lib/citus_decoders/*.so
 
 install: cleanup-before-install install-cdc
 
 install-cdc:
-	$(MAKE) DECODER=pgoutput -C cdc install
+	$(MAKE) DECODER=pgoutput cdc_install_dir
+	$(MAKE) DECODER=wal2json cdc_install_dir
 
 # install and install-downgrades should be run sequentially
 install-all: install

--- a/src/backend/distributed/Makefile
+++ b/src/backend/distributed/Makefile
@@ -52,21 +52,16 @@ cdc_build_dir:
 	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
 	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
 	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		citus_subdir=$(DECODER_BUILD_DIR) \
 		-C $(DECODER_BUILD_DIR)
 
 cdc_clean_dir:
 	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
-	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
 	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		citus_subdir=$(DECODER_BUILD_DIR) \
 		-C $(DECODER_BUILD_DIR) clean
 
 cdc_install_dir:
 	$(eval DECODER_BUILD_DIR = $(citus_abs_srcdir)/build/cdc-$(DECODER))
-	$(MAKE) DECODER_BUILD_DIR=$(DECODER_BUILD_DIR) setup_cdc_build_dir_copy_files
 	$(MAKE) DECODER=$(DECODER) citus_top_builddir="../../../../.." \
-		citus_subdir=$(DECODER_BUILD_DIR) \
 		-C $(DECODER_BUILD_DIR) install
 
 cdc:

--- a/src/backend/distributed/cdc/Makefile
+++ b/src/backend/distributed/cdc/Makefile
@@ -3,13 +3,20 @@ ifndef DECODER
 endif
 
 MODULE_big = citus_$(DECODER)
-citus_subdir = src/backend/distributed/cdc
-citus_top_builddir = ../../../..
+
 citus_decoders_dir = $(DESTDIR)$(pkglibdir)/citus_decoders
+
+# Set the default value to citus_top_builddir as relative path to the
+# citus top directory from current directory.
+ifeq ($(strip $(citus_top_builddir)),)
+citus_top_builddir = ../../../..
+citus_subdir = $(shell pwd)
+endif
 
 OBJS += cdc_decoder.o cdc_decoder_utils.o
 
 include $(citus_top_builddir)/Makefile.global
+
 
 override CFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
 override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include

--- a/src/backend/distributed/cdc/Makefile
+++ b/src/backend/distributed/cdc/Makefile
@@ -32,7 +32,6 @@ install-cdc-decoders:
 	$(foreach base_decoder,$(cdc_base_decoders),$(MAKE) DECODER=$(base_decoder) -C build-cdc-$(base_decoder) install;)
 
 clean-cdc-decoders:
-	$(foreach base_decoder,$(cdc_base_decoders),$(MAKE) DECODER=$(base_decoder) -C build-cdc-$(base_decoder) clean;)
 	$(foreach base_decoder,$(cdc_base_decoders),rm -rf build-cdc-$(base_decoder);)
 
 

--- a/src/backend/distributed/cdc/Makefile
+++ b/src/backend/distributed/cdc/Makefile
@@ -1,55 +1,46 @@
-ifndef DECODER
-	DECODER = pgoutput
-endif
-
-MODULE_big = citus_$(DECODER)
-
-citus_decoders_dir = $(DESTDIR)$(pkglibdir)/citus_decoders
-
-# Set the default value to citus_top_builddir as relative path to the
-# citus top directory from current directory.
-ifeq ($(strip $(citus_top_builddir)),)
 citus_top_builddir = ../../../..
-citus_subdir = src/backend/distributed/cdc
-endif
-
-OBJS += cdc_decoder.o cdc_decoder_utils.o
-
 include $(citus_top_builddir)/Makefile.global
 
-override CFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
-override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
+citus_subdir = src/backend/distributed/cdc
 SRC_DIR = $(citus_abs_top_srcdir)/$(citus_subdir)
 
-all: cdc_pgouput cdc_wal2json
+#List of supported based decoders. Add new decoders here.
+cdc_base_decoders :=pgoutput wal2json
 
-copy_decoder_files_to_build_dir:
+all: build-cdc-decoders
+
+copy-decoder-files-to-build-dir:
+	$(eval DECODER_BUILD_DIR=build-cdc-$(DECODER))
 	mkdir -p $(DECODER_BUILD_DIR)
 	@for file in $(SRC_DIR)/*.c $(SRC_DIR)/*.h; do \
 		if [ -f $$file ]; then \
-			if ! diff -q $$file $(DECODER_BUILD_DIR)/$$(basename $$file); then \
+			if [ -f $(DECODER_BUILD_DIR)/$$(basename $$file) ]; then \
+				if ! diff -q $$file $(DECODER_BUILD_DIR)/$$(basename $$file); then \
+					cp $$file $(DECODER_BUILD_DIR)/$$(basename $$file); \
+				fi \
+			else \
 				cp $$file $(DECODER_BUILD_DIR)/$$(basename $$file); \
 			fi \
 		fi \
 	done
 	cp $(SRC_DIR)/Makefile.decoder $(DECODER_BUILD_DIR)/Makefile
 
-cdc_pgouput:
-	$(MAKE) DECODER_BUILD_DIR=build_pgoutput copy_decoder_files_to_build_dir
-	$(MAKE) DECODER=pgoutput -C build_pgoutput
+build-cdc-decoders:
+	$(foreach base_decoder,$(cdc_base_decoders),$(MAKE) DECODER=$(base_decoder) build-cdc-decoder;)
 
-cdc_wal2json:
-	$(MAKE) DECODER_BUILD_DIR=build_wal2json copy_decoder_files_to_build_dir
-	$(MAKE) DECODER=wal2json -C build_wal2json
+install-cdc-decoders:
+	$(foreach base_decoder,$(cdc_base_decoders),$(MAKE) DECODER=$(base_decoder) -C build-cdc-$(base_decoder) install;)
 
-install: install-cdc
+clean-cdc-decoders:
+	$(foreach base_decoder,$(cdc_base_decoders),$(MAKE) DECODER=$(base_decoder) -C build-cdc-$(base_decoder) clean;)
+	$(foreach base_decoder,$(cdc_base_decoders),rm -rf build-cdc-$(base_decoder);)
 
-clean: clean-cdc
 
-install-cdc:
-	$(MAKE) DECODER=pgoutput -C build_pgoutput install
-	$(MAKE) DECODER=wal2json -C build_wal2json install
+build-cdc-decoder:
+	$(MAKE) DECODER=$(DECODER) copy-decoder-files-to-build-dir
+	$(MAKE) DECODER=$(DECODER) -C build-cdc-$(DECODER)
 
-clean-cdc:
-	rm -rf build_pgoutput build_wal2json
-	rm -f '$(DESTDIR)$(datadir)/$(datamoduledir)/citus_decoders/$(DECODER).so'
+install: install-cdc-decoders
+
+clean: clean-cdc-decoders
+

--- a/src/backend/distributed/cdc/Makefile
+++ b/src/backend/distributed/cdc/Makefile
@@ -19,19 +19,20 @@ include $(citus_top_builddir)/Makefile.global
 
 override CFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
 override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
+SRC_DIR = $(citus_abs_top_srcdir)/$(citus_subdir)
 
 all: cdc_pgouput cdc_wal2json
 
 copy_decoder_files_to_build_dir:
 	mkdir -p $(DECODER_BUILD_DIR)
-	@for file in *.c *.h; do \
+	@for file in $(SRC_DIR)/*.c $(SRC_DIR)/*.h; do \
 		if [ -f $$file ]; then \
 			if ! diff -q $$file $(DECODER_BUILD_DIR)/$$(basename $$file); then \
 				cp $$file $(DECODER_BUILD_DIR)/$$(basename $$file); \
 			fi \
 		fi \
 	done
-	cp Makefile.decoder $(DECODER_BUILD_DIR)/Makefile
+	cp $(SRC_DIR)/Makefile.decoder $(DECODER_BUILD_DIR)/Makefile
 
 cdc_pgouput:
 	$(MAKE) DECODER_BUILD_DIR=build_pgoutput copy_decoder_files_to_build_dir

--- a/src/backend/distributed/cdc/Makefile
+++ b/src/backend/distributed/cdc/Makefile
@@ -10,24 +10,45 @@ citus_decoders_dir = $(DESTDIR)$(pkglibdir)/citus_decoders
 # citus top directory from current directory.
 ifeq ($(strip $(citus_top_builddir)),)
 citus_top_builddir = ../../../..
-citus_subdir = $(shell pwd)
+citus_subdir = src/backend/distributed/cdc
 endif
 
 OBJS += cdc_decoder.o cdc_decoder_utils.o
 
 include $(citus_top_builddir)/Makefile.global
 
-
 override CFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
 override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
+
+all: cdc_pgouput cdc_wal2json
+
+copy_decoder_files_to_build_dir:
+	mkdir -p $(DECODER_BUILD_DIR)
+	@for file in *.c *.h; do \
+		if [ -f $$file ]; then \
+			if ! diff -q $$file $(DECODER_BUILD_DIR)/$$(basename $$file); then \
+				cp $$file $(DECODER_BUILD_DIR)/$$(basename $$file); \
+			fi \
+		fi \
+	done
+	cp Makefile.decoder $(DECODER_BUILD_DIR)/Makefile
+
+cdc_pgouput:
+	$(MAKE) DECODER_BUILD_DIR=build_pgoutput copy_decoder_files_to_build_dir
+	$(MAKE) DECODER=pgoutput -C build_pgoutput
+
+cdc_wal2json:
+	$(MAKE) DECODER_BUILD_DIR=build_wal2json copy_decoder_files_to_build_dir
+	$(MAKE) DECODER=wal2json -C build_wal2json
 
 install: install-cdc
 
 clean: clean-cdc
 
 install-cdc:
-	mkdir -p '$(citus_decoders_dir)'
-	$(INSTALL_SHLIB) citus_$(DECODER).so '$(citus_decoders_dir)/$(DECODER).so'
+	$(MAKE) DECODER=pgoutput -C build_pgoutput install
+	$(MAKE) DECODER=wal2json -C build_wal2json install
 
 clean-cdc:
+	rm -rf build_pgoutput build_wal2json
 	rm -f '$(DESTDIR)$(datadir)/$(datamoduledir)/citus_decoders/$(DECODER).so'

--- a/src/backend/distributed/cdc/Makefile.decoder
+++ b/src/backend/distributed/cdc/Makefile.decoder
@@ -1,7 +1,3 @@
-ifndef DECODER
-	DECODER = pgoutput
-endif
-
 MODULE_big = citus_$(DECODER)
 
 citus_decoders_dir = $(DESTDIR)$(pkglibdir)/citus_decoders

--- a/src/backend/distributed/cdc/Makefile.decoder
+++ b/src/backend/distributed/cdc/Makefile.decoder
@@ -1,0 +1,28 @@
+ifndef DECODER
+	DECODER = pgoutput
+endif
+
+MODULE_big = citus_$(DECODER)
+
+citus_decoders_dir = $(DESTDIR)$(pkglibdir)/citus_decoders
+
+citus_top_builddir = ../../../../..
+citus_subdir = src/backend/distributed/cdc/cdc_$(DECODER)
+
+OBJS += cdc_decoder.o cdc_decoder_utils.o
+
+include $(citus_top_builddir)/Makefile.global
+
+override CFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
+override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
+
+install: install-cdc
+
+clean: clean-cdc
+
+install-cdc:
+	mkdir -p '$(citus_decoders_dir)'
+	$(INSTALL_SHLIB) citus_$(DECODER).so '$(citus_decoders_dir)/$(DECODER).so'
+
+clean-cdc:
+	rm -f '$(DESTDIR)$(datadir)/$(datamoduledir)/citus_decoders/$(DECODER).so'

--- a/src/test/cdc/t/016_cdc_wal2json.pl
+++ b/src/test/cdc/t/016_cdc_wal2json.pl
@@ -46,6 +46,6 @@ if ($output =~ /$change_string_expected/) {
 }
 
 is($result, 1, 'CDC create_distributed_table - wal2json test');
-my $output = $node_coordinator->safe_psql('postgres',"SELECT pg_drop_replication_slot('cdc_replication_slot');");
+$node_coordinator->safe_psql('postgres',"SELECT pg_drop_replication_slot('cdc_replication_slot');");
 
 done_testing();

--- a/src/test/cdc/t/016_cdc_wal2json.pl
+++ b/src/test/cdc/t/016_cdc_wal2json.pl
@@ -16,8 +16,6 @@ my $result = 0;
 ### Create the citus cluster with coordinator and two worker nodes
 our ($node_coordinator, @workers) = create_citus_cluster(1,"localhost",57636);
 
-our $node_cdc_client = create_node('cdc_client', 0, "localhost", 57639);
-
 print("coordinator port: " . $node_coordinator->port() . "\n");
 print("worker0 port:" . $workers[0]->port() . "\n");
 
@@ -29,16 +27,13 @@ my $initial_schema = "
 
 $node_coordinator->safe_psql('postgres',$initial_schema);
 $node_coordinator->safe_psql('postgres','ALTER TABLE data_100008 REPLICA IDENTITY FULL;');
-
-$node_cdc_client->safe_psql('postgres',$initial_schema);
-
 $node_coordinator->safe_psql('postgres',"SELECT pg_catalog.pg_create_logical_replication_slot('cdc_replication_slot','wal2json');");
 
 #insert data into the data_100008 table in the coordinator node before distributing the table.
 $node_coordinator->safe_psql('postgres',"
   	INSERT INTO data_100008
   SELECT i, 'my test data ' || i
-  FROM generate_series(0,0)i;");
+  FROM generate_series(-1,1)i;");
 
 my $output = $node_coordinator->safe_psql('postgres',"SELECT * FROM pg_logical_slot_get_changes('cdc_replication_slot', NULL, NULL);");
 print($output);
@@ -51,6 +46,6 @@ if ($output =~ /$change_string_expected/) {
 }
 
 is($result, 1, 'CDC create_distributed_table - wal2json test');
+my $output = $node_coordinator->safe_psql('postgres',"SELECT pg_drop_replication_slot('cdc_replication_slot');");
 
-#$node_cdc_client->safe_psql('postgres',"drop subscription cdc_subscription");
 done_testing();

--- a/src/test/cdc/t/016_cdc_wal2json.pl
+++ b/src/test/cdc/t/016_cdc_wal2json.pl
@@ -1,0 +1,56 @@
+# Schema change CDC test for Citus
+use strict;
+use warnings;
+
+use Test::More;
+
+use lib './t';
+use cdctestlib;
+
+use threads;
+
+# Initialize co-ordinator node
+my $select_stmt = qq(SELECT * FROM data_100008 ORDER BY id;);
+my $result = 0;
+
+### Create the citus cluster with coordinator and two worker nodes
+our ($node_coordinator, @workers) = create_citus_cluster(1,"localhost",57636);
+
+our $node_cdc_client = create_node('cdc_client', 0, "localhost", 57639);
+
+print("coordinator port: " . $node_coordinator->port() . "\n");
+print("worker0 port:" . $workers[0]->port() . "\n");
+
+my $initial_schema = "
+        CREATE TABLE data_100008(
+                id  integer,
+                data text,
+                PRIMARY KEY (data));";
+
+$node_coordinator->safe_psql('postgres',$initial_schema);
+$node_coordinator->safe_psql('postgres','ALTER TABLE data_100008 REPLICA IDENTITY FULL;');
+
+$node_cdc_client->safe_psql('postgres',$initial_schema);
+
+$node_coordinator->safe_psql('postgres',"SELECT pg_catalog.pg_create_logical_replication_slot('cdc_replication_slot','wal2json');");
+
+#insert data into the data_100008 table in the coordinator node before distributing the table.
+$node_coordinator->safe_psql('postgres',"
+  	INSERT INTO data_100008
+  SELECT i, 'my test data ' || i
+  FROM generate_series(0,0)i;");
+
+my $output = $node_coordinator->safe_psql('postgres',"SELECT * FROM pg_logical_slot_get_changes('cdc_replication_slot', NULL, NULL);");
+print($output);
+
+my $change_string_expected = '[0,"my test data 0"]';
+if ($output =~ /$change_string_expected/) {
+  $result = 1;
+} else {
+  $result = 0;
+}
+
+is($result, 1, 'CDC create_distributed_table - wal2json test');
+
+#$node_cdc_client->safe_psql('postgres',"drop subscription cdc_subscription");
+done_testing();


### PR DESCRIPTION
DESCRIPTION: 

1) CHnaged src/backend/distributed/Makefile to setup a build directory for CDC in build/ dir and copy the source files (.c.h and Makefile) to the build dir and start building.

2) copy the pgoutput.so and wal2json.so into the above build dir and install them in PG

3)Added a testcase 016_cdc_wal2json.pl for testing the wal2json decoder using pg_recv_logical_changes function.
