### PR TITLE
Push down window functions more liberally if the table doesn't have a dist key

### DIFF
--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -422,38 +422,14 @@ IsOuterJoinExpr(Node *node)
 bool
 SafeToPushdownWindowFunction(Query *query, StringInfo *errorDetail)
 {
-	ListCell *windowClauseCell = NULL;
-	List *windowClauseList = query->windowClause;
-
-	/*
-	 * We need to check each window clause separately if there is a partition by clause
-	 * and if it is partitioned on the distribution column.
-	 */
-	foreach(windowClauseCell, windowClauseList)
-	{
-		WindowClause *windowClause = lfirst(windowClauseCell);
-
-		if (!windowClause->partitionClause)
-		{
-			if (errorDetail)
-			{
-				*errorDetail = makeStringInfo();
-				appendStringInfoString(*errorDetail,
-									   "Window functions without PARTITION BY on distribution "
-									   "column is currently unsupported");
-			}
-			return false;
-		}
-	}
-
 	if (!WindowPartitionOnDistributionColumn(query))
 	{
 		if (errorDetail)
 		{
 			*errorDetail = makeStringInfo();
 			appendStringInfoString(*errorDetail,
-								   "Window functions with PARTITION BY list missing distribution "
-								   "column is currently unsupported");
+								   "Window functions should have a PARTITION BY clause list "
+								   "that contains distribution column");
 		}
 		return false;
 	}


### PR DESCRIPTION
Do not require using PARTITION BY clause to push down a query having
window functions unnecessarily.

WindowPartitionOnDistributionColumn anyway returns true (and hence
allows pushing down the query) if none of the relations that the
window functions in the query doesn't reference a relation that
has a shard key.

This would be mostly useful for the reference tables, local tables
added to metadata and the distributed tables that don't have a shard
key (in future).

TODO: Need to add a few tests by setting "client_min_messages" to "debug2".