### PR TITLE
fixes update propagation bug when `citus_set_coordinator_host` is called more than once

### DIFF
--- a/src/test/regress/expected/failure_mx_metadata_sync_multi_trans.out
+++ b/src/test/regress/expected/failure_mx_metadata_sync_multi_trans.out
@@ -52,11 +52,27 @@ CREATE TABLE loc1 (id int PRIMARY KEY);
 INSERT INTO loc1 SELECT i FROM generate_series(1,100) i;
 CREATE TABLE loc2 (id int REFERENCES loc1(id));
 INSERT INTO loc2 SELECT i FROM generate_series(1,100) i;
+-- citus_set_coordinator_host with wrong port
+SELECT citus_set_coordinator_host('localhost', 9999);
+ citus_set_coordinator_host
+---------------------------------------------------------------------
+
+(1 row)
+
+-- citus_set_coordinator_host with correct port
 SELECT citus_set_coordinator_host('localhost', :master_port);
  citus_set_coordinator_host
 ---------------------------------------------------------------------
 
 (1 row)
+
+-- show coordinator port is correct on all workers
+SELECT * FROM run_command_on_workers($$SELECT row(nodename,nodeport) FROM pg_dist_node WHERE groupid = 0$$);
+ nodename  | nodeport | success |      result
+---------------------------------------------------------------------
+ localhost |     9060 | t       | (localhost,57636)
+ localhost |    57637 | t       | (localhost,57636)
+(2 rows)
 
 SELECT citus_add_local_table_to_metadata('loc1', cascade_via_foreign_keys => true);
  citus_add_local_table_to_metadata

--- a/src/test/regress/sql/failure_mx_metadata_sync_multi_trans.sql
+++ b/src/test/regress/sql/failure_mx_metadata_sync_multi_trans.sql
@@ -42,7 +42,12 @@ INSERT INTO loc1 SELECT i FROM generate_series(1,100) i;
 CREATE TABLE loc2 (id int REFERENCES loc1(id));
 INSERT INTO loc2 SELECT i FROM generate_series(1,100) i;
 
+-- citus_set_coordinator_host with wrong port
+SELECT citus_set_coordinator_host('localhost', 9999);
+-- citus_set_coordinator_host with correct port
 SELECT citus_set_coordinator_host('localhost', :master_port);
+-- show coordinator port is correct on all workers
+SELECT * FROM run_command_on_workers($$SELECT row(nodename,nodeport) FROM pg_dist_node WHERE groupid = 0$$);
 SELECT citus_add_local_table_to_metadata('loc1', cascade_via_foreign_keys => true);
 
 -- Create partitioned distributed table


### PR DESCRIPTION
DESCRIPTION: Fixes update propagation bug when `citus_set_coordinator_host` is called more than once.

Fixes https://github.com/citusdata/citus/issues/6731.