### PR TITLE
Add build-cdc-* temporary directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ lib*.pc
 /Makefile.global
 /src/Makefile.custom
 /compile_commands.json
+/src/backend/distributed/cdc/build-cdc-*/*
+/src/test/cdc/tmp_check/*
+
 
 # temporary files vim creates
 *.swp


### PR DESCRIPTION
The CDC decoder buillds different versions of CDC base decoders during the build. Since the source files are copied to the temporay directories, they come in git status for files to be added. So these directories and a temporary CDC TAP test directory(tmpcheck) are added to .gitignore file.