### PR TITLE
Add CPU usage to citus_stat_tenants

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_stat_tenants/11.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_stat_tenants/11.3-1.sql
@@ -8,6 +8,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_tenants (
     OUT read_count_in_last_period INT,
     OUT query_count_in_this_period INT,
     OUT query_count_in_last_period INT,
+    OUT cpu_usage_in_this_period DOUBLE PRECISION,
+    OUT cpu_usage_in_last_period DOUBLE PRECISION,
     OUT score BIGINT
 )
     RETURNS SETOF record
@@ -51,6 +53,8 @@ AS (
     read_count_in_last_period INT,
     query_count_in_this_period INT,
     query_count_in_last_period INT,
+    cpu_usage_in_this_period DOUBLE PRECISION,
+    cpu_usage_in_last_period DOUBLE PRECISION,
     score BIGINT
 )
     ORDER BY score DESC
@@ -66,7 +70,9 @@ SELECT
     read_count_in_this_period,
     read_count_in_last_period,
     query_count_in_this_period,
-    query_count_in_last_period
+    query_count_in_last_period,
+    cpu_usage_in_this_period,
+    cpu_usage_in_last_period
 FROM pg_catalog.citus_stat_tenants(FALSE);
 
 ALTER VIEW citus.citus_stat_tenants SET SCHEMA pg_catalog;

--- a/src/backend/distributed/sql/udfs/citus_stat_tenants/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_stat_tenants/latest.sql
@@ -8,6 +8,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_tenants (
     OUT read_count_in_last_period INT,
     OUT query_count_in_this_period INT,
     OUT query_count_in_last_period INT,
+    OUT cpu_usage_in_this_period DOUBLE PRECISION,
+    OUT cpu_usage_in_last_period DOUBLE PRECISION,
     OUT score BIGINT
 )
     RETURNS SETOF record
@@ -51,6 +53,8 @@ AS (
     read_count_in_last_period INT,
     query_count_in_this_period INT,
     query_count_in_last_period INT,
+    cpu_usage_in_this_period DOUBLE PRECISION,
+    cpu_usage_in_last_period DOUBLE PRECISION,
     score BIGINT
 )
     ORDER BY score DESC
@@ -66,7 +70,9 @@ SELECT
     read_count_in_this_period,
     read_count_in_last_period,
     query_count_in_this_period,
-    query_count_in_last_period
+    query_count_in_last_period,
+    cpu_usage_in_this_period,
+    cpu_usage_in_last_period
 FROM pg_catalog.citus_stat_tenants(FALSE);
 
 ALTER VIEW citus.citus_stat_tenants SET SCHEMA pg_catalog;

--- a/src/backend/distributed/sql/udfs/citus_stat_tenants_local/11.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_stat_tenants_local/11.3-1.sql
@@ -6,6 +6,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_tenants_local(
     OUT read_count_in_last_period INT,
     OUT query_count_in_this_period INT,
     OUT query_count_in_last_period INT,
+    OUT cpu_usage_in_this_period DOUBLE PRECISION,
+    OUT cpu_usage_in_last_period DOUBLE PRECISION,
     OUT score BIGINT)
 RETURNS SETOF RECORD
 LANGUAGE C
@@ -19,7 +21,9 @@ SELECT
     read_count_in_this_period,
     read_count_in_last_period,
     query_count_in_this_period,
-    query_count_in_last_period
+    query_count_in_last_period,
+    cpu_usage_in_this_period,
+    cpu_usage_in_last_period
 FROM pg_catalog.citus_stat_tenants_local()
 ORDER BY score DESC;
 

--- a/src/backend/distributed/sql/udfs/citus_stat_tenants_local/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_stat_tenants_local/latest.sql
@@ -6,6 +6,8 @@ CREATE OR REPLACE FUNCTION pg_catalog.citus_stat_tenants_local(
     OUT read_count_in_last_period INT,
     OUT query_count_in_this_period INT,
     OUT query_count_in_last_period INT,
+    OUT cpu_usage_in_this_period DOUBLE PRECISION,
+    OUT cpu_usage_in_last_period DOUBLE PRECISION,
     OUT score BIGINT)
 RETURNS SETOF RECORD
 LANGUAGE C
@@ -19,7 +21,9 @@ SELECT
     read_count_in_this_period,
     read_count_in_last_period,
     query_count_in_this_period,
-    query_count_in_last_period
+    query_count_in_last_period,
+    cpu_usage_in_this_period,
+    cpu_usage_in_last_period
 FROM pg_catalog.citus_stat_tenants_local()
 ORDER BY score DESC;
 

--- a/src/include/distributed/utils/citus_stat_tenants.h
+++ b/src/include/distributed/utils/citus_stat_tenants.h
@@ -42,6 +42,13 @@ typedef struct TenantStats
 	int writesInLastPeriod;
 	int writesInThisPeriod;
 
+
+	/*
+	 * CPU time usage of this tenant in this and last periods.
+	 */
+	double cpuUsageInLastPeriod;
+	double cpuUsageInThisPeriod;
+
 	/*
 	 * The latest time this tenant ran a query. This value is used to update the score later.
 	 */

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -71,14 +71,14 @@ INSERT INTO dist_tbl VALUES (2, 'abcd');
 UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
 UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
 DELETE FROM dist_tbl WHERE a = 5;
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
 ---------------------------------------------------------------------
- 1                |                         0 |                         0 |                          1 |                          0
- 2                |                         0 |                         0 |                          1 |                          0
- 3                |                         0 |                         0 |                          1 |                          0
- 4                |                         0 |                         0 |                          1 |                          0
- 5                |                         0 |                         0 |                          1 |                          0
+ 1                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 2                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 3                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 4                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t        | f
 (5 rows)
 
 SELECT citus_stat_tenants_reset();
@@ -241,11 +241,11 @@ SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 
 INSERT INTO dist_tbl VALUES (5, 'abcd');
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
 ---------------------------------------------------------------------
- 1                |                         1 |                         0 |                          1 |                          0
- 5                |                         0 |                         0 |                          1 |                          0
+ 1                |                         1 |                         0 |                          1 |                          0 | t        | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t        | f
 (2 rows)
 
 -- simulate passing the period
@@ -256,11 +256,11 @@ SELECT sleep_until_next_period();
 
 (1 row)
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
 ---------------------------------------------------------------------
- 1                |                         0 |                         1 |                          0 |                          1
- 5                |                         0 |                         0 |                          0 |                          1
+ 1                |                         0 |                         1 |                          0 |                          1 | f        | t
+ 5                |                         0 |                         0 |                          0 |                          1 | f        | t
 (2 rows)
 
 SELECT sleep_until_next_period();

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -71,14 +71,17 @@ INSERT INTO dist_tbl VALUES (2, 'abcd');
 UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
 UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
 DELETE FROM dist_tbl WHERE a = 5;
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants(true)
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
 ---------------------------------------------------------------------
- 1                |                         0 |                         0 |                          1 |                          0 | t        | f
- 2                |                         0 |                         0 |                          1 |                          0 | t        | f
- 3                |                         0 |                         0 |                          1 |                          0 | t        | f
- 4                |                         0 |                         0 |                          1 |                          0 | t        | f
- 5                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 1                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 2                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 3                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 4                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t                          | f
 (5 rows)
 
 SELECT citus_stat_tenants_reset();
@@ -241,11 +244,14 @@ SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 
 INSERT INTO dist_tbl VALUES (5, 'abcd');
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
 ---------------------------------------------------------------------
- 1                |                         1 |                         0 |                          1 |                          0 | t        | f
- 5                |                         0 |                         0 |                          1 |                          0 | t        | f
+ 1                |                         1 |                         0 |                          1 |                          0 | t                          | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t                          | f
 (2 rows)
 
 -- simulate passing the period
@@ -256,11 +262,14 @@ SELECT sleep_until_next_period();
 
 (1 row)
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | ?column? | ?column?
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
 ---------------------------------------------------------------------
- 1                |                         0 |                         1 |                          0 |                          1 | f        | t
- 5                |                         0 |                         0 |                          0 |                          1 | f        | t
+ 1                |                         0 |                         1 |                          0 |                          1 | f                          | t
+ 5                |                         0 |                         0 |                          0 |                          1 | f                          | t
 (2 rows)
 
 SELECT sleep_until_next_period();
@@ -269,11 +278,14 @@ SELECT sleep_until_next_period();
 
 (1 row)
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
 ---------------------------------------------------------------------
- 1                |                         0 |                         0 |                          0 |                          0
- 5                |                         0 |                         0 |                          0 |                          0
+ 1                |                         0 |                         0 |                          0 |                          0 | f                          | f
+ 5                |                         0 |                         0 |                          0 |                          0 | f                          | f
 (2 rows)
 
 \c - - - :master_port

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -35,7 +35,10 @@ UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
 UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
 DELETE FROM dist_tbl WHERE a = 5;
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants(true)
+ORDER BY tenant_attribute;
 
 SELECT citus_stat_tenants_reset();
 
@@ -84,17 +87,26 @@ SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 INSERT INTO dist_tbl VALUES (5, 'abcd');
 
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
 
 -- simulate passing the period
 SET citus.stat_tenants_period TO 2;
 SELECT sleep_until_next_period();
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
 
 SELECT sleep_until_next_period();
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants_local
+ORDER BY tenant_attribute;
 
 \c - - - :master_port
 SET search_path TO citus_stat_tenants;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -35,7 +35,7 @@ UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
 UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
 DELETE FROM dist_tbl WHERE a = 5;
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
 
 SELECT citus_stat_tenants_reset();
 
@@ -84,13 +84,13 @@ SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 INSERT INTO dist_tbl VALUES (5, 'abcd');
 
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
 
 -- simulate passing the period
 SET citus.stat_tenants_period TO 2;
 SELECT sleep_until_next_period();
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period, (cpu_usage_in_this_period>0), (cpu_usage_in_last_period>0) FROM citus_stat_tenants_local ORDER BY tenant_attribute;
 
 SELECT sleep_until_next_period();
 


### PR DESCRIPTION
This PR adds CPU usage to `citus_stat_tenants` monitor.
CPU usage is tracked in periods, similar to query counts.