### PR TITLE
When creating a HTAB we need to use HASH_COMPARE  flag in order to set a user defined comparison function.

### DIFF
--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1810,7 +1810,7 @@ CreateWorkerForPlacementSet(List *workersForPlacementList)
 	/* we don't have value field as it's a set */
 	info.entrysize = info.keysize;
 
-	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+	uint32 hashFlags = (HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT | HASH_COMPARE);
 
 	HTAB *workerForPlacementSet = hash_create("worker placement set", 32, &info,
 											  hashFlags);


### PR DESCRIPTION
DESCRIPTION: Fixes an uninitialized memory access in shard split API

When running Citus tests under Postgres with valgrind, the test cases calling into `NonBlockingShardSplit` function produce valgrind errors of type "conditional jump or move depends on uninitialized value".  

The issue is caused by creating a HTAB in a wrong way. HASH_COMPARE flag should have been used when creating a HTAB with user defined comparison function.  In the absence of HASH_COMPARE flag, HTAB falls back into built-in string comparison function.  However, valgrind somehow discovers that the match function is not assigned to the user defined function as intended.

Fixes #6835