### PR TITLE
Add support for creating distributed tables without shard key

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -134,7 +134,6 @@ static List * HashSplitPointsForShardList(List *shardList);
 static List * HashSplitPointsForShardCount(int shardCount);
 static List * WorkerNodesForShardList(List *shardList);
 static List * RoundRobinWorkerNodeList(List *workerNodeList, int listLength);
-static void CreateNullShardKeyDistTable(Oid relationId, char *colocateWithTableName);
 static CitusTableParams DecideCitusTableParams(CitusTableType tableType,
 											   DistributedTableParams *
 											   distributedTableParams);
@@ -1031,7 +1030,7 @@ CreateReferenceTable(Oid relationId)
  * CreateNullShardKeyDistTable is a wrapper around CreateCitusTable that creates a
  * single shard distributed table that doesn't have a shard key.
  */
-static void
+void
 CreateNullShardKeyDistTable(Oid relationId, char *colocateWithTableName)
 {
 	DistributedTableParams distributedTableParams = {

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -134,6 +134,7 @@ static List * HashSplitPointsForShardList(List *shardList);
 static List * HashSplitPointsForShardCount(int shardCount);
 static List * WorkerNodesForShardList(List *shardList);
 static List * RoundRobinWorkerNodeList(List *workerNodeList, int listLength);
+static void CreateNullShardKeyDistTable(Oid relationId, char *colocateWithTableName);
 static CitusTableParams DecideCitusTableParams(CitusTableType tableType,
 											   DistributedTableParams *
 											   distributedTableParams);
@@ -141,6 +142,8 @@ static void CreateCitusTable(Oid relationId, CitusTableType tableType,
 							 DistributedTableParams *distributedTableParams);
 static void CreateHashDistributedTableShards(Oid relationId, int shardCount,
 											 Oid colocatedTableId, bool localTableEmpty);
+static void CreateNullShardKeyDistTableShard(Oid relationId, Oid colocatedTableId,
+											 uint32 colocationId);
 static uint32 ColocationIdForNewTable(Oid relationId, CitusTableType tableType,
 									  DistributedTableParams *distributedTableParams,
 									  Var *distributionColumn);
@@ -216,51 +219,86 @@ create_distributed_table(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 
-	if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(3))
 	{
 		PG_RETURN_VOID();
 	}
 
 	Oid relationId = PG_GETARG_OID(0);
-	text *distributionColumnText = PG_GETARG_TEXT_P(1);
+	text *distributionColumnText = PG_ARGISNULL(1) ? NULL : PG_GETARG_TEXT_P(1);
 	Oid distributionMethodOid = PG_GETARG_OID(2);
 	text *colocateWithTableNameText = PG_GETARG_TEXT_P(3);
 	char *colocateWithTableName = text_to_cstring(colocateWithTableNameText);
 
 	bool shardCountIsStrict = false;
-	int shardCount = ShardCount;
-	if (!PG_ARGISNULL(4))
+	if (distributionColumnText)
 	{
-		if (pg_strncasecmp(colocateWithTableName, "default", NAMEDATALEN) != 0 &&
-			pg_strncasecmp(colocateWithTableName, "none", NAMEDATALEN) != 0)
+		if (PG_ARGISNULL(2))
 		{
-			ereport(ERROR, (errmsg("Cannot use colocate_with with a table "
-								   "and shard_count at the same time")));
+			PG_RETURN_VOID();
 		}
 
-		shardCount = PG_GETARG_INT32(4);
+		int shardCount = ShardCount;
+		if (!PG_ARGISNULL(4))
+		{
+			if (!IsColocateWithDefault(colocateWithTableName) &&
+				!IsColocateWithNone(colocateWithTableName))
+			{
+				ereport(ERROR, (errmsg("Cannot use colocate_with with a table "
+									   "and shard_count at the same time")));
+			}
 
-		/*
-		 * if shard_count parameter is given than we have to
-		 * make sure table has that many shards
-		 */
-		shardCountIsStrict = true;
+			shardCount = PG_GETARG_INT32(4);
+
+			/*
+			 * If shard_count parameter is given, then we have to
+			 * make sure table has that many shards.
+			 */
+			shardCountIsStrict = true;
+		}
+
+		char *distributionColumnName = text_to_cstring(distributionColumnText);
+		Assert(distributionColumnName != NULL);
+
+		char distributionMethod = LookupDistributionMethod(distributionMethodOid);
+
+		if (shardCount < 1 || shardCount > MAX_SHARD_COUNT)
+		{
+			ereport(ERROR, (errmsg("%d is outside the valid range for "
+								   "parameter \"shard_count\" (1 .. %d)",
+								   shardCount, MAX_SHARD_COUNT)));
+		}
+
+		CreateDistributedTable(relationId, distributionColumnName, distributionMethod,
+							   shardCount, shardCountIsStrict, colocateWithTableName);
 	}
-
-	char *distributionColumnName = text_to_cstring(distributionColumnText);
-	Assert(distributionColumnName != NULL);
-
-	char distributionMethod = LookupDistributionMethod(distributionMethodOid);
-
-	if (shardCount < 1 || shardCount > MAX_SHARD_COUNT)
+	else
 	{
-		ereport(ERROR, (errmsg("%d is outside the valid range for "
-							   "parameter \"shard_count\" (1 .. %d)",
-							   shardCount, MAX_SHARD_COUNT)));
-	}
+		if (!PG_ARGISNULL(4))
+		{
+			ereport(ERROR, (errmsg("shard_count can't be specified when the "
+								   "distribution column is null because in "
+								   "that case it's automatically set to 1")));
+		}
 
-	CreateDistributedTable(relationId, distributionColumnName, distributionMethod,
-						   shardCount, shardCountIsStrict, colocateWithTableName);
+		if (!PG_ARGISNULL(2) &&
+			LookupDistributionMethod(PG_GETARG_OID(2)) != DISTRIBUTE_BY_HASH)
+		{
+			/*
+			 * As we do for shard_count parameter, we could throw an error if
+			 * distribution_type is not NULL when creating a null-shard-key table.
+			 * However, this requires changing the default value of distribution_type
+			 * parameter to NULL and this would mean a breaking change for most
+			 * users because they're mostly using this API to create sharded
+			 * tables. For this reason, here we instead do nothing if the distribution
+			 * method is DISTRIBUTE_BY_HASH.
+			 */
+			ereport(ERROR, (errmsg("distribution_type can't be specified "
+								   "when the distribution column is null ")));
+		}
+
+		CreateNullShardKeyDistTable(relationId, colocateWithTableName);
+	}
 
 	PG_RETURN_VOID();
 }
@@ -276,9 +314,16 @@ create_distributed_table_concurrently(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 
-	if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(2) || PG_ARGISNULL(3))
 	{
 		PG_RETURN_VOID();
+	}
+
+	if (PG_ARGISNULL(1))
+	{
+		ereport(ERROR, (errmsg("cannot use create_distributed_table_concurrently "
+							   "to create a distributed table with a null shard "
+							   "key, consider using create_distributed_table()")));
 	}
 
 	Oid relationId = PG_GETARG_OID(0);
@@ -983,6 +1028,23 @@ CreateReferenceTable(Oid relationId)
 
 
 /*
+ * CreateNullShardKeyDistTable is a wrapper around CreateCitusTable that creates a
+ * single shard distributed table that doesn't have a shard key.
+ */
+static void
+CreateNullShardKeyDistTable(Oid relationId, char *colocateWithTableName)
+{
+	DistributedTableParams distributedTableParams = {
+		.colocateWithTableName = colocateWithTableName,
+		.shardCount = 1,
+		.shardCountIsStrict = true,
+		.distributionColumnName = NULL
+	};
+	CreateCitusTable(relationId, NULL_KEY_DISTRIBUTED_TABLE, &distributedTableParams);
+}
+
+
+/*
  * CreateCitusTable is the internal method that creates a Citus table in
  * given configuration.
  *
@@ -1000,7 +1062,8 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 				 DistributedTableParams *distributedTableParams)
 {
 	if ((tableType == HASH_DISTRIBUTED || tableType == APPEND_DISTRIBUTED ||
-		 tableType == RANGE_DISTRIBUTED) != (distributedTableParams != NULL))
+		 tableType == RANGE_DISTRIBUTED || tableType == NULL_KEY_DISTRIBUTED_TABLE) !=
+		(distributedTableParams != NULL))
 	{
 		ereport(ERROR, (errmsg("distributed table params must be provided "
 							   "when creating a distributed table and must "
@@ -1078,7 +1141,7 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 	PropagatePrerequisiteObjectsForDistributedTable(relationId);
 
 	Var *distributionColumn = NULL;
-	if (distributedTableParams)
+	if (distributedTableParams && distributedTableParams->distributionColumnName)
 	{
 		distributionColumn = BuildDistributionKeyFromColumnName(relationId,
 																distributedTableParams->
@@ -1150,6 +1213,11 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 	{
 		CreateReferenceTableShard(relationId);
 	}
+	else if (tableType == NULL_KEY_DISTRIBUTED_TABLE)
+	{
+		CreateNullShardKeyDistTableShard(relationId, colocatedTableId,
+										 colocationId);
+	}
 
 	if (ShouldSyncTableMetadata(relationId))
 	{
@@ -1204,7 +1272,8 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 	}
 
 	/* copy over data for hash distributed and reference tables */
-	if (tableType == HASH_DISTRIBUTED || tableType == REFERENCE_TABLE)
+	if (tableType == HASH_DISTRIBUTED || tableType == NULL_KEY_DISTRIBUTED_TABLE ||
+		tableType == REFERENCE_TABLE)
 	{
 		if (RegularTable(relationId))
 		{
@@ -1265,6 +1334,13 @@ DecideCitusTableParams(CitusTableType tableType,
 				DecideDistTableReplicationModel(RANGE_DISTRIBUTED,
 												distributedTableParams->
 												colocateWithTableName);
+			break;
+		}
+
+		case NULL_KEY_DISTRIBUTED_TABLE:
+		{
+			citusTableParams.distributionMethod = DISTRIBUTE_BY_NONE;
+			citusTableParams.replicationModel = REPLICATION_MODEL_STREAMING;
 			break;
 		}
 
@@ -1631,6 +1707,41 @@ CreateHashDistributedTableShards(Oid relationId, int shardCount,
 
 
 /*
+ * CreateHashDistributedTableShards creates the shard of given null-shard-key
+ * distributed table.
+ */
+static void
+CreateNullShardKeyDistTableShard(Oid relationId, Oid colocatedTableId,
+								 uint32 colocationId)
+{
+	if (colocatedTableId != InvalidOid)
+	{
+		/*
+		 * We currently allow concurrent distribution of colocated tables (which
+		 * we probably should not be allowing because of foreign keys /
+		 * partitioning etc).
+		 *
+		 * We also prevent concurrent shard moves / copy / splits) while creating
+		 * a colocated table.
+		 */
+		AcquirePlacementColocationLock(colocatedTableId, ShareLock,
+									   "colocate distributed table");
+
+		/*
+		 * We don't need to force using exclusive connections because we're anyway
+		 * creating a single shard.
+		 */
+		bool useExclusiveConnection = false;
+		CreateColocatedShards(relationId, colocatedTableId, useExclusiveConnection);
+	}
+	else
+	{
+		CreateNullKeyShardWithRoundRobinPolicy(relationId, colocationId);
+	}
+}
+
+
+/*
  * ColocationIdForNewTable returns a colocation id for given table
  * according to given configuration. If there is no such configuration, it
  * creates one and returns colocation id of newly the created colocation group.
@@ -1662,8 +1773,8 @@ ColocationIdForNewTable(Oid relationId, CitusTableType tableType,
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot distribute relation"),
-							errdetail("Currently, colocate_with option is only supported "
-									  "for hash distributed tables.")));
+							errdetail("Currently, colocate_with option is not supported "
+									  "for append / range distributed tables.")));
 		}
 
 		return colocationId;
@@ -1679,10 +1790,11 @@ ColocationIdForNewTable(Oid relationId, CitusTableType tableType,
 		 * can be sure that there will no modifications on the colocation table
 		 * until this transaction is committed.
 		 */
-		Assert(citusTableParams.distributionMethod == DISTRIBUTE_BY_HASH);
 
-		Oid distributionColumnType = distributionColumn->vartype;
-		Oid distributionColumnCollation = get_typcollation(distributionColumnType);
+		Oid distributionColumnType =
+			distributionColumn ? distributionColumn->vartype : InvalidOid;
+		Oid distributionColumnCollation =
+			distributionColumn ? get_typcollation(distributionColumnType) : InvalidOid;
 
 		/* get an advisory lock to serialize concurrent default group creations */
 		if (IsColocateWithDefault(distributedTableParams->colocateWithTableName))
@@ -1871,8 +1983,15 @@ EnsureRelationCanBeDistributed(Oid relationId, Var *distributionColumn,
 	 */
 	if (PartitionedTableNoLock(relationId))
 	{
-		/* distributing partitioned tables in only supported for hash-distribution */
-		if (distributionMethod != DISTRIBUTE_BY_HASH)
+		/*
+		 * Distributing partitioned tables is only supported for hash-distribution
+		 * or null-shard-key tables.
+		 */
+		bool isNullShardKeyTable =
+			distributionMethod == DISTRIBUTE_BY_NONE &&
+			replicationModel == REPLICATION_MODEL_STREAMING &&
+			colocationId != INVALID_COLOCATION_ID;
+		if (distributionMethod != DISTRIBUTE_BY_HASH && !isNullShardKeyTable)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("distributing partitioned tables in only supported "

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2146,6 +2146,7 @@ CitusCopyDestReceiverStartup(DestReceiver *dest, int operation,
 	}
 
 	if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) &&
+		!IsCitusTableTypeCacheEntry(cacheEntry, NULL_KEY_DISTRIBUTED_TABLE) &&
 		copyDest->partitionColumnIndex == INVALID_PARTITION_COLUMN_INDEX)
 	{
 		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -324,7 +324,8 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
 
-		if (IsCitusTable(relationId) && !HasDistributionKey(relationId) &&
+		if ((IsCitusTableType(relationId, REFERENCE_TABLE) ||
+			 IsCitusTableType(relationId, CITUS_LOCAL_TABLE)) &&
 			TableReferenced(relationId))
 		{
 			char *relationName = get_rel_name(relationId);

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -508,11 +508,21 @@ IsCitusTableTypeInternal(char partitionMethod, char replicationModel,
 			return partitionMethod == DISTRIBUTE_BY_RANGE;
 		}
 
+		case NULL_KEY_DISTRIBUTED_TABLE:
+		{
+			return partitionMethod == DISTRIBUTE_BY_NONE &&
+				   replicationModel != REPLICATION_MODEL_2PC &&
+				   colocationId != INVALID_COLOCATION_ID;
+		}
+
 		case DISTRIBUTED_TABLE:
 		{
 			return partitionMethod == DISTRIBUTE_BY_HASH ||
 				   partitionMethod == DISTRIBUTE_BY_RANGE ||
-				   partitionMethod == DISTRIBUTE_BY_APPEND;
+				   partitionMethod == DISTRIBUTE_BY_APPEND ||
+				   (partitionMethod == DISTRIBUTE_BY_NONE &&
+					replicationModel != REPLICATION_MODEL_2PC &&
+					colocationId != INVALID_COLOCATION_ID);
 		}
 
 		case STRICTLY_PARTITIONED_DISTRIBUTED_TABLE:
@@ -812,6 +822,21 @@ IsCitusLocalTableByDistParams(char partitionMethod, char replicationModel,
 	return partitionMethod == DISTRIBUTE_BY_NONE &&
 		   replicationModel != REPLICATION_MODEL_2PC &&
 		   colocationId == INVALID_COLOCATION_ID;
+}
+
+
+/*
+ * IsNullShardKeyTableByDistParams returns true if given partitionMethod,
+ * replicationModel and colocationId would identify a distributed table that
+ * has a null shard key.
+ */
+bool
+IsNullShardKeyTableByDistParams(char partitionMethod, char replicationModel,
+								uint32 colocationId)
+{
+	return partitionMethod == DISTRIBUTE_BY_NONE &&
+		   replicationModel != REPLICATION_MODEL_2PC &&
+		   colocationId != INVALID_COLOCATION_ID;
 }
 
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -515,7 +515,7 @@ ShouldSyncUserCommandForObject(ObjectAddress objectAddress)
 /*
  * ShouldSyncTableMetadata checks if the metadata of a distributed table should be
  * propagated to metadata workers, i.e. the table is a hash distributed table or
- * reference/citus local table.
+ * a Citus table that doesn't have shard key.
  */
 bool
 ShouldSyncTableMetadata(Oid relationId)
@@ -537,10 +537,11 @@ ShouldSyncTableMetadata(Oid relationId)
 
 
 /*
- * ShouldSyncTableMetadataViaCatalog checks if the metadata of a distributed table should
- * be propagated to metadata workers, i.e. the table is an MX table or reference table.
+ * ShouldSyncTableMetadataViaCatalog checks if the metadata of a Citus table should
+ * be propagated to metadata workers, i.e. the table is an MX table or Citus table
+ * that doesn't have shard key.
  * Tables with streaming replication model (which means RF=1) and hash distribution are
- * considered as MX tables while tables with none distribution are reference tables.
+ * considered as MX tables.
  *
  * ShouldSyncTableMetadataViaCatalog does not use the CitusTableCache and instead reads
  * from catalog tables directly.
@@ -1080,7 +1081,7 @@ EnsureObjectMetadataIsSane(int distributionArgumentIndex, int colocationId)
 
 /*
  * DistributionCreateCommands generates a commands that can be
- * executed to replicate the metadata for a distributed table.
+ * executed to replicate the metadata for a Citus table.
  */
 char *
 DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -217,9 +217,9 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
 	List *insertedShardPlacements = NIL;
 	List *insertedShardIds = NIL;
 
-	/* make sure that tables are hash partitioned */
-	CheckHashPartitionedTable(targetRelationId);
-	CheckHashPartitionedTable(sourceRelationId);
+	CitusTableCacheEntry *targetCacheEntry = GetCitusTableCacheEntry(targetRelationId);
+	Assert(targetCacheEntry->partitionMethod == DISTRIBUTE_BY_HASH ||
+		   targetCacheEntry->partitionMethod == DISTRIBUTE_BY_NONE);
 
 	/*
 	 * In contrast to append/range partitioned tables it makes more sense to
@@ -259,10 +259,20 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
 		*newShardIdPtr = GetNextShardId();
 		insertedShardIds = lappend(insertedShardIds, newShardIdPtr);
 
-		int32 shardMinValue = DatumGetInt32(sourceShardInterval->minValue);
-		int32 shardMaxValue = DatumGetInt32(sourceShardInterval->maxValue);
-		text *shardMinValueText = IntegerToText(shardMinValue);
-		text *shardMaxValueText = IntegerToText(shardMaxValue);
+		text *shardMinValueText = NULL;
+		text *shardMaxValueText = NULL;
+		if (targetCacheEntry->partitionMethod == DISTRIBUTE_BY_NONE)
+		{
+			Assert(list_length(sourceShardIntervalList) == 1);
+		}
+		else
+		{
+			int32 shardMinValue = DatumGetInt32(sourceShardInterval->minValue);
+			int32 shardMaxValue = DatumGetInt32(sourceShardInterval->maxValue);
+			shardMinValueText = IntegerToText(shardMinValue);
+			shardMaxValueText = IntegerToText(shardMaxValue);
+		}
+
 		List *sourceShardPlacementList = ShardPlacementListSortedByWorker(
 			sourceShardId);
 
@@ -358,6 +368,70 @@ CreateReferenceTableShard(Oid distributedTableId)
 															 replicationFactor);
 
 	CreateShardsOnWorkers(distributedTableId, insertedShardPlacements,
+						  useExclusiveConnection, colocatedShard);
+}
+
+
+/*
+ * CreateNullKeyShardWithRoundRobinPolicy creates a single shard for the given
+ * distributedTableId. The created shard does not have min/max values.
+ * Unlike CreateReferenceTableShard, the shard is _not_ replicated to
+ * all nodes but would have a single placement like Citus local tables.
+ * However, this placement doesn't necessarily need to be placed on
+ * coordinator. This is determined based on modulo of the colocation
+ * id that given table has been associated to.
+ */
+void
+CreateNullKeyShardWithRoundRobinPolicy(Oid relationId, uint32 colocationId)
+{
+	EnsureTableOwner(relationId);
+
+	/* we plan to add shards: get an exclusive lock on relation oid */
+	LockRelationOid(relationId, ExclusiveLock);
+
+	/*
+	 * Load and sort the worker node list for deterministic placement.
+	 *
+	 * Also take a RowShareLock on pg_dist_node to disallow concurrent
+	 * node list changes that require an exclusive lock.
+	 */
+	List *workerNodeList = DistributedTablePlacementNodeList(RowShareLock);
+	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
+
+	int32 workerNodeCount = list_length(workerNodeList);
+	if (workerNodeCount == 0)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						errmsg("couldn't find any worker nodes"),
+						errhint("Add more worker nodes")));
+	}
+
+	char shardStorageType = ShardStorageType(relationId);
+	text *minHashTokenText = NULL;
+	text *maxHashTokenText = NULL;
+	uint64 shardId = GetNextShardId();
+	InsertShardRow(relationId, shardId, shardStorageType,
+				   minHashTokenText, maxHashTokenText);
+
+	/* determine the node index based on colocation id */
+	int roundRobinNodeIdx = colocationId % workerNodeCount;
+
+	int replicationFactor = 1;
+	List *insertedShardPlacements = InsertShardPlacementRows(
+		relationId,
+		shardId,
+		workerNodeList,
+		roundRobinNodeIdx,
+		replicationFactor);
+
+	/*
+	 * We don't need to force using exclusive connections because we're anyway
+	 * creating a single shard.
+	 */
+	bool useExclusiveConnection = false;
+
+	bool colocatedShard = false;
+	CreateShardsOnWorkers(relationId, insertedShardPlacements,
 						  useExclusiveConnection, colocatedShard);
 }
 

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -521,7 +521,8 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 	relationShard->shardId = shardInterval->shardId;
 	List *relationShardList = list_make1(relationShard);
 
-	if (IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) &&
+	if ((IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) ||
+		 IsCitusTableTypeCacheEntry(cacheEntry, NULL_KEY_DISTRIBUTED_TABLE)) &&
 		cacheEntry->colocationId != INVALID_COLOCATION_ID)
 	{
 		shardIndex = ShardIndex(shardInterval);

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1025,6 +1025,17 @@ CreateDistributedPlan(uint64 planId, bool allowRecursivePlanning, Query *origina
 	{
 		return distributedPlan;
 	}
+	else if (ContainsNullDistKeyTable(originalQuery))
+	{
+		/*
+		 * We only support router queries if the query contains reference to
+		 * a null-dist-key table. This temporary restriction will be removed
+		 * once we support recursive planning for the queries that reference
+		 * null-dist-key tables.
+		 */
+		WrapRouterErrorForNullDistKeyTable(distributedPlan->planningError);
+		RaiseDeferredError(distributedPlan->planningError, ERROR);
+	}
 	else
 	{
 		RaiseDeferredError(distributedPlan->planningError, DEBUG2);
@@ -2463,6 +2474,18 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 
 
 /*
+ * ContainsNullDistKeyTable returns true if given query contains reference
+ * to a null-dist-key table.
+ */
+bool
+ContainsNullDistKeyTable(Query *query)
+{
+	RTEListProperties *rteListProperties = GetRTEListPropertiesForQuery(query);
+	return rteListProperties->hasDistTableWithoutShardKey;
+}
+
+
+/*
  * GetRTEListPropertiesForQuery is a wrapper around GetRTEListProperties that
  * returns RTEListProperties for the rte list retrieved from query.
  */
@@ -2538,6 +2561,15 @@ GetRTEListProperties(List *rangeTableList)
 		else if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE))
 		{
 			rteListProperties->hasDistributedTable = true;
+
+			if (!HasDistributionKeyCacheEntry(cacheEntry))
+			{
+				rteListProperties->hasDistTableWithoutShardKey = true;
+			}
+			else
+			{
+				rteListProperties->hasDistTableWithShardKey = true;
+			}
 		}
 		else
 		{

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -212,19 +212,22 @@ FastPathRouterQuery(Query *query, Node **distributionKeyValue)
 		return false;
 	}
 
+	/*
+	 * If the table doesn't have a distribution column, we don't need to
+	 * check anything further.
+	 */
+	Var *distributionKey = PartitionColumn(distributedTableId, 1);
+	if (!distributionKey)
+	{
+		return true;
+	}
+
 	/* WHERE clause should not be empty for distributed tables */
 	if (joinTree == NULL ||
 		(IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) && joinTree->quals ==
 		 NULL))
 	{
 		return false;
-	}
-
-	/* if that's a reference table, we don't need to check anything further */
-	Var *distributionKey = PartitionColumn(distributedTableId, 1);
-	if (!distributionKey)
-	{
-		return true;
 	}
 
 	/* convert list of expressions into expression tree for further processing */

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -715,6 +715,13 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 								 NULL, NULL);
 		}
 	}
+	else if (IsCitusTableType(targetRelationId, NULL_KEY_DISTRIBUTED_TABLE))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "distributed INSERT ... SELECT cannot target a distributed "
+							 "table with a null shard key",
+							 NULL, NULL);
+	}
 	else
 	{
 		/*

--- a/src/backend/distributed/planner/merge_planner.c
+++ b/src/backend/distributed/planner/merge_planner.c
@@ -524,6 +524,11 @@ InsertDistributionColumnMatchesSource(Query *query, RangeTblEntry *resultRte)
 		return NULL;
 	}
 
+	if (!HasDistributionKey(resultRte->relid))
+	{
+		return NULL;
+	}
+
 	bool foundDistributionColumn = false;
 	MergeAction *action = NULL;
 	foreach_ptr(action, query->mergeActionList)

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -1404,7 +1404,7 @@ DistPartitionKeyOrError(Oid relationId)
 	if (partitionKey == NULL)
 	{
 		ereport(ERROR, (errmsg(
-							"no distribution column found for relation %d, because it is a reference table",
+							"no distribution column found for relation %d",
 							relationId)));
 	}
 

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -272,7 +272,7 @@ TargetListOnPartitionColumn(Query *query, List *targetEntryList)
 	if (!targetListOnPartitionColumn)
 	{
 		if (!FindNodeMatchingCheckFunctionInRangeTableList(query->rtable,
-														   IsDistributedTableRTE))
+														   IsTableWithDistKeyRTE))
 		{
 			targetListOnPartitionColumn = true;
 		}
@@ -376,6 +376,20 @@ IsReferenceTableRTE(Node *node)
 {
 	Oid relationId = NodeTryGetRteRelid(node);
 	return relationId != InvalidOid && IsCitusTableType(relationId, REFERENCE_TABLE);
+}
+
+
+/*
+ * IsTableWithDistKeyRTE gets a node and returns true if the node
+ * is a range table relation entry that points to a distributed table
+ * that has a distribution column.
+ */
+bool
+IsTableWithDistKeyRTE(Node *node)
+{
+	Oid relationId = NodeTryGetRteRelid(node);
+	return relationId != InvalidOid && IsCitusTable(relationId) &&
+		   HasDistributionKey(relationId);
 }
 
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2487,7 +2487,7 @@ QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 			/* non-distributed tables have only one shard */
 			shardInterval = cacheEntry->sortedShardIntervalArray[0];
 
-			/* only use reference table as anchor shard if none exists yet */
+			/* use as anchor shard only if we couldn't find any yet */
 			if (anchorShardId == INVALID_SHARD_ID)
 			{
 				anchorShardId = shardInterval->shardId;

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -259,6 +259,22 @@ CreateModifyPlan(Query *originalQuery, Query *query,
 
 
 /*
+ * WrapRouterErrorForNullDistKeyTable wraps given planning error with a
+ * generic error message if given query references a distributed table
+ * that doesn't have a distribution key.
+ */
+void
+WrapRouterErrorForNullDistKeyTable(DeferredErrorMessage *planningError)
+{
+	planningError->detail = planningError->message;
+	planningError->message = pstrdup("queries that reference a distributed "
+									 "table without a shard key can only "
+									 "reference colocated distributed "
+									 "tables or reference tables");
+}
+
+
+/*
  * CreateSingleTaskRouterSelectPlan creates a physical plan for given SELECT query.
  * The returned plan is a router task that returns query results from a single worker.
  * If not router plannable, the returned plan's planningError describes the problem.
@@ -1870,6 +1886,11 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 		 */
 		if (IsMergeQuery(originalQuery))
 		{
+			if (ContainsNullDistKeyTable(originalQuery))
+			{
+				WrapRouterErrorForNullDistKeyTable(*planningError);
+			}
+
 			RaiseDeferredError(*planningError, ERROR);
 		}
 		else
@@ -3854,7 +3875,8 @@ ErrorIfQueryHasUnroutableModifyingCTE(Query *queryTree)
 			CitusTableCacheEntry *modificationTableCacheEntry =
 				GetCitusTableCacheEntry(distributedTableId);
 
-			if (!HasDistributionKeyCacheEntry(modificationTableCacheEntry))
+			if (!IsCitusTableTypeCacheEntry(modificationTableCacheEntry,
+											DISTRIBUTED_TABLE))
 			{
 				return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 									 "cannot router plan modification of a non-distributed table",

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -195,7 +195,7 @@ RecordRelationAccessIfNonDistTable(Oid relationId, ShardPlacementAccessType acce
 	 * recursively calling RecordRelationAccessBase(), so becareful about
 	 * removing this check.
 	 */
-	if (IsCitusTable(relationId) && HasDistributionKey(relationId))
+	if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
 	{
 		return;
 	}
@@ -732,7 +732,7 @@ CheckConflictingRelationAccesses(Oid relationId, ShardPlacementAccessType access
 
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
-	if (HasDistributionKeyCacheEntry(cacheEntry) ||
+	if (IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE) ||
 		cacheEntry->referencingRelationsViaForeignKey == NIL)
 	{
 		return;
@@ -931,7 +931,7 @@ HoldsConflictingLockWithReferencedRelations(Oid relationId, ShardPlacementAccess
 		 * We're only interested in foreign keys to reference tables and citus
 		 * local tables.
 		 */
-		if (IsCitusTable(referencedRelation) && HasDistributionKey(referencedRelation))
+		if (IsCitusTableType(referencedRelation, DISTRIBUTED_TABLE))
 		{
 			continue;
 		}
@@ -993,7 +993,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 	bool holdsConflictingLocks = false;
 
-	Assert(!HasDistributionKeyCacheEntry(cacheEntry));
+	Assert(!IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE));
 
 	Oid referencingRelation = InvalidOid;
 	foreach_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)

--- a/src/backend/distributed/utils/distribution_column.c
+++ b/src/backend/distributed/utils/distribution_column.c
@@ -135,7 +135,7 @@ BuildDistributionKeyFromColumnName(Oid relationId, char *columnName, LOCKMODE lo
 
 	char *tableName = get_rel_name(relationId);
 
-	/* short circuit for reference tables */
+	/* short circuit for reference tables and null-shard key tables */
 	if (columnName == NULL)
 	{
 		return NULL;

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -206,7 +206,7 @@ CompareRelationShards(const void *leftElement, const void *rightElement)
  *
  * For hash partitioned tables, it calculates hash value of a number in its
  * range (e.g. min value) and finds which shard should contain the hashed
- * value. For reference tables and citus local tables, it simply returns 0.
+ * value. For the tables that don't have a shard key, it simply returns 0.
  * For the other table types, the function errors out.
  */
 int
@@ -231,12 +231,11 @@ ShardIndex(ShardInterval *shardInterval)
 							   "tables that are added to citus metadata")));
 	}
 
-	/* short-circuit for reference tables */
+	/* short-circuit for the tables that don't have a distribution key */
 	if (!HasDistributionKeyCacheEntry(cacheEntry))
 	{
 		/*
-		 * Reference tables and citus local tables have only a single shard,
-		 * so the index is fixed to 0.
+		 * Such tables have only a single shard, so the index is fixed to 0.
 		 */
 		shardIndex = 0;
 

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -262,6 +262,7 @@ extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shard
 extern void CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId,
 								  bool useExclusiveConnections);
 extern void CreateReferenceTableShard(Oid distributedTableId);
+extern void CreateNullKeyShardWithRoundRobinPolicy(Oid relationId, uint32 colocationId);
 extern List * WorkerCreateShardCommandList(Oid relationId, int shardIndex, uint64 shardId,
 										   List *ddlCommandList,
 										   List *foreignConstraintCommandList);

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -147,8 +147,18 @@ typedef struct RTEListProperties
 	bool hasReferenceTable;
 	bool hasCitusLocalTable;
 
-	/* includes hash, append and range partitioned tables */
+	/* includes hash, null dist key, append and range partitioned tables */
 	bool hasDistributedTable;
+
+	/*
+	 * Effectively, hasDistributedTable is equal to
+	 *  "hasDistTableWithShardKey || hasDistTableWithoutShardKey".
+	 *
+	 * We provide below two for the callers that want to know what kind of
+	 * distributed tables that given query has references to.
+	 */
+	bool hasDistTableWithShardKey;
+	bool hasDistTableWithoutShardKey;
 
 	/* union of hasReferenceTable, hasCitusLocalTable and hasDistributedTable */
 	bool hasCitusTable;
@@ -243,6 +253,7 @@ extern int32 BlessRecordExpression(Expr *expr);
 extern void DissuadePlannerFromUsingPlan(PlannedStmt *plan);
 extern PlannedStmt * FinalizePlan(PlannedStmt *localPlan,
 								  struct DistributedPlan *distributedPlan);
+extern bool ContainsNullDistKeyTable(Query *query);
 extern RTEListProperties * GetRTEListPropertiesForQuery(Query *query);
 
 

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -123,6 +123,7 @@ typedef enum
 	HASH_DISTRIBUTED,
 	APPEND_DISTRIBUTED,
 	RANGE_DISTRIBUTED,
+	NULL_KEY_DISTRIBUTED_TABLE,
 
 	/* hash, range or append distributed table */
 	DISTRIBUTED_TABLE,
@@ -157,6 +158,8 @@ extern uint32 ColocationIdViaCatalog(Oid relationId);
 bool IsReferenceTableByDistParams(char partitionMethod, char replicationModel);
 extern bool IsCitusLocalTableByDistParams(char partitionMethod, char replicationModel,
 										  uint32 colocationId);
+extern bool IsNullShardKeyTableByDistParams(char partitionMethod, char replicationModel,
+											uint32 colocationId);
 extern List * CitusTableList(void);
 extern ShardInterval * LoadShardInterval(uint64 shardId);
 extern bool ShardExists(uint64 shardId);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -326,6 +326,7 @@ extern void DeletePartitionRow(Oid distributedRelationId);
 extern void DeleteShardRow(uint64 shardId);
 extern void UpdatePlacementGroupId(uint64 placementId, int groupId);
 extern void DeleteShardPlacementRow(uint64 placementId);
+extern void CreateNullShardKeyDistTable(Oid relationId, char *colocateWithTableName);
 extern void CreateDistributedTable(Oid relationId, char *distributionColumnName,
 								   char distributionMethod, int shardCount,
 								   bool shardCountIsStrict, char *colocateWithTableName);

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -200,6 +200,7 @@ extern bool IsCitusTableRTE(Node *node);
 extern bool IsDistributedOrReferenceTableRTE(Node *node);
 extern bool IsDistributedTableRTE(Node *node);
 extern bool IsReferenceTableRTE(Node *node);
+extern bool IsTableWithDistKeyRTE(Node *node);
 extern bool IsCitusExtraDataContainerRelation(RangeTblEntry *rte);
 extern bool ContainsReadIntermediateResultFunction(Node *node);
 extern bool ContainsReadIntermediateResultArrayFunction(Node *node);

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -36,6 +36,7 @@ extern DistributedPlan * CreateRouterPlan(Query *originalQuery, Query *query,
 extern DistributedPlan * CreateModifyPlan(Query *originalQuery, Query *query,
 										  PlannerRestrictionContext *
 										  plannerRestrictionContext);
+extern void WrapRouterErrorForNullDistKeyTable(DeferredErrorMessage *planningError);
 extern DeferredErrorMessage * PlanRouterQuery(Query *originalQuery,
 											  PlannerRestrictionContext *
 											  plannerRestrictionContext,

--- a/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
+++ b/src/test/regress/citus_tests/arbitrary_configs/citus_arbitrary_configs.py
@@ -76,6 +76,17 @@ def run_for_config(config, lock, sql_schedule_name):
             cfg.SUPER_USER_NAME,
         )
         common.save_regression_diff("postgres", config.output_dir)
+    elif config.all_null_dist_key:
+        exitCode |= common.run_pg_regress_without_exit(
+            config.bindir,
+            config.pg_srcdir,
+            config.coordinator_port(),
+            cfg.NULL_DIST_KEY_PREP_SCHEDULE,
+            config.output_dir,
+            config.input_dir,
+            cfg.SUPER_USER_NAME,
+        )
+        common.save_regression_diff("null_dist_key_prep_regression", config.output_dir)
 
     exitCode |= _run_pg_regress_on_port(
         config, config.coordinator_port(), cfg.CREATE_SCHEDULE

--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -234,12 +234,6 @@ class AllNullDistKeyDefaultConfig(CitusDefaultClusterConfig):
             # group 8
             "function_create",
             "functions",
-            # group 9
-            "merge_arbitrary_create",
-            "merge_arbitrary",
-            # group 10
-            "arbitrary_configs_router_create",
-            "arbitrary_configs_router",
             #
             # ii) Skip the following test as it requires support for create_distributed_function.
             "nested_execution",

--- a/src/test/regress/citus_tests/config.py
+++ b/src/test/regress/citus_tests/config.py
@@ -20,6 +20,7 @@ ARBITRARY_SCHEDULE_NAMES = [
     "sql_schedule",
     "sql_base_schedule",
     "postgres_schedule",
+    "null_dist_key_prep_schedule",
 ]
 
 BEFORE_PG_UPGRADE_SCHEDULE = "./before_pg_upgrade_schedule"
@@ -27,6 +28,7 @@ AFTER_PG_UPGRADE_SCHEDULE = "./after_pg_upgrade_schedule"
 
 CREATE_SCHEDULE = "./create_schedule"
 POSTGRES_SCHEDULE = "./postgres_schedule"
+NULL_DIST_KEY_PREP_SCHEDULE = "./null_dist_key_prep_schedule"
 SQL_SCHEDULE = "./sql_schedule"
 SQL_BASE_SCHEDULE = "./sql_base_schedule"
 
@@ -98,6 +100,7 @@ class CitusBaseClusterConfig(object, metaclass=NewInitCaller):
         self.user = REGULAR_USER_NAME
         self.is_mx = True
         self.is_citus = True
+        self.all_null_dist_key = False
         self.name = type(self).__name__
         self.settings = {
             "shared_preload_libraries": "citus",
@@ -197,6 +200,49 @@ class PostgresConfig(CitusDefaultClusterConfig):
             # Alter Table statement cannot be run from an arbitrary node so this test will fail
             "arbitrary_configs_alter_table_add_constraint_without_name_create",
             "arbitrary_configs_alter_table_add_constraint_without_name",
+        ]
+
+
+class AllNullDistKeyDefaultConfig(CitusDefaultClusterConfig):
+    def __init__(self, arguments):
+        super().__init__(arguments)
+        self.all_null_dist_key = True
+        self.skip_tests += [
+            # i) Skip the following tests because they require SQL support beyond
+            #    router planner / supporting more DDL command types.
+            #
+            # group 1
+            "dropped_columns_create_load",
+            "dropped_columns_1",
+            # group 2
+            "distributed_planning_create_load",
+            "distributed_planning",
+            # group 4
+            "views_create",
+            "views",
+            # group 5
+            "intermediate_result_pruning_create",
+            "intermediate_result_pruning_queries_1",
+            "intermediate_result_pruning_queries_2",
+            # group 6
+            "local_dist_join_load",
+            "local_dist_join",
+            "arbitrary_configs_recurring_outer_join",
+            # group 7
+            "sequences_create",
+            "sequences",
+            # group 8
+            "function_create",
+            "functions",
+            # group 9
+            "merge_arbitrary_create",
+            "merge_arbitrary",
+            # group 10
+            "arbitrary_configs_router_create",
+            "arbitrary_configs_router",
+            #
+            # ii) Skip the following test as it requires support for create_distributed_function.
+            "nested_execution",
         ]
 
 

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -128,6 +128,7 @@ DEPS = {
     "multi_mx_copy_data": TestDeps(None, ["multi_mx_create_table"]),
     "multi_mx_schema_support": TestDeps(None, ["multi_mx_copy_data"]),
     "multi_simple_queries": TestDeps("base_schedule"),
+    "create_null_dist_key": TestDeps("minimal_schedule"),
 }
 
 

--- a/src/test/regress/expected/create_null_dist_key.out
+++ b/src/test/regress/expected/create_null_dist_key.out
@@ -1796,6 +1796,7 @@ ALTER TABLE trigger_table_3 ENABLE TRIGGER ALL;
 -- try a few simple queries at least to make sure that we don't crash
 BEGIN;
   INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
+ERROR:  cannot select from a non-colocated distributed table when inserting into a distributed table that does not have a shard key
 ROLLBACK;
 DROP TRIGGER IF EXISTS trigger_1 ON trigger_table_1;
 DROP TRIGGER trigger_2 ON trigger_table_2 CASCADE;

--- a/src/test/regress/expected/create_null_dist_key.out
+++ b/src/test/regress/expected/create_null_dist_key.out
@@ -497,7 +497,8 @@ SELECT * FROM null_dist_key_table_2 ORDER BY a;
 DROP TABLE null_dist_key_table_1, null_dist_key_table_2;
 -- create indexes before creating the null dist key tables
 -- .. for an initially empty table
-CREATE TABLE null_dist_key_table_1(a int);
+CREATE TABLE null_dist_key_table_1(a int, b int);
+CREATE STATISTICS s1 (dependencies) ON a, b FROM null_dist_key_table_1;
 CREATE INDEX null_dist_key_table_1_idx ON null_dist_key_table_1(a);
 SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
  create_distributed_table
@@ -505,6 +506,7 @@ SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'n
 
 (1 row)
 
+CREATE STATISTICS s2 (dependencies) ON a, b FROM null_dist_key_table_1;
 -- .. and for another table having data in it before creating null dist key table
 CREATE TABLE null_dist_key_table_2(a int);
 INSERT INTO null_dist_key_table_2 VALUES(1);
@@ -515,6 +517,11 @@ SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'n
 
 (1 row)
 
+-- test create index concurrently, then reindex
+CREATE INDEX CONCURRENTLY ind_conc ON null_dist_key_table_2(a);
+REINDEX INDEX ind_conc;
+REINDEX INDEX CONCURRENTLY ind_conc;
+DROP INDEX ind_conc;
 SELECT * FROM null_dist_key_table_2 ORDER BY a;
  a
 ---------------------------------------------------------------------
@@ -536,15 +543,23 @@ BEGIN;
   CREATE ROLE table_users;
   CREATE POLICY table_policy ON null_dist_key_table_3 TO table_users
       USING (table_user = current_user);
+  GRANT ALL ON TABLE null_dist_key_table_3 TO table_users;
+  ALTER TABLE null_dist_key_table_3 OWNER TO table_users;
   SELECT create_distributed_table('null_dist_key_table_3', null, colocate_with=>'none');
  create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
+  REVOKE ALL ON TABLE null_dist_key_table_3 FROM table_users;
+  ALTER TABLE null_dist_key_table_3 OWNER TO postgres;
+  GRANT ALL ON TABLE null_dist_key_table_3 TO table_users;
 ROLLBACK;
+ALTER STATISTICS s2 SET STATISTICS 46;
+ALTER TABLE null_dist_key_table_1 SET SCHEMA public;
+DROP STATISTICS s1, s2;
 -- drop them for next tests
-DROP TABLE null_dist_key_table_1, null_dist_key_table_2, distributed_table;
+DROP TABLE public.null_dist_key_table_1, null_dist_key_table_2, distributed_table;
 -- tests for object names that should be escaped properly
 CREATE SCHEMA "NULL_!_dist_key";
 CREATE TABLE "NULL_!_dist_key"."my_TABLE.1!?!"(id int, "Second_Id" int);
@@ -643,6 +658,341 @@ SELECT create_distributed_table('sensors', NULL, distribution_type=>null);
 
 (1 row)
 
+-- verify we can create new partitions after distributing the parent table
+CREATE TABLE sensors_2001 PARTITION OF sensors FOR VALUES FROM ('2001-01-01') TO ('2002-01-01');
+-- verify we can attach to a null dist key table
+CREATE TABLE sensors_2002 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+ALTER TABLE sensors ATTACH PARTITION sensors_2002 FOR VALUES FROM ('2002-01-01') TO ('2003-01-01');
+-- verify we can detach from a null dist key table
+ALTER TABLE sensors DETACH PARTITION sensors_2001;
+-- error out when attaching a noncolocated partition
+CREATE TABLE sensors_2003 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('sensors_2003', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE sensors ATTACH PARTITION sensors_2003 FOR VALUES FROM ('2003-01-01') TO ('2004-01-01');
+ERROR:  distributed tables cannot have non-colocated distributed tables as a partition
+DROP TABLE sensors_2003;
+-- verify we can attach after distributing, if the parent and partition are colocated
+CREATE TABLE sensors_2004 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('sensors_2004', NULL, distribution_type=>null, colocate_with=>'sensors');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE sensors ATTACH PARTITION sensors_2004 FOR VALUES FROM ('2004-01-01') TO ('2005-01-01');
+-- verify we can attach a citus local table
+CREATE TABLE sensors_2005 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT citus_add_local_table_to_metadata('sensors_2005');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE sensors ATTACH PARTITION sensors_2005 FOR VALUES FROM ('2005-01-01') TO ('2006-01-01');
+-- check metadata
+-- check all partitions and the parent on pg_dist_partition
+SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005') ORDER BY logicalrelid::text;
+ logicalrelid
+---------------------------------------------------------------------
+ sensors
+ sensors_2000
+ sensors_2001
+ sensors_2002
+ sensors_2004
+ sensors_2005
+(6 rows)
+
+-- verify they are all colocated
+SELECT COUNT(DISTINCT(colocationid)) FROM pg_dist_partition WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005');
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- verify all partitions are placed on the same node
+SELECT COUNT(DISTINCT(groupid)) FROM pg_dist_placement WHERE shardid IN
+    (SELECT shardid FROM pg_dist_shard WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005'));
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- verify the shard of sensors_2000 is attached to the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2000_1______';$$)
+    WHERE length(result) > 0;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- verify the shard of sensors_2001 is detached from the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2001_1______';$$)
+    WHERE length(result) > 0;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- verify the shard of sensors_2002 is attached to the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2002_1______';$$)
+    WHERE length(result) > 0;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- create a partitioned citus local table and verify we error out when attaching a partition with null dist key
+CREATE TABLE partitioned_citus_local_tbl(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+PRIMARY KEY (measureid, eventdatetime, measure_data))
+PARTITION BY RANGE(eventdatetime);
+SELECT citus_add_local_table_to_metadata('partitioned_citus_local_tbl');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE partition_with_null_key (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('partition_with_null_key', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE partitioned_citus_local_tbl ATTACH PARTITION partition_with_null_key FOR VALUES FROM ('2004-01-01') TO ('2005-01-01');
+ERROR:  non-distributed partitioned tables cannot have distributed partitions
+-- test partitioned tables + indexes with long names
+CREATE TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(
+  id int PRIMARY KEY,
+  "TeNANt_Id" int,
+  "jsondata" jsonb NOT NULL,
+  name text,
+  price numeric CHECK (price > 0),
+  serial_data bigserial, UNIQUE (id, price))
+  PARTITION BY LIST(id);
+CREATE TABLE "NULL_!_dist_key"."partition1_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (1);
+CREATE TABLE "NULL_!_dist_key"."partition2_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (2);
+CREATE TABLE "NULL_!_dist_key"."partition100_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (100);
+-- create some objects before create_distributed_table
+CREATE INDEX "my!Index1New" ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) WITH ( fillfactor = 80 ) WHERE  id > 10;
+CREATE UNIQUE INDEX uniqueIndexNew ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" (id);
+-- ingest some data before create_distributed_table
+set client_min_messages to ERROR;
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (1, 1, row_to_json(row(1,1), true)),
+                                     (2, 1, row_to_json(row(2,2), 'false'));
+reset client_min_messages;
+-- create a replica identity before create_distributed_table
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" REPLICA IDENTITY USING INDEX uniqueIndexNew;
+NOTICE:  identifier "nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" will be truncated to "nullKeyTable.1!?!9012345678901234567890123456789012345678901234"
+-- test triggers
+SET client_min_messages TO ERROR;
+CREATE FUNCTION insert_id_100() RETURNS trigger AS $insert_100$
+BEGIN
+    INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+    RETURN NEW;
+END;
+$insert_100$ LANGUAGE plpgsql;
+CREATE TABLE null_key_table_with_trigger(a INT);
+SELECT create_distributed_table('null_key_table_with_trigger', null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- try to add a trigger after distributing the table, fails
+CREATE TRIGGER insert_100_trigger
+    AFTER UPDATE ON null_key_table_with_trigger
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+ERROR:  triggers are not supported on distributed tables
+-- now try to distribute a table that already has a trigger on it
+CREATE TRIGGER insert_100_trigger
+    AFTER UPDATE ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+-- error out because of the trigger
+SELECT create_distributed_table('"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"', null);
+ERROR:  cannot distribute relation "nullKeyTable.1!?!9012345678901234567890123456789012345678901234" because it has triggers
+HINT:  Consider dropping all the triggers on "nullKeyTable.1!?!9012345678901234567890123456789012345678901234" and retry.
+SET citus.enable_unsafe_triggers TO ON;
+RESET client_min_messages;
+-- this shouldn't give any syntax errors
+SELECT create_distributed_table('"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"', null);
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$"NULL_!_dist_key"."partition1_nullKeyTable.1!?!90123456789012345678901234567890123"$$)
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$"NULL_!_dist_key"."partition2_nullKeyTable.1!?!90123456789012345678901234567890123"$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- now we can add triggers on distributed tables, because we set the GUC to on
+CREATE TRIGGER insert_100_trigger_2
+    AFTER UPDATE ON null_key_table_with_trigger
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+SET client_min_messages TO ERROR;
+UPDATE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" SET "TeNANt_Id"="TeNANt_Id"+1;
+-- we should see one row with id = 100
+SELECT COUNT(*) FROM "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" WHERE id = 100;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- create some objects after create_distributed_table
+CREATE INDEX "my!Index2New" ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) WITH ( fillfactor = 90 ) WHERE id < 20;
+CREATE UNIQUE INDEX uniqueIndex2New ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+-- error out for already existing, because of the unique index
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (1, 1, row_to_json(row(1,1), true));
+ERROR:  duplicate key value violates unique constraint "partition1_nullKeyTable.1!?!901234567890123456_bf4a8ac1_1730056"
+DETAIL:  Key (id)=(X) already exists.
+CONTEXT:  while executing command on localhost:xxxxx
+-- verify all 4 shard indexes are created on the same node
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*) FROM pg_indexes WHERE indexname LIKE '%my!Index_New_1%' OR indexname LIKE '%uniqueindex%new_1%';$$)
+    ORDER BY nodeport;
+ result
+---------------------------------------------------------------------
+ 4
+ 0
+(2 rows)
+
+-- foreign key to a ref table
+CREATE TABLE dummy_reference_table (a INT PRIMARY KEY);
+SELECT create_reference_table('dummy_reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+TRUNCATE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789";
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_ref FOREIGN KEY (id) REFERENCES dummy_reference_table(a);
+BEGIN; -- try to add the same fkey, reversed
+    ALTER TABLE dummy_reference_table
+        ADD CONSTRAINT fkey_to_dummy_ref FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+-- errors out because of foreign key violation
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+ERROR:  insert or update on table "partition100_nullKeyTable.1!?!9012345678901234_0aba0bf3_1730058" violates foreign key constraint "fkey_to_dummy_ref_1730055"
+DETAIL:  Key (id)=(X) is not present in table "dummy_reference_table_1730059".
+CONTEXT:  while executing command on localhost:xxxxx
+-- now inserts successfully
+INSERT INTO dummy_reference_table VALUES (100);
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+DELETE FROM "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" WHERE id = 100;
+-- foreign key to a local table, errors out
+CREATE TABLE local_table_for_fkey (a INT PRIMARY KEY);
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_local FOREIGN KEY (id) REFERENCES local_table_for_fkey(a);
+ERROR:  referenced table "local_table_for_fkey" must be a distributed table or a reference table
+DETAIL:  To enforce foreign keys, the referencing and referenced rows need to be stored on the same node.
+HINT:  You could use SELECT create_reference_table('local_table_for_fkey') to replicate the referenced table to all nodes or consider dropping the foreign key
+-- Normally, we support foreign keys from Postgres tables to distributed
+-- tables assuming that the user will soon distribute the local table too
+-- anyway. However, this is not the case for null-shard-key tables before
+-- we improve SQL support.
+ALTER TABLE local_table_for_fkey
+    ADD CONSTRAINT fkey_from_dummy_local FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+CONTEXT:  SQL statement "SELECT fk."a" FROM ONLY "create_null_dist_key"."local_table_for_fkey" fk LEFT OUTER JOIN "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234" pk ON ( pk."id" OPERATOR(pg_catalog.=) fk."a") WHERE pk."id" IS NULL AND (fk."a" IS NOT NULL)"
+-- foreign key to a citus local table, errors out
+CREATE TABLE citus_local_table_for_fkey (a INT PRIMARY KEY);
+SELECT citus_add_local_table_to_metadata('citus_local_table_for_fkey');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_citus_local FOREIGN KEY (id) REFERENCES citus_local_table_for_fkey(a);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+-- reversed, still fails
+ALTER TABLE citus_local_table_for_fkey
+    ADD CONSTRAINT fkey_from_dummy_citus_local FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+-- foreign key to a distributed table, errors out because not colocated
+CREATE TABLE dist_table_for_fkey (a INT PRIMARY KEY);
+SELECT create_distributed_table('dist_table_for_fkey', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES dist_table_for_fkey(a);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+-- reversed, still fails
+ALTER TABLE dist_table_for_fkey
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+-- create a null key distributed table, not colocated with the partitioned table, and then try to create a fkey
+CREATE TABLE null_key_dist_not_colocated (a INT PRIMARY KEY);
+SELECT create_distributed_table('null_key_dist_not_colocated', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES null_key_dist_not_colocated(a);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+-- create a null key distributed table, colocated with the partitioned table, and then create a fkey
+CREATE TABLE null_key_dist (a INT PRIMARY KEY);
+SELECT create_distributed_table('null_key_dist', null, colocate_with=>'"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES null_key_dist(a);
+-- check supported ON DELETE and ON UPDATE commands
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_1 FOREIGN KEY(a)
+    REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) ON DELETE SET DEFAULT;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_2 FOREIGN KEY(a)
+    REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) ON UPDATE CASCADE;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_3 FOREIGN KEY(a)
+    REFERENCES dummy_reference_table(a) ON DELETE SET DEFAULT;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_4 FOREIGN KEY(a)
+    REFERENCES dummy_reference_table(a) ON UPDATE CASCADE;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_1;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_2;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_3;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_4;
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" DROP CONSTRAINT fkey_to_dummy_dist;
+DELETE FROM null_key_dist;
+VACUUM null_key_dist;
+TRUNCATE null_key_dist;
+DROP TABLE null_key_dist;
+RESET client_min_messages;
 CREATE TABLE multi_level_partitioning_parent(
     measureid integer,
     eventdatetime date,
@@ -771,7 +1121,7 @@ BEGIN;
   INSERT INTO referencing_table VALUES (1, 2);
   -- fails
   INSERT INTO referencing_table VALUES (2, 2);
-ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730049"
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730098"
 DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
@@ -817,7 +1167,7 @@ BEGIN;
   INSERT INTO referencing_table VALUES (1, 2);
   -- fails
   INSERT INTO referencing_table VALUES (2, 2);
-ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730085"
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730134"
 DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
@@ -935,8 +1285,8 @@ SELECT result, success FROM run_command_on_workers($$
 $$);
                                                               result                                                              | success
 ---------------------------------------------------------------------
- ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730102" | f
- ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730102" | f
+ ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730151" | f
+ ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730151" | f
 (2 rows)
 
 DROP TABLE referencing_table, referenced_table;
@@ -951,8 +1301,8 @@ SELECT create_distributed_table('self_fkey_test', NULL, distribution_type=>null)
 
 INSERT INTO self_fkey_test VALUES (1, 1); -- ok
 INSERT INTO self_fkey_test VALUES (2, 3); -- fails
-ERROR:  insert or update on table "self_fkey_test_1730103" violates foreign key constraint "self_fkey_test_b_fkey_1730103"
-DETAIL:  Key (b)=(3) is not present in table "self_fkey_test_1730103".
+ERROR:  insert or update on table "self_fkey_test_1730152" violates foreign key constraint "self_fkey_test_b_fkey_1730152"
+DETAIL:  Key (b)=(3) is not present in table "self_fkey_test_1730152".
 CONTEXT:  while executing command on localhost:xxxxx
 -- similar foreign key tests but this time create the referencing table later on
 -- referencing table is a null shard key table
@@ -976,7 +1326,7 @@ BEGIN;
   INSERT INTO referencing_table VALUES (1, 2);
   -- fails
   INSERT INTO referencing_table VALUES (2, 2);
-ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730105"
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730154"
 DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
@@ -999,7 +1349,7 @@ BEGIN;
   INSERT INTO referencing_table VALUES (2, 1);
   -- fails
   INSERT INTO referencing_table VALUES (1, 2);
-ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_b_fkey_1730107"
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_b_fkey_1730156"
 DETAIL:  Key (a, b)=(1, 2) is not present in table "referenced_table_xxxxxxx".
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
@@ -1038,6 +1388,24 @@ BEGIN;
 
   CREATE TABLE referencing_table(a serial, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET DEFAULT);
   SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ERROR:  cannot create foreign key constraint since Citus does not support ON DELETE / UPDATE SET DEFAULT actions on the columns that default to sequences
+ROLLBACK;
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a serial, b int);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  ALTER TABLE referencing_table ADD CONSTRAINT fkey_to_dummy_ref_on_update FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET DEFAULT;
 ERROR:  cannot create foreign key constraint since Citus does not support ON DELETE / UPDATE SET DEFAULT actions on the columns that default to sequences
 ROLLBACK;
 -- to a non-colocated null dist key table
@@ -1088,7 +1456,7 @@ BEGIN;
   INSERT INTO referencing_table VALUES (1, 2);
   -- fails
   INSERT INTO referencing_table VALUES (2, 2);
-ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730146"
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730197"
 DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
 CONTEXT:  while executing command on localhost:xxxxx
 ROLLBACK;
@@ -1340,10 +1708,6 @@ CREATE TRIGGER trigger_1
 BEFORE INSERT ON trigger_table_1
 FOR EACH ROW EXECUTE FUNCTION increment_value();
 SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
-ERROR:  cannot distribute relation "trigger_table_1" because it has triggers
-HINT:  Consider dropping all the triggers on "trigger_table_1" and retry.
-SET citus.enable_unsafe_triggers TO ON;
-SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
  create_distributed_table
 ---------------------------------------------------------------------
 
@@ -1423,10 +1787,19 @@ TRUNCATE trigger_table_3;
 NOTICE:  notice_truncate()
 CONTEXT:  PL/pgSQL function notice_truncate() line XX at RAISE
 SET client_min_messages TO WARNING;
+-- test rename, disable and drop trigger
+ALTER TRIGGER trigger_4 ON trigger_table_3 RENAME TO trigger_new_name;
+ALTER TABLE trigger_table_3 DISABLE TRIGGER ALL;
+DROP TRIGGER trigger_new_name ON trigger_table_3;
+-- enable the remaining triggers
+ALTER TABLE trigger_table_3 ENABLE TRIGGER ALL;
 -- try a few simple queries at least to make sure that we don't crash
 BEGIN;
   INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
 ROLLBACK;
+DROP TRIGGER IF EXISTS trigger_1 ON trigger_table_1;
+DROP TRIGGER trigger_2 ON trigger_table_2 CASCADE;
+DROP TRIGGER trigger_3 ON trigger_table_3 RESTRICT;
 -- cleanup at exit
 SET client_min_messages TO ERROR;
 DROP SCHEMA create_null_dist_key, "NULL_!_dist_key" CASCADE;

--- a/src/test/regress/expected/create_null_dist_key.out
+++ b/src/test/regress/expected/create_null_dist_key.out
@@ -1,0 +1,1432 @@
+CREATE SCHEMA create_null_dist_key;
+SET search_path TO create_null_dist_key;
+SET citus.next_shard_id TO 1720000;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+SELECT 1 FROM citus_remove_node('localhost', :worker_1_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT 1 FROM citus_remove_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+CREATE TABLE add_node_test(a int, "b" text);
+-- add a node before creating the null-shard-key table
+SELECT 1 FROM citus_add_node('localhost', :worker_1_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT create_distributed_table('add_node_test', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- add a node after creating the null-shard-key table
+SELECT 1 FROM citus_add_node('localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- make sure that table is created on the worker nodes added before/after create_distributed_table
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*)=1 FROM pg_class WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+                                          relname='add_node_test'
+$$);
+ result
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+-- and check the metadata tables
+SELECT result FROM run_command_on_workers($$
+    SELECT (partmethod, partkey, repmodel, autoconverted) FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+$$);
+  result
+---------------------------------------------------------------------
+ (n,,s,f)
+ (n,,s,f)
+(2 rows)
+
+SELECT result FROM run_command_on_workers($$
+    SELECT (shardstorage, shardminvalue, shardmaxvalue) FROM pg_dist_shard
+    WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+$$);
+ result
+---------------------------------------------------------------------
+ (t,,)
+ (t,,)
+(2 rows)
+
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*)=1 FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+    );
+$$);
+ result
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+SELECT result FROM run_command_on_workers($$
+    SELECT (shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation) FROM pg_dist_colocation
+    WHERE colocationid = (
+        SELECT colocationid FROM pg_dist_partition
+        WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+    );
+$$);
+  result
+---------------------------------------------------------------------
+ (1,1,0,0)
+ (1,1,0,0)
+(2 rows)
+
+SET client_min_messages TO WARNING;
+SELECT 1 FROM citus_add_node('localhost', :master_port, groupid => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SET client_min_messages TO NOTICE;
+CREATE TABLE invalid_configs_1(a int primary key);
+SELECT create_distributed_table('invalid_configs_1', null, shard_count=>2);
+ERROR:  shard_count can't be specified when the distribution column is null because in that case it's automatically set to 1
+SELECT create_distributed_table('invalid_configs_1', null, shard_count=>1);
+ERROR:  shard_count can't be specified when the distribution column is null because in that case it's automatically set to 1
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+CREATE TABLE nullkey_c1_t3(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT colocationid AS nullkey_c1_t1_colocation_id FROM pg_dist_partition WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass \gset
+BEGIN;
+  DROP TABLE nullkey_c1_t1;
+  -- make sure that we delete the colocation group after dropping the last table that belongs to it
+  SELECT COUNT(*)=0 FROM pg_dist_colocation WHERE colocationid = :'nullkey_c1_t1_colocation_id';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ROLLBACK;
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c1_t3', null, colocate_with=>'nullkey_c1_t1', distribution_type=>'append');
+ERROR:  distribution_type can't be specified when the distribution column is null
+SELECT create_distributed_table('nullkey_c1_t3', null, colocate_with=>'nullkey_c1_t1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+CREATE TABLE nullkey_c2_t3(a int, b int);
+-- create_distributed_table_concurrently is not yet supported yet
+SELECT create_distributed_table_concurrently('nullkey_c2_t1', null);
+ERROR:  cannot use create_distributed_table_concurrently to create a distributed table with a null shard key, consider using create_distributed_table()
+SELECT create_distributed_table_concurrently('nullkey_c2_t1', null, colocate_with=>'none');
+ERROR:  cannot use create_distributed_table_concurrently to create a distributed table with a null shard key, consider using create_distributed_table()
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>'hash'); -- distribution_type is ignored anyway
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c2_t3', null, colocate_with=>'nullkey_c2_t2', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- check the metadata for the colocated tables whose names start with nullkey_c1_
+SELECT logicalrelid, partmethod, partkey, repmodel, autoconverted FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+ORDER BY 1;
+ logicalrelid  | partmethod | partkey | repmodel | autoconverted
+---------------------------------------------------------------------
+ nullkey_c1_t1 | n          |         | s        | f
+ nullkey_c1_t2 | n          |         | s        | f
+ nullkey_c1_t3 | n          |         | s        | f
+(3 rows)
+
+-- make sure that all those 3 tables belong to same colocation group
+SELECT COUNT(*) FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+GROUP BY colocationid;
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+SELECT logicalrelid, shardstorage, shardminvalue, shardmaxvalue FROM pg_dist_shard
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+ORDER BY 1;
+ logicalrelid  | shardstorage | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ nullkey_c1_t1 | t            |               |
+ nullkey_c1_t2 | t            |               |
+ nullkey_c1_t3 | t            |               |
+(3 rows)
+
+-- make sure that all those 3 shards are created on the same node group
+SELECT COUNT(*) FROM pg_dist_placement
+WHERE shardid IN (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid IN (
+        SELECT oid FROM pg_class
+        WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+              relname LIKE 'nullkey_c1_%'
+    )
+)
+GROUP BY groupid;
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+-- check the metadata for the colocated tables whose names start with nullkey_c2_
+SELECT logicalrelid, partmethod, partkey, repmodel, autoconverted FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+ORDER BY 1;
+ logicalrelid  | partmethod | partkey | repmodel | autoconverted
+---------------------------------------------------------------------
+ nullkey_c2_t1 | n          |         | s        | f
+ nullkey_c2_t2 | n          |         | s        | f
+ nullkey_c2_t3 | n          |         | s        | f
+(3 rows)
+
+-- make sure that all those 3 tables belong to same colocation group
+SELECT COUNT(*) FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+GROUP BY colocationid;
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+SELECT logicalrelid, shardstorage, shardminvalue, shardmaxvalue FROM pg_dist_shard
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+ORDER BY 1;
+ logicalrelid  | shardstorage | shardminvalue | shardmaxvalue
+---------------------------------------------------------------------
+ nullkey_c2_t1 | t            |               |
+ nullkey_c2_t2 | t            |               |
+ nullkey_c2_t3 | t            |               |
+(3 rows)
+
+-- make sure that all those 3 shards created on the same node group
+SELECT COUNT(*) FROM pg_dist_placement
+WHERE shardid IN (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid IN (
+        SELECT oid FROM pg_class
+        WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+              relname LIKE 'nullkey_c2_%'
+    )
+)
+GROUP BY groupid;
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+-- Make sure that the colocated tables whose names start with nullkey_c1_
+-- belong to a different colocation group than the ones whose names start
+-- with nullkey_c2_.
+--
+-- It's ok to only compare nullkey_c1_t1 and nullkey_c2_t1 because we already
+-- verified that null_dist_key.nullkey_c1_t1 is colocated with the other two
+-- and null_dist_key.nullkey_c2_t1 is colocated with the other two.
+SELECT
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+)
+!=
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- Since we determine node for the placement based on the module of colocation id,
+-- we don't expect those two colocation groups to get assigned to same node.
+SELECT
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+    )
+)
+!=
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+    )
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- It's ok to only check nullkey_c1_t1 and nullkey_c2_t1 because we already
+-- verified that null_dist_key.nullkey_c1_t1 is colocated with the other two
+-- and null_dist_key.nullkey_c2_t1 is colocated with the other two.
+SELECT shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation FROM pg_dist_colocation
+WHERE colocationid = (
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+);
+ shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation
+---------------------------------------------------------------------
+          1 |                 1 |                      0 |                           0
+(1 row)
+
+SELECT shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation FROM pg_dist_colocation
+WHERE colocationid = (
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+);
+ shardcount | replicationfactor | distributioncolumntype | distributioncolumncollation
+---------------------------------------------------------------------
+          1 |                 1 |                      0 |                           0
+(1 row)
+
+CREATE TABLE round_robin_test_c1(a int, b int);
+SELECT create_distributed_table('round_robin_test_c1', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+\c - - - :master_port
+SET search_path TO create_null_dist_key;
+SET citus.next_shard_id TO 1730000;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+SET client_min_messages TO NOTICE;
+CREATE TABLE round_robin_test_c2(a int, b int);
+SELECT create_distributed_table('round_robin_test_c2', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Since we determine node for the placement based on the module of colocation id,
+-- we don't expect those two colocation groups to get assigned to same node even
+-- after reconnecting to the coordinator.
+SELECT
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.round_robin_test_c1'::regclass
+    )
+)
+!=
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.round_robin_test_c2'::regclass
+    )
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+CREATE TABLE distributed_table(a int, b int);
+-- cannot colocate a sharded table with null shard key table
+SELECT create_distributed_table('distributed_table', 'a', colocate_with=>'nullkey_c1_t1');
+ERROR:  cannot colocate tables nullkey_c1_t1 and distributed_table
+DETAIL:  Distribution column types don't match for nullkey_c1_t1 and distributed_table.
+CREATE TABLE reference_table(a int, b int);
+CREATE TABLE local(a int, b int);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('distributed_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- cannot colocate null shard key tables with other table types
+CREATE TABLE cannot_colocate_with_other_types (a int, b int);
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'reference_table');
+ERROR:  cannot colocate tables reference_table and cannot_colocate_with_other_types
+DETAIL:  Replication models don't match for reference_table and cannot_colocate_with_other_types.
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'distributed_table');
+ERROR:  cannot colocate tables distributed_table and cannot_colocate_with_other_types
+DETAIL:  Distribution column types don't match for distributed_table and cannot_colocate_with_other_types.
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'local'); -- postgres local
+ERROR:  relation local is not distributed
+SELECT citus_add_local_table_to_metadata('local');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+-- cannot colocate null shard key tables with citus local tables
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'local'); -- citus local
+ERROR:  cannot distribute relation
+DETAIL:  Currently, colocate_with option is not supported with append / range distributed tables and local tables added to metadata.
+SET client_min_messages TO WARNING;
+-- can't create such a distributed table from another Citus table, except Citus local tables
+SELECT create_distributed_table('reference_table', null, colocate_with=>'none');
+ERROR:  table "reference_table" is already distributed
+SELECT create_distributed_table('distributed_table', null, colocate_with=>'none');
+ERROR:  table "distributed_table" is already distributed
+SELECT create_distributed_table('local', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+  -- creating a null-shard-key table from a temporary table is not supported
+  CREATE TEMPORARY TABLE temp_table (a int);
+  SELECT create_distributed_table('temp_table', null, colocate_with=>'none', distribution_type=>null);
+ERROR:  cannot distribute a temporary table
+ROLLBACK;
+-- creating a null-shard-key table from a catalog table is not supported
+SELECT create_distributed_table('pg_catalog.pg_index', NULL, distribution_type=>null);
+ERROR:  cannot create a citus table from a catalog table
+-- creating a null-shard-key table from an unlogged table is supported
+CREATE UNLOGGED TABLE unlogged_table (a int);
+SELECT create_distributed_table('unlogged_table', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- creating a null-shard-key table from a foreign table is not supported
+CREATE FOREIGN TABLE foreign_table (
+  id bigint not null,
+  full_name text not null default ''
+) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true', table_name 'foreign_table');
+SELECT create_distributed_table('foreign_table', null, colocate_with=>'none', distribution_type=>null);
+ERROR:  foreign tables cannot be distributed
+HINT:  Can add foreign table "foreign_table" to metadata by running: SELECT citus_add_local_table_to_metadata($$create_null_dist_key.foreign_table$$);
+-- create a null dist key table that has no tuples
+CREATE TABLE null_dist_key_table_1 (a int primary key);
+SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- create a null dist key table that has some tuples
+CREATE TABLE null_dist_key_table_2(a int primary key);
+INSERT INTO null_dist_key_table_2 VALUES(1);
+SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM null_dist_key_table_2 ORDER BY a;
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+DROP TABLE null_dist_key_table_1, null_dist_key_table_2;
+-- create indexes before creating the null dist key tables
+-- .. for an initially empty table
+CREATE TABLE null_dist_key_table_1(a int);
+CREATE INDEX null_dist_key_table_1_idx ON null_dist_key_table_1(a);
+SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- .. and for another table having data in it before creating null dist key table
+CREATE TABLE null_dist_key_table_2(a int);
+INSERT INTO null_dist_key_table_2 VALUES(1);
+CREATE INDEX null_dist_key_table_2_idx ON null_dist_key_table_2(a);
+SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT * FROM null_dist_key_table_2 ORDER BY a;
+ a
+---------------------------------------------------------------------
+ 1
+(1 row)
+
+-- show that we do not support inheritance relationships
+CREATE TABLE parent_table (a int, b text);
+CREATE TABLE child_table () INHERITS (parent_table);
+-- both of below should error out
+SELECT create_distributed_table('parent_table', null, colocate_with=>'none');
+ERROR:  parent_table is not a regular, foreign or partitioned table
+SELECT create_distributed_table('child_table', null, colocate_with=>'none');
+ERROR:  child_table is not a regular, foreign or partitioned table
+-- show that we support policies
+BEGIN;
+  CREATE TABLE null_dist_key_table_3 (table_user text);
+  ALTER TABLE null_dist_key_table_3 ENABLE ROW LEVEL SECURITY;
+  CREATE ROLE table_users;
+  CREATE POLICY table_policy ON null_dist_key_table_3 TO table_users
+      USING (table_user = current_user);
+  SELECT create_distributed_table('null_dist_key_table_3', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+-- drop them for next tests
+DROP TABLE null_dist_key_table_1, null_dist_key_table_2, distributed_table;
+-- tests for object names that should be escaped properly
+CREATE SCHEMA "NULL_!_dist_key";
+CREATE TABLE "NULL_!_dist_key"."my_TABLE.1!?!"(id int, "Second_Id" int);
+SELECT create_distributed_table('"NULL_!_dist_key"."my_TABLE.1!?!"', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- drop the table before creating it when the search path is set
+SET search_path to "NULL_!_dist_key" ;
+DROP TABLE "my_TABLE.1!?!";
+CREATE TYPE int_jsonb_type AS (key int, value jsonb);
+CREATE DOMAIN age_with_default AS int CHECK (value >= 0) DEFAULT 0;
+CREATE TYPE yes_no_enum AS ENUM ('yes', 'no');
+CREATE EXTENSION btree_gist;
+CREATE SEQUENCE my_seq_1 START WITH 10;
+CREATE TABLE "Table?!.1Table"(
+  id int PRIMARY KEY,
+  "Second_Id" int,
+  "local_Type" int_jsonb_type,
+  "jsondata" jsonb NOT NULL,
+  name text,
+  price numeric CHECK (price > 0),
+  age_with_default_col age_with_default,
+  yes_no_enum_col yes_no_enum,
+  seq_col_1 bigserial,
+  seq_col_2 int DEFAULT nextval('my_seq_1'),
+  generated_column int GENERATED ALWAYS AS (seq_col_1 * seq_col_2 + 4) STORED,
+  UNIQUE (id, price),
+  EXCLUDE USING GIST (name WITH =));
+-- create some objects before create_distributed_table
+CREATE INDEX "my!Index1" ON "Table?!.1Table"(id) WITH ( fillfactor = 80 ) WHERE id > 10;
+CREATE INDEX text_index ON "Table?!.1Table"(name);
+CREATE UNIQUE INDEX uniqueIndex ON "Table?!.1Table" (id);
+CREATE STATISTICS stats_1 ON id, price FROM "Table?!.1Table";
+CREATE TEXT SEARCH CONFIGURATION text_search_cfg (parser = default);
+CREATE INDEX text_search_index ON "Table?!.1Table"
+USING gin (to_tsvector('text_search_cfg'::regconfig, (COALESCE(name, ''::character varying))::text));
+-- ingest some data before create_distributed_table
+INSERT INTO "Table?!.1Table" VALUES (1, 1, (1, row_to_json(row(1,1)))::int_jsonb_type, row_to_json(row(1,1), true)),
+                                    (2, 1, (2, row_to_json(row(2,2)))::int_jsonb_type, row_to_json(row(2,2), 'false'));
+-- create a replica identity before create_distributed_table
+ALTER TABLE "Table?!.1Table" REPLICA IDENTITY USING INDEX uniqueIndex;
+SELECT create_distributed_table('"Table?!.1Table"', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO "Table?!.1Table" VALUES (10, 15, (150, row_to_json(row(4,8)))::int_jsonb_type, '{}', 'text_1', 10, 27, 'yes', 60, 70);
+INSERT INTO "Table?!.1Table" VALUES (5, 5, (5, row_to_json(row(5,5)))::int_jsonb_type, row_to_json(row(5,5), true));
+-- tuples that are supposed to violate different data type / check constraints
+INSERT INTO "Table?!.1Table"(id, jsondata, name) VALUES (101, '{"a": 1}', 'text_1');
+ERROR:  conflicting key value violates exclusion constraint "Table?!.1Table_name_excl_1730043"
+DETAIL:  Key (name)=(text_1) conflicts with existing key (name)=(text_1).
+CONTEXT:  while executing command on localhost:xxxxx
+INSERT INTO "Table?!.1Table"(id, jsondata, price) VALUES (101, '{"a": 1}', -1);
+ERROR:  new row for relation "Table?!.1Table_1730043" violates check constraint "Table?!.1Table_price_check"
+DETAIL:  Failing row contains (101, null, null, {"a": 1}, null, -1, 0, null, 5, 14, 74).
+CONTEXT:  while executing command on localhost:xxxxx
+INSERT INTO "Table?!.1Table"(id, jsondata, age_with_default_col) VALUES (101, '{"a": 1}', -1);
+ERROR:  value for domain age_with_default violates check constraint "age_with_default_check"
+INSERT INTO "Table?!.1Table"(id, jsondata, yes_no_enum_col) VALUES (101, '{"a": 1}', 'what?');
+ERROR:  invalid input value for enum yes_no_enum: "what?"
+SELECT * FROM "Table?!.1Table" ORDER BY id;
+ id | Second_Id |           local_Type           |      jsondata      |  name  | price | age_with_default_col | yes_no_enum_col | seq_col_1 | seq_col_2 | generated_column
+---------------------------------------------------------------------
+  1 |         1 | (1,"{""f1"": 1, ""f2"": 1}")   | {"f1": 1, "f2": 1} |        |       |                    0 |                 |         1 |        10 |               14
+  2 |         1 | (2,"{""f1"": 2, ""f2"": 2}")   | {"f1": 2, "f2": 2} |        |       |                    0 |                 |         2 |        11 |               26
+  5 |         5 | (5,"{""f1"": 5, ""f2"": 5}")   | {"f1": 5, "f2": 5} |        |       |                    0 |                 |         3 |        12 |               40
+ 10 |        15 | (150,"{""f1"": 4, ""f2"": 8}") | {}                 | text_1 |    10 |                   27 | yes             |        60 |        70 |             4204
+(4 rows)
+
+SET search_path TO create_null_dist_key;
+-- create a partitioned table with some columns that
+-- are going to be dropped within the tests
+CREATE TABLE sensors(
+    col_to_drop_1 text,
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+PRIMARY KEY (measureid, eventdatetime, measure_data))
+PARTITION BY RANGE(eventdatetime);
+-- drop column even before attaching any partitions
+ALTER TABLE sensors DROP COLUMN col_to_drop_1;
+CREATE TABLE sensors_2000 PARTITION OF sensors FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+-- cannot distribute child table without distributing the parent
+SELECT create_distributed_table('sensors_2000', NULL, distribution_type=>null);
+ERROR:  cannot distribute relation "sensors_2000" which is partition of "sensors"
+DETAIL:  Citus does not support distributing partitions if their parent is not distributed table.
+HINT:  Distribute the partitioned table "sensors" instead.
+SELECT create_distributed_table('sensors', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE multi_level_partitioning_parent(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb)
+PARTITION BY RANGE(eventdatetime);
+CREATE TABLE multi_level_partitioning_level_1(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb)
+PARTITION BY RANGE(eventdatetime);
+ALTER TABLE multi_level_partitioning_parent ATTACH PARTITION multi_level_partitioning_level_1
+FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+CREATE TABLE multi_level_partitioning_level_2 PARTITION OF multi_level_partitioning_level_1
+FOR VALUES FROM ('2000-01-01') TO ('2000-06-06');
+-- multi-level partitioning is not supported
+SELECT create_distributed_table('multi_level_partitioning_parent', NULL, distribution_type=>null);
+ERROR:  distributing multi-level partitioned tables is not supported
+DETAIL:  Relation "multi_level_partitioning_level_1" is partitioned table itself and it is also partition of relation "multi_level_partitioning_parent".
+CREATE FUNCTION normalize_generate_always_as_error(query text) RETURNS void AS $$
+BEGIN
+        EXECUTE query;
+        EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE 'cannot insert into column %' OR
+           SQLERRM LIKE 'cannot insert a non-DEFAULT value into column %'
+        THEN
+            RAISE 'cannot insert a non-DEFAULT value into column';
+        ELSE
+            RAISE 'unknown error';
+        END IF;
+END;
+$$LANGUAGE plpgsql;
+CREATE TABLE identity_test (
+    a int GENERATED BY DEFAULT AS IDENTITY (START WITH 10 INCREMENT BY 10),
+    b bigint GENERATED ALWAYS AS IDENTITY (START WITH 100 INCREMENT BY 100),
+    c bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 1000 INCREMENT BY 1000)
+);
+SELECT create_distributed_table('identity_test', NULL, distribution_type=>null);
+ERROR:  cannot complete operation on create_null_dist_key.identity_test with smallint/int identity column
+HINT:  Use bigint identity column instead.
+DROP TABLE identity_test;
+-- Above failed because we don't support using a data type other than BIGINT
+-- for identity columns, so drop the table and create a new one with BIGINT
+-- identity columns.
+CREATE TABLE identity_test (
+    a bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 10 INCREMENT BY 10),
+    b bigint GENERATED ALWAYS AS IDENTITY (START WITH 100 INCREMENT BY 100),
+    c bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 1000 INCREMENT BY 1000)
+);
+SELECT create_distributed_table('identity_test', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO identity_test (a) VALUES (5);
+SELECT normalize_generate_always_as_error($$INSERT INTO identity_test (b) VALUES (5)$$); -- fails due to missing OVERRIDING SYSTEM VALUE
+ERROR:  cannot insert a non-DEFAULT value into column
+CONTEXT:  PL/pgSQL function normalize_generate_always_as_error(text) line XX at RAISE
+INSERT INTO identity_test (b) OVERRIDING SYSTEM VALUE VALUES (5);
+INSERT INTO identity_test (c) VALUES (5);
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (a) VALUES (6)
+$$);
+   result   | success
+---------------------------------------------------------------------
+ INSERT 0 1 | t
+ INSERT 0 1 | t
+(2 rows)
+
+SELECT result, success FROM run_command_on_workers($$
+    SELECT create_null_dist_key.normalize_generate_always_as_error('INSERT INTO create_null_dist_key.identity_test (b) VALUES (1)')
+$$);
+                        result                         | success
+---------------------------------------------------------------------
+ ERROR:  cannot insert a non-DEFAULT value into column | f
+ ERROR:  cannot insert a non-DEFAULT value into column | f
+(2 rows)
+
+-- This should fail due to missing OVERRIDING SYSTEM VALUE.
+SELECT result, success FROM run_command_on_workers($$
+    SELECT create_null_dist_key.normalize_generate_always_as_error('INSERT INTO create_null_dist_key.identity_test (a, b) VALUES (1, 1)')
+$$);
+                        result                         | success
+---------------------------------------------------------------------
+ ERROR:  cannot insert a non-DEFAULT value into column | f
+ ERROR:  cannot insert a non-DEFAULT value into column | f
+(2 rows)
+
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (a, b) OVERRIDING SYSTEM VALUE VALUES (7, 7)
+$$);
+   result   | success
+---------------------------------------------------------------------
+ INSERT 0 1 | t
+ INSERT 0 1 | t
+(2 rows)
+
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (c, a) OVERRIDING SYSTEM VALUE VALUES (8, 8)
+$$);
+   result   | success
+---------------------------------------------------------------------
+ INSERT 0 1 | t
+ INSERT 0 1 | t
+(2 rows)
+
+-- test foreign keys
+CREATE TABLE referenced_table(a int UNIQUE, b int);
+CREATE TABLE referencing_table(a int, b int,
+    FOREIGN KEY (a) REFERENCES referenced_table(a));
+-- to a colocated null dist key table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730049"
+DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+-- to a non-colocated null dist key table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a sharded table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a reference table
+BEGIN;
+  SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730085"
+DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+-- to a citus local table
+BEGIN;
+  SELECT citus_add_local_table_to_metadata('referenced_table', cascade_via_foreign_keys=>true);
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a postgres table
+SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ERROR:  referenced table "referenced_table" must be a distributed table or a reference table
+DETAIL:  To enforce foreign keys, the referencing and referenced rows need to be stored on the same node.
+HINT:  You could use SELECT create_reference_table('referenced_table') to replicate the referenced table to all nodes or consider dropping the foreign key
+-- from a reference table
+BEGIN;
+  SELECT create_reference_table('referencing_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_reference_table('referencing_table');
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+-- from a sharded table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referencing_table', 'a');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- from a citus local table
+BEGIN;
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+-- from a postgres table (only useful to preserve legacy behavior)
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ROLLBACK;
+-- make sure that we enforce the foreign key constraint when inserting from workers too
+SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO referenced_table VALUES (1, 1);
+-- ok
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.referencing_table VALUES (1, 2)
+$$);
+   result   | success
+---------------------------------------------------------------------
+ INSERT 0 1 | t
+ INSERT 0 1 | t
+(2 rows)
+
+-- fails
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.referencing_table VALUES (2, 2)
+$$);
+                                                              result                                                              | success
+---------------------------------------------------------------------
+ ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730102" | f
+ ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730102" | f
+(2 rows)
+
+DROP TABLE referencing_table, referenced_table;
+CREATE TABLE self_fkey_test(a int UNIQUE, b int,
+    FOREIGN KEY (b) REFERENCES self_fkey_test(a),
+    FOREIGN KEY (a) REFERENCES self_fkey_test(a));
+SELECT create_distributed_table('self_fkey_test', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO self_fkey_test VALUES (1, 1); -- ok
+INSERT INTO self_fkey_test VALUES (2, 3); -- fails
+ERROR:  insert or update on table "self_fkey_test_1730103" violates foreign key constraint "self_fkey_test_b_fkey_1730103"
+DETAIL:  Key (b)=(3) is not present in table "self_fkey_test_1730103".
+CONTEXT:  while executing command on localhost:xxxxx
+-- similar foreign key tests but this time create the referencing table later on
+-- referencing table is a null shard key table
+-- to a colocated null dist key table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730105"
+DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+BEGIN;
+  CREATE TABLE referenced_table(a int, b int, UNIQUE(b, a));
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a, b) REFERENCES referenced_table(b, a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 2);
+  INSERT INTO referencing_table VALUES (2, 1);
+  -- fails
+  INSERT INTO referencing_table VALUES (1, 2);
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_b_fkey_1730107"
+DETAIL:  Key (a, b)=(1, 2) is not present in table "referenced_table_xxxxxxx".
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET NULL);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  UPDATE referenced_table SET a = 5;
+  SELECT * FROM referencing_table;
+ a | b
+---------------------------------------------------------------------
+   | 2
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a serial, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET DEFAULT);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ERROR:  cannot create foreign key constraint since Citus does not support ON DELETE / UPDATE SET DEFAULT actions on the columns that default to sequences
+ROLLBACK;
+-- to a non-colocated null dist key table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a sharded table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a reference table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ERROR:  insert or update on table "referencing_table_xxxxxxx" violates foreign key constraint "referencing_table_a_fkey_1730146"
+DETAIL:  Key (a)=(2) is not present in table "referenced_table_xxxxxxx".
+CONTEXT:  while executing command on localhost:xxxxx
+ROLLBACK;
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON DELETE CASCADE);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+  DELETE FROM referenced_table CASCADE;
+  SELECT * FROM referencing_table;
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+ROLLBACK;
+-- to a citus local table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT citus_add_local_table_to_metadata('referenced_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- to a postgres table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ERROR:  referenced table "referenced_table" must be a distributed table or a reference table
+DETAIL:  To enforce foreign keys, the referencing and referenced rows need to be stored on the same node.
+HINT:  You could use SELECT create_reference_table('referenced_table') to replicate the referenced table to all nodes or consider dropping the foreign key
+ROLLBACK;
+-- referenced table is a null shard key table
+-- from a sharded table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', 'a');
+ERROR:  cannot create foreign key constraint since relations are not colocated or not referencing a reference table
+DETAIL:  A distributed table can only have foreign keys if it is referencing another colocated hash distributed table or a reference table
+ROLLBACK;
+-- from a reference table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_reference_table('referencing_table');
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+-- from a citus local table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+ERROR:  cannot create foreign key constraint since foreign keys from reference tables and local tables to distributed tables are not supported
+DETAIL:  Reference tables and local tables can only have foreign keys to reference tables and local tables
+ROLLBACK;
+-- from a postgres table (only useful to preserve legacy behavior)
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+ROLLBACK;
+-- Test whether we switch to sequential execution to enforce foreign
+-- key restrictions.
+CREATE TABLE referenced_table(id int PRIMARY KEY, value_1 int);
+SELECT create_reference_table('referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE referencing_table(id int PRIMARY KEY, value_1 int, CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEBUG1;
+BEGIN;
+	-- Switches to sequential execution because referenced_table is a reference table
+	-- and referenced by a null-shard-key distributed table.
+    --
+    -- Given that we cannot do parallel access on null-shard-key, this is not useful.
+    -- However, this is already what we're doing for, e.g., a foreign key from a
+    -- reference table to another reference table.
+	TRUNCATE referenced_table CASCADE;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "referenced_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+NOTICE:  truncate cascades to table "referencing_table"
+DEBUG:  truncate cascades to table "referencing_table_xxxxxxx"
+DETAIL:  from localhost:xxxxx
+	SELECT COUNT(*) FROM referencing_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COMMIT;
+BEGIN;
+	SELECT COUNT(*) FROM referencing_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	-- Doesn't fail because the SELECT didn't perform parallel execution.
+	TRUNCATE referenced_table CASCADE;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "referenced_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+NOTICE:  truncate cascades to table "referencing_table"
+DEBUG:  truncate cascades to table "referencing_table_xxxxxxx"
+DETAIL:  from localhost:xxxxx
+COMMIT;
+BEGIN;
+	UPDATE referencing_table SET value_1 = 15;
+	-- Doesn't fail because the UPDATE didn't perform parallel execution.
+	TRUNCATE referenced_table CASCADE;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "referenced_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+NOTICE:  truncate cascades to table "referencing_table"
+DEBUG:  truncate cascades to table "referencing_table_xxxxxxx"
+DETAIL:  from localhost:xxxxx
+COMMIT;
+BEGIN;
+	SELECT COUNT(*) FROM referenced_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	-- doesn't switch to sequential execution
+	ALTER TABLE referencing_table ADD COLUMN X INT;
+ROLLBACK;
+BEGIN;
+	-- Switches to sequential execution because referenced_table is a reference table
+	-- and referenced by a null-shard-key distributed table.
+    --
+    -- Given that we cannot do parallel access on null-shard-key, this is not useful.
+    -- However, this is already what we're doing for, e.g., a foreign key from a
+    -- reference table to another reference table.
+	UPDATE referenced_table SET id = 101 WHERE id = 99;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "referenced_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+	UPDATE referencing_table SET value_1 = 15;
+ROLLBACK;
+BEGIN;
+	UPDATE referencing_table SET value_1 = 15;
+    -- Doesn't fail because prior UPDATE didn't perform parallel execution.
+    UPDATE referenced_table SET id = 101 WHERE id = 99;
+DEBUG:  switching to sequential query execution mode
+DETAIL:  Table "referenced_table" is modified, which might lead to data inconsistencies or distributed deadlocks via parallel accesses to hash distributed tables due to foreign keys. Any parallel modification to those hash distributed tables in the same transaction can only be executed in sequential query execution mode
+ROLLBACK;
+SET client_min_messages TO WARNING;
+DROP TABLE referenced_table, referencing_table;
+-- Test whether we unnecessarily switch to sequential execution
+-- when the referenced relation is a null-shard-key table.
+CREATE TABLE referenced_table(id int PRIMARY KEY, value_1 int);
+SELECT create_distributed_table('referenced_table', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE referencing_table(id int PRIMARY KEY, value_1 int, CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', null, colocate_with=>'referenced_table', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEBUG1;
+BEGIN;
+	SELECT COUNT(*) FROM referenced_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+	-- Doesn't switch to sequential execution because the referenced_table is
+	-- a null-shard-key distributed table.
+	ALTER TABLE referencing_table ADD COLUMN X INT;
+ROLLBACK;
+BEGIN;
+	-- Doesn't switch to sequential execution because the referenced_table is
+	-- a null-shard-key distributed table.
+	TRUNCATE referenced_table CASCADE;
+NOTICE:  truncate cascades to table "referencing_table"
+DEBUG:  truncate cascades to table "referencing_table_xxxxxxx"
+DETAIL:  from localhost:xxxxx
+	SELECT COUNT(*) FROM referencing_table;
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+COMMIT;
+SET client_min_messages TO WARNING;
+CREATE FUNCTION increment_value() RETURNS trigger AS $increment_value$
+BEGIN
+    NEW.value := NEW.value+1;
+    RETURN NEW;
+END;
+$increment_value$ LANGUAGE plpgsql;
+CREATE TABLE trigger_table_1 (value int);
+CREATE TRIGGER trigger_1
+BEFORE INSERT ON trigger_table_1
+FOR EACH ROW EXECUTE FUNCTION increment_value();
+SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
+ERROR:  cannot distribute relation "trigger_table_1" because it has triggers
+HINT:  Consider dropping all the triggers on "trigger_table_1" and retry.
+SET citus.enable_unsafe_triggers TO ON;
+SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO trigger_table_1 VALUES(1), (2);
+SELECT * FROM trigger_table_1 ORDER BY value;
+ value
+---------------------------------------------------------------------
+     2
+     3
+(2 rows)
+
+CREATE FUNCTION insert_some() RETURNS trigger AS $insert_some$
+BEGIN
+    RAISE NOTICE 'inserted some rows';
+    RETURN NEW;
+END;
+$insert_some$ LANGUAGE plpgsql;
+CREATE TABLE trigger_table_2 (value int);
+CREATE TRIGGER trigger_2
+AFTER INSERT ON trigger_table_2
+FOR EACH STATEMENT EXECUTE FUNCTION insert_some();
+ALTER TABLE trigger_table_2 DISABLE TRIGGER trigger_2;
+SELECT create_distributed_table('trigger_table_2', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO NOTICE;
+INSERT INTO trigger_table_2 VALUES(3), (4);
+SET client_min_messages TO WARNING;
+SELECT * FROM trigger_table_2 ORDER BY value;
+ value
+---------------------------------------------------------------------
+     3
+     4
+(2 rows)
+
+CREATE FUNCTION combine_old_new_val() RETURNS trigger AS $combine_old_new_val$
+BEGIN
+    NEW.value = NEW.value * 10 + OLD.value;
+    RETURN NEW;
+END;
+$combine_old_new_val$ LANGUAGE plpgsql;
+CREATE FUNCTION notice_truncate() RETURNS trigger AS $notice_truncate$
+BEGIN
+    RAISE NOTICE 'notice_truncate()';
+    RETURN NEW;
+END;
+$notice_truncate$ LANGUAGE plpgsql;
+CREATE TABLE trigger_table_3 (value int);
+CREATE TRIGGER trigger_3
+BEFORE UPDATE ON trigger_table_3
+FOR EACH ROW EXECUTE FUNCTION combine_old_new_val();
+CREATE TRIGGER trigger_4
+AFTER TRUNCATE ON trigger_table_3
+FOR EACH STATEMENT EXECUTE FUNCTION notice_truncate();
+INSERT INTO trigger_table_3 VALUES(3), (4);
+SELECT create_distributed_table('trigger_table_3', NULL, distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+UPDATE trigger_table_3 SET value = 5;
+SELECT * FROM trigger_table_3 ORDER BY value;
+ value
+---------------------------------------------------------------------
+    53
+    54
+(2 rows)
+
+SET client_min_messages TO NOTICE;
+TRUNCATE trigger_table_3;
+NOTICE:  notice_truncate()
+CONTEXT:  PL/pgSQL function notice_truncate() line XX at RAISE
+SET client_min_messages TO WARNING;
+-- try a few simple queries at least to make sure that we don't crash
+BEGIN;
+  INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
+ROLLBACK;
+-- cleanup at exit
+SET client_min_messages TO ERROR;
+DROP SCHEMA create_null_dist_key, "NULL_!_dist_key" CASCADE;

--- a/src/test/regress/expected/merge.out
+++ b/src/test/regress/expected/merge.out
@@ -3103,6 +3103,153 @@ WHEN NOT MATCHED THEN
 INSERT VALUES(dist_source.id, dist_source.val);
 ERROR:  For MERGE command, all the distributed tables must be colocated, for append/range distribution, colocation is not supported
 HINT:  Consider using hash distribution instead
+-- test merge with null shard key tables
+CREATE SCHEMA query_null_dist_key;
+SET search_path TO query_null_dist_key;
+SET client_min_messages TO DEBUG2;
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE reference_table(a int, b int);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO reference_table SELECT i, i FROM generate_series(0, 5) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+CREATE TABLE distributed_table(a int, b int);
+SELECT create_distributed_table('distributed_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO distributed_table SELECT i, i FROM generate_series(3, 8) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+CREATE TABLE citus_local_table(a int, b int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO citus_local_table SELECT i, i FROM generate_series(0, 10) i;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+CREATE TABLE postgres_local_table(a int, b int);
+INSERT INTO postgres_local_table SELECT i, i FROM generate_series(5, 10) i;
+-- with a colocated table
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b;
+DEBUG:  <Deparsed MERGE query: MERGE INTO query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1 USING query_null_dist_key.nullkey_c1_t2_4000146 nullkey_c1_t2 ON (nullkey_c1_t1.a OPERATOR(pg_catalog.=) nullkey_c1_t2.a) WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b>
+DEBUG:  Creating MERGE router plan
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN DELETE;
+DEBUG:  <Deparsed MERGE query: MERGE INTO query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1 USING query_null_dist_key.nullkey_c1_t2_4000146 nullkey_c1_t2 ON (nullkey_c1_t1.a OPERATOR(pg_catalog.=) nullkey_c1_t2.a) WHEN MATCHED THEN DELETE>
+DEBUG:  Creating MERGE router plan
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b);
+DEBUG:  <Deparsed MERGE query: MERGE INTO query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1 USING query_null_dist_key.nullkey_c1_t2_4000146 nullkey_c1_t2 ON (nullkey_c1_t1.a OPERATOR(pg_catalog.=) nullkey_c1_t2.a) WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b)>
+DEBUG:  Creating MERGE router plan
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b);
+DEBUG:  <Deparsed MERGE query: MERGE INTO query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1 USING query_null_dist_key.nullkey_c1_t2_4000146 nullkey_c1_t2 ON (nullkey_c1_t1.a OPERATOR(pg_catalog.=) nullkey_c1_t2.a) WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT (a, b) VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b)>
+DEBUG:  Creating MERGE router plan
+-- with non-colocated null-dist-key table
+MERGE INTO nullkey_c1_t1 USING nullkey_c2_t1 ON (nullkey_c1_t1.a = nullkey_c2_t1.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c2_t1.b;
+ERROR:  For MERGE command, all the distributed tables must be colocated
+MERGE INTO nullkey_c1_t1 USING nullkey_c2_t1 ON (nullkey_c1_t1.a = nullkey_c2_t1.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c2_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c2_t1.a, nullkey_c2_t1.b);
+ERROR:  For MERGE command, all the distributed tables must be colocated
+-- with a distributed table
+MERGE INTO nullkey_c1_t1 USING distributed_table ON (nullkey_c1_t1.a = distributed_table.a)
+WHEN MATCHED THEN UPDATE SET b = distributed_table.b
+WHEN NOT MATCHED THEN INSERT VALUES (distributed_table.a, distributed_table.b);
+ERROR:  For MERGE command, all the distributed tables must be colocated
+MERGE INTO distributed_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = distributed_table.a)
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+ERROR:  For MERGE command, all the distributed tables must be colocated
+-- with a reference table
+MERGE INTO nullkey_c1_t1 USING reference_table ON (nullkey_c1_t1.a = reference_table.a)
+WHEN MATCHED THEN UPDATE SET b = reference_table.b;
+ERROR:  MERGE command is not supported on reference tables yet
+MERGE INTO reference_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = reference_table.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+ERROR:  MERGE command is not supported on reference tables yet
+-- with a citus local table
+MERGE INTO nullkey_c1_t1 USING citus_local_table ON (nullkey_c1_t1.a = citus_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = citus_local_table.b;
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
+MERGE INTO citus_local_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = citus_local_table.a)
+WHEN MATCHED THEN DELETE;
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
+-- with a postgres table
+MERGE INTO nullkey_c1_t1 USING postgres_local_table ON (nullkey_c1_t1.a = postgres_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = postgres_local_table.b;
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
+MERGE INTO postgres_local_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = postgres_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+ERROR:  MERGE command is not supported with combination of distributed/local tables yet
+-- using ctes
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t1
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+DEBUG:  <Deparsed MERGE query: WITH cte AS (SELECT nullkey_c1_t1_1.a, nullkey_c1_t1_1.b FROM query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1_1) MERGE INTO query_null_dist_key.nullkey_c1_t1_4000145 nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a OPERATOR(pg_catalog.=) cte.a) WHEN MATCHED THEN UPDATE SET b = cte.b>
+DEBUG:  Creating MERGE router plan
+WITH cte AS (
+    SELECT * FROM distributed_table
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+ERROR:  For MERGE command, all the distributed tables must be colocated
+WITH cte AS materialized (
+    SELECT * FROM distributed_table
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+ERROR:  For MERGE command, all the distributed tables must be colocated
+SET client_min_messages TO WARNING;
+DROP SCHEMA query_null_dist_key CASCADE;
+RESET client_min_messages;
+SET search_path TO merge_schema;
 DROP SERVER foreign_server CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to user mapping for postgres on server foreign_server

--- a/src/test/regress/expected/multi_colocation_utils.out
+++ b/src/test/regress/expected/multi_colocation_utils.out
@@ -612,10 +612,10 @@ CREATE TABLE table_postgresql( id int );
 CREATE TABLE table_failing ( id int );
 SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_append');
 ERROR:  cannot distribute relation
-DETAIL:  Currently, colocate_with option is only supported for hash distributed tables.
+DETAIL:  Currently, colocate_with option is not supported with append / range distributed tables and local tables added to metadata.
 SELECT create_distributed_table('table_failing', 'id', 'append', 'table1_groupE');
 ERROR:  cannot distribute relation
-DETAIL:  Currently, colocate_with option is only supported for hash distributed tables.
+DETAIL:  Currently, colocate_with option is not supported for append / range distributed tables.
 SELECT create_distributed_table('table_failing', 'id', colocate_with => 'table_postgresql');
 ERROR:  relation table_postgresql is not distributed
 SELECT create_distributed_table('table_failing', 'id', colocate_with => 'no_table');

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1735,6 +1735,33 @@ HINT:  To remove the local data, run: SELECT truncate_local_data_after_distribut
 
 DROP TABLE test;
 TRUNCATE pg_dist_node;
+-- confirm that we can create a null shard key table on an empty node
+CREATE TABLE test (x int, y int);
+INSERT INTO test VALUES (1,2);
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('test', null, colocate_with=>'none', distribution_type=>null);
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$public.test$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- and make sure that we can't remove the coordinator due to "test"
+SELECT citus_remove_node('localhost', :master_port);
+ERROR:  cannot remove or disable the node localhost:xxxxx because because it contains the only shard placement for shard xxxxx
+DETAIL:  One of the table(s) that prevents the operation complete successfully is public.test
+HINT:  To proceed, either drop the tables or use undistribute_table() function to convert them to local tables
+DROP TABLE test;
+-- and now we should be able to remove the coordinator
+SELECT citus_remove_node('localhost', :master_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
 -- confirm that we can create a reference table on an empty node
 CREATE TABLE test (x int, y int);
 INSERT INTO test VALUES (1,2);

--- a/src/test/regress/expected/null_dist_key_prep.out
+++ b/src/test/regress/expected/null_dist_key_prep.out
@@ -1,0 +1,13 @@
+ALTER FUNCTION create_distributed_table RENAME TO create_distributed_table_internal;
+CREATE OR REPLACE FUNCTION pg_catalog.create_distributed_table(table_name regclass,
+                                                               distribution_column text,
+                                                               distribution_type citus.distribution_type DEFAULT 'hash',
+                                                               colocate_with text DEFAULT 'default',
+                                                               shard_count int DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    PERFORM create_distributed_table_internal(table_name, NULL, NULL, colocate_with, NULL);
+END;
+$function$;

--- a/src/test/regress/expected/query_null_dist_key.out
+++ b/src/test/regress/expected/query_null_dist_key.out
@@ -1,0 +1,1796 @@
+CREATE SCHEMA query_null_dist_key;
+SET search_path TO query_null_dist_key;
+SET citus.next_shard_id TO 1620000;
+SET citus.shard_count TO 32;
+SET client_min_messages TO WARNING;
+SELECT 1 FROM citus_add_node('localhost', :master_port, groupid => 0);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SET client_min_messages TO NOTICE;
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO nullkey_c1_t1 SELECT i, i FROM generate_series(1, 8) i;
+INSERT INTO nullkey_c1_t2 SELECT i, i FROM generate_series(2, 7) i;
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO nullkey_c2_t1 SELECT i, i FROM generate_series(2, 7) i;
+INSERT INTO nullkey_c2_t2 SELECT i, i FROM generate_series(1, 8) i;
+CREATE TABLE nullkey_c3_t1(a int, b int);
+SELECT create_distributed_table('nullkey_c3_t1', null, colocate_with=>'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO nullkey_c3_t1 SELECT i, i FROM generate_series(1, 8) i;
+CREATE TABLE reference_table(a int, b int);
+SELECT create_reference_table('reference_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO reference_table SELECT i, i FROM generate_series(0, 5) i;
+CREATE TABLE distributed_table(a int, b int);
+SELECT create_distributed_table('distributed_table', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO distributed_table SELECT i, i FROM generate_series(3, 8) i;
+CREATE TABLE citus_local_table(a int, b int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO citus_local_table SELECT i, i FROM generate_series(0, 10) i;
+CREATE TABLE postgres_local_table(a int, b int);
+INSERT INTO postgres_local_table SELECT i, i FROM generate_series(5, 10) i;
+CREATE TABLE articles_hash (
+	id bigint NOT NULL,
+	author_id bigint NOT NULL,
+	title varchar(20) NOT NULL,
+	word_count integer
+);
+INSERT INTO articles_hash VALUES ( 4,  4, 'altdorfer', 14551),( 5,  5, 'aruru', 11389),
+								 (13,  3, 'aseyev', 2255),(15,  5, 'adversa', 3164),
+								 (18,  8, 'assembly', 911),(19,  9, 'aubergiste', 4981),
+								 (28,  8, 'aerophyte', 5454),(29,  9, 'amateur', 9524),
+								 (42,  2, 'ausable', 15885),(43,  3, 'affixal', 12723),
+								 (49,  9, 'anyone', 2681),(50, 10, 'anjanette', 19519);
+SELECT create_distributed_table('articles_hash', null, colocate_with=>'none');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$query_null_dist_key.articles_hash$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE raw_events_first (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint, UNIQUE(user_id, value_1));
+SELECT create_distributed_table('raw_events_first', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE raw_events_second (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint, UNIQUE(user_id, value_1));
+SELECT create_distributed_table('raw_events_second', null, colocate_with=>'raw_events_first', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE agg_events (user_id int, value_1_agg int, value_2_agg int, value_3_agg float, value_4_agg bigint, agg_time timestamp, UNIQUE(user_id, value_1_agg));
+SELECT create_distributed_table('agg_events', null, colocate_with=>'raw_events_first', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE users_ref_table (user_id int);
+SELECT create_reference_table('users_ref_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO raw_events_first VALUES (1, '1970-01-01', 10, 100, 1000.1, 10000), (3, '1971-01-01', 30, 300, 3000.1, 30000),
+                                    (5, '1972-01-01', 50, 500, 5000.1, 50000), (2, '1973-01-01', 20, 200, 2000.1, 20000),
+                                    (4, '1974-01-01', 40, 400, 4000.1, 40000), (6, '1975-01-01', 60, 600, 6000.1, 60000);
+CREATE TABLE modify_fast_path(key int, value_1 int, value_2 text);
+SELECT create_distributed_table('modify_fast_path', null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE modify_fast_path_reference(key int, value_1 int, value_2 text);
+SELECT create_reference_table('modify_fast_path_reference');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE bigserial_test (x int, y int, z bigserial);
+SELECT create_distributed_table('bigserial_test', null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE append_table (text_col text, a int);
+SELECT create_distributed_table('append_table', 'a', 'append');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT master_create_empty_shard('append_table') AS shardid1 \gset
+SELECT master_create_empty_shard('append_table') AS shardid2 \gset
+SELECT master_create_empty_shard('append_table') AS shardid3 \gset
+COPY append_table (text_col, a) FROM STDIN WITH (format 'csv', append_to_shard :shardid1);
+COPY append_table (text_col, a) FROM STDIN WITH (format 'csv', append_to_shard :shardid2);
+CREATE TABLE range_table(a int, b int);
+SELECT create_distributed_table('range_table', 'a', 'range');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CALL public.create_range_partitioned_shards('range_table', '{"0","25"}','{"24","49"}');
+INSERT INTO range_table VALUES (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 50);
+SET client_min_messages to DEBUG2;
+-- simple insert
+INSERT INTO nullkey_c1_t1 VALUES (1,2), (2,2), (3,4);
+DEBUG:  Creating router plan
+INSERT INTO nullkey_c1_t2 VALUES (1,3), (3,4), (5,1), (6,2);
+DEBUG:  Creating router plan
+INSERT INTO nullkey_c2_t1 VALUES (1,0), (2,5), (4,3), (5,2);
+DEBUG:  Creating router plan
+INSERT INTO nullkey_c2_t2 VALUES (2,4), (3,2), (5,2), (7,4);
+DEBUG:  Creating router plan
+-- simple select
+SELECT * FROM nullkey_c1_t1 ORDER BY 1,2;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ a | b
+---------------------------------------------------------------------
+ 1 | 1
+ 1 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 4
+ 4 | 4
+ 5 | 5
+ 6 | 6
+ 7 | 7
+ 8 | 8
+(11 rows)
+
+-- for update / share
+SELECT * FROM modify_fast_path WHERE key = 1 FOR UPDATE;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * FROM modify_fast_path WHERE key = 1 FOR SHARE;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * FROM modify_fast_path FOR UPDATE;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * FROM modify_fast_path FOR SHARE;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+-- cartesian product with different table types
+--    with other table types
+SELECT COUNT(*) FROM distributed_table d1, nullkey_c1_t1;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM reference_table d1, nullkey_c1_t1;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    66
+(1 row)
+
+SELECT COUNT(*) FROM citus_local_table d1, nullkey_c1_t1;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM postgres_local_table d1, nullkey_c1_t1;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+--    with a colocated null dist key table
+SELECT COUNT(*) FROM nullkey_c1_t1 d1, nullkey_c1_t2;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+   110
+(1 row)
+
+--    with a non-colocated null dist key table
+SELECT COUNT(*) FROM nullkey_c1_t1 d1, nullkey_c2_t1;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+-- First, show that nullkey_c1_t1 and nullkey_c3_t1 are not colocated.
+SELECT
+  (SELECT colocationid FROM pg_dist_partition WHERE logicalrelid = 'query_null_dist_key.nullkey_c1_t1'::regclass) !=
+  (SELECT colocationid FROM pg_dist_partition WHERE logicalrelid = 'query_null_dist_key.nullkey_c3_t1'::regclass);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- Now verify that we can join them via router planner because it doesn't care
+-- about whether two tables are colocated or not but physical location of shards
+-- when citus.enable_non_colocated_router_query_pushdown is set to on.
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c3_t1 USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    11
+(1 row)
+
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c3_t1 USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  router planner does not support queries that reference non-colocated distributed tables
+RESET citus.enable_non_colocated_router_query_pushdown;
+-- colocated join between null dist key tables
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c1_t2 USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    14
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN nullkey_c1_t2 USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    15
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN nullkey_c1_t2 USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    15
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    11
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t2 t2 WHERE t2.b = t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     7
+(1 row)
+
+-- non-colocated inner joins between null dist key tables
+SELECT * FROM nullkey_c1_t1 JOIN nullkey_c2_t1 USING(a) ORDER BY 1,2,3;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+-- non-colocated outer joins between null dist key tables
+SELECT * FROM nullkey_c1_t1 LEFT JOIN nullkey_c2_t2 USING(a) ORDER BY 1,2,3 LIMIT 4;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT * FROM nullkey_c1_t1 FULL JOIN nullkey_c2_t2 USING(a) ORDER BY 1,2,3 LIMIT 4;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT * FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a) ORDER BY 1,2,3 OFFSET 3 LIMIT 4;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c2_t2 t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+-- join with a reference table
+SELECT COUNT(*) FROM nullkey_c1_t1, reference_table WHERE nullkey_c1_t1.a = reference_table.a;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     8
+(1 row)
+
+WITH cte_1 AS
+	(SELECT * FROM nullkey_c1_t1, reference_table WHERE nullkey_c1_t1.a = reference_table.a ORDER BY 1,2,3,4 FOR UPDATE)
+SELECT COUNT(*) FROM cte_1;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     8
+(1 row)
+
+-- join with postgres / citus local tables
+SELECT * FROM nullkey_c1_t1 JOIN postgres_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT * FROM nullkey_c1_t1 JOIN citus_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+-- join with a distributed table
+SELECT * FROM distributed_table d1 JOIN nullkey_c1_t1 USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM distributed_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+-- outer joins with different table types
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN reference_table USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    11
+(1 row)
+
+SELECT COUNT(*) FROM reference_table LEFT JOIN nullkey_c1_t1 USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN citus_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM citus_local_table LEFT JOIN nullkey_c1_t1 USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN postgres_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM postgres_local_table LEFT JOIN nullkey_c1_t1 USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN citus_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN postgres_local_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN reference_table USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    12
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN append_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner does not support append-partitioned tables.
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a) WHERE range_table.a = 20;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a) WHERE range_table.a = 20;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  router planner does not support queries that reference non-colocated distributed tables
+RESET citus.enable_non_colocated_router_query_pushdown;
+-- lateral / semi / anti joins with different table types
+--    with a reference table
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    11
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM reference_table t2 WHERE t2.b = t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM reference_table t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     9
+(1 row)
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM reference_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     6
+(1 row)
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     6
+(1 row)
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     4
+(1 row)
+
+SELECT COUNT(*) FROM reference_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+--    with a distributed table
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM distributed_table t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM distributed_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM distributed_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM distributed_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM distributed_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+SELECT COUNT(*) FROM distributed_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+--    with postgres / citus local tables
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM citus_local_table t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM citus_local_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM postgres_local_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM citus_local_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM postgres_local_table t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+SELECT COUNT(*) FROM postgres_local_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+-- insert .. select
+--    between two colocated null dist key tables
+--    The target list of "distributed statement"s that we send to workers
+--    differ(*) in Postgres versions < 15. For this reason, we temporarily
+--    disable debug messages here and run the EXPLAIN'ed version of the
+--    command.
+--
+--    (*):  < SELECT a, b > vs  < SELECT table_name.a, table_name.b >
+SET client_min_messages TO WARNING;
+EXPLAIN (ANALYZE TRUE, TIMING FALSE, COSTS FALSE, SUMMARY FALSE, VERBOSE FALSE)
+INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c1_t2;
+                                         QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive) (actual rows=0 loops=1)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on nullkey_c1_t1_1620000 citus_table_alias (actual rows=0 loops=1)
+               ->  Seq Scan on nullkey_c1_t2_1620001 nullkey_c1_t2 (actual rows=10 loops=1)
+(7 rows)
+
+SET client_min_messages TO DEBUG2;
+--    between two non-colocated null dist key tables
+INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
+ERROR:  cannot select from a non-colocated distributed table when inserting into a distributed table that does not have a shard key
+--    between a null dist key table and a table of different type
+INSERT INTO nullkey_c1_t1 SELECT * FROM reference_table;
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+INSERT INTO nullkey_c1_t1 SELECT * FROM distributed_table;
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+INSERT INTO nullkey_c1_t1 SELECT * FROM citus_local_table;
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+INSERT INTO nullkey_c1_t1 SELECT * FROM postgres_local_table;
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+INSERT INTO reference_table SELECT * FROM nullkey_c1_t1;
+ERROR:  cannot select from a distributed table that does not have a shard key when inserting into a different table type
+INSERT INTO distributed_table SELECT * FROM nullkey_c1_t1;
+ERROR:  cannot select from a distributed table that does not have a shard key when inserting into a different table type
+INSERT INTO citus_local_table SELECT * FROM nullkey_c1_t1;
+ERROR:  cannot select from a distributed table that does not have a shard key when inserting into a different table type
+INSERT INTO postgres_local_table SELECT * FROM nullkey_c1_t1;
+ERROR:  cannot select from a distributed table that does not have a shard key when inserting into a local table
+-- test subquery
+SELECT count(*) FROM
+(
+	SELECT * FROM (SELECT * FROM nullkey_c1_t2) as subquery_inner
+) AS subquery_top;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+    10
+(1 row)
+
+-- test cte inlining
+WITH cte_nullkey_c1_t1 AS (SELECT * FROM nullkey_c1_t1),
+     cte_postgres_local_table AS (SELECT * FROM postgres_local_table),
+     cte_distributed_table AS (SELECT * FROM distributed_table)
+SELECT COUNT(*) FROM cte_distributed_table, cte_nullkey_c1_t1, cte_postgres_local_table
+WHERE cte_nullkey_c1_t1.a > 3 AND cte_distributed_table.a < 5;
+DEBUG:  CTE cte_nullkey_c1_t1 is going to be inlined via distributed planning
+DEBUG:  CTE cte_postgres_local_table is going to be inlined via distributed planning
+DEBUG:  CTE cte_distributed_table is going to be inlined via distributed planning
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Local tables cannot be used in distributed queries.
+-- test recursive ctes
+WITH level_0 AS (
+  WITH level_1 AS (
+    WITH RECURSIVE level_2_recursive(x) AS (
+        VALUES (1)
+      UNION ALL
+        SELECT a + 1 FROM nullkey_c1_t1 JOIN level_2_recursive ON (a = x) WHERE a < 100
+    )
+    SELECT * FROM level_2_recursive RIGHT JOIN reference_table ON (level_2_recursive.x = reference_table.a)
+  )
+  SELECT * FROM level_1
+)
+SELECT COUNT(*) FROM level_0;
+DEBUG:  CTE level_0 is going to be inlined via distributed planning
+DEBUG:  CTE level_1 is going to be inlined via distributed planning
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+   122
+(1 row)
+
+WITH level_0 AS (
+  WITH level_1 AS (
+    WITH RECURSIVE level_2_recursive(x) AS (
+        VALUES (1)
+      UNION ALL
+        SELECT a + 1 FROM nullkey_c1_t1 JOIN level_2_recursive ON (a = x) WHERE a < 100
+    )
+    SELECT * FROM level_2_recursive JOIN distributed_table ON (level_2_recursive.x = distributed_table.a)
+  )
+  SELECT * FROM level_1
+)
+SELECT COUNT(*) FROM level_0;
+DEBUG:  CTE level_0 is going to be inlined via distributed planning
+DEBUG:  CTE level_1 is going to be inlined via distributed planning
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+-- grouping set
+SELECT
+	id, substring(title, 2, 1) AS subtitle, count(*)
+	FROM articles_hash
+	WHERE author_id = 1 or author_id = 2
+	GROUP BY GROUPING SETS ((id),(subtitle))
+	ORDER BY id, subtitle;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | subtitle | count
+---------------------------------------------------------------------
+ 42 |          |     1
+    | u        |     1
+(2 rows)
+
+-- subquery in SELECT clause
+SELECT a.title AS name, (SELECT a2.id FROM articles_hash a2 WHERE a.id = a2.id  LIMIT 1)
+						 AS special_price FROM articles_hash a
+ORDER BY 1,2;
+DEBUG:  Creating router plan
+    name    | special_price
+---------------------------------------------------------------------
+ adversa    |            15
+ aerophyte  |            28
+ affixal    |            43
+ altdorfer  |             4
+ amateur    |            29
+ anjanette  |            50
+ anyone     |            49
+ aruru      |             5
+ aseyev     |            13
+ assembly   |            18
+ aubergiste |            19
+ ausable    |            42
+(12 rows)
+
+-- test prepared statements
+-- prepare queries can be router plannable
+PREPARE author_1_articles as
+	SELECT *
+	FROM articles_hash
+	WHERE author_id = 1;
+EXECUTE author_1_articles;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_1_articles;
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_1_articles;
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_1_articles;
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_1_articles;
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_1_articles;
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+-- parametric prepare queries can be router plannable
+PREPARE author_articles(int) as
+	SELECT *
+	FROM articles_hash
+	WHERE author_id = $1;
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+EXECUTE author_articles(NULL);
+ id | author_id | title | word_count
+---------------------------------------------------------------------
+(0 rows)
+
+PREPARE author_articles_update(int) AS
+	UPDATE articles_hash SET title = 'test' WHERE author_id = $1;
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE author_articles_update(NULL);
+-- More tests with insert .. select.
+--
+-- The target list of "distributed statement"s that we send to workers
+-- might differ(*) in Postgres versions < 15 and they are reported when
+-- "log level >= DEBUG2". For this reason, we set log level to DEBUG1 to
+-- avoid reporting them.
+--
+-- DEBUG1 still allows reporting the reason why given INSERT .. SELECT
+-- query is not distributed / requires pull-to-coordinator.
+SET client_min_messages TO DEBUG1;
+INSERT INTO bigserial_test (x, y) SELECT x, y FROM bigserial_test;
+DEBUG:  volatile functions are not allowed in distributed INSERT ... SELECT queries
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Sequences cannot be used in router queries
+INSERT INTO agg_events
+            (user_id)
+SELECT f2.id FROM
+(SELECT
+      id
+FROM   (SELECT users_ref_table.user_id      AS id
+        FROM   raw_events_first,
+               users_ref_table
+        WHERE  raw_events_first.user_id = users_ref_table.user_id ) AS foo) as f
+INNER JOIN
+(SELECT v4,
+       v1,
+       id
+FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
+               SUM(raw_events_first.value_1) AS v1,
+               raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id
+        GROUP  BY raw_events_second.user_id
+        HAVING SUM(raw_events_second.value_4) > 1000) AS foo2 ) as f2
+ON (f.id = f2.id)
+WHERE f.id IN (SELECT user_id
+               FROM   raw_events_second);
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+-- upsert with returning
+INSERT INTO agg_events AS ae
+            (
+                        user_id,
+                        value_1_agg,
+                        agg_time
+            )
+SELECT user_id,
+       value_1,
+       time
+FROM   raw_events_first
+ON conflict (user_id, value_1_agg)
+DO UPDATE
+   SET    agg_time = EXCLUDED.agg_time
+   WHERE  ae.agg_time < EXCLUDED.agg_time
+RETURNING user_id, value_1_agg;
+ user_id | value_1_agg
+---------------------------------------------------------------------
+       1 |          10
+       2 |          20
+       3 |          30
+       4 |          40
+       5 |          50
+       6 |          60
+(6 rows)
+
+-- using a left join
+INSERT INTO agg_events (user_id)
+SELECT
+  raw_events_first.user_id
+FROM
+  raw_events_first LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id
+  WHERE raw_events_second.user_id = 10 OR raw_events_second.user_id = 11;
+-- using a full join
+INSERT INTO agg_events (user_id, value_1_agg)
+SELECT t1.user_id AS col1,
+       t2.user_id AS col2
+FROM   raw_events_first t1
+       FULL JOIN raw_events_second t2
+              ON t1.user_id = t2.user_id;
+-- using semi join
+INSERT INTO raw_events_second
+            (user_id)
+SELECT user_id
+FROM   raw_events_first
+WHERE  user_id IN (SELECT raw_events_second.user_id
+                   FROM   raw_events_second, raw_events_first
+                   WHERE  raw_events_second.user_id = raw_events_first.user_id AND raw_events_first.user_id = 200);
+-- using lateral join
+INSERT INTO raw_events_second
+            (user_id)
+SELECT user_id
+FROM   raw_events_first
+WHERE  NOT EXISTS (SELECT 1
+                   FROM   raw_events_second
+                   WHERE  raw_events_second.user_id =raw_events_first.user_id);
+-- using inner join
+INSERT INTO agg_events (user_id)
+SELECT raw_events_first.user_id
+FROM raw_events_first INNER JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.value_1
+WHERE raw_events_first.value_1 IN (10, 11,12) OR raw_events_second.user_id IN (1,2,3,4);
+-- We could relax distributed insert .. select checks to allow pushing
+-- down more clauses down to the worker nodes when inserting into a single
+-- shard by selecting from a colocated one. We might want to do something
+-- like https://github.com/citusdata/citus/pull/6772.
+--
+--  e.g., insert into null_shard_key_1/citus_local/reference
+--        select * from null_shard_key_1/citus_local/reference limit 1
+--
+-- Below "limit / offset clause" test and some others are examples of this.
+-- limit / offset clause
+INSERT INTO agg_events (user_id) SELECT raw_events_first.user_id FROM raw_events_first LIMIT 1;
+DEBUG:  LIMIT clauses are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO agg_events (user_id) SELECT raw_events_first.user_id FROM raw_events_first OFFSET 1;
+DEBUG:  OFFSET clauses are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+-- using a materialized cte
+WITH cte AS MATERIALIZED
+  (SELECT max(value_1)+1 as v1_agg, user_id FROM raw_events_first GROUP BY user_id)
+INSERT INTO agg_events (value_1_agg, user_id)
+SELECT v1_agg, user_id FROM cte;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO raw_events_second
+  WITH cte AS MATERIALIZED (SELECT * FROM raw_events_first)
+  SELECT user_id * 1000, time, value_1, value_2, value_3, value_4 FROM cte;
+-- using a regular cte
+WITH cte AS (SELECT * FROM raw_events_first)
+INSERT INTO raw_events_second
+  SELECT user_id * 7000, time, value_1, value_2, value_3, value_4 FROM cte;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  CTE cte is going to be inlined via distributed planning
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+INSERT INTO raw_events_second
+  WITH cte AS (SELECT * FROM raw_events_first)
+  SELECT * FROM cte;
+DEBUG:  CTE cte is going to be inlined via distributed planning
+INSERT INTO agg_events
+  WITH sub_cte AS (SELECT 1)
+  SELECT
+    raw_events_first.user_id, (SELECT * FROM sub_cte)
+  FROM
+    raw_events_first;
+DEBUG:  CTE sub_cte is going to be inlined via distributed planning
+DEBUG:  Subqueries without relations are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+-- we still support complex joins via INSERT's cte list ..
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+INSERT INTO raw_events_second (user_id, value_1)
+  SELECT (a+5)*-1, b FROM cte;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  CTE cte is going to be inlined via distributed planning
+DEBUG:  recursively planning left side of the right join since the outer side is a recurring rel
+DEBUG:  recursively planning distributed relation "distributed_table" since it is part of a distributed join node that is outer joined with a recurring rel
+DEBUG:  Wrapping relation "distributed_table" to a subquery
+DEBUG:  generating subplan XXX_1 for subquery SELECT a FROM query_null_dist_key.distributed_table WHERE true
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT "?column?" AS user_id, b AS value_1 FROM (SELECT ((cte.a OPERATOR(pg_catalog.+) 5) OPERATOR(pg_catalog.*) '-1'::integer), cte.b FROM (SELECT reference_table.a, 1 AS b FROM ((SELECT distributed_table_1.a, NULL::integer AS b FROM (SELECT intermediate_result.a FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(a integer)) distributed_table_1) distributed_table RIGHT JOIN query_null_dist_key.reference_table USING (a))) cte) citus_insert_select_subquery("?column?", b)
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+-- .. but can't do so via via SELECT's cte list
+INSERT INTO raw_events_second (user_id, value_1)
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+  SELECT (a+5)*-1, b FROM cte;
+DEBUG:  CTE cte is going to be inlined via distributed planning
+ERROR:  cannot select from different table types when inserting into a distributed table that does not have a shard key
+-- using set operations
+INSERT INTO
+  raw_events_first(user_id)
+  (SELECT user_id FROM raw_events_first) INTERSECT
+  (SELECT user_id FROM raw_events_first);
+DEBUG:  Set operations are not allowed in distributed INSERT ... SELECT queries
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+-- group by clause inside subquery
+INSERT INTO agg_events
+            (user_id)
+SELECT f2.id FROM
+(SELECT
+      id
+FROM   (SELECT raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id ) AS foo) as f
+INNER JOIN
+(SELECT v4,
+       v1,
+       id
+FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
+               SUM(raw_events_first.value_1) AS v1,
+               raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id
+        GROUP  BY raw_events_second.user_id
+        HAVING SUM(raw_events_second.value_4) > 1000) AS foo2 ) as f2
+ON (f.id = f2.id)
+WHERE f.id IN (SELECT user_id
+               FROM   raw_events_second);
+-- group by clause inside lateral subquery
+INSERT INTO agg_events (user_id, value_4_agg)
+SELECT
+  averages.user_id, avg(averages.value_4)
+FROM
+    (SELECT
+      t1.user_id
+    FROM
+      raw_events_second t1 JOIN raw_events_second t2 on (t1.user_id = t2.user_id)
+    ) reference_ids
+  JOIN LATERAL
+    (SELECT
+      user_id, value_4
+    FROM
+      raw_events_first) as averages ON averages.value_4 = reference_ids.user_id
+    GROUP BY averages.user_id;
+-- using aggregates
+INSERT INTO agg_events
+            (value_3_agg,
+             value_4_agg,
+             value_1_agg,
+             value_2_agg,
+             user_id)
+SELECT SUM(value_3),
+       Count(value_4),
+       user_id,
+       SUM(value_1),
+       Avg(value_2)
+FROM   raw_events_first
+GROUP  BY user_id;
+-- using generate_series
+INSERT INTO raw_events_first (user_id, value_1, value_2)
+SELECT s, s, s FROM generate_series(1, 5) s;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+CREATE SEQUENCE insert_select_test_seq;
+-- nextval() expression in select's targetlist
+INSERT INTO raw_events_first (user_id, value_1, value_2)
+SELECT s, nextval('insert_select_test_seq'), (random()*10)::int
+FROM generate_series(100, 105) s;
+DEBUG:  distributed INSERT ... SELECT can only select from distributed tables
+DEBUG:  Collecting INSERT ... SELECT results on coordinator
+-- non-immutable function
+INSERT INTO modify_fast_path (key, value_1) VALUES (2,1) RETURNING value_1, random() * key;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  non-IMMUTABLE functions are not allowed in the RETURNING clause
+SET client_min_messages TO DEBUG2;
+-- update / delete
+UPDATE nullkey_c1_t1 SET a = 1 WHERE b = 5;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 SET a = 1 WHERE a = 5;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 SET a = random();
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  functions used in UPDATE queries on distributed tables must not be VOLATILE
+UPDATE nullkey_c1_t1 SET a = 1 WHERE a = random();
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+DELETE FROM nullkey_c1_t1 WHERE b = 5;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DELETE FROM nullkey_c1_t1 WHERE a = random();
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  functions used in the WHERE/ON/WHEN clause of modification queries on distributed tables must not be VOLATILE
+-- simple update queries between different table types / colocated tables
+UPDATE nullkey_c1_t1 SET b = 5 FROM nullkey_c1_t2 WHERE nullkey_c1_t1.b = nullkey_c1_t2.b;
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 SET b = 5 FROM nullkey_c2_t1 WHERE nullkey_c1_t1.b = nullkey_c2_t1.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+UPDATE nullkey_c1_t1 SET b = 5 FROM reference_table WHERE nullkey_c1_t1.b = reference_table.b;
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 SET b = 5 FROM distributed_table WHERE nullkey_c1_t1.b = distributed_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+UPDATE nullkey_c1_t1 SET b = 5 FROM distributed_table WHERE nullkey_c1_t1.b = distributed_table.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+UPDATE nullkey_c1_t1 SET b = 5 FROM citus_local_table WHERE nullkey_c1_t1.b = citus_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  local table citus_local_table cannot be joined with these distributed tables
+UPDATE nullkey_c1_t1 SET b = 5 FROM postgres_local_table WHERE nullkey_c1_t1.b = postgres_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  relation postgres_local_table is not distributed
+UPDATE reference_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = reference_table.b;
+ERROR:  cannot perform select on a distributed table and modify a reference table
+UPDATE distributed_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+UPDATE distributed_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+UPDATE citus_local_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = citus_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  local table citus_local_table cannot be joined with these distributed tables
+UPDATE postgres_local_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = postgres_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  relation postgres_local_table is not distributed
+-- simple delete queries between different table types / colocated tables
+DELETE FROM nullkey_c1_t1 USING nullkey_c1_t2 WHERE nullkey_c1_t1.b = nullkey_c1_t2.b;
+DEBUG:  Creating router plan
+DELETE FROM nullkey_c1_t1 USING nullkey_c2_t1 WHERE nullkey_c1_t1.b = nullkey_c2_t1.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+DELETE FROM nullkey_c1_t1 USING reference_table WHERE nullkey_c1_t1.b = reference_table.b;
+DEBUG:  Creating router plan
+DELETE FROM nullkey_c1_t1 USING distributed_table WHERE nullkey_c1_t1.b = distributed_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DELETE FROM nullkey_c1_t1 USING distributed_table WHERE nullkey_c1_t1.b = distributed_table.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DELETE FROM nullkey_c1_t1 USING citus_local_table WHERE nullkey_c1_t1.b = citus_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  local table citus_local_table cannot be joined with these distributed tables
+DELETE FROM nullkey_c1_t1 USING postgres_local_table WHERE nullkey_c1_t1.b = postgres_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  relation postgres_local_table is not distributed
+DELETE FROM reference_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = reference_table.b;
+ERROR:  cannot perform select on a distributed table and modify a reference table
+DELETE FROM distributed_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DELETE FROM distributed_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DELETE FROM citus_local_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = citus_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  local table citus_local_table cannot be joined with these distributed tables
+DELETE FROM postgres_local_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = postgres_local_table.b;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  relation postgres_local_table is not distributed
+-- slightly more complex update queries
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.b IN (SELECT b FROM distributed_table);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+WITH cte AS materialized(
+    SELECT * FROM distributed_table
+)
+UPDATE nullkey_c1_t1 SET b = 5 FROM cte WHERE nullkey_c1_t1.b = cte.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.b IN (SELECT b FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+UPDATE nullkey_c1_t1 SET b = 5 FROM reference_table WHERE EXISTS (
+    SELECT 1 FROM reference_table LEFT JOIN nullkey_c1_t1 USING (a) WHERE nullkey_c1_t1.b IS NULL
+);
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 tx SET b = (
+    SELECT nullkey_c1_t2.b FROM nullkey_c1_t2 JOIN nullkey_c1_t1 ON (nullkey_c1_t1.a != nullkey_c1_t2.a) WHERE nullkey_c1_t1.a = tx.a ORDER BY 1 LIMIT 1
+);
+DEBUG:  Creating router plan
+UPDATE nullkey_c1_t1 tx SET b = t2.b FROM nullkey_c1_t1 t1 JOIN nullkey_c1_t2 t2 ON (t1.a = t2.a);
+DEBUG:  Creating router plan
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t2 ORDER BY 1,2 LIMIT 10
+)
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.a IN (SELECT b FROM cte);
+DEBUG:  Creating router plan
+UPDATE modify_fast_path SET value_1 = value_1 + 12 * value_1 WHERE key = 1;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+UPDATE modify_fast_path SET value_1 = NULL WHERE value_1 = 15 AND (key = 1 OR value_2 = 'citus');
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+UPDATE modify_fast_path SET value_1 = 5 WHERE key = 2 RETURNING value_1 * 15, value_1::numeric * 16;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ ?column? | ?column?
+---------------------------------------------------------------------
+(0 rows)
+
+UPDATE modify_fast_path
+	SET value_1 = 1
+	FROM modify_fast_path_reference
+	WHERE
+		modify_fast_path.key = modify_fast_path_reference.key AND
+		modify_fast_path.key  = 1 AND
+		modify_fast_path_reference.key = 1;
+DEBUG:  Creating router plan
+PREPARE p1 (int, int, int) AS
+	UPDATE modify_fast_path SET value_1 = value_1 + $1 WHERE key = $2 AND value_1 = $3;
+EXECUTE p1(1,1,1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(2,2,2);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(3,3,3);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(4,4,4);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(5,5,5);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(6,6,6);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p1(7,7,7);
+PREPARE prepared_zero_shard_update(int) AS UPDATE modify_fast_path SET value_1 = 1 WHERE key = $1 AND false;
+EXECUTE prepared_zero_shard_update(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(2);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(3);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(4);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(5);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(6);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_update(7);
+-- slightly more complex delete queries
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b IN (SELECT b FROM distributed_table);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+WITH cte AS materialized(
+    SELECT * FROM distributed_table
+)
+DELETE FROM nullkey_c1_t1 USING cte WHERE nullkey_c1_t1.b = cte.a;
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b IN (SELECT b FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  complex joins are only supported when all distributed tables are co-located and joined on their distribution columns
+DELETE FROM nullkey_c1_t1 USING reference_table WHERE EXISTS (
+    SELECT 1 FROM reference_table LEFT JOIN nullkey_c1_t1 USING (a) WHERE nullkey_c1_t1.b IS NULL
+);
+DEBUG:  Creating router plan
+DELETE FROM nullkey_c1_t1 tx USING nullkey_c1_t1 t1 JOIN nullkey_c1_t2 t2 ON (t1.a = t2.a);
+DEBUG:  Creating router plan
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t2 ORDER BY 1,2 LIMIT 10
+)
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.a IN (SELECT b FROM cte);
+DEBUG:  Creating router plan
+DELETE FROM modify_fast_path WHERE value_1 = 15 AND (key = 1 OR value_2 = 'citus');
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DELETE FROM modify_fast_path WHERE key = 2 RETURNING value_1 * 15, value_1::numeric * 16;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ ?column? | ?column?
+---------------------------------------------------------------------
+(0 rows)
+
+DELETE FROM modify_fast_path
+	USING modify_fast_path_reference
+	WHERE
+		modify_fast_path.key = modify_fast_path_reference.key AND
+		modify_fast_path.key  = 1 AND
+		modify_fast_path_reference.key = 1;
+DEBUG:  Creating router plan
+PREPARE p2 (int, int, int) AS
+	DELETE FROM modify_fast_path WHERE key = ($2)*$1 AND value_1 = $3;
+EXECUTE p2(1,1,1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(2,2,2);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(3,3,3);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(4,4,4);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(5,5,5);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(6,6,6);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE p2(7,7,7);
+PREPARE prepared_zero_shard_delete(int) AS DELETE FROM modify_fast_path WHERE key = $1 AND false;
+EXECUTE prepared_zero_shard_delete(1);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(2);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(3);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(4);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(5);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(6);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+EXECUTE prepared_zero_shard_delete(7);
+-- test modifying ctes
+WITH cte AS (
+    UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1 RETURNING *
+)
+SELECT * FROM cte;
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+SELECT * FROM modify_fast_path;
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+SELECT * FROM modify_fast_path_reference WHERE key IN (SELECT key FROM cte);
+DEBUG:  Creating router plan
+ key | value_1 | value_2
+---------------------------------------------------------------------
+(0 rows)
+
+WITH cte AS (
+    DELETE FROM reference_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  cannot router plan modification of a non-distributed table
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t2 WHERE a IN (SELECT a FROM cte);
+DEBUG:  Creating router plan
+ a | b
+---------------------------------------------------------------------
+(0 rows)
+
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c2_t1 WHERE a IN (SELECT a FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  found no worker with all shard placements
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM distributed_table WHERE a IN (SELECT a FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  Router planner cannot handle multi-shard select queries
+-- Below two queries fail very late when
+-- citus.enable_non_colocated_router_query_pushdown is set to on.
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+ERROR:  relation "query_null_dist_key.nullkey_c1_t1_1620000" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE b IN (SELECT b FROM cte);
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+ERROR:  relation "query_null_dist_key.nullkey_c1_t1_1620000" does not exist
+CONTEXT:  while executing command on localhost:xxxxx
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  router planner does not support queries that reference non-colocated distributed tables
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE b IN (SELECT b FROM cte);
+ERROR:  queries that reference a distributed table without a shard key can only reference colocated distributed tables or reference tables
+DETAIL:  router planner does not support queries that reference non-colocated distributed tables
+RESET citus.enable_non_colocated_router_query_pushdown;
+WITH cte AS (
+    UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1 RETURNING *
+)
+UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1;
+DEBUG:  Creating router plan
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+DELETE FROM modify_fast_path WHERE key = 1;
+DEBUG:  Creating router plan
+-- test window functions
+SELECT
+	user_id, avg(avg(value_3)) OVER (PARTITION BY user_id, MIN(value_2))
+FROM
+	raw_events_first
+GROUP BY
+	1
+ORDER BY
+	2 DESC NULLS LAST, 1 DESC;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ user_id |  avg
+---------------------------------------------------------------------
+       6 | 6000.1
+       5 | 5000.1
+       4 | 4000.1
+       3 | 3000.1
+       2 | 2000.1
+       1 | 1000.1
+     105 |
+     104 |
+     103 |
+     102 |
+     101 |
+     100 |
+(12 rows)
+
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, us.value_1, random() as r1
+	FROM
+		raw_events_first as us, raw_events_second
+	WHERE
+		us.user_id = raw_events_second.user_id
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+DEBUG:  Creating router plan
+ user_id | max
+---------------------------------------------------------------------
+       1 |
+       2 |
+       3 |
+       4 |
+       5 |
+       6 |
+       6 |  60
+       5 |  50
+       4 |  40
+       3 |  30
+       2 |  20
+       1 |  10
+       5 |   5
+       4 |   4
+       3 |   3
+       2 |   2
+       1 |   1
+(17 rows)
+
+SELECT
+	DISTINCT ON (raw_events_second.user_id, rnk) raw_events_second.user_id, rank() OVER my_win AS rnk
+FROM
+	raw_events_second, raw_events_first
+WHERE
+	raw_events_first.user_id = raw_events_second.user_id
+WINDOW
+	my_win AS (PARTITION BY raw_events_second.user_id, raw_events_first.value_1 ORDER BY raw_events_second.time DESC)
+ORDER BY
+	rnk DESC, 1 DESC
+LIMIT 10;
+DEBUG:  Creating router plan
+ user_id | rnk
+---------------------------------------------------------------------
+       6 |   2
+       5 |   2
+       4 |   2
+       3 |   2
+       2 |   2
+       1 |   2
+       6 |   1
+       5 |   1
+       4 |   1
+       3 |   1
+(10 rows)
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA query_null_dist_key CASCADE;
+SELECT citus_remove_node('localhost', :master_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+

--- a/src/test/regress/expected/single_node.out
+++ b/src/test/regress/expected/single_node.out
@@ -101,8 +101,63 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+CREATE TABLE single_node_nullkey_c1(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c1', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE single_node_nullkey_c2(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c2', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- created on different colocation groups ..
+SELECT
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+)
+!=
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- .. but both are associated to coordinator
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- try creating a null-shard-key distributed table from a shard relation
+SELECT shardid AS round_robin_test_c1_shard_id FROM pg_dist_shard WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass \gset
+SELECT create_distributed_table('single_node_nullkey_c1_' || :round_robin_test_c1_shard_id , null, colocate_with=>'none', distribution_type=>null);
+ERROR:  relation "single_node_nullkey_c1_90630532" is a shard relation
 SET client_min_messages TO WARNING;
-DROP TABLE failover_to_local;
+DROP TABLE failover_to_local, single_node_nullkey_c1, single_node_nullkey_c2;
 RESET client_min_messages;
 -- so that we don't have to update rest of the test output
 SET citus.next_shard_id TO 90630500;

--- a/src/test/regress/expected/single_node_0.out
+++ b/src/test/regress/expected/single_node_0.out
@@ -101,8 +101,63 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+CREATE TABLE single_node_nullkey_c1(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c1', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE single_node_nullkey_c2(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c2', null, colocate_with=>'none', distribution_type=>null);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- created on different colocation groups ..
+SELECT
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+)
+!=
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- .. but both are associated to coordinator
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- try creating a null-shard-key distributed table from a shard relation
+SELECT shardid AS round_robin_test_c1_shard_id FROM pg_dist_shard WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass \gset
+SELECT create_distributed_table('single_node_nullkey_c1_' || :round_robin_test_c1_shard_id , null, colocate_with=>'none', distribution_type=>null);
+ERROR:  relation "single_node_nullkey_c1_90630532" is a shard relation
 SET client_min_messages TO WARNING;
-DROP TABLE failover_to_local;
+DROP TABLE failover_to_local, single_node_nullkey_c1, single_node_nullkey_c2;
 RESET client_min_messages;
 -- so that we don't have to update rest of the test output
 SET citus.next_shard_id TO 90630500;

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -32,6 +32,7 @@ test: escape_extension_name
 test: ref_citus_local_fkeys
 test: alter_database_owner
 test: distributed_triggers
+test: create_null_dist_key
 
 test: multi_test_catalog_views
 test: multi_table_ddl

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -200,6 +200,7 @@ test: local_table_join
 test: local_dist_join_mixed
 test: citus_local_dist_joins
 test: recurring_outer_join
+test: query_null_dist_key
 test: pg_dump
 
 # ---------

--- a/src/test/regress/null_dist_key_prep_schedule
+++ b/src/test/regress/null_dist_key_prep_schedule
@@ -1,0 +1,1 @@
+test: null_dist_key_prep

--- a/src/test/regress/sql/create_null_dist_key.sql
+++ b/src/test/regress/sql/create_null_dist_key.sql
@@ -1,0 +1,962 @@
+CREATE SCHEMA create_null_dist_key;
+SET search_path TO create_null_dist_key;
+
+SET citus.next_shard_id TO 1720000;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+
+SELECT 1 FROM citus_remove_node('localhost', :worker_1_port);
+SELECT 1 FROM citus_remove_node('localhost', :worker_2_port);
+
+CREATE TABLE add_node_test(a int, "b" text);
+
+-- add a node before creating the null-shard-key table
+SELECT 1 FROM citus_add_node('localhost', :worker_1_port);
+
+SELECT create_distributed_table('add_node_test', null, colocate_with=>'none', distribution_type=>null);
+
+-- add a node after creating the null-shard-key table
+SELECT 1 FROM citus_add_node('localhost', :worker_2_port);
+
+-- make sure that table is created on the worker nodes added before/after create_distributed_table
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*)=1 FROM pg_class WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+                                          relname='add_node_test'
+$$);
+
+-- and check the metadata tables
+
+SELECT result FROM run_command_on_workers($$
+    SELECT (partmethod, partkey, repmodel, autoconverted) FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+$$);
+
+SELECT result FROM run_command_on_workers($$
+    SELECT (shardstorage, shardminvalue, shardmaxvalue) FROM pg_dist_shard
+    WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+$$);
+
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*)=1 FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+    );
+$$);
+
+SELECT result FROM run_command_on_workers($$
+    SELECT (shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation) FROM pg_dist_colocation
+    WHERE colocationid = (
+        SELECT colocationid FROM pg_dist_partition
+        WHERE logicalrelid = 'create_null_dist_key.add_node_test'::regclass
+    );
+$$);
+
+SET client_min_messages TO WARNING;
+SELECT 1 FROM citus_add_node('localhost', :master_port, groupid => 0);
+
+SET client_min_messages TO NOTICE;
+
+CREATE TABLE invalid_configs_1(a int primary key);
+SELECT create_distributed_table('invalid_configs_1', null, shard_count=>2);
+SELECT create_distributed_table('invalid_configs_1', null, shard_count=>1);
+
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+CREATE TABLE nullkey_c1_t3(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+
+SELECT colocationid AS nullkey_c1_t1_colocation_id FROM pg_dist_partition WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass \gset
+
+BEGIN;
+  DROP TABLE nullkey_c1_t1;
+  -- make sure that we delete the colocation group after dropping the last table that belongs to it
+  SELECT COUNT(*)=0 FROM pg_dist_colocation WHERE colocationid = :'nullkey_c1_t1_colocation_id';
+ROLLBACK;
+
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+SELECT create_distributed_table('nullkey_c1_t3', null, colocate_with=>'nullkey_c1_t1', distribution_type=>'append');
+SELECT create_distributed_table('nullkey_c1_t3', null, colocate_with=>'nullkey_c1_t1');
+
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+CREATE TABLE nullkey_c2_t3(a int, b int);
+
+-- create_distributed_table_concurrently is not yet supported yet
+SELECT create_distributed_table_concurrently('nullkey_c2_t1', null);
+SELECT create_distributed_table_concurrently('nullkey_c2_t1', null, colocate_with=>'none');
+
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>'hash'); -- distribution_type is ignored anyway
+SELECT create_distributed_table('nullkey_c2_t3', null, colocate_with=>'nullkey_c2_t2', distribution_type=>null);
+
+-- check the metadata for the colocated tables whose names start with nullkey_c1_
+
+SELECT logicalrelid, partmethod, partkey, repmodel, autoconverted FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+ORDER BY 1;
+
+-- make sure that all those 3 tables belong to same colocation group
+SELECT COUNT(*) FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+GROUP BY colocationid;
+
+SELECT logicalrelid, shardstorage, shardminvalue, shardmaxvalue FROM pg_dist_shard
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c1_%'
+)
+ORDER BY 1;
+
+-- make sure that all those 3 shards are created on the same node group
+SELECT COUNT(*) FROM pg_dist_placement
+WHERE shardid IN (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid IN (
+        SELECT oid FROM pg_class
+        WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+              relname LIKE 'nullkey_c1_%'
+    )
+)
+GROUP BY groupid;
+
+-- check the metadata for the colocated tables whose names start with nullkey_c2_
+
+SELECT logicalrelid, partmethod, partkey, repmodel, autoconverted FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+ORDER BY 1;
+
+-- make sure that all those 3 tables belong to same colocation group
+SELECT COUNT(*) FROM pg_dist_partition
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+GROUP BY colocationid;
+
+SELECT logicalrelid, shardstorage, shardminvalue, shardmaxvalue FROM pg_dist_shard
+WHERE logicalrelid IN (
+    SELECT oid FROM pg_class
+    WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+          relname LIKE 'nullkey_c2_%'
+)
+ORDER BY 1;
+
+-- make sure that all those 3 shards created on the same node group
+SELECT COUNT(*) FROM pg_dist_placement
+WHERE shardid IN (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid IN (
+        SELECT oid FROM pg_class
+        WHERE relnamespace = 'create_null_dist_key'::regnamespace AND
+              relname LIKE 'nullkey_c2_%'
+    )
+)
+GROUP BY groupid;
+
+-- Make sure that the colocated tables whose names start with nullkey_c1_
+-- belong to a different colocation group than the ones whose names start
+-- with nullkey_c2_.
+--
+-- It's ok to only compare nullkey_c1_t1 and nullkey_c2_t1 because we already
+-- verified that null_dist_key.nullkey_c1_t1 is colocated with the other two
+-- and null_dist_key.nullkey_c2_t1 is colocated with the other two.
+SELECT
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+)
+!=
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+);
+
+-- Since we determine node for the placement based on the module of colocation id,
+-- we don't expect those two colocation groups to get assigned to same node.
+SELECT
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+    )
+)
+!=
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+    )
+);
+
+-- It's ok to only check nullkey_c1_t1 and nullkey_c2_t1 because we already
+-- verified that null_dist_key.nullkey_c1_t1 is colocated with the other two
+-- and null_dist_key.nullkey_c2_t1 is colocated with the other two.
+SELECT shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation FROM pg_dist_colocation
+WHERE colocationid = (
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c1_t1'::regclass
+);
+
+SELECT shardcount, replicationfactor, distributioncolumntype, distributioncolumncollation FROM pg_dist_colocation
+WHERE colocationid = (
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'create_null_dist_key.nullkey_c2_t1'::regclass
+);
+
+CREATE TABLE round_robin_test_c1(a int, b int);
+SELECT create_distributed_table('round_robin_test_c1', null, colocate_with=>'none', distribution_type=>null);
+
+\c - - - :master_port
+SET search_path TO create_null_dist_key;
+SET citus.next_shard_id TO 1730000;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+SET client_min_messages TO NOTICE;
+
+CREATE TABLE round_robin_test_c2(a int, b int);
+SELECT create_distributed_table('round_robin_test_c2', null, colocate_with=>'none', distribution_type=>null);
+
+-- Since we determine node for the placement based on the module of colocation id,
+-- we don't expect those two colocation groups to get assigned to same node even
+-- after reconnecting to the coordinator.
+SELECT
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.round_robin_test_c1'::regclass
+    )
+)
+!=
+(
+    SELECT groupid FROM pg_dist_placement
+    WHERE shardid = (
+        SELECT shardid FROM pg_dist_shard
+        WHERE logicalrelid = 'create_null_dist_key.round_robin_test_c2'::regclass
+    )
+);
+
+CREATE TABLE distributed_table(a int, b int);
+
+-- cannot colocate a sharded table with null shard key table
+SELECT create_distributed_table('distributed_table', 'a', colocate_with=>'nullkey_c1_t1');
+
+CREATE TABLE reference_table(a int, b int);
+CREATE TABLE local(a int, b int);
+SELECT create_reference_table('reference_table');
+SELECT create_distributed_table('distributed_table', 'a');
+
+-- cannot colocate null shard key tables with other table types
+CREATE TABLE cannot_colocate_with_other_types (a int, b int);
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'reference_table');
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'distributed_table');
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'local'); -- postgres local
+
+SELECT citus_add_local_table_to_metadata('local');
+
+-- cannot colocate null shard key tables with citus local tables
+SELECT create_distributed_table('cannot_colocate_with_other_types', null, colocate_with=>'local'); -- citus local
+
+SET client_min_messages TO WARNING;
+
+-- can't create such a distributed table from another Citus table, except Citus local tables
+SELECT create_distributed_table('reference_table', null, colocate_with=>'none');
+SELECT create_distributed_table('distributed_table', null, colocate_with=>'none');
+SELECT create_distributed_table('local', null, colocate_with=>'none');
+
+BEGIN;
+  -- creating a null-shard-key table from a temporary table is not supported
+  CREATE TEMPORARY TABLE temp_table (a int);
+  SELECT create_distributed_table('temp_table', null, colocate_with=>'none', distribution_type=>null);
+ROLLBACK;
+
+-- creating a null-shard-key table from a catalog table is not supported
+SELECT create_distributed_table('pg_catalog.pg_index', NULL, distribution_type=>null);
+
+-- creating a null-shard-key table from an unlogged table is supported
+CREATE UNLOGGED TABLE unlogged_table (a int);
+SELECT create_distributed_table('unlogged_table', null, colocate_with=>'none', distribution_type=>null);
+
+-- creating a null-shard-key table from a foreign table is not supported
+CREATE FOREIGN TABLE foreign_table (
+  id bigint not null,
+  full_name text not null default ''
+) SERVER fake_fdw_server OPTIONS (encoding 'utf-8', compression 'true', table_name 'foreign_table');
+SELECT create_distributed_table('foreign_table', null, colocate_with=>'none', distribution_type=>null);
+
+-- create a null dist key table that has no tuples
+CREATE TABLE null_dist_key_table_1 (a int primary key);
+SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
+
+-- create a null dist key table that has some tuples
+CREATE TABLE null_dist_key_table_2(a int primary key);
+INSERT INTO null_dist_key_table_2 VALUES(1);
+SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'none');
+
+SELECT * FROM null_dist_key_table_2 ORDER BY a;
+
+DROP TABLE null_dist_key_table_1, null_dist_key_table_2;
+
+-- create indexes before creating the null dist key tables
+
+-- .. for an initially empty table
+CREATE TABLE null_dist_key_table_1(a int);
+CREATE INDEX null_dist_key_table_1_idx ON null_dist_key_table_1(a);
+SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
+
+-- .. and for another table having data in it before creating null dist key table
+CREATE TABLE null_dist_key_table_2(a int);
+INSERT INTO null_dist_key_table_2 VALUES(1);
+CREATE INDEX null_dist_key_table_2_idx ON null_dist_key_table_2(a);
+SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'none');
+
+SELECT * FROM null_dist_key_table_2 ORDER BY a;
+
+-- show that we do not support inheritance relationships
+CREATE TABLE parent_table (a int, b text);
+CREATE TABLE child_table () INHERITS (parent_table);
+
+-- both of below should error out
+SELECT create_distributed_table('parent_table', null, colocate_with=>'none');
+SELECT create_distributed_table('child_table', null, colocate_with=>'none');
+
+-- show that we support policies
+BEGIN;
+  CREATE TABLE null_dist_key_table_3 (table_user text);
+
+  ALTER TABLE null_dist_key_table_3 ENABLE ROW LEVEL SECURITY;
+
+  CREATE ROLE table_users;
+  CREATE POLICY table_policy ON null_dist_key_table_3 TO table_users
+      USING (table_user = current_user);
+
+  SELECT create_distributed_table('null_dist_key_table_3', null, colocate_with=>'none');
+ROLLBACK;
+
+-- drop them for next tests
+DROP TABLE null_dist_key_table_1, null_dist_key_table_2, distributed_table;
+
+-- tests for object names that should be escaped properly
+
+CREATE SCHEMA "NULL_!_dist_key";
+
+CREATE TABLE "NULL_!_dist_key"."my_TABLE.1!?!"(id int, "Second_Id" int);
+SELECT create_distributed_table('"NULL_!_dist_key"."my_TABLE.1!?!"', null, colocate_with=>'none');
+
+-- drop the table before creating it when the search path is set
+SET search_path to "NULL_!_dist_key" ;
+DROP TABLE "my_TABLE.1!?!";
+
+CREATE TYPE int_jsonb_type AS (key int, value jsonb);
+CREATE DOMAIN age_with_default AS int CHECK (value >= 0) DEFAULT 0;
+CREATE TYPE yes_no_enum AS ENUM ('yes', 'no');
+CREATE EXTENSION btree_gist;
+
+CREATE SEQUENCE my_seq_1 START WITH 10;
+
+CREATE TABLE "Table?!.1Table"(
+  id int PRIMARY KEY,
+  "Second_Id" int,
+  "local_Type" int_jsonb_type,
+  "jsondata" jsonb NOT NULL,
+  name text,
+  price numeric CHECK (price > 0),
+  age_with_default_col age_with_default,
+  yes_no_enum_col yes_no_enum,
+  seq_col_1 bigserial,
+  seq_col_2 int DEFAULT nextval('my_seq_1'),
+  generated_column int GENERATED ALWAYS AS (seq_col_1 * seq_col_2 + 4) STORED,
+  UNIQUE (id, price),
+  EXCLUDE USING GIST (name WITH =));
+
+-- create some objects before create_distributed_table
+CREATE INDEX "my!Index1" ON "Table?!.1Table"(id) WITH ( fillfactor = 80 ) WHERE id > 10;
+CREATE INDEX text_index ON "Table?!.1Table"(name);
+CREATE UNIQUE INDEX uniqueIndex ON "Table?!.1Table" (id);
+CREATE STATISTICS stats_1 ON id, price FROM "Table?!.1Table";
+
+CREATE TEXT SEARCH CONFIGURATION text_search_cfg (parser = default);
+CREATE INDEX text_search_index ON "Table?!.1Table"
+USING gin (to_tsvector('text_search_cfg'::regconfig, (COALESCE(name, ''::character varying))::text));
+
+-- ingest some data before create_distributed_table
+INSERT INTO "Table?!.1Table" VALUES (1, 1, (1, row_to_json(row(1,1)))::int_jsonb_type, row_to_json(row(1,1), true)),
+                                    (2, 1, (2, row_to_json(row(2,2)))::int_jsonb_type, row_to_json(row(2,2), 'false'));
+
+-- create a replica identity before create_distributed_table
+ALTER TABLE "Table?!.1Table" REPLICA IDENTITY USING INDEX uniqueIndex;
+
+SELECT create_distributed_table('"Table?!.1Table"', null, colocate_with=>'none');
+
+INSERT INTO "Table?!.1Table" VALUES (10, 15, (150, row_to_json(row(4,8)))::int_jsonb_type, '{}', 'text_1', 10, 27, 'yes', 60, 70);
+INSERT INTO "Table?!.1Table" VALUES (5, 5, (5, row_to_json(row(5,5)))::int_jsonb_type, row_to_json(row(5,5), true));
+
+-- tuples that are supposed to violate different data type / check constraints
+INSERT INTO "Table?!.1Table"(id, jsondata, name) VALUES (101, '{"a": 1}', 'text_1');
+INSERT INTO "Table?!.1Table"(id, jsondata, price) VALUES (101, '{"a": 1}', -1);
+INSERT INTO "Table?!.1Table"(id, jsondata, age_with_default_col) VALUES (101, '{"a": 1}', -1);
+INSERT INTO "Table?!.1Table"(id, jsondata, yes_no_enum_col) VALUES (101, '{"a": 1}', 'what?');
+
+SELECT * FROM "Table?!.1Table" ORDER BY id;
+
+SET search_path TO create_null_dist_key;
+
+-- create a partitioned table with some columns that
+-- are going to be dropped within the tests
+CREATE TABLE sensors(
+    col_to_drop_1 text,
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+PRIMARY KEY (measureid, eventdatetime, measure_data))
+PARTITION BY RANGE(eventdatetime);
+
+-- drop column even before attaching any partitions
+ALTER TABLE sensors DROP COLUMN col_to_drop_1;
+
+CREATE TABLE sensors_2000 PARTITION OF sensors FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+
+-- cannot distribute child table without distributing the parent
+SELECT create_distributed_table('sensors_2000', NULL, distribution_type=>null);
+
+SELECT create_distributed_table('sensors', NULL, distribution_type=>null);
+
+CREATE TABLE multi_level_partitioning_parent(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb)
+PARTITION BY RANGE(eventdatetime);
+
+CREATE TABLE multi_level_partitioning_level_1(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb)
+PARTITION BY RANGE(eventdatetime);
+
+ALTER TABLE multi_level_partitioning_parent ATTACH PARTITION multi_level_partitioning_level_1
+FOR VALUES FROM ('2000-01-01') TO ('2001-01-01');
+
+CREATE TABLE multi_level_partitioning_level_2 PARTITION OF multi_level_partitioning_level_1
+FOR VALUES FROM ('2000-01-01') TO ('2000-06-06');
+
+-- multi-level partitioning is not supported
+SELECT create_distributed_table('multi_level_partitioning_parent', NULL, distribution_type=>null);
+
+CREATE FUNCTION normalize_generate_always_as_error(query text) RETURNS void AS $$
+BEGIN
+        EXECUTE query;
+        EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM LIKE 'cannot insert into column %' OR
+           SQLERRM LIKE 'cannot insert a non-DEFAULT value into column %'
+        THEN
+            RAISE 'cannot insert a non-DEFAULT value into column';
+        ELSE
+            RAISE 'unknown error';
+        END IF;
+END;
+$$LANGUAGE plpgsql;
+
+CREATE TABLE identity_test (
+    a int GENERATED BY DEFAULT AS IDENTITY (START WITH 10 INCREMENT BY 10),
+    b bigint GENERATED ALWAYS AS IDENTITY (START WITH 100 INCREMENT BY 100),
+    c bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 1000 INCREMENT BY 1000)
+);
+
+SELECT create_distributed_table('identity_test', NULL, distribution_type=>null);
+
+DROP TABLE identity_test;
+
+-- Above failed because we don't support using a data type other than BIGINT
+-- for identity columns, so drop the table and create a new one with BIGINT
+-- identity columns.
+CREATE TABLE identity_test (
+    a bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 10 INCREMENT BY 10),
+    b bigint GENERATED ALWAYS AS IDENTITY (START WITH 100 INCREMENT BY 100),
+    c bigint GENERATED BY DEFAULT AS IDENTITY (START WITH 1000 INCREMENT BY 1000)
+);
+
+SELECT create_distributed_table('identity_test', NULL, distribution_type=>null);
+
+INSERT INTO identity_test (a) VALUES (5);
+
+SELECT normalize_generate_always_as_error($$INSERT INTO identity_test (b) VALUES (5)$$); -- fails due to missing OVERRIDING SYSTEM VALUE
+INSERT INTO identity_test (b) OVERRIDING SYSTEM VALUE VALUES (5);
+
+INSERT INTO identity_test (c) VALUES (5);
+
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (a) VALUES (6)
+$$);
+
+SELECT result, success FROM run_command_on_workers($$
+    SELECT create_null_dist_key.normalize_generate_always_as_error('INSERT INTO create_null_dist_key.identity_test (b) VALUES (1)')
+$$);
+
+-- This should fail due to missing OVERRIDING SYSTEM VALUE.
+SELECT result, success FROM run_command_on_workers($$
+    SELECT create_null_dist_key.normalize_generate_always_as_error('INSERT INTO create_null_dist_key.identity_test (a, b) VALUES (1, 1)')
+$$);
+
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (a, b) OVERRIDING SYSTEM VALUE VALUES (7, 7)
+$$);
+
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.identity_test (c, a) OVERRIDING SYSTEM VALUE VALUES (8, 8)
+$$);
+
+-- test foreign keys
+
+CREATE TABLE referenced_table(a int UNIQUE, b int);
+CREATE TABLE referencing_table(a int, b int,
+    FOREIGN KEY (a) REFERENCES referenced_table(a));
+
+-- to a colocated null dist key table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ROLLBACK;
+
+-- to a non-colocated null dist key table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ROLLBACK;
+
+-- to a sharded table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', 'a');
+
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ROLLBACK;
+
+-- to a reference table
+BEGIN;
+  SELECT create_reference_table('referenced_table');
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ROLLBACK;
+
+-- to a citus local table
+BEGIN;
+  SELECT citus_add_local_table_to_metadata('referenced_table', cascade_via_foreign_keys=>true);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+ROLLBACK;
+
+-- to a postgres table
+SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+
+-- from a reference table
+BEGIN;
+  SELECT create_reference_table('referencing_table');
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ROLLBACK;
+
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+  SELECT create_reference_table('referencing_table');
+ROLLBACK;
+
+-- from a sharded table
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+  SELECT create_distributed_table('referencing_table', 'a');
+ROLLBACK;
+
+-- from a citus local table
+BEGIN;
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ROLLBACK;
+
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+ROLLBACK;
+
+-- from a postgres table (only useful to preserve legacy behavior)
+BEGIN;
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+ROLLBACK;
+
+-- make sure that we enforce the foreign key constraint when inserting from workers too
+SELECT create_reference_table('referenced_table');
+SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null);
+INSERT INTO referenced_table VALUES (1, 1);
+-- ok
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.referencing_table VALUES (1, 2)
+$$);
+-- fails
+SELECT result, success FROM run_command_on_workers($$
+    INSERT INTO create_null_dist_key.referencing_table VALUES (2, 2)
+$$);
+
+DROP TABLE referencing_table, referenced_table;
+
+CREATE TABLE self_fkey_test(a int UNIQUE, b int,
+    FOREIGN KEY (b) REFERENCES self_fkey_test(a),
+    FOREIGN KEY (a) REFERENCES self_fkey_test(a));
+SELECT create_distributed_table('self_fkey_test', NULL, distribution_type=>null);
+
+INSERT INTO self_fkey_test VALUES (1, 1); -- ok
+INSERT INTO self_fkey_test VALUES (2, 3); -- fails
+
+-- similar foreign key tests but this time create the referencing table later on
+
+-- referencing table is a null shard key table
+
+-- to a colocated null dist key table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ROLLBACK;
+
+BEGIN;
+  CREATE TABLE referenced_table(a int, b int, UNIQUE(b, a));
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a, b) REFERENCES referenced_table(b, a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+
+  INSERT INTO referenced_table VALUES (1, 2);
+  INSERT INTO referencing_table VALUES (2, 1);
+
+  -- fails
+  INSERT INTO referencing_table VALUES (1, 2);
+ROLLBACK;
+
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET NULL);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  UPDATE referenced_table SET a = 5;
+  SELECT * FROM referencing_table;
+ROLLBACK;
+
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a serial, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET DEFAULT);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+ROLLBACK;
+
+-- to a non-colocated null dist key table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ROLLBACK;
+
+-- to a sharded table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', 'a');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ROLLBACK;
+
+-- to a reference table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_reference_table('referenced_table');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  -- fails
+  INSERT INTO referencing_table VALUES (2, 2);
+ROLLBACK;
+
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_reference_table('referenced_table');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a) ON DELETE CASCADE);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  INSERT INTO referenced_table VALUES (1, 1);
+  INSERT INTO referencing_table VALUES (1, 2);
+
+  DELETE FROM referenced_table CASCADE;
+  SELECT * FROM referencing_table;
+ROLLBACK;
+
+-- to a citus local table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT citus_add_local_table_to_metadata('referenced_table');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ROLLBACK;
+
+-- to a postgres table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'none');
+ROLLBACK;
+
+-- referenced table is a null shard key table
+
+-- from a sharded table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_distributed_table('referencing_table', 'a');
+ROLLBACK;
+
+-- from a reference table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT create_reference_table('referencing_table');
+ROLLBACK;
+
+-- from a citus local table
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+  SELECT citus_add_local_table_to_metadata('referencing_table', cascade_via_foreign_keys=>true);
+ROLLBACK;
+
+-- from a postgres table (only useful to preserve legacy behavior)
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null, colocate_with=>'none');
+
+  CREATE TABLE referencing_table(a int, b int, FOREIGN KEY (a) REFERENCES referenced_table(a));
+ROLLBACK;
+
+-- Test whether we switch to sequential execution to enforce foreign
+-- key restrictions.
+
+CREATE TABLE referenced_table(id int PRIMARY KEY, value_1 int);
+SELECT create_reference_table('referenced_table');
+
+CREATE TABLE referencing_table(id int PRIMARY KEY, value_1 int, CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', null, colocate_with=>'none', distribution_type=>null);
+
+SET client_min_messages TO DEBUG1;
+
+BEGIN;
+	-- Switches to sequential execution because referenced_table is a reference table
+	-- and referenced by a null-shard-key distributed table.
+    --
+    -- Given that we cannot do parallel access on null-shard-key, this is not useful.
+    -- However, this is already what we're doing for, e.g., a foreign key from a
+    -- reference table to another reference table.
+	TRUNCATE referenced_table CASCADE;
+	SELECT COUNT(*) FROM referencing_table;
+COMMIT;
+
+BEGIN;
+	SELECT COUNT(*) FROM referencing_table;
+	-- Doesn't fail because the SELECT didn't perform parallel execution.
+	TRUNCATE referenced_table CASCADE;
+COMMIT;
+
+BEGIN;
+	UPDATE referencing_table SET value_1 = 15;
+	-- Doesn't fail because the UPDATE didn't perform parallel execution.
+	TRUNCATE referenced_table CASCADE;
+COMMIT;
+
+BEGIN;
+	SELECT COUNT(*) FROM referenced_table;
+	-- doesn't switch to sequential execution
+	ALTER TABLE referencing_table ADD COLUMN X INT;
+ROLLBACK;
+
+BEGIN;
+	-- Switches to sequential execution because referenced_table is a reference table
+	-- and referenced by a null-shard-key distributed table.
+    --
+    -- Given that we cannot do parallel access on null-shard-key, this is not useful.
+    -- However, this is already what we're doing for, e.g., a foreign key from a
+    -- reference table to another reference table.
+	UPDATE referenced_table SET id = 101 WHERE id = 99;
+	UPDATE referencing_table SET value_1 = 15;
+ROLLBACK;
+
+BEGIN;
+	UPDATE referencing_table SET value_1 = 15;
+    -- Doesn't fail because prior UPDATE didn't perform parallel execution.
+    UPDATE referenced_table SET id = 101 WHERE id = 99;
+ROLLBACK;
+
+SET client_min_messages TO WARNING;
+
+DROP TABLE referenced_table, referencing_table;
+
+-- Test whether we unnecessarily switch to sequential execution
+-- when the referenced relation is a null-shard-key table.
+
+CREATE TABLE referenced_table(id int PRIMARY KEY, value_1 int);
+SELECT create_distributed_table('referenced_table', null, colocate_with=>'none', distribution_type=>null);
+
+CREATE TABLE referencing_table(id int PRIMARY KEY, value_1 int, CONSTRAINT fkey FOREIGN KEY(value_1) REFERENCES referenced_table(id) ON UPDATE CASCADE);
+SELECT create_distributed_table('referencing_table', null, colocate_with=>'referenced_table', distribution_type=>null);
+
+SET client_min_messages TO DEBUG1;
+
+BEGIN;
+	SELECT COUNT(*) FROM referenced_table;
+	-- Doesn't switch to sequential execution because the referenced_table is
+	-- a null-shard-key distributed table.
+	ALTER TABLE referencing_table ADD COLUMN X INT;
+ROLLBACK;
+
+BEGIN;
+	-- Doesn't switch to sequential execution because the referenced_table is
+	-- a null-shard-key distributed table.
+	TRUNCATE referenced_table CASCADE;
+	SELECT COUNT(*) FROM referencing_table;
+COMMIT;
+
+SET client_min_messages TO WARNING;
+
+CREATE FUNCTION increment_value() RETURNS trigger AS $increment_value$
+BEGIN
+    NEW.value := NEW.value+1;
+    RETURN NEW;
+END;
+$increment_value$ LANGUAGE plpgsql;
+
+CREATE TABLE trigger_table_1 (value int);
+
+CREATE TRIGGER trigger_1
+BEFORE INSERT ON trigger_table_1
+FOR EACH ROW EXECUTE FUNCTION increment_value();
+
+SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
+
+SET citus.enable_unsafe_triggers TO ON;
+SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
+
+INSERT INTO trigger_table_1 VALUES(1), (2);
+SELECT * FROM trigger_table_1 ORDER BY value;
+
+CREATE FUNCTION insert_some() RETURNS trigger AS $insert_some$
+BEGIN
+    RAISE NOTICE 'inserted some rows';
+    RETURN NEW;
+END;
+$insert_some$ LANGUAGE plpgsql;
+
+CREATE TABLE trigger_table_2 (value int);
+
+CREATE TRIGGER trigger_2
+AFTER INSERT ON trigger_table_2
+FOR EACH STATEMENT EXECUTE FUNCTION insert_some();
+
+ALTER TABLE trigger_table_2 DISABLE TRIGGER trigger_2;
+
+SELECT create_distributed_table('trigger_table_2', NULL, distribution_type=>null);
+
+SET client_min_messages TO NOTICE;
+INSERT INTO trigger_table_2 VALUES(3), (4);
+SET client_min_messages TO WARNING;
+
+SELECT * FROM trigger_table_2 ORDER BY value;
+
+CREATE FUNCTION combine_old_new_val() RETURNS trigger AS $combine_old_new_val$
+BEGIN
+    NEW.value = NEW.value * 10 + OLD.value;
+    RETURN NEW;
+END;
+$combine_old_new_val$ LANGUAGE plpgsql;
+
+CREATE FUNCTION notice_truncate() RETURNS trigger AS $notice_truncate$
+BEGIN
+    RAISE NOTICE 'notice_truncate()';
+    RETURN NEW;
+END;
+$notice_truncate$ LANGUAGE plpgsql;
+
+CREATE TABLE trigger_table_3 (value int);
+
+CREATE TRIGGER trigger_3
+BEFORE UPDATE ON trigger_table_3
+FOR EACH ROW EXECUTE FUNCTION combine_old_new_val();
+
+CREATE TRIGGER trigger_4
+AFTER TRUNCATE ON trigger_table_3
+FOR EACH STATEMENT EXECUTE FUNCTION notice_truncate();
+
+INSERT INTO trigger_table_3 VALUES(3), (4);
+
+SELECT create_distributed_table('trigger_table_3', NULL, distribution_type=>null);
+
+UPDATE trigger_table_3 SET value = 5;
+SELECT * FROM trigger_table_3 ORDER BY value;
+
+SET client_min_messages TO NOTICE;
+TRUNCATE trigger_table_3;
+SET client_min_messages TO WARNING;
+
+-- try a few simple queries at least to make sure that we don't crash
+BEGIN;
+  INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
+ROLLBACK;
+
+-- cleanup at exit
+SET client_min_messages TO ERROR;
+DROP SCHEMA create_null_dist_key, "NULL_!_dist_key" CASCADE;

--- a/src/test/regress/sql/create_null_dist_key.sql
+++ b/src/test/regress/sql/create_null_dist_key.sql
@@ -317,15 +317,23 @@ DROP TABLE null_dist_key_table_1, null_dist_key_table_2;
 -- create indexes before creating the null dist key tables
 
 -- .. for an initially empty table
-CREATE TABLE null_dist_key_table_1(a int);
+CREATE TABLE null_dist_key_table_1(a int, b int);
+CREATE STATISTICS s1 (dependencies) ON a, b FROM null_dist_key_table_1;
 CREATE INDEX null_dist_key_table_1_idx ON null_dist_key_table_1(a);
 SELECT create_distributed_table('null_dist_key_table_1', null, colocate_with=>'none');
+CREATE STATISTICS s2 (dependencies) ON a, b FROM null_dist_key_table_1;
 
 -- .. and for another table having data in it before creating null dist key table
 CREATE TABLE null_dist_key_table_2(a int);
 INSERT INTO null_dist_key_table_2 VALUES(1);
 CREATE INDEX null_dist_key_table_2_idx ON null_dist_key_table_2(a);
 SELECT create_distributed_table('null_dist_key_table_2', null, colocate_with=>'none');
+
+-- test create index concurrently, then reindex
+CREATE INDEX CONCURRENTLY ind_conc ON null_dist_key_table_2(a);
+REINDEX INDEX ind_conc;
+REINDEX INDEX CONCURRENTLY ind_conc;
+DROP INDEX ind_conc;
 
 SELECT * FROM null_dist_key_table_2 ORDER BY a;
 
@@ -347,11 +355,22 @@ BEGIN;
   CREATE POLICY table_policy ON null_dist_key_table_3 TO table_users
       USING (table_user = current_user);
 
+  GRANT ALL ON TABLE null_dist_key_table_3 TO table_users;
+  ALTER TABLE null_dist_key_table_3 OWNER TO table_users;
+
   SELECT create_distributed_table('null_dist_key_table_3', null, colocate_with=>'none');
+
+  REVOKE ALL ON TABLE null_dist_key_table_3 FROM table_users;
+  ALTER TABLE null_dist_key_table_3 OWNER TO postgres;
+  GRANT ALL ON TABLE null_dist_key_table_3 TO table_users;
 ROLLBACK;
 
+ALTER STATISTICS s2 SET STATISTICS 46;
+ALTER TABLE null_dist_key_table_1 SET SCHEMA public;
+DROP STATISTICS s1, s2;
+
 -- drop them for next tests
-DROP TABLE null_dist_key_table_1, null_dist_key_table_2, distributed_table;
+DROP TABLE public.null_dist_key_table_1, null_dist_key_table_2, distributed_table;
 
 -- tests for object names that should be escaped properly
 
@@ -437,6 +456,236 @@ CREATE TABLE sensors_2000 PARTITION OF sensors FOR VALUES FROM ('2000-01-01') TO
 SELECT create_distributed_table('sensors_2000', NULL, distribution_type=>null);
 
 SELECT create_distributed_table('sensors', NULL, distribution_type=>null);
+
+-- verify we can create new partitions after distributing the parent table
+CREATE TABLE sensors_2001 PARTITION OF sensors FOR VALUES FROM ('2001-01-01') TO ('2002-01-01');
+
+-- verify we can attach to a null dist key table
+CREATE TABLE sensors_2002 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+ALTER TABLE sensors ATTACH PARTITION sensors_2002 FOR VALUES FROM ('2002-01-01') TO ('2003-01-01');
+
+-- verify we can detach from a null dist key table
+ALTER TABLE sensors DETACH PARTITION sensors_2001;
+
+-- error out when attaching a noncolocated partition
+CREATE TABLE sensors_2003 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('sensors_2003', NULL, distribution_type=>null, colocate_with=>'none');
+ALTER TABLE sensors ATTACH PARTITION sensors_2003 FOR VALUES FROM ('2003-01-01') TO ('2004-01-01');
+DROP TABLE sensors_2003;
+
+-- verify we can attach after distributing, if the parent and partition are colocated
+CREATE TABLE sensors_2004 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('sensors_2004', NULL, distribution_type=>null, colocate_with=>'sensors');
+ALTER TABLE sensors ATTACH PARTITION sensors_2004 FOR VALUES FROM ('2004-01-01') TO ('2005-01-01');
+
+-- verify we can attach a citus local table
+CREATE TABLE sensors_2005 (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT citus_add_local_table_to_metadata('sensors_2005');
+ALTER TABLE sensors ATTACH PARTITION sensors_2005 FOR VALUES FROM ('2005-01-01') TO ('2006-01-01');
+
+-- check metadata
+-- check all partitions and the parent on pg_dist_partition
+SELECT logicalrelid::text FROM pg_dist_partition WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005') ORDER BY logicalrelid::text;
+-- verify they are all colocated
+SELECT COUNT(DISTINCT(colocationid)) FROM pg_dist_partition WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005');
+-- verify all partitions are placed on the same node
+SELECT COUNT(DISTINCT(groupid)) FROM pg_dist_placement WHERE shardid IN
+    (SELECT shardid FROM pg_dist_shard WHERE logicalrelid::text IN ('sensors', 'sensors_2000', 'sensors_2001', 'sensors_2002', 'sensors_2004', 'sensors_2005'));
+
+-- verify the shard of sensors_2000 is attached to the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2000_1______';$$)
+    WHERE length(result) > 0;
+
+-- verify the shard of sensors_2001 is detached from the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2001_1______';$$)
+    WHERE length(result) > 0;
+
+-- verify the shard of sensors_2002 is attached to the parent shard, on the worker node
+SELECT COUNT(*) FROM run_command_on_workers($$
+    SELECT relpartbound FROM pg_class WHERE relname LIKE 'sensors_2002_1______';$$)
+    WHERE length(result) > 0;
+
+-- create a partitioned citus local table and verify we error out when attaching a partition with null dist key
+CREATE TABLE partitioned_citus_local_tbl(
+    measureid integer,
+    eventdatetime date,
+    measure_data jsonb,
+PRIMARY KEY (measureid, eventdatetime, measure_data))
+PARTITION BY RANGE(eventdatetime);
+SELECT citus_add_local_table_to_metadata('partitioned_citus_local_tbl');
+CREATE TABLE partition_with_null_key (measureid integer, eventdatetime date, measure_data jsonb, PRIMARY KEY (measureid, eventdatetime, measure_data));
+SELECT create_distributed_table('partition_with_null_key', NULL, distribution_type=>null);
+ALTER TABLE partitioned_citus_local_tbl ATTACH PARTITION partition_with_null_key FOR VALUES FROM ('2004-01-01') TO ('2005-01-01');
+
+-- test partitioned tables + indexes with long names
+CREATE TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(
+  id int PRIMARY KEY,
+  "TeNANt_Id" int,
+  "jsondata" jsonb NOT NULL,
+  name text,
+  price numeric CHECK (price > 0),
+  serial_data bigserial, UNIQUE (id, price))
+  PARTITION BY LIST(id);
+
+CREATE TABLE "NULL_!_dist_key"."partition1_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (1);
+CREATE TABLE "NULL_!_dist_key"."partition2_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (2);
+CREATE TABLE "NULL_!_dist_key"."partition100_nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    PARTITION OF "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR VALUES IN (100);
+
+-- create some objects before create_distributed_table
+CREATE INDEX "my!Index1New" ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) WITH ( fillfactor = 80 ) WHERE  id > 10;
+CREATE UNIQUE INDEX uniqueIndexNew ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" (id);
+
+-- ingest some data before create_distributed_table
+set client_min_messages to ERROR;
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (1, 1, row_to_json(row(1,1), true)),
+                                     (2, 1, row_to_json(row(2,2), 'false'));
+reset client_min_messages;
+-- create a replica identity before create_distributed_table
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" REPLICA IDENTITY USING INDEX uniqueIndexNew;
+
+-- test triggers
+SET client_min_messages TO ERROR;
+CREATE FUNCTION insert_id_100() RETURNS trigger AS $insert_100$
+BEGIN
+    INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+    RETURN NEW;
+END;
+$insert_100$ LANGUAGE plpgsql;
+
+CREATE TABLE null_key_table_with_trigger(a INT);
+SELECT create_distributed_table('null_key_table_with_trigger', null);
+-- try to add a trigger after distributing the table, fails
+CREATE TRIGGER insert_100_trigger
+    AFTER UPDATE ON null_key_table_with_trigger
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+
+-- now try to distribute a table that already has a trigger on it
+CREATE TRIGGER insert_100_trigger
+    AFTER UPDATE ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+
+-- error out because of the trigger
+SELECT create_distributed_table('"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"', null);
+
+SET citus.enable_unsafe_triggers TO ON;
+RESET client_min_messages;
+
+-- this shouldn't give any syntax errors
+SELECT create_distributed_table('"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"', null);
+
+-- now we can add triggers on distributed tables, because we set the GUC to on
+CREATE TRIGGER insert_100_trigger_2
+    AFTER UPDATE ON null_key_table_with_trigger
+    FOR EACH STATEMENT EXECUTE FUNCTION insert_id_100();
+
+SET client_min_messages TO ERROR;
+UPDATE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" SET "TeNANt_Id"="TeNANt_Id"+1;
+-- we should see one row with id = 100
+SELECT COUNT(*) FROM "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" WHERE id = 100;
+
+-- create some objects after create_distributed_table
+CREATE INDEX "my!Index2New" ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) WITH ( fillfactor = 90 ) WHERE id < 20;
+CREATE UNIQUE INDEX uniqueIndex2New ON "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+
+-- error out for already existing, because of the unique index
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (1, 1, row_to_json(row(1,1), true));
+
+-- verify all 4 shard indexes are created on the same node
+SELECT result FROM run_command_on_workers($$
+    SELECT COUNT(*) FROM pg_indexes WHERE indexname LIKE '%my!Index_New_1%' OR indexname LIKE '%uniqueindex%new_1%';$$)
+    ORDER BY nodeport;
+
+-- foreign key to a ref table
+CREATE TABLE dummy_reference_table (a INT PRIMARY KEY);
+SELECT create_reference_table('dummy_reference_table');
+TRUNCATE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789";
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_ref FOREIGN KEY (id) REFERENCES dummy_reference_table(a);
+BEGIN; -- try to add the same fkey, reversed
+    ALTER TABLE dummy_reference_table
+        ADD CONSTRAINT fkey_to_dummy_ref FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+ROLLBACK;
+
+-- errors out because of foreign key violation
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+
+-- now inserts successfully
+INSERT INTO dummy_reference_table VALUES (100);
+INSERT INTO "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" VALUES (100, 1, row_to_json(row(1,1), true));
+DELETE FROM "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" WHERE id = 100;
+
+-- foreign key to a local table, errors out
+CREATE TABLE local_table_for_fkey (a INT PRIMARY KEY);
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_local FOREIGN KEY (id) REFERENCES local_table_for_fkey(a);
+
+-- Normally, we support foreign keys from Postgres tables to distributed
+-- tables assuming that the user will soon distribute the local table too
+-- anyway. However, this is not the case for null-shard-key tables before
+-- we improve SQL support.
+ALTER TABLE local_table_for_fkey
+    ADD CONSTRAINT fkey_from_dummy_local FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+
+-- foreign key to a citus local table, errors out
+CREATE TABLE citus_local_table_for_fkey (a INT PRIMARY KEY);
+SELECT citus_add_local_table_to_metadata('citus_local_table_for_fkey');
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_citus_local FOREIGN KEY (id) REFERENCES citus_local_table_for_fkey(a);
+-- reversed, still fails
+ALTER TABLE citus_local_table_for_fkey
+    ADD CONSTRAINT fkey_from_dummy_citus_local FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+
+-- foreign key to a distributed table, errors out because not colocated
+CREATE TABLE dist_table_for_fkey (a INT PRIMARY KEY);
+SELECT create_distributed_table('dist_table_for_fkey', 'a');
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES dist_table_for_fkey(a);
+-- reversed, still fails
+ALTER TABLE dist_table_for_fkey
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (a) REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id);
+
+-- create a null key distributed table, not colocated with the partitioned table, and then try to create a fkey
+CREATE TABLE null_key_dist_not_colocated (a INT PRIMARY KEY);
+SELECT create_distributed_table('null_key_dist_not_colocated', null, colocate_with=>'none');
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES null_key_dist_not_colocated(a);
+
+-- create a null key distributed table, colocated with the partitioned table, and then create a fkey
+CREATE TABLE null_key_dist (a INT PRIMARY KEY);
+SELECT create_distributed_table('null_key_dist', null, colocate_with=>'"NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"');
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"
+    ADD CONSTRAINT fkey_to_dummy_dist FOREIGN KEY (id) REFERENCES null_key_dist(a);
+
+-- check supported ON DELETE and ON UPDATE commands
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_1 FOREIGN KEY(a)
+    REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) ON DELETE SET DEFAULT;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_2 FOREIGN KEY(a)
+    REFERENCES "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789"(id) ON UPDATE CASCADE;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_3 FOREIGN KEY(a)
+    REFERENCES dummy_reference_table(a) ON DELETE SET DEFAULT;
+ALTER TABLE null_key_dist ADD CONSTRAINT fkey_add_test_4 FOREIGN KEY(a)
+    REFERENCES dummy_reference_table(a) ON UPDATE CASCADE;
+
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_1;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_2;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_3;
+ALTER TABLE null_key_dist DROP CONSTRAINT fkey_add_test_4;
+ALTER TABLE "NULL_!_dist_key"."nullKeyTable.1!?!9012345678901234567890123456789012345678901234567890123456789" DROP CONSTRAINT fkey_to_dummy_dist;
+
+DELETE FROM null_key_dist;
+VACUUM null_key_dist;
+TRUNCATE null_key_dist;
+DROP TABLE null_key_dist;
+
+RESET client_min_messages;
 
 CREATE TABLE multi_level_partitioning_parent(
     measureid integer,
@@ -685,6 +934,15 @@ BEGIN;
   SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
 ROLLBACK;
 
+BEGIN;
+  CREATE TABLE referenced_table(a int UNIQUE, b int);
+  SELECT create_distributed_table('referenced_table', NULL, distribution_type=>null);
+
+  CREATE TABLE referencing_table(a serial, b int);
+  SELECT create_distributed_table('referencing_table', NULL, distribution_type=>null, colocate_with=>'referenced_table');
+  ALTER TABLE referencing_table ADD CONSTRAINT fkey_to_dummy_ref_on_update FOREIGN KEY (a) REFERENCES referenced_table(a) ON UPDATE SET DEFAULT;
+ROLLBACK;
+
 -- to a non-colocated null dist key table
 BEGIN;
   CREATE TABLE referenced_table(a int UNIQUE, b int);
@@ -888,9 +1146,6 @@ FOR EACH ROW EXECUTE FUNCTION increment_value();
 
 SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
 
-SET citus.enable_unsafe_triggers TO ON;
-SELECT create_distributed_table('trigger_table_1', NULL, distribution_type=>null);
-
 INSERT INTO trigger_table_1 VALUES(1), (2);
 SELECT * FROM trigger_table_1 ORDER BY value;
 
@@ -952,10 +1207,21 @@ SET client_min_messages TO NOTICE;
 TRUNCATE trigger_table_3;
 SET client_min_messages TO WARNING;
 
+-- test rename, disable and drop trigger
+ALTER TRIGGER trigger_4 ON trigger_table_3 RENAME TO trigger_new_name;
+ALTER TABLE trigger_table_3 DISABLE TRIGGER ALL;
+DROP TRIGGER trigger_new_name ON trigger_table_3;
+-- enable the remaining triggers
+ALTER TABLE trigger_table_3 ENABLE TRIGGER ALL;
+
 -- try a few simple queries at least to make sure that we don't crash
 BEGIN;
   INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
 ROLLBACK;
+
+DROP TRIGGER IF EXISTS trigger_1 ON trigger_table_1;
+DROP TRIGGER trigger_2 ON trigger_table_2 CASCADE;
+DROP TRIGGER trigger_3 ON trigger_table_3 RESTRICT;
 
 -- cleanup at exit
 SET client_min_messages TO ERROR;

--- a/src/test/regress/sql/merge.sql
+++ b/src/test/regress/sql/merge.sql
@@ -1950,6 +1950,118 @@ UPDATE SET val = dist_source.val
 WHEN NOT MATCHED THEN
 INSERT VALUES(dist_source.id, dist_source.val);
 
+-- test merge with null shard key tables
+
+CREATE SCHEMA query_null_dist_key;
+
+SET search_path TO query_null_dist_key;
+SET client_min_messages TO DEBUG2;
+
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>null);
+
+CREATE TABLE reference_table(a int, b int);
+SELECT create_reference_table('reference_table');
+INSERT INTO reference_table SELECT i, i FROM generate_series(0, 5) i;
+
+CREATE TABLE distributed_table(a int, b int);
+SELECT create_distributed_table('distributed_table', 'a');
+INSERT INTO distributed_table SELECT i, i FROM generate_series(3, 8) i;
+
+CREATE TABLE citus_local_table(a int, b int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+INSERT INTO citus_local_table SELECT i, i FROM generate_series(0, 10) i;
+
+CREATE TABLE postgres_local_table(a int, b int);
+INSERT INTO postgres_local_table SELECT i, i FROM generate_series(5, 10) i;
+
+-- with a colocated table
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b;
+
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN DELETE;
+
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t2.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b);
+
+MERGE INTO nullkey_c1_t1 USING nullkey_c1_t2 ON (nullkey_c1_t1.a = nullkey_c1_t2.a)
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t2.a, nullkey_c1_t2.b);
+
+-- with non-colocated null-dist-key table
+MERGE INTO nullkey_c1_t1 USING nullkey_c2_t1 ON (nullkey_c1_t1.a = nullkey_c2_t1.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c2_t1.b;
+
+MERGE INTO nullkey_c1_t1 USING nullkey_c2_t1 ON (nullkey_c1_t1.a = nullkey_c2_t1.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c2_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c2_t1.a, nullkey_c2_t1.b);
+
+-- with a distributed table
+MERGE INTO nullkey_c1_t1 USING distributed_table ON (nullkey_c1_t1.a = distributed_table.a)
+WHEN MATCHED THEN UPDATE SET b = distributed_table.b
+WHEN NOT MATCHED THEN INSERT VALUES (distributed_table.a, distributed_table.b);
+
+MERGE INTO distributed_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = distributed_table.a)
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+
+-- with a reference table
+MERGE INTO nullkey_c1_t1 USING reference_table ON (nullkey_c1_t1.a = reference_table.a)
+WHEN MATCHED THEN UPDATE SET b = reference_table.b;
+
+MERGE INTO reference_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = reference_table.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+
+-- with a citus local table
+MERGE INTO nullkey_c1_t1 USING citus_local_table ON (nullkey_c1_t1.a = citus_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = citus_local_table.b;
+
+MERGE INTO citus_local_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = citus_local_table.a)
+WHEN MATCHED THEN DELETE;
+
+-- with a postgres table
+MERGE INTO nullkey_c1_t1 USING postgres_local_table ON (nullkey_c1_t1.a = postgres_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = postgres_local_table.b;
+
+MERGE INTO postgres_local_table USING nullkey_c1_t1 ON (nullkey_c1_t1.a = postgres_local_table.a)
+WHEN MATCHED THEN UPDATE SET b = nullkey_c1_t1.b
+WHEN NOT MATCHED THEN INSERT VALUES (nullkey_c1_t1.a, nullkey_c1_t1.b);
+
+-- using ctes
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t1
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+
+WITH cte AS (
+    SELECT * FROM distributed_table
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+
+WITH cte AS materialized (
+    SELECT * FROM distributed_table
+)
+MERGE INTO nullkey_c1_t1 USING cte ON (nullkey_c1_t1.a = cte.a)
+WHEN MATCHED THEN UPDATE SET b = cte.b;
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA query_null_dist_key CASCADE;
+
+RESET client_min_messages;
+SET search_path TO merge_schema;
+
 DROP SERVER foreign_server CASCADE;
 DROP FUNCTION merge_when_and_write();
 DROP SCHEMA merge_schema CASCADE;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -904,6 +904,20 @@ SELECT create_distributed_table('test','x');
 DROP TABLE test;
 TRUNCATE pg_dist_node;
 
+-- confirm that we can create a null shard key table on an empty node
+CREATE TABLE test (x int, y int);
+INSERT INTO test VALUES (1,2);
+SET citus.shard_replication_factor TO 1;
+SELECT create_distributed_table('test', null, colocate_with=>'none', distribution_type=>null);
+
+-- and make sure that we can't remove the coordinator due to "test"
+SELECT citus_remove_node('localhost', :master_port);
+
+DROP TABLE test;
+
+-- and now we should be able to remove the coordinator
+SELECT citus_remove_node('localhost', :master_port);
+
 -- confirm that we can create a reference table on an empty node
 CREATE TABLE test (x int, y int);
 INSERT INTO test VALUES (1,2);

--- a/src/test/regress/sql/null_dist_key_prep.sql
+++ b/src/test/regress/sql/null_dist_key_prep.sql
@@ -1,0 +1,14 @@
+ALTER FUNCTION create_distributed_table RENAME TO create_distributed_table_internal;
+
+CREATE OR REPLACE FUNCTION pg_catalog.create_distributed_table(table_name regclass,
+                                                               distribution_column text,
+                                                               distribution_type citus.distribution_type DEFAULT 'hash',
+                                                               colocate_with text DEFAULT 'default',
+                                                               shard_count int DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    PERFORM create_distributed_table_internal(table_name, NULL, NULL, colocate_with, NULL);
+END;
+$function$;

--- a/src/test/regress/sql/query_null_dist_key.sql
+++ b/src/test/regress/sql/query_null_dist_key.sql
@@ -1,0 +1,1132 @@
+CREATE SCHEMA query_null_dist_key;
+SET search_path TO query_null_dist_key;
+
+SET citus.next_shard_id TO 1620000;
+SET citus.shard_count TO 32;
+
+SET client_min_messages TO WARNING;
+SELECT 1 FROM citus_add_node('localhost', :master_port, groupid => 0);
+
+SET client_min_messages TO NOTICE;
+
+CREATE TABLE nullkey_c1_t1(a int, b int);
+CREATE TABLE nullkey_c1_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c1_t1', null, colocate_with=>'none');
+SELECT create_distributed_table('nullkey_c1_t2', null, colocate_with=>'nullkey_c1_t1');
+INSERT INTO nullkey_c1_t1 SELECT i, i FROM generate_series(1, 8) i;
+INSERT INTO nullkey_c1_t2 SELECT i, i FROM generate_series(2, 7) i;
+
+CREATE TABLE nullkey_c2_t1(a int, b int);
+CREATE TABLE nullkey_c2_t2(a int, b int);
+SELECT create_distributed_table('nullkey_c2_t1', null, colocate_with=>'none');
+SELECT create_distributed_table('nullkey_c2_t2', null, colocate_with=>'nullkey_c2_t1', distribution_type=>null);
+INSERT INTO nullkey_c2_t1 SELECT i, i FROM generate_series(2, 7) i;
+INSERT INTO nullkey_c2_t2 SELECT i, i FROM generate_series(1, 8) i;
+
+CREATE TABLE nullkey_c3_t1(a int, b int);
+SELECT create_distributed_table('nullkey_c3_t1', null, colocate_with=>'none');
+INSERT INTO nullkey_c3_t1 SELECT i, i FROM generate_series(1, 8) i;
+
+CREATE TABLE reference_table(a int, b int);
+SELECT create_reference_table('reference_table');
+INSERT INTO reference_table SELECT i, i FROM generate_series(0, 5) i;
+
+CREATE TABLE distributed_table(a int, b int);
+SELECT create_distributed_table('distributed_table', 'a');
+INSERT INTO distributed_table SELECT i, i FROM generate_series(3, 8) i;
+
+CREATE TABLE citus_local_table(a int, b int);
+SELECT citus_add_local_table_to_metadata('citus_local_table');
+INSERT INTO citus_local_table SELECT i, i FROM generate_series(0, 10) i;
+
+CREATE TABLE postgres_local_table(a int, b int);
+INSERT INTO postgres_local_table SELECT i, i FROM generate_series(5, 10) i;
+
+CREATE TABLE articles_hash (
+	id bigint NOT NULL,
+	author_id bigint NOT NULL,
+	title varchar(20) NOT NULL,
+	word_count integer
+);
+
+INSERT INTO articles_hash VALUES ( 4,  4, 'altdorfer', 14551),( 5,  5, 'aruru', 11389),
+								 (13,  3, 'aseyev', 2255),(15,  5, 'adversa', 3164),
+								 (18,  8, 'assembly', 911),(19,  9, 'aubergiste', 4981),
+								 (28,  8, 'aerophyte', 5454),(29,  9, 'amateur', 9524),
+								 (42,  2, 'ausable', 15885),(43,  3, 'affixal', 12723),
+								 (49,  9, 'anyone', 2681),(50, 10, 'anjanette', 19519);
+
+SELECT create_distributed_table('articles_hash', null, colocate_with=>'none');
+
+CREATE TABLE raw_events_first (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint, UNIQUE(user_id, value_1));
+SELECT create_distributed_table('raw_events_first', null, colocate_with=>'none', distribution_type=>null);
+
+CREATE TABLE raw_events_second (user_id int, time timestamp, value_1 int, value_2 int, value_3 float, value_4 bigint, UNIQUE(user_id, value_1));
+SELECT create_distributed_table('raw_events_second', null, colocate_with=>'raw_events_first', distribution_type=>null);
+
+CREATE TABLE agg_events (user_id int, value_1_agg int, value_2_agg int, value_3_agg float, value_4_agg bigint, agg_time timestamp, UNIQUE(user_id, value_1_agg));
+SELECT create_distributed_table('agg_events', null, colocate_with=>'raw_events_first', distribution_type=>null);
+
+CREATE TABLE users_ref_table (user_id int);
+SELECT create_reference_table('users_ref_table');
+
+INSERT INTO raw_events_first VALUES (1, '1970-01-01', 10, 100, 1000.1, 10000), (3, '1971-01-01', 30, 300, 3000.1, 30000),
+                                    (5, '1972-01-01', 50, 500, 5000.1, 50000), (2, '1973-01-01', 20, 200, 2000.1, 20000),
+                                    (4, '1974-01-01', 40, 400, 4000.1, 40000), (6, '1975-01-01', 60, 600, 6000.1, 60000);
+
+CREATE TABLE modify_fast_path(key int, value_1 int, value_2 text);
+SELECT create_distributed_table('modify_fast_path', null);
+
+CREATE TABLE modify_fast_path_reference(key int, value_1 int, value_2 text);
+SELECT create_reference_table('modify_fast_path_reference');
+
+CREATE TABLE bigserial_test (x int, y int, z bigserial);
+SELECT create_distributed_table('bigserial_test', null);
+
+CREATE TABLE append_table (text_col text, a int);
+SELECT create_distributed_table('append_table', 'a', 'append');
+SELECT master_create_empty_shard('append_table') AS shardid1 \gset
+SELECT master_create_empty_shard('append_table') AS shardid2 \gset
+SELECT master_create_empty_shard('append_table') AS shardid3 \gset
+
+COPY append_table (text_col, a) FROM STDIN WITH (format 'csv', append_to_shard :shardid1);
+abc,234
+bcd,123
+bcd,234
+cde,345
+def,456
+efg,234
+\.
+
+COPY append_table (text_col, a) FROM STDIN WITH (format 'csv', append_to_shard :shardid2);
+abc,123
+efg,123
+hij,123
+hij,234
+ijk,1
+jkl,0
+\.
+
+CREATE TABLE range_table(a int, b int);
+SELECT create_distributed_table('range_table', 'a', 'range');
+CALL public.create_range_partitioned_shards('range_table', '{"0","25"}','{"24","49"}');
+INSERT INTO range_table VALUES (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 50);
+
+SET client_min_messages to DEBUG2;
+
+-- simple insert
+INSERT INTO nullkey_c1_t1 VALUES (1,2), (2,2), (3,4);
+INSERT INTO nullkey_c1_t2 VALUES (1,3), (3,4), (5,1), (6,2);
+
+INSERT INTO nullkey_c2_t1 VALUES (1,0), (2,5), (4,3), (5,2);
+INSERT INTO nullkey_c2_t2 VALUES (2,4), (3,2), (5,2), (7,4);
+
+-- simple select
+SELECT * FROM nullkey_c1_t1 ORDER BY 1,2;
+
+-- for update / share
+SELECT * FROM modify_fast_path WHERE key = 1 FOR UPDATE;
+SELECT * FROM modify_fast_path WHERE key = 1 FOR SHARE;
+SELECT * FROM modify_fast_path FOR UPDATE;
+SELECT * FROM modify_fast_path FOR SHARE;
+
+-- cartesian product with different table types
+
+--    with other table types
+SELECT COUNT(*) FROM distributed_table d1, nullkey_c1_t1;
+SELECT COUNT(*) FROM reference_table d1, nullkey_c1_t1;
+SELECT COUNT(*) FROM citus_local_table d1, nullkey_c1_t1;
+SELECT COUNT(*) FROM postgres_local_table d1, nullkey_c1_t1;
+
+--    with a colocated null dist key table
+SELECT COUNT(*) FROM nullkey_c1_t1 d1, nullkey_c1_t2;
+
+--    with a non-colocated null dist key table
+SELECT COUNT(*) FROM nullkey_c1_t1 d1, nullkey_c2_t1;
+
+-- First, show that nullkey_c1_t1 and nullkey_c3_t1 are not colocated.
+SELECT
+  (SELECT colocationid FROM pg_dist_partition WHERE logicalrelid = 'query_null_dist_key.nullkey_c1_t1'::regclass) !=
+  (SELECT colocationid FROM pg_dist_partition WHERE logicalrelid = 'query_null_dist_key.nullkey_c3_t1'::regclass);
+
+-- Now verify that we can join them via router planner because it doesn't care
+-- about whether two tables are colocated or not but physical location of shards
+-- when citus.enable_non_colocated_router_query_pushdown is set to on.
+
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c3_t1 USING(a);
+
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c3_t1 USING(a);
+
+RESET citus.enable_non_colocated_router_query_pushdown;
+
+-- colocated join between null dist key tables
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN nullkey_c1_t2 USING(a);
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN nullkey_c1_t2 USING(a);
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN nullkey_c1_t2 USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t2 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t2 t2 WHERE t2.b > t1.a
+);
+
+-- non-colocated inner joins between null dist key tables
+SELECT * FROM nullkey_c1_t1 JOIN nullkey_c2_t1 USING(a) ORDER BY 1,2,3;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+-- non-colocated outer joins between null dist key tables
+SELECT * FROM nullkey_c1_t1 LEFT JOIN nullkey_c2_t2 USING(a) ORDER BY 1,2,3 LIMIT 4;
+SELECT * FROM nullkey_c1_t1 FULL JOIN nullkey_c2_t2 USING(a) ORDER BY 1,2,3 LIMIT 4;
+SELECT * FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a) ORDER BY 1,2,3 OFFSET 3 LIMIT 4;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c2_t2 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
+);
+
+-- join with a reference table
+SELECT COUNT(*) FROM nullkey_c1_t1, reference_table WHERE nullkey_c1_t1.a = reference_table.a;
+
+WITH cte_1 AS
+	(SELECT * FROM nullkey_c1_t1, reference_table WHERE nullkey_c1_t1.a = reference_table.a ORDER BY 1,2,3,4 FOR UPDATE)
+SELECT COUNT(*) FROM cte_1;
+
+-- join with postgres / citus local tables
+SELECT * FROM nullkey_c1_t1 JOIN postgres_local_table USING(a);
+SELECT * FROM nullkey_c1_t1 JOIN citus_local_table USING(a);
+
+-- join with a distributed table
+SELECT * FROM distributed_table d1 JOIN nullkey_c1_t1 USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM distributed_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+-- outer joins with different table types
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN reference_table USING(a);
+SELECT COUNT(*) FROM reference_table LEFT JOIN nullkey_c1_t1 USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN citus_local_table USING(a);
+SELECT COUNT(*) FROM citus_local_table LEFT JOIN nullkey_c1_t1 USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 LEFT JOIN postgres_local_table USING(a);
+SELECT COUNT(*) FROM postgres_local_table LEFT JOIN nullkey_c1_t1 USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN citus_local_table USING(a);
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN postgres_local_table USING(a);
+SELECT COUNT(*) FROM nullkey_c1_t1 FULL JOIN reference_table USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN append_table USING(a);
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a);
+
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a) WHERE range_table.a = 20;
+
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+
+SELECT COUNT(*) FROM nullkey_c1_t1 JOIN range_table USING(a) WHERE range_table.a = 20;
+
+RESET citus.enable_non_colocated_router_query_pushdown;
+
+-- lateral / semi / anti joins with different table types
+
+--    with a reference table
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM reference_table t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM reference_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM reference_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM reference_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM reference_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM reference_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+--    with a distributed table
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM distributed_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM distributed_table t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM distributed_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM distributed_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM distributed_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM distributed_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM distributed_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+--    with postgres / citus local tables
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM citus_local_table t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM citus_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM citus_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM citus_local_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM postgres_local_table t1
+LEFT JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM citus_local_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM citus_local_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+LEFT JOIN LATERAL (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE EXISTS (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE NOT EXISTS (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b IN (
+    SELECT b+1 FROM postgres_local_table t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+WHERE t1.b NOT IN (
+    SELECT a FROM postgres_local_table t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM nullkey_c1_t1 t1
+JOIN LATERAL (
+    SELECT * FROM postgres_local_table t2 WHERE t2.b > t1.a
+) q USING(a);
+
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE EXISTS (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE t1.b IN (
+    SELECT b+1 FROM nullkey_c1_t1 t2 WHERE t2.b = t1.a
+);
+
+SELECT COUNT(*) FROM postgres_local_table t1
+WHERE t1.b NOT IN (
+    SELECT a FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+);
+
+SELECT COUNT(*) FROM postgres_local_table t1
+JOIN LATERAL (
+    SELECT * FROM nullkey_c1_t1 t2 WHERE t2.b > t1.a
+) q USING(a);
+
+-- insert .. select
+
+--    between two colocated null dist key tables
+
+--    The target list of "distributed statement"s that we send to workers
+--    differ(*) in Postgres versions < 15. For this reason, we temporarily
+--    disable debug messages here and run the EXPLAIN'ed version of the
+--    command.
+--
+--    (*):  < SELECT a, b > vs  < SELECT table_name.a, table_name.b >
+SET client_min_messages TO WARNING;
+EXPLAIN (ANALYZE TRUE, TIMING FALSE, COSTS FALSE, SUMMARY FALSE, VERBOSE FALSE)
+INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c1_t2;
+SET client_min_messages TO DEBUG2;
+
+--    between two non-colocated null dist key tables
+INSERT INTO nullkey_c1_t1 SELECT * FROM nullkey_c2_t1;
+
+--    between a null dist key table and a table of different type
+INSERT INTO nullkey_c1_t1 SELECT * FROM reference_table;
+INSERT INTO nullkey_c1_t1 SELECT * FROM distributed_table;
+INSERT INTO nullkey_c1_t1 SELECT * FROM citus_local_table;
+INSERT INTO nullkey_c1_t1 SELECT * FROM postgres_local_table;
+
+INSERT INTO reference_table SELECT * FROM nullkey_c1_t1;
+INSERT INTO distributed_table SELECT * FROM nullkey_c1_t1;
+INSERT INTO citus_local_table SELECT * FROM nullkey_c1_t1;
+INSERT INTO postgres_local_table SELECT * FROM nullkey_c1_t1;
+
+-- test subquery
+SELECT count(*) FROM
+(
+	SELECT * FROM (SELECT * FROM nullkey_c1_t2) as subquery_inner
+) AS subquery_top;
+
+-- test cte inlining
+WITH cte_nullkey_c1_t1 AS (SELECT * FROM nullkey_c1_t1),
+     cte_postgres_local_table AS (SELECT * FROM postgres_local_table),
+     cte_distributed_table AS (SELECT * FROM distributed_table)
+SELECT COUNT(*) FROM cte_distributed_table, cte_nullkey_c1_t1, cte_postgres_local_table
+WHERE cte_nullkey_c1_t1.a > 3 AND cte_distributed_table.a < 5;
+
+-- test recursive ctes
+WITH level_0 AS (
+  WITH level_1 AS (
+    WITH RECURSIVE level_2_recursive(x) AS (
+        VALUES (1)
+      UNION ALL
+        SELECT a + 1 FROM nullkey_c1_t1 JOIN level_2_recursive ON (a = x) WHERE a < 100
+    )
+    SELECT * FROM level_2_recursive RIGHT JOIN reference_table ON (level_2_recursive.x = reference_table.a)
+  )
+  SELECT * FROM level_1
+)
+SELECT COUNT(*) FROM level_0;
+
+WITH level_0 AS (
+  WITH level_1 AS (
+    WITH RECURSIVE level_2_recursive(x) AS (
+        VALUES (1)
+      UNION ALL
+        SELECT a + 1 FROM nullkey_c1_t1 JOIN level_2_recursive ON (a = x) WHERE a < 100
+    )
+    SELECT * FROM level_2_recursive JOIN distributed_table ON (level_2_recursive.x = distributed_table.a)
+  )
+  SELECT * FROM level_1
+)
+SELECT COUNT(*) FROM level_0;
+
+-- grouping set
+SELECT
+	id, substring(title, 2, 1) AS subtitle, count(*)
+	FROM articles_hash
+	WHERE author_id = 1 or author_id = 2
+	GROUP BY GROUPING SETS ((id),(subtitle))
+	ORDER BY id, subtitle;
+
+-- subquery in SELECT clause
+SELECT a.title AS name, (SELECT a2.id FROM articles_hash a2 WHERE a.id = a2.id  LIMIT 1)
+						 AS special_price FROM articles_hash a
+ORDER BY 1,2;
+
+-- test prepared statements
+
+-- prepare queries can be router plannable
+PREPARE author_1_articles as
+	SELECT *
+	FROM articles_hash
+	WHERE author_id = 1;
+
+EXECUTE author_1_articles;
+EXECUTE author_1_articles;
+EXECUTE author_1_articles;
+EXECUTE author_1_articles;
+EXECUTE author_1_articles;
+EXECUTE author_1_articles;
+
+-- parametric prepare queries can be router plannable
+PREPARE author_articles(int) as
+	SELECT *
+	FROM articles_hash
+	WHERE author_id = $1;
+
+EXECUTE author_articles(1);
+EXECUTE author_articles(1);
+EXECUTE author_articles(1);
+EXECUTE author_articles(1);
+EXECUTE author_articles(1);
+EXECUTE author_articles(1);
+
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+EXECUTE author_articles(NULL);
+
+PREPARE author_articles_update(int) AS
+	UPDATE articles_hash SET title = 'test' WHERE author_id = $1;
+
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+EXECUTE author_articles_update(NULL);
+
+-- More tests with insert .. select.
+--
+-- The target list of "distributed statement"s that we send to workers
+-- might differ(*) in Postgres versions < 15 and they are reported when
+-- "log level >= DEBUG2". For this reason, we set log level to DEBUG1 to
+-- avoid reporting them.
+--
+-- DEBUG1 still allows reporting the reason why given INSERT .. SELECT
+-- query is not distributed / requires pull-to-coordinator.
+
+SET client_min_messages TO DEBUG1;
+
+INSERT INTO bigserial_test (x, y) SELECT x, y FROM bigserial_test;
+
+INSERT INTO agg_events
+            (user_id)
+SELECT f2.id FROM
+
+(SELECT
+      id
+FROM   (SELECT users_ref_table.user_id      AS id
+        FROM   raw_events_first,
+               users_ref_table
+        WHERE  raw_events_first.user_id = users_ref_table.user_id ) AS foo) as f
+INNER JOIN
+(SELECT v4,
+       v1,
+       id
+FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
+               SUM(raw_events_first.value_1) AS v1,
+               raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id
+        GROUP  BY raw_events_second.user_id
+        HAVING SUM(raw_events_second.value_4) > 1000) AS foo2 ) as f2
+ON (f.id = f2.id)
+WHERE f.id IN (SELECT user_id
+               FROM   raw_events_second);
+
+-- upsert with returning
+INSERT INTO agg_events AS ae
+            (
+                        user_id,
+                        value_1_agg,
+                        agg_time
+            )
+SELECT user_id,
+       value_1,
+       time
+FROM   raw_events_first
+ON conflict (user_id, value_1_agg)
+DO UPDATE
+   SET    agg_time = EXCLUDED.agg_time
+   WHERE  ae.agg_time < EXCLUDED.agg_time
+RETURNING user_id, value_1_agg;
+
+-- using a left join
+INSERT INTO agg_events (user_id)
+SELECT
+  raw_events_first.user_id
+FROM
+  raw_events_first LEFT JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.user_id
+  WHERE raw_events_second.user_id = 10 OR raw_events_second.user_id = 11;
+
+-- using a full join
+INSERT INTO agg_events (user_id, value_1_agg)
+SELECT t1.user_id AS col1,
+       t2.user_id AS col2
+FROM   raw_events_first t1
+       FULL JOIN raw_events_second t2
+              ON t1.user_id = t2.user_id;
+
+-- using semi join
+INSERT INTO raw_events_second
+            (user_id)
+SELECT user_id
+FROM   raw_events_first
+WHERE  user_id IN (SELECT raw_events_second.user_id
+                   FROM   raw_events_second, raw_events_first
+                   WHERE  raw_events_second.user_id = raw_events_first.user_id AND raw_events_first.user_id = 200);
+
+-- using lateral join
+INSERT INTO raw_events_second
+            (user_id)
+SELECT user_id
+FROM   raw_events_first
+WHERE  NOT EXISTS (SELECT 1
+                   FROM   raw_events_second
+                   WHERE  raw_events_second.user_id =raw_events_first.user_id);
+
+-- using inner join
+INSERT INTO agg_events (user_id)
+SELECT raw_events_first.user_id
+FROM raw_events_first INNER JOIN raw_events_second ON raw_events_first.user_id = raw_events_second.value_1
+WHERE raw_events_first.value_1 IN (10, 11,12) OR raw_events_second.user_id IN (1,2,3,4);
+
+-- We could relax distributed insert .. select checks to allow pushing
+-- down more clauses down to the worker nodes when inserting into a single
+-- shard by selecting from a colocated one. We might want to do something
+-- like https://github.com/citusdata/citus/pull/6772.
+--
+--  e.g., insert into null_shard_key_1/citus_local/reference
+--        select * from null_shard_key_1/citus_local/reference limit 1
+--
+-- Below "limit / offset clause" test and some others are examples of this.
+
+-- limit / offset clause
+INSERT INTO agg_events (user_id) SELECT raw_events_first.user_id FROM raw_events_first LIMIT 1;
+INSERT INTO agg_events (user_id) SELECT raw_events_first.user_id FROM raw_events_first OFFSET 1;
+
+-- using a materialized cte
+WITH cte AS MATERIALIZED
+  (SELECT max(value_1)+1 as v1_agg, user_id FROM raw_events_first GROUP BY user_id)
+INSERT INTO agg_events (value_1_agg, user_id)
+SELECT v1_agg, user_id FROM cte;
+
+INSERT INTO raw_events_second
+  WITH cte AS MATERIALIZED (SELECT * FROM raw_events_first)
+  SELECT user_id * 1000, time, value_1, value_2, value_3, value_4 FROM cte;
+
+-- using a regular cte
+WITH cte AS (SELECT * FROM raw_events_first)
+INSERT INTO raw_events_second
+  SELECT user_id * 7000, time, value_1, value_2, value_3, value_4 FROM cte;
+
+INSERT INTO raw_events_second
+  WITH cte AS (SELECT * FROM raw_events_first)
+  SELECT * FROM cte;
+
+INSERT INTO agg_events
+  WITH sub_cte AS (SELECT 1)
+  SELECT
+    raw_events_first.user_id, (SELECT * FROM sub_cte)
+  FROM
+    raw_events_first;
+
+-- we still support complex joins via INSERT's cte list ..
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+INSERT INTO raw_events_second (user_id, value_1)
+  SELECT (a+5)*-1, b FROM cte;
+
+-- .. but can't do so via via SELECT's cte list
+INSERT INTO raw_events_second (user_id, value_1)
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+  SELECT (a+5)*-1, b FROM cte;
+
+-- using set operations
+INSERT INTO
+  raw_events_first(user_id)
+  (SELECT user_id FROM raw_events_first) INTERSECT
+  (SELECT user_id FROM raw_events_first);
+
+-- group by clause inside subquery
+INSERT INTO agg_events
+            (user_id)
+SELECT f2.id FROM
+
+(SELECT
+      id
+FROM   (SELECT raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id ) AS foo) as f
+INNER JOIN
+(SELECT v4,
+       v1,
+       id
+FROM   (SELECT SUM(raw_events_second.value_4) AS v4,
+               SUM(raw_events_first.value_1) AS v1,
+               raw_events_second.user_id      AS id
+        FROM   raw_events_first,
+               raw_events_second
+        WHERE  raw_events_first.user_id = raw_events_second.user_id
+        GROUP  BY raw_events_second.user_id
+        HAVING SUM(raw_events_second.value_4) > 1000) AS foo2 ) as f2
+ON (f.id = f2.id)
+WHERE f.id IN (SELECT user_id
+               FROM   raw_events_second);
+
+-- group by clause inside lateral subquery
+INSERT INTO agg_events (user_id, value_4_agg)
+SELECT
+  averages.user_id, avg(averages.value_4)
+FROM
+    (SELECT
+      t1.user_id
+    FROM
+      raw_events_second t1 JOIN raw_events_second t2 on (t1.user_id = t2.user_id)
+    ) reference_ids
+  JOIN LATERAL
+    (SELECT
+      user_id, value_4
+    FROM
+      raw_events_first) as averages ON averages.value_4 = reference_ids.user_id
+    GROUP BY averages.user_id;
+
+-- using aggregates
+INSERT INTO agg_events
+            (value_3_agg,
+             value_4_agg,
+             value_1_agg,
+             value_2_agg,
+             user_id)
+SELECT SUM(value_3),
+       Count(value_4),
+       user_id,
+       SUM(value_1),
+       Avg(value_2)
+FROM   raw_events_first
+GROUP  BY user_id;
+
+-- using generate_series
+INSERT INTO raw_events_first (user_id, value_1, value_2)
+SELECT s, s, s FROM generate_series(1, 5) s;
+
+CREATE SEQUENCE insert_select_test_seq;
+
+-- nextval() expression in select's targetlist
+INSERT INTO raw_events_first (user_id, value_1, value_2)
+SELECT s, nextval('insert_select_test_seq'), (random()*10)::int
+FROM generate_series(100, 105) s;
+
+-- non-immutable function
+INSERT INTO modify_fast_path (key, value_1) VALUES (2,1) RETURNING value_1, random() * key;
+
+SET client_min_messages TO DEBUG2;
+
+-- update / delete
+
+UPDATE nullkey_c1_t1 SET a = 1 WHERE b = 5;
+UPDATE nullkey_c1_t1 SET a = 1 WHERE a = 5;
+UPDATE nullkey_c1_t1 SET a = random();
+UPDATE nullkey_c1_t1 SET a = 1 WHERE a = random();
+
+DELETE FROM nullkey_c1_t1 WHERE b = 5;
+DELETE FROM nullkey_c1_t1 WHERE a = random();
+
+-- simple update queries between different table types / colocated tables
+UPDATE nullkey_c1_t1 SET b = 5 FROM nullkey_c1_t2 WHERE nullkey_c1_t1.b = nullkey_c1_t2.b;
+UPDATE nullkey_c1_t1 SET b = 5 FROM nullkey_c2_t1 WHERE nullkey_c1_t1.b = nullkey_c2_t1.b;
+UPDATE nullkey_c1_t1 SET b = 5 FROM reference_table WHERE nullkey_c1_t1.b = reference_table.b;
+UPDATE nullkey_c1_t1 SET b = 5 FROM distributed_table WHERE nullkey_c1_t1.b = distributed_table.b;
+UPDATE nullkey_c1_t1 SET b = 5 FROM distributed_table WHERE nullkey_c1_t1.b = distributed_table.a;
+UPDATE nullkey_c1_t1 SET b = 5 FROM citus_local_table WHERE nullkey_c1_t1.b = citus_local_table.b;
+UPDATE nullkey_c1_t1 SET b = 5 FROM postgres_local_table WHERE nullkey_c1_t1.b = postgres_local_table.b;
+
+UPDATE reference_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = reference_table.b;
+UPDATE distributed_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.b;
+UPDATE distributed_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.a;
+UPDATE citus_local_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = citus_local_table.b;
+UPDATE postgres_local_table SET b = 5 FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b = postgres_local_table.b;
+
+-- simple delete queries between different table types / colocated tables
+DELETE FROM nullkey_c1_t1 USING nullkey_c1_t2 WHERE nullkey_c1_t1.b = nullkey_c1_t2.b;
+DELETE FROM nullkey_c1_t1 USING nullkey_c2_t1 WHERE nullkey_c1_t1.b = nullkey_c2_t1.b;
+DELETE FROM nullkey_c1_t1 USING reference_table WHERE nullkey_c1_t1.b = reference_table.b;
+DELETE FROM nullkey_c1_t1 USING distributed_table WHERE nullkey_c1_t1.b = distributed_table.b;
+DELETE FROM nullkey_c1_t1 USING distributed_table WHERE nullkey_c1_t1.b = distributed_table.a;
+DELETE FROM nullkey_c1_t1 USING citus_local_table WHERE nullkey_c1_t1.b = citus_local_table.b;
+DELETE FROM nullkey_c1_t1 USING postgres_local_table WHERE nullkey_c1_t1.b = postgres_local_table.b;
+
+DELETE FROM reference_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = reference_table.b;
+DELETE FROM distributed_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.b;
+DELETE FROM distributed_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = distributed_table.a;
+DELETE FROM citus_local_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = citus_local_table.b;
+DELETE FROM postgres_local_table USING nullkey_c1_t1 WHERE nullkey_c1_t1.b = postgres_local_table.b;
+
+-- slightly more complex update queries
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.b IN (SELECT b FROM distributed_table);
+
+WITH cte AS materialized(
+    SELECT * FROM distributed_table
+)
+UPDATE nullkey_c1_t1 SET b = 5 FROM cte WHERE nullkey_c1_t1.b = cte.a;
+
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.b IN (SELECT b FROM cte);
+
+UPDATE nullkey_c1_t1 SET b = 5 FROM reference_table WHERE EXISTS (
+    SELECT 1 FROM reference_table LEFT JOIN nullkey_c1_t1 USING (a) WHERE nullkey_c1_t1.b IS NULL
+);
+
+UPDATE nullkey_c1_t1 tx SET b = (
+    SELECT nullkey_c1_t2.b FROM nullkey_c1_t2 JOIN nullkey_c1_t1 ON (nullkey_c1_t1.a != nullkey_c1_t2.a) WHERE nullkey_c1_t1.a = tx.a ORDER BY 1 LIMIT 1
+);
+
+UPDATE nullkey_c1_t1 tx SET b = t2.b FROM nullkey_c1_t1 t1 JOIN nullkey_c1_t2 t2 ON (t1.a = t2.a);
+
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t2 ORDER BY 1,2 LIMIT 10
+)
+UPDATE nullkey_c1_t1 SET b = 5 WHERE nullkey_c1_t1.a IN (SELECT b FROM cte);
+
+UPDATE modify_fast_path SET value_1 = value_1 + 12 * value_1 WHERE key = 1;
+UPDATE modify_fast_path SET value_1 = NULL WHERE value_1 = 15 AND (key = 1 OR value_2 = 'citus');
+UPDATE modify_fast_path SET value_1 = 5 WHERE key = 2 RETURNING value_1 * 15, value_1::numeric * 16;
+UPDATE modify_fast_path
+	SET value_1 = 1
+	FROM modify_fast_path_reference
+	WHERE
+		modify_fast_path.key = modify_fast_path_reference.key AND
+		modify_fast_path.key  = 1 AND
+		modify_fast_path_reference.key = 1;
+
+PREPARE p1 (int, int, int) AS
+	UPDATE modify_fast_path SET value_1 = value_1 + $1 WHERE key = $2 AND value_1 = $3;
+EXECUTE p1(1,1,1);
+EXECUTE p1(2,2,2);
+EXECUTE p1(3,3,3);
+EXECUTE p1(4,4,4);
+EXECUTE p1(5,5,5);
+EXECUTE p1(6,6,6);
+EXECUTE p1(7,7,7);
+
+PREPARE prepared_zero_shard_update(int) AS UPDATE modify_fast_path SET value_1 = 1 WHERE key = $1 AND false;
+EXECUTE prepared_zero_shard_update(1);
+EXECUTE prepared_zero_shard_update(2);
+EXECUTE prepared_zero_shard_update(3);
+EXECUTE prepared_zero_shard_update(4);
+EXECUTE prepared_zero_shard_update(5);
+EXECUTE prepared_zero_shard_update(6);
+EXECUTE prepared_zero_shard_update(7);
+
+-- slightly more complex delete queries
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b IN (SELECT b FROM distributed_table);
+
+WITH cte AS materialized(
+    SELECT * FROM distributed_table
+)
+DELETE FROM nullkey_c1_t1 USING cte WHERE nullkey_c1_t1.b = cte.a;
+
+WITH cte AS (
+    SELECT reference_table.a AS a, 1 AS b
+    FROM distributed_table RIGHT JOIN reference_table USING (a)
+)
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.b IN (SELECT b FROM cte);
+
+DELETE FROM nullkey_c1_t1 USING reference_table WHERE EXISTS (
+    SELECT 1 FROM reference_table LEFT JOIN nullkey_c1_t1 USING (a) WHERE nullkey_c1_t1.b IS NULL
+);
+
+DELETE FROM nullkey_c1_t1 tx USING nullkey_c1_t1 t1 JOIN nullkey_c1_t2 t2 ON (t1.a = t2.a);
+
+WITH cte AS (
+    SELECT * FROM nullkey_c1_t2 ORDER BY 1,2 LIMIT 10
+)
+DELETE FROM nullkey_c1_t1 WHERE nullkey_c1_t1.a IN (SELECT b FROM cte);
+
+DELETE FROM modify_fast_path WHERE value_1 = 15 AND (key = 1 OR value_2 = 'citus');
+DELETE FROM modify_fast_path WHERE key = 2 RETURNING value_1 * 15, value_1::numeric * 16;
+DELETE FROM modify_fast_path
+	USING modify_fast_path_reference
+	WHERE
+		modify_fast_path.key = modify_fast_path_reference.key AND
+		modify_fast_path.key  = 1 AND
+		modify_fast_path_reference.key = 1;
+
+PREPARE p2 (int, int, int) AS
+	DELETE FROM modify_fast_path WHERE key = ($2)*$1 AND value_1 = $3;
+EXECUTE p2(1,1,1);
+EXECUTE p2(2,2,2);
+EXECUTE p2(3,3,3);
+EXECUTE p2(4,4,4);
+EXECUTE p2(5,5,5);
+EXECUTE p2(6,6,6);
+EXECUTE p2(7,7,7);
+
+PREPARE prepared_zero_shard_delete(int) AS DELETE FROM modify_fast_path WHERE key = $1 AND false;
+EXECUTE prepared_zero_shard_delete(1);
+EXECUTE prepared_zero_shard_delete(2);
+EXECUTE prepared_zero_shard_delete(3);
+EXECUTE prepared_zero_shard_delete(4);
+EXECUTE prepared_zero_shard_delete(5);
+EXECUTE prepared_zero_shard_delete(6);
+EXECUTE prepared_zero_shard_delete(7);
+
+-- test modifying ctes
+
+WITH cte AS (
+    UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1 RETURNING *
+)
+SELECT * FROM cte;
+
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+SELECT * FROM modify_fast_path;
+
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+SELECT * FROM modify_fast_path_reference WHERE key IN (SELECT key FROM cte);
+
+WITH cte AS (
+    DELETE FROM reference_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t2 WHERE a IN (SELECT a FROM cte);
+
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c2_t1 WHERE a IN (SELECT a FROM cte);
+
+WITH cte AS (
+    DELETE FROM nullkey_c1_t1 WHERE a = 1 RETURNING *
+)
+SELECT * FROM distributed_table WHERE a IN (SELECT a FROM cte);
+
+-- Below two queries fail very late when
+-- citus.enable_non_colocated_router_query_pushdown is set to on.
+
+SET citus.enable_non_colocated_router_query_pushdown TO ON;
+
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE b IN (SELECT b FROM cte);
+
+SET citus.enable_non_colocated_router_query_pushdown TO OFF;
+
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE a IN (SELECT a FROM cte);
+
+WITH cte AS (
+    DELETE FROM distributed_table WHERE a = 1 RETURNING *
+)
+SELECT * FROM nullkey_c1_t1 WHERE b IN (SELECT b FROM cte);
+
+RESET citus.enable_non_colocated_router_query_pushdown;
+
+WITH cte AS (
+    UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1 RETURNING *
+)
+UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1;
+
+WITH cte AS (
+    DELETE FROM modify_fast_path WHERE key = 1 RETURNING *
+)
+DELETE FROM modify_fast_path WHERE key = 1;
+
+-- test window functions
+
+SELECT
+	user_id, avg(avg(value_3)) OVER (PARTITION BY user_id, MIN(value_2))
+FROM
+	raw_events_first
+GROUP BY
+	1
+ORDER BY
+	2 DESC NULLS LAST, 1 DESC;
+
+SELECT
+	user_id, max(value_1) OVER (PARTITION BY user_id, MIN(value_2))
+FROM (
+	SELECT
+		DISTINCT us.user_id, us.value_2, us.value_1, random() as r1
+	FROM
+		raw_events_first as us, raw_events_second
+	WHERE
+		us.user_id = raw_events_second.user_id
+	ORDER BY
+		user_id, value_2
+	) s
+GROUP BY
+	1, value_1
+ORDER BY
+	2 DESC, 1;
+
+SELECT
+	DISTINCT ON (raw_events_second.user_id, rnk) raw_events_second.user_id, rank() OVER my_win AS rnk
+FROM
+	raw_events_second, raw_events_first
+WHERE
+	raw_events_first.user_id = raw_events_second.user_id
+WINDOW
+	my_win AS (PARTITION BY raw_events_second.user_id, raw_events_first.value_1 ORDER BY raw_events_second.time DESC)
+ORDER BY
+	rnk DESC, 1 DESC
+LIMIT 10;
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA query_null_dist_key CASCADE;
+
+SELECT citus_remove_node('localhost', :master_port);

--- a/src/test/regress/sql/single_node.sql
+++ b/src/test/regress/sql/single_node.sql
@@ -63,8 +63,43 @@ ALTER SYSTEM RESET citus.local_shared_pool_size;
 ALTER SYSTEM RESET citus.max_cached_conns_per_worker;
 SELECT pg_reload_conf();
 
+CREATE TABLE single_node_nullkey_c1(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c1', null, colocate_with=>'none', distribution_type=>null);
+
+CREATE TABLE single_node_nullkey_c2(a int, b int);
+SELECT create_distributed_table('single_node_nullkey_c2', null, colocate_with=>'none', distribution_type=>null);
+
+-- created on different colocation groups ..
+SELECT
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+)
+!=
+(
+    SELECT colocationid FROM pg_dist_partition
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+
+-- .. but both are associated to coordinator
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass
+);
+
+SELECT groupid = 0 FROM pg_dist_placement
+WHERE shardid = (
+    SELECT shardid FROM pg_dist_shard
+    WHERE logicalrelid = 'single_node.single_node_nullkey_c2'::regclass
+);
+
+-- try creating a null-shard-key distributed table from a shard relation
+SELECT shardid AS round_robin_test_c1_shard_id FROM pg_dist_shard WHERE logicalrelid = 'single_node.single_node_nullkey_c1'::regclass \gset
+SELECT create_distributed_table('single_node_nullkey_c1_' || :round_robin_test_c1_shard_id , null, colocate_with=>'none', distribution_type=>null);
+
 SET client_min_messages TO WARNING;
-DROP TABLE failover_to_local;
+DROP TABLE failover_to_local, single_node_nullkey_c1, single_node_nullkey_c2;
 RESET client_min_messages;
 
 -- so that we don't have to update rest of the test output


### PR DESCRIPTION
DESCRIPTION: Add support for creating distributed tables without shard key

With this PR, we allow creating distributed tables without
specifying a shard key via create_distributed_table(). Here are the
the important details about those tables:
* Specifying `shard_count` is not allowed because it is assumed to be 1.
* We mostly call such tables as "null shard-key" table in code / comments.
* `colocate_with` param allows colocating such null shard-key tables to
  each other.
* We define this table type, i.e., NULL_SHARD_KEY_TABLE, as a subclass of
  DISTRIBUTED_TABLE because we mostly want to treat them as distributed
  tables in terms of SQL / DDL / operation support.
* Metadata for such tables look like:
  - distribution method => DISTRIBUTE_BY_NONE
  - replication model => REPLICATION_MODEL_STREAMING
  - colocation id => **!=** INVALID_COLOCATION_ID (distinguishes from Citus local tables)
* We assign colocation groups for such tables to different nodes in a
  round-robin fashion based on the modulo of "colocation id".

There are also still more work that needs to be done, such as improving SQL
support, making sure that Citus operations work well such distributed tables
and making sure that latest features merged in at 11.3 (such as CDC) works
fine. We will take care of them in subsequent PRs.

At 12.0, we will build schema-based-sharding on top of this infrastructure.
And it's likely that we will use this infra for some other nice features in
future too.