### PR TITLE
Add changelog entries for backport releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+### citus v11.2.1 (April 20, 2023) ###
+
+* Correctly reports shard size in `citus_shards` view (#6748)
+
+* Fixes a bug in shard copy operations (#6721)
+
+* Fixes a bug with `INSERT .. SELECT` queries with identity columns (#6802)
+
+* Fixes an uninitialized memory access in shard split API (#6845)
+
+* Fixes compilation for PG13.10 and PG14.7 (#6711)
+
+* Fixes memory leak in `alter_distributed_table` (#6726)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Prevents using `alter_distributed_table` and `undistribute_table` UDFs when a
+  table has identity columns (#6738)
+
+* Prevents using identity columns on data types other than `bigint` on
+  distributed tables (#6738)
+
 ### citus v11.1.6 (April 20, 2023) ###
 
 * Correctly reports shard size in `citus_shards` view (#6748)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+### citus v11.1.6 (April 20, 2023) ###
+
+* Correctly reports shard size in `citus_shards` view (#6748)
+
+* Fixes a bug in shard copy operations (#6721)
+
+* Fixes a bug that breaks pg upgrades if the user has a columnar table (#6624)
+
+* Fixes a bug that causes background rebalancer to fail when a reference table
+  doesn't have a primary key (#6682)
+
+* Fixes a regression in allowed foreign keys on distributed tables (#6550)
+
+* Fixes a use-after-free bug in connection management (#6685)
+
+* Fixes an unexpected foreign table error by disallowing to drop the
+  `table_name` option (#6669)
+
+* Fixes an uninitialized memory access in shard split API (#6845)
+
+* Fixes compilation for PG13.10 and PG14.7 (#6711)
+
+* Fixes crash that happens when trying to replicate a reference table that is
+  actually dropped (#6595)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Fixes the modifiers for subscription and role creation (#6603)
+
+* Makes sure to quote all identifiers used for logical replication to prevent
+  potential issues (#6604)
+
+* Makes sure to skip foreign key validations at the end of shard moves (#6640)
+
 ### citus v11.0.8 (April 20, 2023) ###
 
 * Correctly reports shard size in `citus_shards` view (#6748)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### citus v10.2.9 (April 20, 2023) ###
+
+* Correctly reports shard size in `citus_shards` view (#6748)
+
+* Fixes a bug in `ALTER EXTENSION citus UPDATE` (#6383)
+
+* Fixes a bug that breaks pg upgrades if the user has a columnar table (#6624)
+
+* Fixes a bug that prevents retaining columnar table options after a
+  table-rewrite (#6337)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Raises memory limits in columnar from 256MB to 1GB for reads and writes
+  (#6419)
+
 ### citus v10.1.5 (April 20, 2023) ###
 
 * Fixes a crash that occurs when the aggregate that cannot be pushed-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### citus v10.1.5 (April 20, 2023) ###
+
+* Fixes a crash that occurs when the aggregate that cannot be pushed-down
+  returns empty result from a worker (#5679)
+
+* Fixes columnar freezing/wraparound bug (#5962)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Prevents alter table functions from dropping extensions (#5974)
+
 ### citus v10.0.7 (April 20, 2023) ###
 
 * Fixes a crash that occurs when the aggregate that cannot be pushed-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### citus v10.0.7 (April 20, 2023) ###
+
+* Fixes a crash that occurs when the aggregate that cannot be pushed-down
+  returns empty result from a worker (#5679)
+
+* Fixes columnar freezing/wraparound bug (#5962)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Prevents alter table functions from dropping extensions (#5974)
+
 ### citus v9.5.11 (April 20, 2023) ###
 
 * Fixes a crash that occurs when the aggregate that cannot be pushed-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+### citus v11.0.8 (April 20, 2023) ###
+
+* Correctly reports shard size in `citus_shards` view (#6748)
+
+* Fixes a bug that breaks pg upgrades if the user has a columnar table (#6624)
+
+* Fixes an unexpected foreign table error by disallowing to drop the
+  `table_name` option (#6669)
+
+* Fixes compilation warning on PG13 + OpenSSL 3.0 (#6038, #6502)
+
+* Fixes crash that happens when trying to replicate a reference table that is
+  actually dropped (#6595)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Fixes the modifiers for subscription and role creation (#6603)
+
+* Fixes two potential dangling pointer issues (#6504, #6507)
+
+* Makes sure to quote all identifiers used for logical replication to prevent
+  potential issues (#6604)
+
 ### citus v10.2.9 (April 20, 2023) ###
 
 * Correctly reports shard size in `citus_shards` view (#6748)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### citus v9.5.11 (April 20, 2023) ###
+
+* Fixes a crash that occurs when the aggregate that cannot be pushed-down
+  returns empty result from a worker (#5679)
+
+* Fixes memory leak issue with query results that returns single row (#6724)
+
+* Prevents alter table functions from dropping extensions (#5974)
+
 ### citus v11.2.0 (January 30, 2023) ###
 
 * Adds support for outer joins with reference tables / complex subquery-CTEs


### PR DESCRIPTION
We plan to have a series of backport releases. This PR contains separate commits for each patch version for 11.2 to 9.5 major versions. We plan to cherry pick each commit to relevant release branches and hence the need to have separate commits for each version.

The ordering of the versions in the changelog is open to discussion.

- [x] 11.2.1
- [x] 11.1.6
- [x] 11.0.8
- [x] 10.2.9
- [x] 10.1.5
- [x] 10.0.7
- [x] 9.5.11