### PR TITLE
Fix treating same numeric value differently in citus_stat_tenants bug

### DIFF
--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -871,5 +871,30 @@ SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
  äbc              |                         11
 (2 rows)
 
+-- test numeric values with different numbers of trailing zeros
+SELECT citus_stat_tenants_reset();
+ citus_stat_tenants_reset
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE dist_tbl_numeric(a numeric);
+SELECT create_distributed_table('dist_tbl_numeric', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist_tbl_numeric VALUES (1);
+INSERT INTO dist_tbl_numeric VALUES (1.0);
+INSERT INTO dist_tbl_numeric VALUES (1.00);
+INSERT INTO dist_tbl_numeric VALUES (1.000);
+SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
+ tenant_attribute | query_count_in_this_period
+---------------------------------------------------------------------
+ 1                |                          4
+(1 row)
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -311,5 +311,19 @@ SELECT count(*)>=0 FROM select_from_dist_tbl_text_view WHERE a = U&'\0061\0308bc
 
 SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
 
+-- test numeric values with different numbers of trailing zeros
+SELECT citus_stat_tenants_reset();
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE dist_tbl_numeric(a numeric);
+SELECT create_distributed_table('dist_tbl_numeric', 'a');
+
+INSERT INTO dist_tbl_numeric VALUES (1);
+INSERT INTO dist_tbl_numeric VALUES (1.0);
+INSERT INTO dist_tbl_numeric VALUES (1.00);
+INSERT INTO dist_tbl_numeric VALUES (1.000);
+
+SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;


### PR DESCRIPTION
Normalizes the numeric values to make sure they are put in the same tenant monitor row.

Fixes #6849 