### PR TITLE
fix flaky test regex

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -154,6 +154,8 @@ def run_python_test(test_name, args):
 
 def run_regress_test(test_name, args):
     original_schedule, schedule_line = find_test_schedule_and_line(test_name, args)
+    print(f"SCHEDULE: {original_schedule}")
+    print(f"SCHEDULE_LINE: {schedule_line}")
 
     dependencies = test_dependencies(test_name, original_schedule, schedule_line, args)
 
@@ -287,7 +289,7 @@ def get_test_name(args):
 def find_test_schedule_and_line(test_name, args):
     for schedule_file_path in sorted(REGRESS_DIR.glob("*_schedule")):
         for schedule_line in open(schedule_file_path, "r"):
-            if re.search(r"\b" + test_name + r"\b", schedule_line):
+            if re.search(r"^test:.*\b" + test_name + r"\b", schedule_line):
                 test_schedule = pathlib.Path(schedule_file_path).stem
                 if args["use_whole_schedule_line"]:
                     return test_schedule, schedule_line


### PR DESCRIPTION
There was a bug related to regex. We sometimes caught the wrong line when the test name is also included in comments.
Example: We caught the wrong line as multi_metadata_sync is included in the comment before the test line.

```
# ----------
# multi_metadata_sync tests the propagation of mx-related metadata changes to metadata workers
# multi_unsupported_worker_operations tests that unsupported operations error out on metadata workers
# ----------
test: multi_metadata_sync
```

Solution: Restrict regex rule better.