### PR TITLE
Add missing entry for 10.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@
 
 ### citus v10.0.8 (April 20, 2023) ###
 
+* Fixes a bug that could break `DROP SCHEMA/EXTENSON` commands when there is a
+  columnar table (#5458)
+
 * Fixes a crash that occurs when the aggregate that cannot be pushed-down
   returns empty result from a worker (#5679)
 


### PR DESCRIPTION
When creating tags for backport releases, I realized that I missed one changelog item. Adding it on the default branch in a commit. See #6885 for the relevant PR for the release branch. 