### PR TITLE
Fix citus_stat_tenants not counting arrays in INSERT queries bug

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -3580,6 +3580,14 @@ ExtractInsertPartitionKeyValue(Query *query)
 		/* single-row INSERT with a constant partition column value */
 		singlePartitionValueConst = (Const *) targetExpression;
 	}
+	else if (IsA(targetExpression, ArrayExpr))
+	{
+		singlePartitionValueConst =
+			(Const *) evaluate_expr((Expr *) targetExpression,
+									exprType(targetExpression),
+									exprTypmod(targetExpression),
+									exprCollation(targetExpression));
+	}
 	else
 	{
 		/* single-row INSERT with a non-constant partition column value */

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -871,5 +871,36 @@ SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
  äbc              |                         11
 (2 rows)
 
+-- test array data type
+SELECT citus_stat_tenants_reset();
+ citus_stat_tenants_reset
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE array_tbl (a int[][]);
+SELECT create_distributed_table ('array_tbl', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[1,2], ARRAY[2,3]]);
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[1,2], ARRAY[2,3]]);
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[5,4], ARRAY[3,2]]);
+SELECT count(*)>=0 FROM array_tbl WHERE a = ARRAY[ARRAY[1,2], ARRAY[2,3]];
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT tenant_attribute, read_count_in_this_period, query_count_in_this_period FROM citus_stat_tenants;
+ tenant_attribute | read_count_in_this_period | query_count_in_this_period
+---------------------------------------------------------------------
+ {{1,2},{2,3}}    |                         1 |                          3
+ {{5,4},{3,2}}    |                         0 |                          1
+(2 rows)
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -311,5 +311,21 @@ SELECT count(*)>=0 FROM select_from_dist_tbl_text_view WHERE a = U&'\0061\0308bc
 
 SELECT tenant_attribute, query_count_in_this_period FROM citus_stat_tenants;
 
+-- test array data type
+SELECT citus_stat_tenants_reset();
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE array_tbl (a int[][]);
+SELECT create_distributed_table ('array_tbl', 'a');
+
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[1,2], ARRAY[2,3]]);
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[1,2], ARRAY[2,3]]);
+
+INSERT INTO array_tbl VALUES (ARRAY[ARRAY[5,4], ARRAY[3,2]]);
+
+SELECT count(*)>=0 FROM array_tbl WHERE a = ARRAY[ARRAY[1,2], ARRAY[2,3]];
+
+SELECT tenant_attribute, read_count_in_this_period, query_count_in_this_period FROM citus_stat_tenants;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;


### PR DESCRIPTION
Arrays were not added as partition key values. This PR adds them.

Fixes #6858 