### PR TITLE
Fix citus.tenant_stats_limit test by setting it to 2

### DIFF
--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -224,10 +224,8 @@ SELECT tenant_attribute, query_count_in_this_period, score FROM citus_stat_tenan
  bcde             |                          3 | 3000000000
  2                |                          1 | 1000000000
  3                |                          1 | 1000000000
- 4                |                          1 | 1000000000
- cdef             |                          1 | 1000000000
  defg             |                          1 | 1000000000
-(7 rows)
+(5 rows)
 
 -- test period passing
 SELECT citus_stat_tenants_reset();
@@ -439,7 +437,7 @@ SELECT count(*)>=0 FROM dist_tbl_text WHERE a = U&'\0061\0308bc';
 (1 row)
 
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
  tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
 ---------------------------------------------------------------------
  /*bcde           |                         1 |                         0 |                          1 |                          0
@@ -456,7 +454,7 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 
 \c - - - :worker_2_port
 SET search_path TO citus_stat_tenants;
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
  tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
 ---------------------------------------------------------------------
  /*bcde           |                         1 |                         0 |                          1 |                          0
@@ -507,7 +505,7 @@ DELETE FROM dist_tbl_text WHERE a = '/b*c/de';
 DELETE FROM dist_tbl_text WHERE a = '/bcde';
 DELETE FROM dist_tbl_text WHERE a = U&'\0061\0308bc';
 DELETE FROM dist_tbl_text WHERE a = 'bcde*';
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local(true) ORDER BY tenant_attribute;
  tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
 ---------------------------------------------------------------------
  /b*c/de          |                         1 |                         0 |                          2 |                          0
@@ -590,7 +588,7 @@ EXECUTE dist_tbl_text_select_plan('bcde*');
  t
 (1 row)
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local(true) ORDER BY tenant_attribute;
  tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
 ---------------------------------------------------------------------
  /b*c/de          |                         4 |                         0 |                          5 |                          0
@@ -676,7 +674,7 @@ EXECUTE dist_tbl_text_select_plan('bcde*');
 
 \c - - - :worker_2_port
 SET search_path TO citus_stat_tenants;
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
  tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
 ---------------------------------------------------------------------
  /b*c/de          |                         7 |                         0 |                          8 |                          0

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -489,7 +489,7 @@ push(@pgOptions, "citus.enable_manual_changes_to_shards=on");
 push(@pgOptions, "citus.allow_unsafe_locks_from_workers=on");
 push(@pgOptions, "citus.stat_statements_track = 'all'");
 push(@pgOptions, "citus.enable_change_data_capture=on");
-push(@pgOptions, "citus.stat_tenants_limit = 10");
+push(@pgOptions, "citus.stat_tenants_limit = 2");
 push(@pgOptions, "citus.stat_tenants_track = 'ALL'");
 
 # Some tests look at shards in pg_class, make sure we can usually see them:

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -158,11 +158,11 @@ SELECT count(*)>=0 FROM dist_tbl_text WHERE a = 'bcde*/';
 SELECT count(*)>=0 FROM dist_tbl_text WHERE a = U&'\0061\0308bc';
 
 \c - - - :worker_1_port
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
 \c - - - :worker_2_port
 SET search_path TO citus_stat_tenants;
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
 
 SELECT citus_stat_tenants_reset();
 
@@ -179,7 +179,7 @@ DELETE FROM dist_tbl_text WHERE a = '/bcde';
 DELETE FROM dist_tbl_text WHERE a = U&'\0061\0308bc';
 DELETE FROM dist_tbl_text WHERE a = 'bcde*';
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local(true) ORDER BY tenant_attribute;
 
 -- test local cached queries & prepared statements
 
@@ -198,7 +198,7 @@ EXECUTE dist_tbl_text_select_plan('/bcde');
 EXECUTE dist_tbl_text_select_plan(U&'\0061\0308bc');
 EXECUTE dist_tbl_text_select_plan('bcde*');
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants_local(true) ORDER BY tenant_attribute;
 
 \c - - - :master_port
 SET search_path TO citus_stat_tenants;
@@ -221,7 +221,7 @@ EXECUTE dist_tbl_text_select_plan('bcde*');
 \c - - - :worker_2_port
 SET search_path TO citus_stat_tenants;
 
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants(true) ORDER BY tenant_attribute;
 
 \c - - - :master_port
 SET search_path TO citus_stat_tenants;


### PR DESCRIPTION
citus.tenant_stats_limit was set to 2 when we were adding tests for it. Then we changed it to 10, making the tests incorrect.
This PR fixes that without breaking other tests.