### PR TITLE
Fix flaky clolumnar_permissions test

### DIFF
--- a/src/test/regress/expected/columnar_permissions.out
+++ b/src/test/regress/expected/columnar_permissions.out
@@ -123,7 +123,7 @@ select relation, stripe_num, row_count, first_row_number
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
   where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
-  order by relation, stripe_num;
+  order by relation, stripe_num, attr_num;
        relation       | stripe_num | attr_num | chunk_group_num | value_count
 ---------------------------------------------------------------------
  no_access            |          1 |        1 |               0 |           1

--- a/src/test/regress/sql/columnar_permissions.sql
+++ b/src/test/regress/sql/columnar_permissions.sql
@@ -75,7 +75,7 @@ select relation, stripe_num, row_count, first_row_number
 select relation, stripe_num, attr_num, chunk_group_num, value_count
   from columnar.chunk
   where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
-  order by relation, stripe_num;
+  order by relation, stripe_num, attr_num;
 select relation, stripe_num, chunk_group_num, row_count
   from columnar.chunk_group
   where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)


### PR DESCRIPTION
As attr_num isn't ordered, order may be random. And regression test may be failed.
This MR adds attr_num to ORDER BY


```
  3 --- /build/contrib/citus/src/test/regress/expected/columnar_permissions.out.modified    2023-05-05 11:13:44.926085432 +0000
  4 +++ /build/contrib/citus/src/test/regress/results/columnar_permissions.out.modified 2023-05-05 11:13:44.934085414 +0000
  5 @@ -124,24 +124,24 @@
  6    from columnar.chunk
  7    where relation in ('no_access'::regclass, 'columnar_permissions'::regclass)
  8    order by relation, stripe_num;
  9         relation       | stripe_num | attr_num | chunk_group_num | value_count
 10  ----------------------+------------+----------+-----------------+-------------
 11   no_access            |          1 |        1 |               0 |           1
 12   no_access            |          2 |        1 |               0 |           1
 13   no_access            |          3 |        1 |               0 |           1
 14   columnar_permissions |          1 |        1 |               0 |           1
 15   columnar_permissions |          1 |        2 |               0 |           1
 16 - columnar_permissions |          2 |        1 |               0 |           1
 17   columnar_permissions |          2 |        2 |               0 |           1
 18 - columnar_permissions |          3 |        1 |               0 |           1
 19 + columnar_permissions |          2 |        1 |               0 |           1
 20   columnar_permissions |          3 |        2 |               0 |           1
 21 + columnar_permissions |          3 |        1 |               0 |           1
 22   columnar_permissions |          4 |        1 |               0 |           1
 23   columnar_permissions |          4 |        2 |               0 |           1
 24  (11 rows)
```