### PR TITLE
Skip flaky test job on release-11.3 branch 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ parameters:
     default: 50
   skip_flaky_tests:
     type: boolean
-    default: false
+    default: true
 
 commands:
   install_extension:


### PR DESCRIPTION
There is an issue with flaky test job on CI that blocks backporting new changes. This PR aims to disable those tests on the release branch to unblock backports.

The problem: 

We compare the current branch with the head of the main branch to get the list of changed test files. This logic however does not really make sense on the release branch.

```sh
detected_changes=$(git diff origin/main... --name-only --diff-filter=AM | (grep 'src/test/regress/sql/.*\.sql\|src/test/regress/spec/.*\.spec\|src/test/regress/citus_tests/test/test_.*\.py' || true))
```

Another alternative is to change this line to compare the current branch with `release-11.3` branch. I do not see much value in doing this, and I'd like to disable these tests instead.