### PR TITLE
Create a new colocation properly after breaking one

### DIFF
--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -175,12 +175,11 @@ BreakColocation(Oid sourceRelationId)
 	 */
 	Relation pgDistColocation = table_open(DistColocationRelationId(), ExclusiveLock);
 
-	uint32 newColocationId = GetNextColocationId();
-	bool localOnly = false;
-	UpdateRelationColocationGroup(sourceRelationId, newColocationId, localOnly);
+	uint32 oldColocationId = TableColocationId(sourceRelationId);
+	CreateColocationGroupForRelation(sourceRelationId);
 
-	/* if there is not any remaining table in the colocation group, delete it */
-	DeleteColocationGroupIfNoTablesBelong(sourceRelationId);
+	/* if there is not any remaining table in the old colocation group, delete it */
+	DeleteColocationGroupIfNoTablesBelong(oldColocationId);
 
 	table_close(pgDistColocation, NoLock);
 }


### PR DESCRIPTION
When breaking a colocation, we need to create a new colocation group record in pg_dist_colocation for the relation. It is not sufficient to have a new colocationid value in pg_dist_partition only.

This patch also fixes a bug when deleting a colocation group if no tables are left in it. Previously we passed a relation id as a parameter to DeleteColocationGroupIfNoTablesBelong function, where we should have passed a colocation id.

Fixes: #6928 