### PR TITLE
Add ORDER BY clauses to some flaky tests

### DIFF
--- a/src/test/regress/expected/citus_local_tables_mx.out
+++ b/src/test/regress/expected/citus_local_tables_mx.out
@@ -805,11 +805,11 @@ SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_views WHERE viewname LIK
  (localhost,57638,t,2)
 (2 rows)
 
-SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view'::regclass::oid, 'viewsc.prop_view2'::regclass::oid);
+SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view'::regclass::oid, 'viewsc.prop_view2'::regclass::oid) ORDER BY 1;
   pg_identify_object_as_address
 ---------------------------------------------------------------------
- (view,"{viewsc,prop_view2}",{})
  (view,"{viewsc,prop_view}",{})
+ (view,"{viewsc,prop_view2}",{})
 (2 rows)
 
 -- drop views
@@ -857,7 +857,7 @@ SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_views WHERE viewname LIK
  (localhost,57638,t,2)
 (2 rows)
 
-SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view3'::regclass::oid, 'viewsc.prop_view4'::regclass::oid);
+SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view3'::regclass::oid, 'viewsc.prop_view4'::regclass::oid) ORDER BY 1;
   pg_identify_object_as_address
 ---------------------------------------------------------------------
  (view,"{viewsc,prop_view3}",{})

--- a/src/test/regress/sql/citus_local_tables_mx.sql
+++ b/src/test/regress/sql/citus_local_tables_mx.sql
@@ -422,7 +422,7 @@ SELECT citus_add_local_table_to_metadata('view_tbl_1');
 SELECT viewname, definition FROM pg_views WHERE viewname LIKE 'prop_view%' ORDER BY viewname;
 
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_views WHERE viewname LIKE 'prop_view%';$$);
-SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view'::regclass::oid, 'viewsc.prop_view2'::regclass::oid);
+SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view'::regclass::oid, 'viewsc.prop_view2'::regclass::oid) ORDER BY 1;
 -- drop views
 DROP VIEW viewsc.prop_view;
 DROP VIEW viewsc.prop_view2;
@@ -441,7 +441,7 @@ SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_views WHERE viewname LIK
 SELECT citus_add_local_table_to_metadata('view_tbl_2');
 -- verify both views are distributed
 SELECT run_command_on_workers($$SELECT COUNT(*) FROM pg_views WHERE viewname LIKE 'prop_view%';$$);
-SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view3'::regclass::oid, 'viewsc.prop_view4'::regclass::oid);
+SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view3'::regclass::oid, 'viewsc.prop_view4'::regclass::oid) ORDER BY 1;
 
 -- test with fkey cascading
 create table ref_tb(a int primary key);


### PR DESCRIPTION
I observed a flaky test output [here](https://app.circleci.com/pipelines/github/citusdata/citus/32692/workflows/32464a22-7fd6-440a-9ff7-cfa62f9ff58a/jobs/1126144) and added `ORDER BY` clauses to similar queries in the failing test file.

```diff
 SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object where objid IN('viewsc.prop_view3'::regclass::oid, 'viewsc.prop_view4'::regclass::oid);
   pg_identify_object_as_address  
 ---------------------------------
- (view,"{viewsc,prop_view3}",{})
  (view,"{viewsc,prop_view4}",{})
+ (view,"{viewsc,prop_view3}",{})
 (2 rows)
```