### PR TITLE
Bump PGversions for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-dev-903b536'
+    default: '-vf5dc39a'
   pg13_version:
     type: string
     default: '13.11'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,19 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-vabeb997'
+    default: '-dev-903b536'
   pg13_version:
     type: string
-    default: '13.10'
+    default: '13.11'
   pg14_version:
     type: string
-    default: '14.7'
+    default: '14.8'
   pg15_version:
     type: string
-    default: '15.2'
+    default: '15.3'
   upgrade_pg_versions:
     type: string
-    default: '13.10-14.7-15.2'
+    default: '13.11-14.8-15.3'
   style_checker_tools_version:
     type: string
     default: '0.8.18'


### PR DESCRIPTION
Postgres got minor updates in May, this starts using the images with the latest
version for our tests.

These new Postgres versions didn't cause any compilation issues or test failures.

Depends on https://github.com/citusdata/the-process/pull/136