### PR TITLE
Disable ALTER TABLE .. SET SCHEMA for tenant tables

### DIFF
--- a/src/backend/distributed/commands/schema_based_sharding.c
+++ b/src/backend/distributed/commands/schema_based_sharding.c
@@ -269,8 +269,9 @@ ErrorIfTenantSchema(Oid nspOid, char *operationName)
 {
 	if (IsTenantSchema(nspOid))
 	{
-		ereport(ERROR, (errmsg("%s is not allowed for %s because it is a tenant schema",
-							   get_namespace_name(nspOid),
-							   operationName)));
+		ereport(ERROR, (errmsg(
+							"%s is not allowed for %s because it is a distributed schema",
+							get_namespace_name(nspOid),
+							operationName)));
 	}
 }

--- a/src/backend/distributed/commands/schema_based_sharding.c
+++ b/src/backend/distributed/commands/schema_based_sharding.c
@@ -258,3 +258,19 @@ ErrorIfTenantTable(Oid relationId, char *operationName)
 							   operationName)));
 	}
 }
+
+
+/*
+ * ErrorIfTenantSchema errors out with the given operation name,
+ * if the given schema is a tenant schema.
+ */
+void
+ErrorIfTenantSchema(Oid nspOid, char *operationName)
+{
+	if (IsTenantSchema(nspOid))
+	{
+		ereport(ERROR, (errmsg("%s is not allowed for %s because it is a tenant schema",
+							   get_namespace_name(nspOid),
+							   operationName)));
+	}
+}

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -2293,8 +2293,9 @@ PreprocessAlterTableSchemaStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
-	ErrorIfTenantTable(relationId, "SET SCHEMA");
-	ErrorIfTenantSchema(get_namespace_oid(stmt->newschema, true), "SET SCHEMA");
+	ErrorIfTenantTable(relationId, "ALTER TABLE SET SCHEMA");
+	ErrorIfTenantSchema(get_namespace_oid(stmt->newschema, false),
+						"ALTER TABLE SET SCHEMA");
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	QualifyTreeNode((Node *) stmt);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -2293,6 +2293,8 @@ PreprocessAlterTableSchemaStmt(Node *node, const char *queryString,
 		return NIL;
 	}
 
+	ErrorIfTenantTable(relationId, "SET SCHEMA");
+
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	QualifyTreeNode((Node *) stmt);
 	ObjectAddressSet(ddlJob->targetObjectAddress, RelationRelationId, relationId);

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -2294,6 +2294,7 @@ PreprocessAlterTableSchemaStmt(Node *node, const char *queryString,
 	}
 
 	ErrorIfTenantTable(relationId, "SET SCHEMA");
+	ErrorIfTenantSchema(get_namespace_oid(stmt->newschema, true), "SET SCHEMA");
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	QualifyTreeNode((Node *) stmt);

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -790,5 +790,6 @@ extern void ErrorIfIllegalPartitioningInTenantSchema(Oid parentRelationId,
 													 Oid partitionRelationId);
 extern void CreateTenantSchemaTable(Oid relationId);
 extern void ErrorIfTenantTable(Oid relationId, char *operationName);
+extern void ErrorIfTenantSchema(Oid nspOid, char *operationName);
 
 #endif /*CITUS_COMMANDS_H */

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -89,6 +89,9 @@ ERROR:  tenant_2.test_table is not allowed for alter_distributed_table because i
 -- verify we also don't allow colocate_with a tenant table
 SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 ERROR:  tenant_2.test_table is not allowed for colocate_with because it is a tenant table
+-- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
+ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
+ERROR:  tenant_2.test_table is not allowed for SET SCHEMA because it is a tenant table
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema
 WHERE schemaid::regnamespace::text IN ('tenant_1', 'tenant_3');

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -92,6 +92,9 @@ ERROR:  tenant_2.test_table is not allowed for colocate_with because it is a ten
 -- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
 ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
 ERROR:  tenant_2.test_table is not allowed for SET SCHEMA because it is a tenant table
+-- verify we don't allow ALTER TABLE SET SCHEMA for tenant schemas
+ALTER TABLE regular_schema.test_table SET SCHEMA tenant_2;
+ERROR:  tenant_2 is not allowed for SET SCHEMA because it is a tenant schema
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema
 WHERE schemaid::regnamespace::text IN ('tenant_1', 'tenant_3');

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -91,10 +91,13 @@ SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'te
 ERROR:  tenant_2.test_table is not allowed for colocate_with because it is a tenant table
 -- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
 ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
-ERROR:  tenant_2.test_table is not allowed for SET SCHEMA because it is a tenant table
+ERROR:  tenant_2.test_table is not allowed for ALTER TABLE SET SCHEMA because it is a tenant table
 -- verify we don't allow ALTER TABLE SET SCHEMA for tenant schemas
 ALTER TABLE regular_schema.test_table SET SCHEMA tenant_2;
-ERROR:  tenant_2 is not allowed for SET SCHEMA because it is a tenant schema
+ERROR:  tenant_2 is not allowed for ALTER TABLE SET SCHEMA because it is a distributed schema
+-- the same, from tenant schema to tenant schema
+ALTER TABLE tenant_2.test_table SET SCHEMA tenant_3;
+ERROR:  tenant_2.test_table is not allowed for ALTER TABLE SET SCHEMA because it is a tenant table
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema
 WHERE schemaid::regnamespace::text IN ('tenant_1', 'tenant_3');

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -67,6 +67,8 @@ SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');
 SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 -- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
 ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
+-- verify we don't allow ALTER TABLE SET SCHEMA for tenant schemas
+ALTER TABLE regular_schema.test_table SET SCHEMA tenant_2;
 
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -69,6 +69,8 @@ SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'te
 ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
 -- verify we don't allow ALTER TABLE SET SCHEMA for tenant schemas
 ALTER TABLE regular_schema.test_table SET SCHEMA tenant_2;
+-- the same, from tenant schema to tenant schema
+ALTER TABLE tenant_2.test_table SET SCHEMA tenant_3;
 
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -65,6 +65,8 @@ SELECT undistribute_table('tenant_2.test_table');
 SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');
 -- verify we also don't allow colocate_with a tenant table
 SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
+-- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
+ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
 
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_tenant_schema


### PR DESCRIPTION
Disables `ALTER TABLE .. SET SCHEMA` for tenant tables.
Disables `ALTER TABLE .. SET SCHEMA` for tenant schemas.