### PR TITLE
Random warning fixes

### DIFF
--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -1557,7 +1557,7 @@ DeserializeDatumArray(StringInfo datumBuffer, bool *existsArray, uint32 datumCou
 										   datumTypeLength);
 		currentDatumDataOffset = att_addlength_datum(currentDatumDataOffset,
 													 datumTypeLength,
-													 currentDatumDataPointer);
+													 datumArray[datumIndex]);
 		currentDatumDataOffset = att_align_nominal(currentDatumDataOffset,
 												   datumTypeAlign);
 

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -2871,15 +2871,15 @@ TupleToWorkerNode(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	 */
 	heap_deform_tuple(heapTuple, tupleDescriptor, datumArray, isNullArray);
 
-	char *nodeName = DatumGetCString(datumArray[Anum_pg_dist_node_nodename - 1]);
-	char *nodeRack = DatumGetCString(datumArray[Anum_pg_dist_node_noderack - 1]);
+	char *nodeName = TextDatumGetCString(datumArray[Anum_pg_dist_node_nodename - 1]);
+	char *nodeRack = TextDatumGetCString(datumArray[Anum_pg_dist_node_noderack - 1]);
 
 	WorkerNode *workerNode = (WorkerNode *) palloc0(sizeof(WorkerNode));
 	workerNode->nodeId = DatumGetUInt32(datumArray[Anum_pg_dist_node_nodeid - 1]);
 	workerNode->workerPort = DatumGetUInt32(datumArray[Anum_pg_dist_node_nodeport - 1]);
 	workerNode->groupId = DatumGetInt32(datumArray[Anum_pg_dist_node_groupid - 1]);
-	strlcpy(workerNode->workerName, TextDatumGetCString(nodeName), WORKER_LENGTH);
-	strlcpy(workerNode->workerRack, TextDatumGetCString(nodeRack), WORKER_LENGTH);
+	strlcpy(workerNode->workerName, nodeName, WORKER_LENGTH);
+	strlcpy(workerNode->workerRack, nodeRack, WORKER_LENGTH);
 	workerNode->hasMetadata = DatumGetBool(datumArray[Anum_pg_dist_node_hasmetadata - 1]);
 	workerNode->metadataSynced =
 		DatumGetBool(datumArray[Anum_pg_dist_node_metadatasynced - 1]);

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -119,7 +119,7 @@ get_referencing_relation_id_list(PG_FUNCTION_ARGS)
 
 		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
-		SRF_RETURN_NEXT(functionContext, PointerGetDatum(refId));
+		SRF_RETURN_NEXT(functionContext, ObjectIdGetDatum(refId));
 	}
 	else
 	{
@@ -178,7 +178,7 @@ get_referenced_relation_id_list(PG_FUNCTION_ARGS)
 
 		wrapper->listCell = lnext(wrapper->list, wrapper->listCell);
 
-		SRF_RETURN_NEXT(functionContext, PointerGetDatum(refId));
+		SRF_RETURN_NEXT(functionContext, ObjectIdGetDatum(refId));
 	}
 	else
 	{

--- a/src/backend/distributed/utils/citus_safe_lib.c
+++ b/src/backend/distributed/utils/citus_safe_lib.c
@@ -23,8 +23,6 @@
 #include "distributed/citus_safe_lib.h"
 #include "lib/stringinfo.h"
 
-#define citus_vsnprintf pg_vsnprintf
-
 
 /*
  * ereport_constraint_handler is a constraint handler that calls ereport. A
@@ -338,7 +336,7 @@ SafeSnprintf(char *restrict buffer, rsize_t bufsz, const char *restrict format, 
 	va_list args;
 
 	va_start(args, format);
-	size_t result = citus_vsnprintf(buffer, bufsz, format, args);
+	int result = pg_vsnprintf(buffer, bufsz, format, args);
 	va_end(args);
 	return result;
 }

--- a/src/include/distributed/citus_safe_lib.h
+++ b/src/include/distributed/citus_safe_lib.h
@@ -25,7 +25,8 @@ extern void SafeQsort(void *ptr, rsize_t count, rsize_t size,
 					  int (*comp)(const void *, const void *));
 void * SafeBsearch(const void *key, const void *ptr, rsize_t count, rsize_t size,
 				   int (*comp)(const void *, const void *));
-int SafeSnprintf(char *str, rsize_t count, const char *fmt, ...);
+int SafeSnprintf(char *str, rsize_t count, const char *fmt, ...) pg_attribute_printf(3,
+																					 0);
 
 #define memset_struct_0(variable) memset(&variable, 0, sizeof(variable))
 


### PR DESCRIPTION
Citus build with PG16 fails because of the following warnings:
 - using char* instead of Datum
``` C
columnar_reader.c:1558:28: note: in expansion of macro ‘att_addlength_datum’
 1558 |   currentDatumDataOffset = att_addlength_datum(currentDatumDataOffset,
      |                            ^~~~~~~~~~~~~~~~~~~
In file included from columnar_reader.c:17:
pgsql-16beta1/include/server/postgres.h:312:23: note:
expected ‘Datum’ {aka ‘long unsigned int’} but argument is of type ‘char *’
  312 | DatumGetPointer(Datum X)
```

``` C
metadata/node_metadata.c: In function ‘TupleToWorkerNode’:
metadata/node_metadata.c:2881:54: warning:
passing argument 1 of ‘DatumGetPointer’ makes integer from pointer without a cast [-Wint-conversion]
 2881 |  strlcpy(workerNode->workerName, TextDatumGetCString(nodeName), WORKER_LENGTH);
      |                                                      ^~~~~~~~
      |                                                      |
      |                                                      char *
pgsql-16beta1/include/server/utils/builtins.h:95:73: note: in definition of macro ‘TextDatumGetCString’
   95 | #define TextDatumGetCString(d) text_to_cstring((text *) DatumGetPointer(d))
      |                                                                         ^
In file included from metadata/node_metadata.c:7:
pgsql-16beta1/include/server/postgres.h:312:23: note:
expected ‘Datum’ {aka ‘long unsigned int’} but argument is of type ‘char *’
  312 | DatumGetPointer(Datum X)
```
 - using pointer instead of oid
``` C
test/foreign_key_relationship_query.c: In function ‘get_referencing_relation_id_list’:
test/foreign_key_relationship_query.c:122:52: warning:
passing argument 1 of ‘PointerGetDatum’ makes pointer from integer without a cast [-Wint-conversion]
  122 |   SRF_RETURN_NEXT(functionContext, PointerGetDatum(refId));
      |                                                    ^~~~~
      |                                                    |
      |                                                    Oid {aka unsigned int}
pgsql-16beta1/include/server/postgres.h:322:29: note:
expected ‘const void *’ but argument is of type ‘Oid’ {aka ‘unsigned int’}
  322 | PointerGetDatum(const void *X)
      |                 ~~~~~~~~~~~~^
```
 - candidate function for format attribute
``` C
utils/citus_safe_lib.c: In function ‘SafeSnprintf’:
utils/citus_safe_lib.c:341:2: warning:
function ‘SafeSnprintf’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
  341 |  size_t result = citus_vsnprintf(buffer, bufsz, format, args);
      |  ^~~~~~
```
 - remove old definition from PG11 compatibility
https://github.com/citusdata/citus/commit/62bf571cedcfdf4451614b8520448d105df07045