### PR TITLE
Fix pg14-pg15 upgrade_distributed_triggers test

### DIFF
--- a/src/test/regress/expected/upgrade_distributed_triggers_after.out
+++ b/src/test/regress/expected/upgrade_distributed_triggers_after.out
@@ -9,9 +9,9 @@
 -- this test is relevant only for pg14-15 upgrade
 --
 SHOW server_version \gset
-SELECT substring(:'server_version', '\d+')::int = 15 AS server_version_eq_15
+SELECT substring(:'server_version', '\d+')::int = 15 AND EXISTS (SELECT * FROM pg_namespace WHERE nspname = 'upgrade_distributed_triggers') AS is_14_15_pg_upgrade
 \gset
-\if :server_version_eq_15
+\if :is_14_15_pg_upgrade
 \else
 \q
 \endif

--- a/src/test/regress/expected/upgrade_distributed_triggers_after_0.out
+++ b/src/test/regress/expected/upgrade_distributed_triggers_after_0.out
@@ -9,8 +9,8 @@
 -- this test is relevant only for pg14-15 upgrade
 --
 SHOW server_version \gset
-SELECT substring(:'server_version', '\d+')::int = 15 AS server_version_eq_15
+SELECT substring(:'server_version', '\d+')::int = 15 AND EXISTS (SELECT * FROM pg_namespace WHERE nspname = 'upgrade_distributed_triggers') AS is_14_15_pg_upgrade
 \gset
-\if :server_version_eq_15
+\if :is_14_15_pg_upgrade
 \else
 \q

--- a/src/test/regress/sql/upgrade_distributed_triggers_after.sql
+++ b/src/test/regress/sql/upgrade_distributed_triggers_after.sql
@@ -10,9 +10,9 @@
 --
 
 SHOW server_version \gset
-SELECT substring(:'server_version', '\d+')::int = 15 AS server_version_eq_15
+SELECT substring(:'server_version', '\d+')::int = 15 AND EXISTS (SELECT * FROM pg_namespace WHERE nspname = 'upgrade_distributed_triggers') AS is_14_15_pg_upgrade
 \gset
-\if :server_version_eq_15
+\if :is_14_15_pg_upgrade
 \else
 \q
 \endif


### PR DESCRIPTION
This test is only relevant for pg14-15 upgrade.
However, the check on `upgrade_distributed_triggers_after` didn't take into consideration the case when we are doing pg15-16 upgrade. Hence, I added one more condition to the test: existence of `upgrade_distributed_triggers` schema which can only be created in pg14.