### PR TITLE
When Creating a FOREIGN KEY without a name, schema qualify referenced table name in deparser.

### DIFF
--- a/src/backend/distributed/deparser/deparse_table_stmts.c
+++ b/src/backend/distributed/deparser/deparse_table_stmts.c
@@ -279,7 +279,9 @@ AppendAlterTableCmdAddConstraint(StringInfo buf, Constraint *constraint,
 
 		appendStringInfoString(buf, " REFERENCES");
 
-		appendStringInfo(buf, " %s", quote_identifier(constraint->pktable->relname));
+		appendStringInfo(buf, " %s", quote_qualified_identifier(
+							 constraint->pktable->schemaname,
+							 constraint->pktable->relname));
 
 		if (list_length(constraint->pk_attrs) > 0)
 		{

--- a/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
@@ -550,6 +550,16 @@ ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1)
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE SET DEFAULT;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE NO ACTION;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE RESTRICT;
+DROP TABLE citus_local_table CASCADE;
+RESET SEARCH_PATH;
+RESET client_min_messages;
+DROP SCHEMA at_add_fk CASCADE;
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to table at_add_fk.referenced_local_table
+drop cascades to table at_add_fk.referenced_table
+drop cascades to table at_add_fk.referencing_table
+drop cascades to table at_add_fk.reference_table
+drop cascades to table at_add_fk.reference_table_1770052
 -- test ADD FOREIGN KEY when REFERENCED table is in another schema.
 CREATE SCHEMA schema_1;
 CREATE TABLE schema_1.referenced_table(a int PRIMARY KEY, b int);
@@ -568,13 +578,3 @@ DETAIL:  drop cascades to table schema_2.referencing_table_1770054
 drop cascades to table schema_2.referencing_table
 drop cascades to table schema_1.referenced_table
 drop cascades to table schema_1.referenced_table_1770053
-DROP TABLE citus_local_table CASCADE;
-RESET SEARCH_PATH;
-RESET client_min_messages;
-DROP SCHEMA at_add_fk CASCADE;
-NOTICE:  drop cascades to 5 other objects
-DETAIL:  drop cascades to table at_add_fk.referenced_local_table
-drop cascades to table at_add_fk.referenced_table
-drop cascades to table at_add_fk.referencing_table
-drop cascades to table at_add_fk.reference_table
-drop cascades to table at_add_fk.reference_table_1770052

--- a/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
@@ -156,7 +156,7 @@ SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname = 'referencing_table';
+              WHERE rel.relname = 'referencing_table' ORDER BY con.conname ASC;
             conname
 ---------------------------------------------------------------------
  referencing_table_ref_id_fkey
@@ -167,7 +167,7 @@ SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname LIKE 'referencing_table%';
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
                 conname
 ---------------------------------------------------------------------
  referencing_table_ref_id_fkey
@@ -184,7 +184,7 @@ SELECT con.conname
   FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname = 'referencing_table';
+              WHERE rel.relname = 'referencing_table' ORDER BY con.conname ASC;
             conname
 ---------------------------------------------------------------------
  referencing_table_ref_id_fkey
@@ -195,7 +195,7 @@ SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname LIKE 'referencing_table%';
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
                 conname
 ---------------------------------------------------------------------
  referencing_table_ref_id_fkey

--- a/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_foreign_key_without_name.out
@@ -550,6 +550,24 @@ ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1)
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE SET DEFAULT;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE NO ACTION;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE RESTRICT;
+-- test ADD FOREIGN KEY when REFERENCED table is in another schema.
+CREATE SCHEMA schema_1;
+CREATE TABLE schema_1.referenced_table(a int PRIMARY KEY, b int);
+SELECT create_reference_table('schema_1.referenced_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE SCHEMA schema_2;
+CREATE TABLE schema_2.referencing_table (a int PRIMARY KEY, b int, c text);
+ALTER TABLE schema_2.referencing_table ADD FOREIGN KEY (b) REFERENCES schema_1.referenced_table(a);
+DROP SCHEMA schema_1, schema_2 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table schema_2.referencing_table_1770054
+drop cascades to table schema_2.referencing_table
+drop cascades to table schema_1.referenced_table
+drop cascades to table schema_1.referenced_table_1770053
 DROP TABLE citus_local_table CASCADE;
 RESET SEARCH_PATH;
 RESET client_min_messages;

--- a/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
@@ -371,6 +371,19 @@ ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1)
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE NO ACTION;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE RESTRICT;
 
+-- test ADD FOREIGN KEY when REFERENCED table is in another schema.
+CREATE SCHEMA schema_1;
+
+CREATE TABLE schema_1.referenced_table(a int PRIMARY KEY, b int);
+SELECT create_reference_table('schema_1.referenced_table');
+
+CREATE SCHEMA schema_2;
+
+CREATE TABLE schema_2.referencing_table (a int PRIMARY KEY, b int, c text);
+ALTER TABLE schema_2.referencing_table ADD FOREIGN KEY (b) REFERENCES schema_1.referenced_table(a);
+
+DROP SCHEMA schema_1, schema_2 CASCADE; 
+
 DROP TABLE citus_local_table CASCADE;
 
 RESET SEARCH_PATH;

--- a/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
@@ -89,14 +89,14 @@ SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname = 'referencing_table';
+              WHERE rel.relname = 'referencing_table' ORDER BY con.conname ASC;
 
 \c - - :public_worker_1_host :worker_1_port
 SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname LIKE 'referencing_table%';
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
 
 \c - - :master_host :master_port
 SET SEARCH_PATH = at_add_fk;
@@ -109,14 +109,14 @@ SELECT con.conname
   FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname = 'referencing_table';
+              WHERE rel.relname = 'referencing_table' ORDER BY con.conname ASC;
 
 \c - - :public_worker_1_host :worker_1_port
 SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
-              WHERE rel.relname LIKE 'referencing_table%';
+              WHERE rel.relname LIKE 'referencing_table%' ORDER BY con.conname ASC;
 
 \c - - :master_host :master_port
 SET SEARCH_PATH = at_add_fk;

--- a/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
@@ -371,6 +371,12 @@ ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1)
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE NO ACTION;
 ALTER TABLE citus_local_table ADD FOREIGN KEY(l1) REFERENCES reference_table(r1) ON DELETE RESTRICT;
 
+DROP TABLE citus_local_table CASCADE;
+
+RESET SEARCH_PATH;
+RESET client_min_messages;
+DROP SCHEMA at_add_fk CASCADE;
+
 -- test ADD FOREIGN KEY when REFERENCED table is in another schema.
 CREATE SCHEMA schema_1;
 
@@ -383,9 +389,3 @@ CREATE TABLE schema_2.referencing_table (a int PRIMARY KEY, b int, c text);
 ALTER TABLE schema_2.referencing_table ADD FOREIGN KEY (b) REFERENCES schema_1.referenced_table(a);
 
 DROP SCHEMA schema_1, schema_2 CASCADE;
-
-DROP TABLE citus_local_table CASCADE;
-
-RESET SEARCH_PATH;
-RESET client_min_messages;
-DROP SCHEMA at_add_fk CASCADE;

--- a/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_foreign_key_without_name.sql
@@ -382,7 +382,7 @@ CREATE SCHEMA schema_2;
 CREATE TABLE schema_2.referencing_table (a int PRIMARY KEY, b int, c text);
 ALTER TABLE schema_2.referencing_table ADD FOREIGN KEY (b) REFERENCES schema_1.referenced_table(a);
 
-DROP SCHEMA schema_1, schema_2 CASCADE; 
+DROP SCHEMA schema_1, schema_2 CASCADE;
 
 DROP TABLE citus_local_table CASCADE;
 


### PR DESCRIPTION
DESCRIPTION: Fixes a bug which causes an error when creating a FOREIGN KEY constraint without a name if the referenced table is schema qualified.

In deparsing the `ALTER TABLE s1.t1 ADD FOREIGN KEY (key) REFERENCES s2.t2; `, command back from its cooked form, we should schema qualify the REFERENCED table.

Fixes #6982.