### PR TITLE
Remove flaky rebalance plan from test

### DIFF
--- a/src/test/regress/expected/background_rebalance_parallel.out
+++ b/src/test/regress/expected/background_rebalance_parallel.out
@@ -466,17 +466,6 @@ SELECT citus_rebalance_start AS job_id from citus_rebalance_start() \gset
 -- see dependent tasks to understand which tasks remain runnable because of
 -- citus.max_background_task_executors_per_node
 -- and which tasks are actually blocked from colocation group dependencies
-SELECT (SELECT T.command FROM pg_dist_background_task T WHERE T.task_id = D.task_id),
-       (SELECT T.command depends_on_command FROM pg_dist_background_task T WHERE T.task_id = D.depends_on)
-FROM pg_dist_background_task_depend D  WHERE job_id in (:job_id) ORDER BY 1, 2 ASC;
-                               command                               |                         depends_on_command
----------------------------------------------------------------------
- SELECT pg_catalog.citus_move_shard_placement(85674026,50,57,'auto') | SELECT pg_catalog.citus_move_shard_placement(85674025,50,56,'auto')
- SELECT pg_catalog.citus_move_shard_placement(85674032,50,57,'auto') | SELECT pg_catalog.citus_move_shard_placement(85674031,50,56,'auto')
- SELECT pg_catalog.citus_move_shard_placement(85674038,50,57,'auto') | SELECT pg_catalog.citus_move_shard_placement(85674037,50,56,'auto')
- SELECT pg_catalog.citus_move_shard_placement(85674044,50,57,'auto') | SELECT pg_catalog.citus_move_shard_placement(85674043,50,56,'auto')
-(4 rows)
-
 SELECT task_id, depends_on
 FROM pg_dist_background_task_depend
 WHERE job_id in (:job_id)

--- a/src/test/regress/sql/background_rebalance_parallel.sql
+++ b/src/test/regress/sql/background_rebalance_parallel.sql
@@ -204,10 +204,6 @@ SELECT citus_rebalance_start AS job_id from citus_rebalance_start() \gset
 -- see dependent tasks to understand which tasks remain runnable because of
 -- citus.max_background_task_executors_per_node
 -- and which tasks are actually blocked from colocation group dependencies
-SELECT (SELECT T.command FROM pg_dist_background_task T WHERE T.task_id = D.task_id),
-       (SELECT T.command depends_on_command FROM pg_dist_background_task T WHERE T.task_id = D.depends_on)
-FROM pg_dist_background_task_depend D  WHERE job_id in (:job_id) ORDER BY 1, 2 ASC;
-
 SELECT task_id, depends_on
 FROM pg_dist_background_task_depend
 WHERE job_id in (:job_id)


### PR DESCRIPTION
Looks like sometimes shards are a slightly different size than we expect, 16k vs 8k,
resulting in a different rebalance plan.