### PR TITLE
ALTER TABLE <tblname> SET SCHEMA <schemaname> for single shard tables

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -248,7 +248,8 @@ undistribute_table(PG_FUNCTION_ARGS)
 
 	TableConversionParameters params = {
 		.relationId = relationId,
-		.cascadeViaForeignKeys = cascadeViaForeignKeys
+		.cascadeViaForeignKeys = cascadeViaForeignKeys,
+		.bypassTenantCheck = false
 	};
 
 	UndistributeTable(&params);
@@ -433,10 +434,31 @@ UndistributeTables(List *relationIdList)
  * EnsureUndistributeTenantTableSafe ensures that it is safe to undistribute a tenant table.
  */
 void
-EnsureUndistributeTenantTableSafe(Oid relationId)
+EnsureUndistributeTenantTableSafe(Oid relationId, const char *operationName)
 {
 	Oid schemaId = get_rel_namespace(relationId);
 	Assert(IsTenantSchema(schemaId));
+
+	/* We only allow undistribute while altering schema */
+	if (strcmp(operationName, TenantOperationNames[TENANT_SET_SCHEMA]) != 0)
+	{
+		ErrorIfTenantTable(relationId, operationName);
+	}
+
+	char *tableName = get_rel_name(relationId);
+	char *schemaName = get_namespace_name(schemaId);
+
+	/*
+	 * Partition table cannot be undistributed. Otherwise, its parent table would still
+	 * be a tenant table whereas partition table would be a local table.
+	 */
+	if (PartitionTable(relationId))
+	{
+		ereport(ERROR, (errmsg("%s is not allowed for partition table %s in distributed "
+							   "schema %s", operationName, tableName, schemaName),
+						errdetail("partition table should be under the same distributed "
+								  "schema as its parent and be a tenant table.")));
+	}
 
 	/*
 	 * When table is referenced by or referencing to a table in the same tenant
@@ -449,10 +471,10 @@ EnsureUndistributeTenantTableSafe(Oid relationId)
 			relationId, INCLUDE_SINGLE_SHARD_TABLES);
 	if (fkeyCommandsWithSingleShardTables != NIL)
 	{
-		ereport(ERROR, (errmsg("cannot undistribute table %s in distributed schema %s",
-							   get_rel_name(relationId), get_namespace_name(schemaId)),
+		ereport(ERROR, (errmsg("%s is not allowed for table %s in distributed schema %s",
+							   operationName, tableName, schemaName),
 						errdetail("distributed schemas cannot have foreign keys from/to "
-								  "local tables")));
+								  "local tables or different schema")));
 	}
 }
 
@@ -478,9 +500,11 @@ UndistributeTable(TableConversionParameters *params)
 	}
 
 	Oid schemaId = get_rel_namespace(params->relationId);
-	if (IsTenantSchema(schemaId))
+	if (!params->bypassTenantCheck && IsTenantSchema(schemaId) &&
+		IsCitusTableType(params->relationId, SINGLE_SHARD_DISTRIBUTED))
 	{
-		EnsureUndistributeTenantTableSafe(params->relationId);
+		EnsureUndistributeTenantTableSafe(params->relationId,
+										  TenantOperationNames[TENANT_UNDISTRIBUTE_TABLE]);
 	}
 
 	if (!params->cascadeViaForeignKeys)
@@ -538,7 +562,7 @@ AlterDistributedTable(TableConversionParameters *params)
 							   "is not distributed")));
 	}
 
-	ErrorIfTenantTable(params->relationId, "alter_distributed_table");
+	ErrorIfTenantTable(params->relationId, TenantOperationNames[TENANT_ALTER_TABLE]);
 	ErrorIfColocateWithTenantTable(params->colocateWith);
 
 	EnsureTableNotForeign(params->relationId);
@@ -1299,7 +1323,8 @@ ErrorIfColocateWithTenantTable(char *colocateWith)
 	{
 		text *colocateWithTableNameText = cstring_to_text(colocateWith);
 		Oid colocateWithTableId = ResolveRelationId(colocateWithTableNameText, false);
-		ErrorIfTenantTable(colocateWithTableId, "colocate_with");
+		ErrorIfTenantTable(colocateWithTableId,
+						   TenantOperationNames[TENANT_COLOCATE_WITH]);
 	}
 }
 

--- a/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
+++ b/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
@@ -468,7 +468,8 @@ ExecuteCascadeOperationForRelationIdList(List *relationIdList,
 				{
 					TableConversionParameters params = {
 						.relationId = relationId,
-						.cascadeViaForeignKeys = cascadeViaForeignKeys
+						.cascadeViaForeignKeys = cascadeViaForeignKeys,
+						.bypassTenantCheck = false
 					};
 					UndistributeTable(&params);
 				}

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -1356,6 +1356,10 @@ IsTableTypeIncluded(Oid relationId, int flags)
 	{
 		return (flags & INCLUDE_LOCAL_TABLES) != 0;
 	}
+	else if (IsCitusTableType(relationId, SINGLE_SHARD_DISTRIBUTED))
+	{
+		return (flags & INCLUDE_SINGLE_SHARD_TABLES) != 0;
+	}
 	else if (IsCitusTableType(relationId, DISTRIBUTED_TABLE))
 	{
 		return (flags & INCLUDE_DISTRIBUTED_TABLES) != 0;

--- a/src/backend/distributed/commands/schema_based_sharding.c
+++ b/src/backend/distributed/commands/schema_based_sharding.c
@@ -404,7 +404,7 @@ EnsureSchemaCanBeDistributed(Oid schemaId, List *schemaTableIdList)
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, schemaTableIdList)
 	{
-		EnsureTenantTable(relationId);
+		EnsureTenantTable(relationId, "citus_schema_distribute");
 	}
 }
 
@@ -418,7 +418,7 @@ EnsureSchemaCanBeDistributed(Oid schemaId, List *schemaTableIdList)
  *  - Table should be Citus local or Postgres local table.
  */
 void
-EnsureTenantTable(Oid relationId)
+EnsureTenantTable(Oid relationId, char *operationName)
 {
 	/* Ensure table owner */
 	EnsureTableOwner(relationId);
@@ -450,9 +450,9 @@ EnsureTenantTable(Oid relationId)
 	/* Only Citus local tables, amongst Citus table types, are allowed */
 	if (!IsCitusTableType(relationId, CITUS_LOCAL_TABLE))
 	{
-		ereport(ERROR, (errmsg("schema already has distributed tables"),
-						errhint("Undistribute distributed tables under "
-								"the schema before distributing the schema.")));
+		ereport(ERROR, (errmsg("distributed schema cannot have distributed tables"),
+						errhint("Undistribute distributed tables before "
+								"'%s'.", operationName)));
 	}
 }
 

--- a/src/backend/distributed/commands/schema_based_sharding.c
+++ b/src/backend/distributed/commands/schema_based_sharding.c
@@ -40,6 +40,14 @@ static void EnsureSchemaExist(Oid schemaId);
 /* controlled via citus.enable_schema_based_sharding GUC */
 bool EnableSchemaBasedSharding = false;
 
+const char *TenantOperationNames[TOTAL_TENANT_OPERATION] = {
+	"undistribute_table",
+	"alter_distributed_table",
+	"colocate_with",
+	"update_distributed_table_colocation",
+	"set schema",
+};
+
 
 PG_FUNCTION_INFO_V1(citus_internal_unregister_tenant_schema_globally);
 PG_FUNCTION_INFO_V1(citus_schema_distribute);
@@ -754,7 +762,7 @@ citus_schema_undistribute(PG_FUNCTION_ARGS)
  * if the given relation is a tenant table.
  */
 void
-ErrorIfTenantTable(Oid relationId, char *operationName)
+ErrorIfTenantTable(Oid relationId, const char *operationName)
 {
 	if (IsTenantSchema(get_rel_namespace(relationId)))
 	{

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -374,7 +374,13 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 			if (context == PROCESS_UTILITY_TOPLEVEL &&
 				IsA(parsetree, AlterObjectSchemaStmt))
 			{
-				ConvertToTenantTableIfNecessary(parsetree);
+				AlterObjectSchemaStmt *alterSchemaStmt = castNode(AlterObjectSchemaStmt,
+																  parsetree);
+				if (alterSchemaStmt->objectType == OBJECT_TABLE ||
+					alterSchemaStmt->objectType == OBJECT_FOREIGN_TABLE)
+				{
+					ConvertToTenantTableIfNecessary(alterSchemaStmt);
+				}
 			}
 		}
 
@@ -1005,7 +1011,8 @@ UndistributeDisconnectedCitusLocalTables(void)
 		TableConversionParameters params = {
 			.relationId = citusLocalTableId,
 			.cascadeViaForeignKeys = true,
-			.suppressNoticeMessages = true
+			.suppressNoticeMessages = true,
+			.bypassTenantCheck = false
 		};
 		UndistributeTable(&params);
 	}

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -370,6 +370,12 @@ multi_ProcessUtility(PlannedStmt *pstmt,
 
 				ConvertNewTableIfNecessary(createStmt);
 			}
+
+			if (context == PROCESS_UTILITY_TOPLEVEL &&
+				IsA(parsetree, AlterObjectSchemaStmt))
+			{
+				ConvertToTenantTableIfNecessary(parsetree);
+			}
 		}
 
 		UtilityHookLevel--;

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -116,7 +116,7 @@ update_distributed_table_colocation(PG_FUNCTION_ARGS)
 	text *colocateWithTableNameText = PG_GETARG_TEXT_P(1);
 
 	EnsureTableOwner(targetRelationId);
-	ErrorIfTenantTable(targetRelationId, "update_distributed_table_colocation");
+	ErrorIfTenantTable(targetRelationId, TenantOperationNames[TENANT_UPDATE_COLOCATION]);
 
 	char *colocateWithTableName = text_to_cstring(colocateWithTableNameText);
 	if (IsColocateWithNone(colocateWithTableName))
@@ -127,7 +127,8 @@ update_distributed_table_colocation(PG_FUNCTION_ARGS)
 	else
 	{
 		Oid colocateWithTableId = ResolveRelationId(colocateWithTableNameText, false);
-		ErrorIfTenantTable(colocateWithTableId, "colocate_with");
+		ErrorIfTenantTable(colocateWithTableId,
+						   TenantOperationNames[TENANT_COLOCATE_WITH]);
 		EnsureTableOwner(colocateWithTableId);
 		MarkTablesColocated(colocateWithTableId, targetRelationId);
 	}

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -159,6 +159,19 @@ typedef enum SearchForeignKeyColumnFlags
 	/* callers can also pass union of above flags */
 } SearchForeignKeyColumnFlags;
 
+
+typedef enum TenantOperation
+{
+	TENANT_UNDISTRIBUTE_TABLE = 0,
+	TENANT_ALTER_TABLE,
+	TENANT_COLOCATE_WITH,
+	TENANT_UPDATE_COLOCATION,
+	TENANT_SET_SCHEMA,
+} TenantOperation;
+
+#define TOTAL_TENANT_OPERATION 5
+extern const char *TenantOperationNames[TOTAL_TENANT_OPERATION];
+
 /* begin.c - forward declarations */
 extern void SaveBeginCommandProperties(TransactionStmt *transactionStmt);
 
@@ -597,7 +610,7 @@ extern char * GetAlterColumnWithNextvalDefaultCmd(Oid sequenceOid, Oid relationI
 
 extern void ErrorIfTableHasIdentityColumn(Oid relationId);
 extern void ConvertNewTableIfNecessary(Node *createStmt);
-extern void ConvertToTenantTableIfNecessary(Node *alterObjectSchemaStmt);
+extern void ConvertToTenantTableIfNecessary(AlterObjectSchemaStmt *alterObjectSchemaStmt);
 
 /* text_search.c - forward declarations */
 extern List * GetCreateTextSearchConfigStatements(const ObjectAddress *address);
@@ -801,7 +814,7 @@ extern void EnsureTenantTable(Oid relationId, char *operationName);
 extern void ErrorIfIllegalPartitioningInTenantSchema(Oid parentRelationId,
 													 Oid partitionRelationId);
 extern void CreateTenantSchemaTable(Oid relationId);
-extern void ErrorIfTenantTable(Oid relationId, char *operationName);
+extern void ErrorIfTenantTable(Oid relationId, const char *operationName);
 extern uint32 CreateTenantSchemaColocationId(void);
 
 #endif /*CITUS_COMMANDS_H */

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -792,11 +792,11 @@ extern void UpdateAutoConvertedForConnectedRelations(List *relationId, bool
 extern bool ShouldUseSchemaBasedSharding(char *schemaName);
 extern bool ShouldCreateTenantSchemaTable(Oid relationId);
 extern bool IsTenantSchema(Oid schemaId);
+extern void EnsureTenantTable(Oid relationId);
 extern void ErrorIfIllegalPartitioningInTenantSchema(Oid parentRelationId,
 													 Oid partitionRelationId);
 extern void CreateTenantSchemaTable(Oid relationId);
 extern void ErrorIfTenantTable(Oid relationId, char *operationName);
-extern void ErrorIfTenantSchema(Oid nspOid, char *operationName);
 extern uint32 CreateTenantSchemaColocationId(void);
 
 #endif /*CITUS_COMMANDS_H */

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -118,7 +118,7 @@ typedef enum ExtractForeignKeyConstraintsMode
 	/* exclude the self-referencing foreign keys */
 	EXCLUDE_SELF_REFERENCES = 1 << 2,
 
-	/* any combination of the 4 flags below is supported */
+	/* any combination of the 5 flags below is supported */
 	/* include foreign keys when the other table is a distributed table*/
 	INCLUDE_DISTRIBUTED_TABLES = 1 << 3,
 
@@ -131,9 +131,13 @@ typedef enum ExtractForeignKeyConstraintsMode
 	/* include foreign keys when the other table is a Postgres local table*/
 	INCLUDE_LOCAL_TABLES = 1 << 6,
 
+	/* include foreign keys when the other table is a single shard table*/
+	INCLUDE_SINGLE_SHARD_TABLES = 1 << 7,
+
 	/* include foreign keys regardless of the other table's type */
 	INCLUDE_ALL_TABLE_TYPES = INCLUDE_DISTRIBUTED_TABLES | INCLUDE_REFERENCE_TABLES |
-							  INCLUDE_CITUS_LOCAL_TABLES | INCLUDE_LOCAL_TABLES
+							  INCLUDE_CITUS_LOCAL_TABLES | INCLUDE_LOCAL_TABLES |
+							  INCLUDE_SINGLE_SHARD_TABLES
 } ExtractForeignKeyConstraintMode;
 
 
@@ -593,6 +597,7 @@ extern char * GetAlterColumnWithNextvalDefaultCmd(Oid sequenceOid, Oid relationI
 
 extern void ErrorIfTableHasIdentityColumn(Oid relationId);
 extern void ConvertNewTableIfNecessary(Node *createStmt);
+extern void ConvertToTenantTableIfNecessary(Node *alterObjectSchemaStmt);
 
 /* text_search.c - forward declarations */
 extern List * GetCreateTextSearchConfigStatements(const ObjectAddress *address);
@@ -792,7 +797,7 @@ extern void UpdateAutoConvertedForConnectedRelations(List *relationId, bool
 extern bool ShouldUseSchemaBasedSharding(char *schemaName);
 extern bool ShouldCreateTenantSchemaTable(Oid relationId);
 extern bool IsTenantSchema(Oid schemaId);
-extern void EnsureTenantTable(Oid relationId);
+extern void EnsureTenantTable(Oid relationId, char *operationName);
 extern void ErrorIfIllegalPartitioningInTenantSchema(Oid parentRelationId,
 													 Oid partitionRelationId);
 extern void CreateTenantSchemaTable(Oid relationId);

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -172,6 +172,12 @@ typedef struct TableConversionParameters
 	 * messages that we explicitly issue
 	 */
 	bool suppressNoticeMessages;
+
+	/*
+	 * bypassTenantCheck skips tenant table checks to allow some internal
+	 * operations which are normally disallowed
+	 */
+	bool bypassTenantCheck;
 } TableConversionParameters;
 
 typedef struct TableConversionReturn
@@ -363,7 +369,7 @@ extern void CreateDistributedTable(Oid relationId, char *distributionColumnName,
 								   bool shardCountIsStrict, char *colocateWithTableName);
 extern void CreateReferenceTable(Oid relationId);
 extern void CreateTruncateTrigger(Oid relationId);
-extern void EnsureUndistributeTenantTableSafe(Oid relationId);
+extern void EnsureUndistributeTenantTableSafe(Oid relationId, const char *operationName);
 extern TableConversionReturn * UndistributeTable(TableConversionParameters *params);
 extern void UndistributeTables(List *relationIdList);
 

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -363,6 +363,7 @@ extern void CreateDistributedTable(Oid relationId, char *distributionColumnName,
 								   bool shardCountIsStrict, char *colocateWithTableName);
 extern void CreateReferenceTable(Oid relationId);
 extern void CreateTruncateTrigger(Oid relationId);
+extern void EnsureUndistributeTenantTableSafe(Oid relationId);
 extern TableConversionReturn * UndistributeTable(TableConversionParameters *params);
 extern void UndistributeTables(List *relationIdList);
 

--- a/src/test/regress/expected/citus_schema_distribute_undistribute.out
+++ b/src/test/regress/expected/citus_schema_distribute_undistribute.out
@@ -482,8 +482,8 @@ SELECT create_distributed_table('tenant1.dist', 'id');
 (1 row)
 
 SELECT citus_schema_distribute('tenant1');
-ERROR:  schema already has distributed tables
-HINT:  Undistribute distributed tables under the schema before distributing the schema.
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'citus_schema_distribute'.
 SELECT undistribute_table('tenant1.dist');
  undistribute_table
 ---------------------------------------------------------------------
@@ -510,8 +510,8 @@ SELECT create_reference_table('tenant1.ref2');
 (1 row)
 
 SELECT citus_schema_distribute('tenant1');
-ERROR:  schema already has distributed tables
-HINT:  Undistribute distributed tables under the schema before distributing the schema.
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'citus_schema_distribute'.
 SELECT undistribute_table('tenant1.ref2');
  undistribute_table
 ---------------------------------------------------------------------
@@ -766,8 +766,8 @@ SELECT create_distributed_table('tenant1.new_dist', 'id');
 (1 row)
 
 SELECT citus_schema_distribute('tenant1');
-ERROR:  schema already has distributed tables
-HINT:  Undistribute distributed tables under the schema before distributing the schema.
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'citus_schema_distribute'.
 SELECT undistribute_table('tenant1.new_dist');
  undistribute_table
 ---------------------------------------------------------------------
@@ -795,8 +795,8 @@ SELECT create_distributed_table('tenant1.single_shard_t', NULL);
 (1 row)
 
 SELECT citus_schema_distribute('tenant1');
-ERROR:  schema already has distributed tables
-HINT:  Undistribute distributed tables under the schema before distributing the schema.
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'citus_schema_distribute'.
 SELECT undistribute_table('tenant1.single_shard_t');
  undistribute_table
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -89,15 +89,51 @@ ERROR:  tenant_2.test_table is not allowed for alter_distributed_table because i
 -- verify we also don't allow colocate_with a tenant table
 SELECT alter_distributed_table('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 ERROR:  tenant_2.test_table is not allowed for colocate_with because it belongs to a distributed schema
--- verify we don't allow ALTER TABLE SET SCHEMA for tenant tables
-ALTER TABLE tenant_2.test_table SET SCHEMA regular_schema;
-ERROR:  tenant_2.test_table is not allowed for ALTER TABLE SET SCHEMA because it belongs to a distributed schema
--- verify we don't allow ALTER TABLE SET SCHEMA for tenant schemas
-ALTER TABLE regular_schema.test_table SET SCHEMA tenant_2;
-ERROR:  tenant_2 is not allowed for ALTER TABLE SET SCHEMA because it is a distributed schema
--- the same, from tenant schema to tenant schema
-ALTER TABLE tenant_2.test_table SET SCHEMA tenant_3;
-ERROR:  tenant_2.test_table is not allowed for ALTER TABLE SET SCHEMA because it belongs to a distributed schema
+-- verify we can set tenant table's schema to regular schema
+CREATE TABLE tenant_2.test_table2(id int);
+ALTER TABLE tenant_2.test_table2 SET SCHEMA regular_schema;
+-- verify that regular_schema.test_table2 does not exist in pg_dist_partition
+SELECT COUNT(*)=0 FROM pg_dist_partition
+WHERE logicalrelid = 'regular_schema.test_table2'::regclass AND
+      partmethod = 'n' AND repmodel = 's' AND colocationid > 0;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- verify that tenant_2.test_table2 does not exist
+SELECT * FROM tenant_2.test_table2;
+ERROR:  relation "tenant_2.test_table2" does not exist
+-- verify we can set regular table's schema to distributed schema
+CREATE TABLE regular_schema.test_table3(id int);
+ALTER TABLE regular_schema.test_table3 SET SCHEMA tenant_2;
+-- verify that tenant_2.test_table3 is recorded in pg_dist_partition as a single-shard table.
+SELECT COUNT(*)=1 FROM pg_dist_partition
+WHERE logicalrelid = 'tenant_2.test_table3'::regclass AND
+      partmethod = 'n' AND repmodel = 's' AND colocationid > 0;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- verify that regular_schema.test_table3 does not exist
+SELECT * FROM regular_schema.test_table3;
+ERROR:  relation "regular_schema.test_table3" does not exist
+-- verify we can set tenant table's schema to another distributed schema
+CREATE TABLE tenant_2.test_table4(id int);
+ALTER TABLE tenant_2.test_table4 SET SCHEMA tenant_3;
+-- verify that tenant_3.test_table4 is recorded in pg_dist_partition as a single-shard table.
+SELECT COUNT(*)=1 FROM pg_dist_partition
+WHERE logicalrelid = 'tenant_3.test_table4'::regclass AND
+      partmethod = 'n' AND repmodel = 's' AND colocationid > 0;
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- verify that tenant_2.test_table4 does not exist
+SELECT * FROM tenant_2.test_table4;
+ERROR:  relation "tenant_2.test_table4" does not exist
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_schema
 WHERE schemaid::regnamespace::text IN ('tenant_1', 'tenant_3');
@@ -265,8 +301,8 @@ SELECT EXISTS(
 (1 row)
 
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');
-ERROR:  insert or update on table "another_partitioned_table_child_1920040" violates foreign key constraint "another_partitioned_table_a_fkey_1920039"
-DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920037".
+ERROR:  insert or update on table "another_partitioned_table_child_1920044" violates foreign key constraint "another_partitioned_table_a_fkey_1920043"
+DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920041".
 CONTEXT:  while executing command on localhost:xxxxx
 INSERT INTO tenant_4.partitioned_table VALUES (1, 'a');
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -93,10 +93,7 @@ ERROR:  tenant_2.test_table is not allowed for colocate_with because it belongs 
 -- verify we can set tenant table's schema to regular schema
 CREATE TABLE tenant_2.test_table2(id int);
 ALTER TABLE tenant_2.test_table2 SET SCHEMA regular_schema;
-NOTICE:  creating a new table for tenant_2.test_table2
-NOTICE:  moving the data of tenant_2.test_table2
-NOTICE:  dropping the old tenant_2.test_table2
-NOTICE:  renaming the new table to tenant_2.test_table2
+NOTICE:  undistributing table test_table2 in distributed schema tenant_2 before altering its schema
 -- verify that regular_schema.test_table2 does not exist in pg_dist_partition
 SELECT COUNT(*)=0 FROM pg_dist_partition
 WHERE logicalrelid = 'regular_schema.test_table2'::regclass AND
@@ -112,6 +109,7 @@ ERROR:  relation "tenant_2.test_table2" does not exist
 -- verify we can set regular table's schema to distributed schema
 CREATE TABLE regular_schema.test_table3(id int);
 ALTER TABLE regular_schema.test_table3 SET SCHEMA tenant_2;
+NOTICE:  converting table test_table3 to a tenant table in distributed schema tenant_2
 -- verify that tenant_2.test_table3 is recorded in pg_dist_partition as a single-shard table.
 SELECT COUNT(*)=1 FROM pg_dist_partition
 WHERE logicalrelid = 'tenant_2.test_table3'::regclass AND
@@ -127,10 +125,8 @@ ERROR:  relation "regular_schema.test_table3" does not exist
 -- verify we can set tenant table's schema to another distributed schema
 CREATE TABLE tenant_2.test_table4(id int);
 ALTER TABLE tenant_2.test_table4 SET SCHEMA tenant_3;
-NOTICE:  creating a new table for tenant_2.test_table4
-NOTICE:  moving the data of tenant_2.test_table4
-NOTICE:  dropping the old tenant_2.test_table4
-NOTICE:  renaming the new table to tenant_2.test_table4
+NOTICE:  undistributing table test_table4 in distributed schema tenant_2 before altering its schema
+NOTICE:  converting table test_table4 to a tenant table in distributed schema tenant_3
 -- verify that tenant_3.test_table4 is recorded in pg_dist_partition as a single-shard table.
 SELECT COUNT(*)=1 FROM pg_dist_partition
 WHERE logicalrelid = 'tenant_3.test_table4'::regclass AND
@@ -146,6 +142,7 @@ ERROR:  relation "tenant_2.test_table4" does not exist
 -- verify that we can put a local table in regular schema into distributed schema
 CREATE TABLE regular_schema.pg_local_tbl(id int);
 ALTER TABLE regular_schema.pg_local_tbl SET SCHEMA tenant_2;
+NOTICE:  converting table pg_local_tbl to a tenant table in distributed schema tenant_2
 -- verify that we can put a Citus local table in regular schema into distributed schema
 CREATE TABLE regular_schema.citus_local_tbl(id int);
 SELECT citus_add_local_table_to_metadata('regular_schema.citus_local_tbl');
@@ -155,6 +152,7 @@ SELECT citus_add_local_table_to_metadata('regular_schema.citus_local_tbl');
 (1 row)
 
 ALTER TABLE regular_schema.citus_local_tbl SET SCHEMA tenant_2;
+NOTICE:  converting table citus_local_tbl to a tenant table in distributed schema tenant_2
 -- verify that we do not allow a hash distributed table in regular schema into distributed schema
 CREATE TABLE regular_schema.hash_dist_tbl(id int);
 SELECT create_distributed_table('regular_schema.hash_dist_tbl', 'id');
@@ -180,17 +178,12 @@ HINT:  Undistribute distributed tables before 'ALTER TABLE SET SCHEMA'.
 -- verify that we can put a table in tenant schema into regular schema
 CREATE TABLE tenant_2.tenant_tbl(id int);
 ALTER TABLE tenant_2.tenant_tbl SET SCHEMA regular_schema;
-NOTICE:  creating a new table for tenant_2.tenant_tbl
-NOTICE:  moving the data of tenant_2.tenant_tbl
-NOTICE:  dropping the old tenant_2.tenant_tbl
-NOTICE:  renaming the new table to tenant_2.tenant_tbl
+NOTICE:  undistributing table tenant_tbl in distributed schema tenant_2 before altering its schema
 -- verify that we can put a table in tenant schema into another tenant schema
 CREATE TABLE tenant_2.tenant_tbl2(id int);
 ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA tenant_3;
-NOTICE:  creating a new table for tenant_2.tenant_tbl2
-NOTICE:  moving the data of tenant_2.tenant_tbl2
-NOTICE:  dropping the old tenant_2.tenant_tbl2
-NOTICE:  renaming the new table to tenant_2.tenant_tbl2
+NOTICE:  undistributing table tenant_tbl2 in distributed schema tenant_2 before altering its schema
+NOTICE:  converting table tenant_tbl2 to a tenant table in distributed schema tenant_3
 -- verify that we do not allow a local table in regular schema into distributed schema if it has foreign key to a non-reference table in another schema
 CREATE TABLE regular_schema.pg_local_tbl1(id int PRIMARY KEY);
 CREATE TABLE regular_schema.pg_local_tbl2(id int REFERENCES regular_schema.pg_local_tbl1(id));
@@ -200,6 +193,7 @@ DETAIL:  "tenant_2.pg_local_tbl2" references "regular_schema.pg_local_tbl1" via 
 -- verify that we allow a local table in regular schema into distributed schema if it has foreign key to a reference table in another schema
 CREATE TABLE regular_schema.pg_local_tbl3(id int REFERENCES regular_schema.ref_tbl(id));
 ALTER TABLE regular_schema.pg_local_tbl3 SET SCHEMA tenant_2;
+NOTICE:  converting table pg_local_tbl3 to a tenant table in distributed schema tenant_2
 -- verify that we do not allow a table in tenant schema into regular schema if it has foreign key to/from another table in the same schema
 CREATE TABLE tenant_2.tenant_tbl1(id int PRIMARY KEY);
 CREATE TABLE tenant_2.tenant_tbl2(id int REFERENCES tenant_2.tenant_tbl1(id));

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -80,9 +80,24 @@ ERROR:  tenant_2.test_table is not allowed for update_distributed_table_colocati
 -- verify we also don't allow colocate_with a tenant table
 SELECT update_distributed_table_colocation('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 ERROR:  tenant_2.test_table is not allowed for colocate_with because it belongs to a distributed schema
--- verify we don't allow undistribute_table for tenant tables
-SELECT undistribute_table('tenant_2.test_table');
-ERROR:  tenant_2.test_table is not allowed for undistribute_table because it belongs to a distributed schema
+-- verify we allow undistribute_table for tenant tables if they do not have foreign key to/from its distributed schema
+CREATE TABLE tenant_2.undist_table1(id int);
+SELECT undistribute_table('tenant_2.undist_table1');
+NOTICE:  creating a new table for tenant_2.undist_table1
+NOTICE:  moving the data of tenant_2.undist_table1
+NOTICE:  dropping the old tenant_2.undist_table1
+NOTICE:  renaming the new table to tenant_2.undist_table1
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- verify we do not allow undistribute_table for tenant tables if they have foreign key to/from its distributed schema
+CREATE TABLE tenant_2.undist_table2(id int PRIMARY KEY);
+CREATE TABLE tenant_2.undist_table3(id int REFERENCES tenant_2.undist_table2(id));
+SELECT undistribute_table('tenant_2.undist_table3');
+ERROR:  cannot undistribute table undist_table3 in distributed schema tenant_2
+DETAIL:  distributed schemas cannot have foreign keys from/to local tables
 -- verify we don't allow alter_distributed_table for tenant tables
 SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');
 ERROR:  tenant_2.test_table is not allowed for alter_distributed_table because it belongs to a distributed schema
@@ -134,6 +149,83 @@ WHERE logicalrelid = 'tenant_3.test_table4'::regclass AND
 -- verify that tenant_2.test_table4 does not exist
 SELECT * FROM tenant_2.test_table4;
 ERROR:  relation "tenant_2.test_table4" does not exist
+-- verify that we can put a local table in regular schema into distributed schema
+CREATE TABLE regular_schema.pg_local_tbl(id int);
+ALTER TABLE regular_schema.pg_local_tbl SET SCHEMA tenant_2;
+-- verify that we can put a Citus local table in regular schema into distributed schema
+CREATE TABLE regular_schema.citus_local_tbl(id int);
+SELECT citus_add_local_table_to_metadata('regular_schema.citus_local_tbl');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE regular_schema.citus_local_tbl SET SCHEMA tenant_2;
+-- verify that we do not allow a hash distributed table in regular schema into distributed schema
+CREATE TABLE regular_schema.hash_dist_tbl(id int);
+SELECT create_distributed_table('regular_schema.hash_dist_tbl', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE regular_schema.hash_dist_tbl SET SCHEMA tenant_2;
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'ALTER TABLE SET SCHEMA'.
+-- verify that we do not allow a reference table in regular schema into distributed schema
+CREATE TABLE regular_schema.ref_tbl(id int  PRIMARY KEY);
+SELECT create_reference_table('regular_schema.ref_tbl');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE regular_schema.ref_tbl SET SCHEMA tenant_2;
+ERROR:  distributed schema cannot have distributed tables
+HINT:  Undistribute distributed tables before 'ALTER TABLE SET SCHEMA'.
+-- verify that we can put a table in tenant schema into regular schema
+CREATE TABLE tenant_2.tenant_tbl(id int);
+ALTER TABLE tenant_2.tenant_tbl SET SCHEMA regular_schema;
+-- verify that we can put a table in tenant schema into another tenant schema
+CREATE TABLE tenant_2.tenant_tbl2(id int);
+ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA tenant_3;
+-- verify that we do not allow a local table in regular schema into distributed schema if it has foreign key to a non-reference table in another schema
+CREATE TABLE regular_schema.pg_local_tbl1(id int PRIMARY KEY);
+CREATE TABLE regular_schema.pg_local_tbl2(id int REFERENCES regular_schema.pg_local_tbl1(id));
+ALTER TABLE regular_schema.pg_local_tbl2 SET SCHEMA tenant_2;
+ERROR:  foreign keys from distributed schemas can only point to the same distributed schema or reference tables in regular schemas
+DETAIL:  "tenant_2.pg_local_tbl2" references "regular_schema.pg_local_tbl1" via foreign key constraint "pg_local_tbl2_id_fkey"
+-- verify that we allow a local table in regular schema into distributed schema if it has foreign key to a reference table in another schema
+CREATE TABLE regular_schema.pg_local_tbl3(id int REFERENCES regular_schema.ref_tbl(id));
+ALTER TABLE regular_schema.pg_local_tbl3 SET SCHEMA tenant_2;
+-- verify that we do not allow a table in tenant schema into regular schema if it has foreign key to/from another table in the same schema
+CREATE TABLE tenant_2.tenant_tbl1(id int PRIMARY KEY);
+CREATE TABLE tenant_2.tenant_tbl2(id int REFERENCES tenant_2.tenant_tbl1(id));
+ALTER TABLE tenant_2.tenant_tbl1 SET SCHEMA regular_schema;
+ERROR:  cannot alter the schema of table tenant_tbl1
+DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA regular_schema;
+ERROR:  cannot alter the schema of table tenant_tbl2
+DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+-- verify that we do not allow a table in distributed schema into another distributed schema if it has foreign key to/from another table in the same schema
+CREATE TABLE tenant_2.tenant_tbl3(id int PRIMARY KEY);
+CREATE TABLE tenant_2.tenant_tbl4(id int REFERENCES tenant_2.tenant_tbl3(id));
+ALTER TABLE tenant_2.tenant_tbl3 SET SCHEMA tenant_3;
+ERROR:  cannot alter the schema of table tenant_tbl3
+DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ALTER TABLE tenant_2.tenant_tbl4 SET SCHEMA tenant_3;
+ERROR:  cannot alter the schema of table tenant_tbl4
+DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+-- alter set non-existent schema
+ALTER TABLE tenant_2.test_table SET SCHEMA ghost_schema;
+ERROR:  schema "ghost_schema" does not exist
+ALTER TABLE IF EXISTS tenant_2.test_table SET SCHEMA ghost_schema;
+ERROR:  schema "ghost_schema" does not exist
+-- alter set non-existent table
+ALTER TABLE tenant_2.ghost_table SET SCHEMA ghost_schema;
+ERROR:  relation "tenant_2.ghost_table" does not exist
+ALTER TABLE IF EXISTS tenant_2.ghost_table SET SCHEMA ghost_schema;
+NOTICE:  relation "ghost_table" does not exist, skipping
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_schema
 WHERE schemaid::regnamespace::text IN ('tenant_1', 'tenant_3');
@@ -301,8 +393,8 @@ SELECT EXISTS(
 (1 row)
 
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');
-ERROR:  insert or update on table "another_partitioned_table_child_1920044" violates foreign key constraint "another_partitioned_table_a_fkey_1920043"
-DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920041".
+ERROR:  insert or update on table "another_partitioned_table_child_1920092" violates foreign key constraint "another_partitioned_table_a_fkey_1920091"
+DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920089".
 CONTEXT:  while executing command on localhost:xxxxx
 INSERT INTO tenant_4.partitioned_table VALUES (1, 'a');
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -80,24 +80,10 @@ ERROR:  tenant_2.test_table is not allowed for update_distributed_table_colocati
 -- verify we also don't allow colocate_with a tenant table
 SELECT update_distributed_table_colocation('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 ERROR:  tenant_2.test_table is not allowed for colocate_with because it belongs to a distributed schema
--- verify we allow undistribute_table for tenant tables if they do not have foreign key to/from its distributed schema
-CREATE TABLE tenant_2.undist_table1(id int);
-SELECT undistribute_table('tenant_2.undist_table1');
-NOTICE:  creating a new table for tenant_2.undist_table1
-NOTICE:  moving the data of tenant_2.undist_table1
-NOTICE:  dropping the old tenant_2.undist_table1
-NOTICE:  renaming the new table to tenant_2.undist_table1
- undistribute_table
----------------------------------------------------------------------
-
-(1 row)
-
--- verify we do not allow undistribute_table for tenant tables if they have foreign key to/from its distributed schema
-CREATE TABLE tenant_2.undist_table2(id int PRIMARY KEY);
-CREATE TABLE tenant_2.undist_table3(id int REFERENCES tenant_2.undist_table2(id));
-SELECT undistribute_table('tenant_2.undist_table3');
-ERROR:  cannot undistribute table undist_table3 in distributed schema tenant_2
-DETAIL:  distributed schemas cannot have foreign keys from/to local tables
+-- verify we do not allow undistribute_table for tenant tables
+CREATE TABLE tenant_2.undist_table(id int);
+SELECT undistribute_table('tenant_2.undist_table');
+ERROR:  tenant_2.undist_table is not allowed for undistribute_table because it belongs to a distributed schema
 -- verify we don't allow alter_distributed_table for tenant tables
 SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');
 ERROR:  tenant_2.test_table is not allowed for alter_distributed_table because it belongs to a distributed schema
@@ -107,6 +93,10 @@ ERROR:  tenant_2.test_table is not allowed for colocate_with because it belongs 
 -- verify we can set tenant table's schema to regular schema
 CREATE TABLE tenant_2.test_table2(id int);
 ALTER TABLE tenant_2.test_table2 SET SCHEMA regular_schema;
+NOTICE:  creating a new table for tenant_2.test_table2
+NOTICE:  moving the data of tenant_2.test_table2
+NOTICE:  dropping the old tenant_2.test_table2
+NOTICE:  renaming the new table to tenant_2.test_table2
 -- verify that regular_schema.test_table2 does not exist in pg_dist_partition
 SELECT COUNT(*)=0 FROM pg_dist_partition
 WHERE logicalrelid = 'regular_schema.test_table2'::regclass AND
@@ -137,6 +127,10 @@ ERROR:  relation "regular_schema.test_table3" does not exist
 -- verify we can set tenant table's schema to another distributed schema
 CREATE TABLE tenant_2.test_table4(id int);
 ALTER TABLE tenant_2.test_table4 SET SCHEMA tenant_3;
+NOTICE:  creating a new table for tenant_2.test_table4
+NOTICE:  moving the data of tenant_2.test_table4
+NOTICE:  dropping the old tenant_2.test_table4
+NOTICE:  renaming the new table to tenant_2.test_table4
 -- verify that tenant_3.test_table4 is recorded in pg_dist_partition as a single-shard table.
 SELECT COUNT(*)=1 FROM pg_dist_partition
 WHERE logicalrelid = 'tenant_3.test_table4'::regclass AND
@@ -186,9 +180,17 @@ HINT:  Undistribute distributed tables before 'ALTER TABLE SET SCHEMA'.
 -- verify that we can put a table in tenant schema into regular schema
 CREATE TABLE tenant_2.tenant_tbl(id int);
 ALTER TABLE tenant_2.tenant_tbl SET SCHEMA regular_schema;
+NOTICE:  creating a new table for tenant_2.tenant_tbl
+NOTICE:  moving the data of tenant_2.tenant_tbl
+NOTICE:  dropping the old tenant_2.tenant_tbl
+NOTICE:  renaming the new table to tenant_2.tenant_tbl
 -- verify that we can put a table in tenant schema into another tenant schema
 CREATE TABLE tenant_2.tenant_tbl2(id int);
 ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA tenant_3;
+NOTICE:  creating a new table for tenant_2.tenant_tbl2
+NOTICE:  moving the data of tenant_2.tenant_tbl2
+NOTICE:  dropping the old tenant_2.tenant_tbl2
+NOTICE:  renaming the new table to tenant_2.tenant_tbl2
 -- verify that we do not allow a local table in regular schema into distributed schema if it has foreign key to a non-reference table in another schema
 CREATE TABLE regular_schema.pg_local_tbl1(id int PRIMARY KEY);
 CREATE TABLE regular_schema.pg_local_tbl2(id int REFERENCES regular_schema.pg_local_tbl1(id));
@@ -202,20 +204,20 @@ ALTER TABLE regular_schema.pg_local_tbl3 SET SCHEMA tenant_2;
 CREATE TABLE tenant_2.tenant_tbl1(id int PRIMARY KEY);
 CREATE TABLE tenant_2.tenant_tbl2(id int REFERENCES tenant_2.tenant_tbl1(id));
 ALTER TABLE tenant_2.tenant_tbl1 SET SCHEMA regular_schema;
-ERROR:  cannot alter the schema of table tenant_tbl1
-DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ERROR:  set schema is not allowed for table tenant_tbl1 in distributed schema tenant_2
+DETAIL:  distributed schemas cannot have foreign keys from/to local tables or different schema
 ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA regular_schema;
-ERROR:  cannot alter the schema of table tenant_tbl2
-DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ERROR:  set schema is not allowed for table tenant_tbl2 in distributed schema tenant_2
+DETAIL:  distributed schemas cannot have foreign keys from/to local tables or different schema
 -- verify that we do not allow a table in distributed schema into another distributed schema if it has foreign key to/from another table in the same schema
 CREATE TABLE tenant_2.tenant_tbl3(id int PRIMARY KEY);
 CREATE TABLE tenant_2.tenant_tbl4(id int REFERENCES tenant_2.tenant_tbl3(id));
 ALTER TABLE tenant_2.tenant_tbl3 SET SCHEMA tenant_3;
-ERROR:  cannot alter the schema of table tenant_tbl3
-DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ERROR:  set schema is not allowed for table tenant_tbl3 in distributed schema tenant_2
+DETAIL:  distributed schemas cannot have foreign keys from/to local tables or different schema
 ALTER TABLE tenant_2.tenant_tbl4 SET SCHEMA tenant_3;
-ERROR:  cannot alter the schema of table tenant_tbl4
-DETAIL:  distributed schemas cannot have foreign keys from/to another schema
+ERROR:  set schema is not allowed for table tenant_tbl4 in distributed schema tenant_2
+DETAIL:  distributed schemas cannot have foreign keys from/to local tables or different schema
 -- alter set non-existent schema
 ALTER TABLE tenant_2.test_table SET SCHEMA ghost_schema;
 ERROR:  schema "ghost_schema" does not exist
@@ -393,8 +395,8 @@ SELECT EXISTS(
 (1 row)
 
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');
-ERROR:  insert or update on table "another_partitioned_table_child_1920092" violates foreign key constraint "another_partitioned_table_a_fkey_1920091"
-DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920089".
+ERROR:  insert or update on table "another_partitioned_table_child_1920090" violates foreign key constraint "another_partitioned_table_a_fkey_1920089"
+DETAIL:  Key (a)=(1) is not present in table "partitioned_table_1920087".
 CONTEXT:  while executing command on localhost:xxxxx
 INSERT INTO tenant_4.partitioned_table VALUES (1, 'a');
 INSERT INTO tenant_4.another_partitioned_table VALUES (1, 'a');

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -59,8 +59,16 @@ SELECT citus_add_local_table_to_metadata('tenant_2.test_table');
 SELECT update_distributed_table_colocation('tenant_2.test_table', colocate_with => 'none');
 -- verify we also don't allow colocate_with a tenant table
 SELECT update_distributed_table_colocation('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
--- verify we don't allow undistribute_table for tenant tables
-SELECT undistribute_table('tenant_2.test_table');
+
+-- verify we allow undistribute_table for tenant tables if they do not have foreign key to/from its distributed schema
+CREATE TABLE tenant_2.undist_table1(id int);
+SELECT undistribute_table('tenant_2.undist_table1');
+
+-- verify we do not allow undistribute_table for tenant tables if they have foreign key to/from its distributed schema
+CREATE TABLE tenant_2.undist_table2(id int PRIMARY KEY);
+CREATE TABLE tenant_2.undist_table3(id int REFERENCES tenant_2.undist_table2(id));
+SELECT undistribute_table('tenant_2.undist_table3');
+
 -- verify we don't allow alter_distributed_table for tenant tables
 SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');
 -- verify we also don't allow colocate_with a tenant table
@@ -95,6 +103,61 @@ WHERE logicalrelid = 'tenant_3.test_table4'::regclass AND
       partmethod = 'n' AND repmodel = 's' AND colocationid > 0;
 -- verify that tenant_2.test_table4 does not exist
 SELECT * FROM tenant_2.test_table4;
+
+-- verify that we can put a local table in regular schema into distributed schema
+CREATE TABLE regular_schema.pg_local_tbl(id int);
+ALTER TABLE regular_schema.pg_local_tbl SET SCHEMA tenant_2;
+
+-- verify that we can put a Citus local table in regular schema into distributed schema
+CREATE TABLE regular_schema.citus_local_tbl(id int);
+SELECT citus_add_local_table_to_metadata('regular_schema.citus_local_tbl');
+ALTER TABLE regular_schema.citus_local_tbl SET SCHEMA tenant_2;
+
+-- verify that we do not allow a hash distributed table in regular schema into distributed schema
+CREATE TABLE regular_schema.hash_dist_tbl(id int);
+SELECT create_distributed_table('regular_schema.hash_dist_tbl', 'id');
+ALTER TABLE regular_schema.hash_dist_tbl SET SCHEMA tenant_2;
+
+-- verify that we do not allow a reference table in regular schema into distributed schema
+CREATE TABLE regular_schema.ref_tbl(id int  PRIMARY KEY);
+SELECT create_reference_table('regular_schema.ref_tbl');
+ALTER TABLE regular_schema.ref_tbl SET SCHEMA tenant_2;
+
+-- verify that we can put a table in tenant schema into regular schema
+CREATE TABLE tenant_2.tenant_tbl(id int);
+ALTER TABLE tenant_2.tenant_tbl SET SCHEMA regular_schema;
+
+-- verify that we can put a table in tenant schema into another tenant schema
+CREATE TABLE tenant_2.tenant_tbl2(id int);
+ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA tenant_3;
+
+-- verify that we do not allow a local table in regular schema into distributed schema if it has foreign key to a non-reference table in another schema
+CREATE TABLE regular_schema.pg_local_tbl1(id int PRIMARY KEY);
+CREATE TABLE regular_schema.pg_local_tbl2(id int REFERENCES regular_schema.pg_local_tbl1(id));
+ALTER TABLE regular_schema.pg_local_tbl2 SET SCHEMA tenant_2;
+
+-- verify that we allow a local table in regular schema into distributed schema if it has foreign key to a reference table in another schema
+CREATE TABLE regular_schema.pg_local_tbl3(id int REFERENCES regular_schema.ref_tbl(id));
+ALTER TABLE regular_schema.pg_local_tbl3 SET SCHEMA tenant_2;
+
+-- verify that we do not allow a table in tenant schema into regular schema if it has foreign key to/from another table in the same schema
+CREATE TABLE tenant_2.tenant_tbl1(id int PRIMARY KEY);
+CREATE TABLE tenant_2.tenant_tbl2(id int REFERENCES tenant_2.tenant_tbl1(id));
+ALTER TABLE tenant_2.tenant_tbl1 SET SCHEMA regular_schema;
+ALTER TABLE tenant_2.tenant_tbl2 SET SCHEMA regular_schema;
+
+-- verify that we do not allow a table in distributed schema into another distributed schema if it has foreign key to/from another table in the same schema
+CREATE TABLE tenant_2.tenant_tbl3(id int PRIMARY KEY);
+CREATE TABLE tenant_2.tenant_tbl4(id int REFERENCES tenant_2.tenant_tbl3(id));
+ALTER TABLE tenant_2.tenant_tbl3 SET SCHEMA tenant_3;
+ALTER TABLE tenant_2.tenant_tbl4 SET SCHEMA tenant_3;
+
+-- alter set non-existent schema
+ALTER TABLE tenant_2.test_table SET SCHEMA ghost_schema;
+ALTER TABLE IF EXISTS tenant_2.test_table SET SCHEMA ghost_schema;
+-- alter set non-existent table
+ALTER TABLE tenant_2.ghost_table SET SCHEMA ghost_schema;
+ALTER TABLE IF EXISTS tenant_2.ghost_table SET SCHEMA ghost_schema;
 
 -- (on coordinator) verify that colocation id is set for empty tenants too
 SELECT colocationid > 0 FROM pg_dist_schema

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -60,14 +60,9 @@ SELECT update_distributed_table_colocation('tenant_2.test_table', colocate_with 
 -- verify we also don't allow colocate_with a tenant table
 SELECT update_distributed_table_colocation('regular_schema.test_table', colocate_with => 'tenant_2.test_table');
 
--- verify we allow undistribute_table for tenant tables if they do not have foreign key to/from its distributed schema
-CREATE TABLE tenant_2.undist_table1(id int);
-SELECT undistribute_table('tenant_2.undist_table1');
-
--- verify we do not allow undistribute_table for tenant tables if they have foreign key to/from its distributed schema
-CREATE TABLE tenant_2.undist_table2(id int PRIMARY KEY);
-CREATE TABLE tenant_2.undist_table3(id int REFERENCES tenant_2.undist_table2(id));
-SELECT undistribute_table('tenant_2.undist_table3');
+-- verify we do not allow undistribute_table for tenant tables
+CREATE TABLE tenant_2.undist_table(id int);
+SELECT undistribute_table('tenant_2.undist_table');
 
 -- verify we don't allow alter_distributed_table for tenant tables
 SELECT alter_distributed_table('tenant_2.test_table', colocate_with => 'none');


### PR DESCRIPTION
Adds support for altering schema of single shard tables. We do that in 2 steps.
1. Undistribute the tenant table at `preprocess` step,
2. Distribute new schema if it is a distributed schema after DDLs are propagated.

- [x] Add basic tests,
- [x] Support altering schema to/from a tenant table,
- [x] We may add check to see whether the old schema is same as the new one so that we can get rid of costly operations. (shortcut)
- [x] Allow undistribution of tenant tables only if they do not have foreign key from/to its own schema (after undistribution the table would be local table and we do not allow fkeys from/to local tables to/from distributed schemas),
- [x] Add more tests with foreign keys and other distributed tables. Nonexistent schemas, partitioned tables, foreign tables etc...
- [ ] Optimization: We do not need to undistribute if source and target schemas are tenant schemas and on the same node. (In another PR)

DESCRIPTION: Adds support for altering a table's schema to/from distributed schemas.
