### PR TITLE
Fix Reference Table Check for CDC

### DIFF
--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -360,12 +360,14 @@ GetTupleForTargetSchemaForCdc(HeapTuple sourceRelationTuple,
 			targetNulls[targetIndex] = true;
 			targetIndex++;
 		}
+
 		/* If this source attribute has been dropped, just skip this source attribute.*/
 		else if (TupleDescAttr(sourceRelDesc, sourceIndex)->attisdropped)
 		{
 			sourceIndex++;
 			continue;
 		}
+
 		/* If both source and target attributes are not dropped, add the attribute field to targetValues. */
 		else if (sourceIndex < sourceRelDesc->natts)
 		{

--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -203,8 +203,7 @@ AddShardIdToHashTable(uint64 shardId, ShardIdHashEntry *entry)
 {
 	entry->shardId = shardId;
 	entry->distributedTableId = CdcLookupShardRelationFromCatalog(shardId, true);
-	entry->isReferenceTable = CdcPartitionMethodViaCatalog(entry->distributedTableId) ==
-							  'n';
+	entry->isReferenceTable = CdcIsReferenceTable(entry->distributedTableId);
 	return entry->distributedTableId;
 }
 

--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -203,7 +203,7 @@ AddShardIdToHashTable(uint64 shardId, ShardIdHashEntry *entry)
 {
 	entry->shardId = shardId;
 	entry->distributedTableId = CdcLookupShardRelationFromCatalog(shardId, true);
-	entry->isReferenceTable = CdcIsReferenceTable(entry->distributedTableId);
+	entry->isReferenceTable = CdcIsReferenceTableViaCatalog(entry->distributedTableId);
 	return entry->distributedTableId;
 }
 

--- a/src/backend/distributed/cdc/cdc_decoder_utils.c
+++ b/src/backend/distributed/cdc/cdc_decoder_utils.c
@@ -331,11 +331,11 @@ CdcPgDistPartitionTupleViaCatalog(Oid relationId)
 
 
 /*
- * CdcIsReferenceTable gets a relationId and returns true if the relation
+ * CdcIsReferenceTableViaCatalog gets a relationId and returns true if the relation
  * is a reference table and false otherwise.
  */
 char
-CdcIsReferenceTable(Oid relationId)
+CdcIsReferenceTableViaCatalog(Oid relationId)
 {
 	HeapTuple partitionTuple = CdcPgDistPartitionTupleViaCatalog(relationId);
 	if (!HeapTupleIsValid(partitionTuple))
@@ -372,6 +372,10 @@ CdcIsReferenceTable(Oid relationId)
 	heap_freetuple(partitionTuple);
 	table_close(pgDistPartition, NoLock);
 
+	/*
+	 * A table is a reference table when its partition method is 'none'
+	 * and replication model is 'two phase commit'
+	 */
 	return partitionMethodChar == 'n' && replicationModelChar == 't';
 }
 

--- a/src/backend/distributed/cdc/cdc_decoder_utils.h
+++ b/src/backend/distributed/cdc/cdc_decoder_utils.h
@@ -25,7 +25,7 @@ uint64 CdcExtractShardIdFromTableName(const char *tableName, bool missingOk);
 
 Oid CdcLookupShardRelationFromCatalog(int64 shardId, bool missingOk);
 
-char CdcIsReferenceTable(Oid relationId);
+char CdcIsReferenceTableViaCatalog(Oid relationId);
 
 bool CdcCitusHasBeenLoaded(void);
 

--- a/src/backend/distributed/cdc/cdc_decoder_utils.h
+++ b/src/backend/distributed/cdc/cdc_decoder_utils.h
@@ -25,7 +25,7 @@ uint64 CdcExtractShardIdFromTableName(const char *tableName, bool missingOk);
 
 Oid CdcLookupShardRelationFromCatalog(int64 shardId, bool missingOk);
 
-char CdcPartitionMethodViaCatalog(Oid relationId);
+char CdcIsReferenceTable(Oid relationId);
 
 bool CdcCitusHasBeenLoaded(void);
 


### PR DESCRIPTION
Previously reference table check only looked at `partition method = 'n'`. This PR adds `replication model = 't'` to that.