### PR TITLE
Add locking mechanism for tenant monitoring probabilistic approach

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2472,17 +2472,6 @@ RegisterCitusConfigVariables(void)
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 
-
-	DefineCustomRealVariable(
-		"citus.stat_tenants_untracked_sample_rate",
-		gettext_noop("Sampling rate for new tenants in citus_stat_tenants."),
-		NULL,
-		&StatTenantsSampleRateForNewTenants,
-		1, 0, 1,
-		PGC_USERSET,
-		GUC_STANDARD,
-		NULL, NULL, NULL);
-
 	DefineCustomEnumVariable(
 		"citus.stat_tenants_track",
 		gettext_noop("Enables/Disables the stats collection for citus_stat_tenants."),
@@ -2493,6 +2482,16 @@ RegisterCitusConfigVariables(void)
 		STAT_TENANTS_TRACK_NONE,
 		stat_tenants_track_options,
 		PGC_SUSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomRealVariable(
+		"citus.stat_tenants_untracked_sample_rate",
+		gettext_noop("Sampling rate for new tenants in citus_stat_tenants."),
+		NULL,
+		&StatTenantsSampleRateForNewTenants,
+		1, 0, 1,
+		PGC_USERSET,
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2473,12 +2473,12 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 
-	DefineCustomIntVariable(
+	DefineCustomRealVariable(
 		"citus.stat_tenants_sample_rate_for_new_tenants",
 		gettext_noop("Sampling rate for new tenants in citus_stat_tenants."),
 		NULL,
 		&StatTenantsSampleRateForNewTenants,
-		100, 1, 100,
+		1, 0, 1,
 		PGC_USERSET,
 		GUC_STANDARD,
 		NULL, NULL, NULL);

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2474,7 +2474,7 @@ RegisterCitusConfigVariables(void)
 
 
 	DefineCustomRealVariable(
-		"citus.stat_tenants_sample_rate_for_new_tenants",
+		"citus.stat_tenants_untracked_sample_rate",
 		gettext_noop("Sampling rate for new tenants in citus_stat_tenants."),
 		NULL,
 		&StatTenantsSampleRateForNewTenants,

--- a/src/backend/distributed/utils/citus_stat_tenants.c
+++ b/src/backend/distributed/utils/citus_stat_tenants.c
@@ -12,7 +12,6 @@
 #include "unistd.h"
 
 #include "access/hash.h"
-
 #include "distributed/citus_safe_lib.h"
 #include "distributed/colocation_utils.h"
 #include "distributed/distributed_planner.h"

--- a/src/backend/distributed/utils/citus_stat_tenants.c
+++ b/src/backend/distributed/utils/citus_stat_tenants.c
@@ -281,7 +281,13 @@ AttributeTask(char *tenantId, int colocationId, CmdType commandType)
 
 	MultiTenantMonitor *monitor = GetMultiTenantMonitor();
 	bool found = false;
+
+	/* Acquire the lock in shared mode to check if the tenant is already in the hash table. */
+	LWLockAcquire(&monitor->lock, LW_SHARED);
+
 	hash_search(monitor->tenants, &key, HASH_FIND, &found);
+
+	LWLockRelease(&monitor->lock);
 
 	/* If the tenant is not found in the hash table, we will track the query with a probability of StatTenantsSampleRateForNewTenants. */
 	if (!found)

--- a/src/backend/distributed/utils/citus_stat_tenants.c
+++ b/src/backend/distributed/utils/citus_stat_tenants.c
@@ -303,7 +303,7 @@ AttributeTask(char *tenantId, int colocationId, CmdType commandType)
 		/* Generate a random double between 0 and 1 */
 		double randomValue = (double) random() / MAX_RANDOM_VALUE;
 #endif
-		bool shouldTrackQuery = randomValue < StatTenantsSampleRateForNewTenants;
+		bool shouldTrackQuery = randomValue <= StatTenantsSampleRateForNewTenants;
 		if (!shouldTrackQuery)
 		{
 			return;

--- a/src/backend/distributed/utils/citus_stat_tenants.c
+++ b/src/backend/distributed/utils/citus_stat_tenants.c
@@ -300,8 +300,6 @@ AttributeTask(char *tenantId, int colocationId, CmdType commandType)
 #if (PG_VERSION_NUM >= PG_VERSION_15)
 		double randomValue = pg_prng_double(&pg_global_prng_state);
 #else
-	    /* Set a good seed for random */
-    	srandom((unsigned int) time(NULL));
 
 		/* Generate a random double between 0 and 1 */
 		double randomValue = (double) random() / RAND_MAX;

--- a/src/backend/distributed/utils/citus_stat_tenants.c
+++ b/src/backend/distributed/utils/citus_stat_tenants.c
@@ -302,7 +302,7 @@ AttributeTask(char *tenantId, int colocationId, CmdType commandType)
 #else
 
 		/* Generate a random double between 0 and 1 */
-		double randomValue = (double) random() / RAND_MAX;
+		double randomValue = (double) random() / MAX_RANDOM_VALUE;
 #endif
 		bool shouldTrackQuery = randomValue < StatTenantsSampleRateForNewTenants;
 		if (!shouldTrackQuery)

--- a/src/include/distributed/utils/citus_stat_tenants.h
+++ b/src/include/distributed/utils/citus_stat_tenants.h
@@ -121,6 +121,6 @@ extern int StatTenantsLogLevel;
 extern int StatTenantsPeriod;
 extern int StatTenantsLimit;
 extern int StatTenantsTrack;
-extern int StatTenantsSampleRateForNewTenants;
+extern double StatTenantsSampleRateForNewTenants;
 
 #endif /*CITUS_ATTRIBUTE_H */

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1009,6 +1009,77 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 
 \c - - - :master_port
 SET search_path TO citus_stat_tenants;
+SET citus.enable_schema_based_sharding TO OFF;
+SELECT citus_stat_tenants_reset();
+ citus_stat_tenants_reset
+---------------------------------------------------------------------
+
+(1 row)
+
+-- test sampling
+-- set rate to 0 to disable sampling
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 0;');
+    result
+---------------------------------------------------------------------
+ ALTER SYSTEM
+ ALTER SYSTEM
+ ALTER SYSTEM
+(3 rows)
+
+SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
+ result
+---------------------------------------------------------------------
+ t
+ t
+ t
+(3 rows)
+
+INSERT INTO dist_tbl VALUES (1, 'abcd');
+INSERT INTO dist_tbl VALUES (2, 'abcd');
+UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
+UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
+DELETE FROM dist_tbl WHERE a = 5;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period
+---------------------------------------------------------------------
+(0 rows)
+
+-- test sampling
+-- set rate to 1 to track all tenants
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 1;');
+    result
+---------------------------------------------------------------------
+ ALTER SYSTEM
+ ALTER SYSTEM
+ ALTER SYSTEM
+(3 rows)
+
+SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
+ result
+---------------------------------------------------------------------
+ t
+ t
+ t
+(3 rows)
+
+INSERT INTO dist_tbl VALUES (1, 'abcd');
+INSERT INTO dist_tbl VALUES (2, 'abcd');
+UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
+UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
+DELETE FROM dist_tbl WHERE a = 5;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants(true)
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
+---------------------------------------------------------------------
+ 1                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 2                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 3                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 4                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t                          | f
+(5 rows)
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;
 DROP SCHEMA citus_stat_tenants_t1 CASCADE;

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1068,6 +1068,12 @@ SELECT sleep_until_next_period();
 
 (1 row)
 
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
 INSERT INTO dist_tbl VALUES (1, 'abcd');
 INSERT INTO dist_tbl VALUES (2, 'abcd');
 UPDATE dist_tbl SET b = a + 1 WHERE a = 3;

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1044,54 +1044,6 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 ---------------------------------------------------------------------
 (0 rows)
 
--- test sampling
--- set rate to 1 to track all tenants
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
-    result
----------------------------------------------------------------------
- ALTER SYSTEM
- ALTER SYSTEM
- ALTER SYSTEM
-(3 rows)
-
-SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
- result
----------------------------------------------------------------------
- t
- t
- t
-(3 rows)
-
-SELECT sleep_until_next_period();
- sleep_until_next_period
----------------------------------------------------------------------
-
-(1 row)
-
-SELECT pg_sleep(0.1);
- pg_sleep
----------------------------------------------------------------------
-
-(1 row)
-
-INSERT INTO dist_tbl VALUES (1, 'abcd');
-INSERT INTO dist_tbl VALUES (2, 'abcd');
-UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
-UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
-DELETE FROM dist_tbl WHERE a = 5;
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
-    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
-FROM citus_stat_tenants(true)
-ORDER BY tenant_attribute;
- tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
----------------------------------------------------------------------
- 1                |                         0 |                         0 |                          1 |                          0 | t                          | f
- 2                |                         0 |                         0 |                          1 |                          0 | t                          | f
- 3                |                         0 |                         0 |                          1 |                          0 | t                          | f
- 4                |                         0 |                         0 |                          1 |                          0 | t                          | f
- 5                |                         0 |                         0 |                          1 |                          0 | t                          | f
-(5 rows)
-
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;
 DROP SCHEMA citus_stat_tenants_t1 CASCADE;

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -240,8 +240,17 @@ SELECT tenant_attribute, query_count_in_this_period, score FROM citus_stat_tenan
 (5 rows)
 
 -- test period passing
+\c - - - :worker_1_port
+SET search_path TO citus_stat_tenants;
+SET citus.stat_tenants_period TO 2;
 SELECT citus_stat_tenants_reset();
  citus_stat_tenants_reset
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT sleep_until_next_period();
+ sleep_until_next_period
 ---------------------------------------------------------------------
 
 (1 row)
@@ -253,7 +262,6 @@ SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 (1 row)
 
 INSERT INTO dist_tbl VALUES (5, 'abcd');
-\c - - - :worker_1_port
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
     (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
 FROM citus_stat_tenants_local
@@ -265,9 +273,14 @@ ORDER BY tenant_attribute;
 (2 rows)
 
 -- simulate passing the period
-SET citus.stat_tenants_period TO 5;
 SELECT sleep_until_next_period();
  sleep_until_next_period
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT pg_sleep(1);
+ pg_sleep
 ---------------------------------------------------------------------
 
 (1 row)
@@ -284,6 +297,12 @@ ORDER BY tenant_attribute;
 
 SELECT sleep_until_next_period();
  sleep_until_next_period
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT pg_sleep(1);
+ pg_sleep
 ---------------------------------------------------------------------
 
 (1 row)

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1018,7 +1018,7 @@ SELECT citus_stat_tenants_reset();
 
 -- test sampling
 -- set rate to 0 to disable sampling
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 0;');
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 0;');
     result
 ---------------------------------------------------------------------
  ALTER SYSTEM
@@ -1046,7 +1046,7 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 
 -- test sampling
 -- set rate to 1 to track all tenants
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 1;');
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
     result
 ---------------------------------------------------------------------
  ALTER SYSTEM

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1062,6 +1062,12 @@ SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
  t
 (3 rows)
 
+SELECT sleep_until_next_period();
+ sleep_until_next_period
+---------------------------------------------------------------------
+
+(1 row)
+
 INSERT INTO dist_tbl VALUES (1, 'abcd');
 INSERT INTO dist_tbl VALUES (2, 'abcd');
 UPDATE dist_tbl SET b = a + 1 WHERE a = 3;

--- a/src/test/regress/expected/citus_stat_tenants.out
+++ b/src/test/regress/expected/citus_stat_tenants.out
@@ -1044,6 +1044,54 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 ---------------------------------------------------------------------
 (0 rows)
 
+-- test sampling
+-- set rate to 1 to track all tenants
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
+    result
+---------------------------------------------------------------------
+ ALTER SYSTEM
+ ALTER SYSTEM
+ ALTER SYSTEM
+(3 rows)
+
+SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
+ result
+---------------------------------------------------------------------
+ t
+ t
+ t
+(3 rows)
+
+SELECT sleep_until_next_period();
+ sleep_until_next_period
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT pg_sleep(0.1);
+ pg_sleep
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist_tbl VALUES (1, 'abcd');
+INSERT INTO dist_tbl VALUES (2, 'abcd');
+UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
+UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
+DELETE FROM dist_tbl WHERE a = 5;
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants(true)
+ORDER BY tenant_attribute;
+ tenant_attribute | read_count_in_this_period | read_count_in_last_period | query_count_in_this_period | query_count_in_last_period | cpu_is_used_in_this_period | cpu_is_used_in_last_period
+---------------------------------------------------------------------
+ 1                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 2                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 3                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 4                |                         0 |                         0 |                          1 |                          0 | t                          | f
+ 5                |                         0 |                         0 |                          1 |                          0 | t                          | f
+(5 rows)
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;
 DROP SCHEMA citus_stat_tenants_t1 CASCADE;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -383,7 +383,7 @@ SELECT citus_stat_tenants_reset();
 
 -- test sampling
 -- set rate to 0 to disable sampling
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 0;');
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 0;');
 SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
 
 INSERT INTO dist_tbl VALUES (1, 'abcd');
@@ -396,7 +396,7 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 
 -- test sampling
 -- set rate to 1 to track all tenants
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 1;');
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
 SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
 
 SELECT sleep_until_next_period();

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -394,25 +394,6 @@ DELETE FROM dist_tbl WHERE a = 5;
 
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
 
--- test sampling
--- set rate to 1 to track all tenants
-SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
-SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
-
-SELECT sleep_until_next_period();
-SELECT pg_sleep(0.1);
-
-INSERT INTO dist_tbl VALUES (1, 'abcd');
-INSERT INTO dist_tbl VALUES (2, 'abcd');
-UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
-UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
-DELETE FROM dist_tbl WHERE a = 5;
-
-SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
-    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
-FROM citus_stat_tenants(true)
-ORDER BY tenant_attribute;
-
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;
 DROP SCHEMA citus_stat_tenants_t1 CASCADE;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -399,6 +399,8 @@ SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, q
 SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_sample_rate_for_new_tenants to 1;');
 SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
 
+SELECT sleep_until_next_period();
+
 INSERT INTO dist_tbl VALUES (1, 'abcd');
 INSERT INTO dist_tbl VALUES (2, 'abcd');
 UPDATE dist_tbl SET b = a + 1 WHERE a = 3;

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -400,6 +400,7 @@ SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants
 SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
 
 SELECT sleep_until_next_period();
+SELECT pg_sleep(0.1);
 
 INSERT INTO dist_tbl VALUES (1, 'abcd');
 INSERT INTO dist_tbl VALUES (2, 'abcd');

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -83,20 +83,24 @@ SELECT count(*)>=0 FROM dist_tbl_text WHERE a = 'defg';
 SELECT tenant_attribute, query_count_in_this_period, score FROM citus_stat_tenants(true) WHERE nodeid = :worker_2_nodeid ORDER BY score DESC, tenant_attribute;
 
 -- test period passing
+\c - - - :worker_1_port
+
+SET search_path TO citus_stat_tenants;
+SET citus.stat_tenants_period TO 2;
 SELECT citus_stat_tenants_reset();
+SELECT sleep_until_next_period();
 
 SELECT count(*)>=0 FROM dist_tbl WHERE a = 1;
 INSERT INTO dist_tbl VALUES (5, 'abcd');
 
-\c - - - :worker_1_port
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
     (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
 FROM citus_stat_tenants_local
 ORDER BY tenant_attribute;
 
 -- simulate passing the period
-SET citus.stat_tenants_period TO 5;
 SELECT sleep_until_next_period();
+SELECT pg_sleep(1);
 
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
     (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
@@ -104,6 +108,7 @@ FROM citus_stat_tenants_local
 ORDER BY tenant_attribute;
 
 SELECT sleep_until_next_period();
+SELECT pg_sleep(1);
 
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
     (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period

--- a/src/test/regress/sql/citus_stat_tenants.sql
+++ b/src/test/regress/sql/citus_stat_tenants.sql
@@ -394,6 +394,25 @@ DELETE FROM dist_tbl WHERE a = 5;
 
 SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period FROM citus_stat_tenants ORDER BY tenant_attribute;
 
+-- test sampling
+-- set rate to 1 to track all tenants
+SELECT result FROM run_command_on_all_nodes('ALTER SYSTEM set citus.stat_tenants_untracked_sample_rate to 1;');
+SELECT result FROM run_command_on_all_nodes('SELECT pg_reload_conf()');
+
+SELECT sleep_until_next_period();
+SELECT pg_sleep(0.1);
+
+INSERT INTO dist_tbl VALUES (1, 'abcd');
+INSERT INTO dist_tbl VALUES (2, 'abcd');
+UPDATE dist_tbl SET b = a + 1 WHERE a = 3;
+UPDATE dist_tbl SET b = a + 1 WHERE a = 4;
+DELETE FROM dist_tbl WHERE a = 5;
+
+SELECT tenant_attribute, read_count_in_this_period, read_count_in_last_period, query_count_in_this_period, query_count_in_last_period,
+    (cpu_usage_in_this_period>0) AS cpu_is_used_in_this_period, (cpu_usage_in_last_period>0) AS cpu_is_used_in_last_period
+FROM citus_stat_tenants(true)
+ORDER BY tenant_attribute;
+
 SET client_min_messages TO ERROR;
 DROP SCHEMA citus_stat_tenants CASCADE;
 DROP SCHEMA citus_stat_tenants_t1 CASCADE;


### PR DESCRIPTION
This PR 
* Addresses a concurrency issue in the probabilistic approach of tenant monitoring by acquiring a shared lock for tenant existence checks.
* Changes `citus.stat_tenants_sample_rate_for_new_tenants` type to double
* Renames `citus.stat_tenants_sample_rate_for_new_tenants` to `citus.stat_tenants_untracked_sample_rate` 
