### PR TITLE
mat view should not be converted to tenant table

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -4154,6 +4154,15 @@ ConvertNewTableIfNecessary(Node *createStmt)
 				return;
 			}
 
+			/*
+			 * We allow mat views in a distributed schema but do not make them a tenant
+			 * table. We should skip converting them.
+			 */
+			if (get_rel_relkind(createdRelationId) == RELKIND_MATVIEW)
+			{
+				return;
+			}
+
 			CreateTenantSchemaTable(createdRelationId);
 		}
 

--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -1694,8 +1694,34 @@ $$);
  t
 (3 rows)
 
+-- mat view can be created under tenant schema
+SET citus.enable_schema_based_sharding TO ON;
+SET citus.shard_replication_factor TO 1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.t1 (a int);
+CREATE MATERIALIZED VIEW sc1.v1 AS SELECT * FROM sc1.t1;
+SET citus.enable_schema_based_sharding TO OFF;
+-- on coordinator, verify that schema is distributed
+SELECT colocationid > 0 FROM pg_dist_schema
+WHERE schemaid::regnamespace::text = 'sc1';
+ ?column?
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- on workers, verify that schema is distributed
+SELECT result FROM run_command_on_workers($$
+    SELECT array_agg(colocationid > 0) FROM pg_dist_schema
+    WHERE schemaid::regnamespace::text = 'sc1'
+$$);
+ result
+---------------------------------------------------------------------
+ {t}
+ {t}
+(2 rows)
+
 SET client_min_messages TO WARNING;
-DROP SCHEMA regular_schema, tenant_3, tenant_5, tenant_7, tenant_6, type_sch, citus_sch1, citus_sch2, citus_empty_sch1, citus_empty_sch2, authschema CASCADE;
+DROP SCHEMA regular_schema, tenant_3, tenant_5, tenant_7, tenant_6, type_sch, citus_sch1, citus_sch2, citus_empty_sch1, citus_empty_sch2, authschema, sc1 CASCADE;
 DROP ROLE citus_schema_role, citus_schema_nonpri, authschema;
 SELECT citus_remove_node('localhost', :master_port);
  citus_remove_node

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -1154,8 +1154,26 @@ SELECT result FROM run_command_on_all_nodes($$
     WHERE schemaid::regnamespace::text = 'authschema';
 $$);
 
+-- mat view can be created under tenant schema
+SET citus.enable_schema_based_sharding TO ON;
+SET citus.shard_replication_factor TO 1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.t1 (a int);
+CREATE MATERIALIZED VIEW sc1.v1 AS SELECT * FROM sc1.t1;
+SET citus.enable_schema_based_sharding TO OFF;
+
+-- on coordinator, verify that schema is distributed
+SELECT colocationid > 0 FROM pg_dist_schema
+WHERE schemaid::regnamespace::text = 'sc1';
+
+-- on workers, verify that schema is distributed
+SELECT result FROM run_command_on_workers($$
+    SELECT array_agg(colocationid > 0) FROM pg_dist_schema
+    WHERE schemaid::regnamespace::text = 'sc1'
+$$);
+
 SET client_min_messages TO WARNING;
-DROP SCHEMA regular_schema, tenant_3, tenant_5, tenant_7, tenant_6, type_sch, citus_sch1, citus_sch2, citus_empty_sch1, citus_empty_sch2, authschema CASCADE;
+DROP SCHEMA regular_schema, tenant_3, tenant_5, tenant_7, tenant_6, type_sch, citus_sch1, citus_sch2, citus_empty_sch1, citus_empty_sch2, authschema, sc1 CASCADE;
 DROP ROLE citus_schema_role, citus_schema_nonpri, authschema;
 
 SELECT citus_remove_node('localhost', :master_port);


### PR DESCRIPTION
We allow materialized view to exist in distrbuted schema but they should not be tried to be converted to a tenant table since they cannot be distributed. 

Fixes https://github.com/citusdata/citus/issues/7041