### PR TITLE
Skip distributed schema insertion into pg_dist_schema, if already exists

### DIFF
--- a/src/test/regress/expected/schema_based_sharding.out
+++ b/src/test/regress/expected/schema_based_sharding.out
@@ -50,6 +50,8 @@ SELECT COUNT(*)=0 FROM pg_dist_schema WHERE schemaid::regnamespace::text = 'regu
 
 -- empty tenant
 CREATE SCHEMA "tenant\'_1";
+CREATE SCHEMA IF NOT EXISTS "tenant\'_1";
+NOTICE:  schema "tenant\'_1" already exists, skipping
 -- non-empty tenant
 CREATE SCHEMA "tenant\'_2";
 CREATE TABLE "tenant\'_2".test_table(a int, b text);

--- a/src/test/regress/sql/schema_based_sharding.sql
+++ b/src/test/regress/sql/schema_based_sharding.sql
@@ -33,6 +33,7 @@ SELECT COUNT(*)=0 FROM pg_dist_schema WHERE schemaid::regnamespace::text = 'regu
 
 -- empty tenant
 CREATE SCHEMA "tenant\'_1";
+CREATE SCHEMA IF NOT EXISTS "tenant\'_1";
 
 -- non-empty tenant
 CREATE SCHEMA "tenant\'_2";


### PR DESCRIPTION
Inserting into `pg_dist_schema` causes unexpected duplicate key errors, for distributed schemas that already exist. With this commit we skip the insertion if the schema already exists in `pg_dist_schema`. 

The error:
```sql
SET citus.enable_schema_based_sharding TO ON;
CREATE SCHEMA sc2;
CREATE SCHEMA IF NOT EXISTS sc2;
NOTICE:  schema "sc2" already exists, skipping
ERROR:  duplicate key value violates unique constraint "pg_dist_schema_pkey"
DETAIL:  Key (schemaid)=(17294) already exists.
```

fixes: #7042 