### PR TITLE
Fixes error surpressions in packaging pipelines

### DIFF
--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -25,7 +25,7 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b v0.8.24 --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
 echo "Package type: ${package_type}"

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -25,7 +25,7 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b 0.8.24 --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b v0.8.24 --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
 echo "Package type: ${package_type}"

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -25,7 +25,7 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b fix_centos8_errors --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
 

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo
 
 # Function to get the OS version
 get_os_version() {
@@ -27,6 +27,9 @@ pyenv activate packaging_env
 
 git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
+
+echo "Package type: ${package_type}"
+echo "OS version: $(get_os_version)"
 
  # if os version is centos 7 or oracle linux 7, then remove urllib3 with pip uninstall and install urllib3<2.0.0 with pip install
 if [[ ${package_type} == "rpm" && $(get_os_version) == 7* ]]; then

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -eo
+set -ex
 
 # Function to get the OS version
 get_os_version() {
     if [[ -f /etc/centos-release ]]; then
         cat /etc/centos-release | awk '{print $4}'
     elif [[ -f /etc/oracle-release ]]; then
-        cat /etc/oracle-release | awk '{print $4}'
+        cat /etc/oracle-release | awk '{print $5}'
     else
         echo "Unknown"
     fi
@@ -34,7 +34,7 @@ echo "OS version: $(get_os_version)"
  # if os version is centos 7 or oracle linux 7, then remove urllib3 with pip uninstall and install urllib3<2.0.0 with pip install
 if [[ ${package_type} == "rpm" && $(get_os_version) == 7* ]]; then
     python3 -m pip uninstall -y urllib3
-    python3 -m pip install urllib3<2.0.0
+    python3 -m pip install 'urllib3<2'
 fi
 
 python3 -m tools.packaging_automation.validate_build_output --output_file output.log \

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e
+
 package_type=${1}
 
 # Since $HOME is set in GH_Actions as /github/home, pyenv fails to create virtualenvs.

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -18,3 +18,6 @@ python3 -m tools.packaging_automation.validate_build_output --output_file output
 pyenv deactivate
 # Set $HOME back to /github/home
 export HOME=${GITHUB_HOME}
+
+# Print the output to the console
+cat output.log

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -25,10 +25,9 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b fix_centos8_errors --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
-python3 -m pip install attrs
 
 echo "Package type: ${package_type}"
 echo "OS version: $(get_rpm_os_version)"

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -25,7 +25,7 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b 0.8.24 --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
 echo "Package type: ${package_type}"

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -10,7 +10,7 @@ pyenv versions
 pyenv virtualenv ${PACKAGING_PYTHON_VERSION} packaging_env
 pyenv activate packaging_env
 
-git clone -b v0.8.24 --depth=1  https://github.com/citusdata/tools.git tools
+git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 python3 -m tools.packaging_automation.validate_build_output --output_file output.log \
                                                             --ignore_file .github/packaging/packaging_ignore.yml \

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -12,7 +12,12 @@ pyenv activate packaging_env
 
 git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
-python3 -m pip install attr
+
+# if os is centos 8 then install attrs package with pip
+if [[ "${package_type}" == "rpm" ]]; then
+    python3 -m pip install attrs
+fi
+
 python3 -m tools.packaging_automation.validate_build_output --output_file output.log \
                                                             --ignore_file .github/packaging/packaging_ignore.yml \
                                                             --package_type ${package_type}

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -12,6 +12,7 @@ pyenv activate packaging_env
 
 git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
+python3 -m pip install attr
 python3 -m tools.packaging_automation.validate_build_output --output_file output.log \
                                                             --ignore_file .github/packaging/packaging_ignore.yml \
                                                             --package_type ${package_type}
@@ -20,4 +21,3 @@ pyenv deactivate
 export HOME=${GITHUB_HOME}
 
 # Print the output to the console
-cat output.log

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -28,6 +28,8 @@ pyenv activate packaging_env
 git clone -b v0.8.27 --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
+python3 -m pip install attrs
+
 echo "Package type: ${package_type}"
 echo "OS version: $(get_rpm_os_version)"
 

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -17,11 +17,6 @@ pyenv activate packaging_env
 git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
-# if os is centos 8 then install attrs package with pip
-if [[ "${package_type}" == "rpm" ]]; then
-    python3 -m pip install attrs
-fi
-
 python3 -m tools.packaging_automation.validate_build_output --output_file output.log \
                                                             --ignore_file .github/packaging/packaging_ignore.yml \
                                                             --package_type ${package_type}

--- a/.github/packaging/validate_build_output.sh
+++ b/.github/packaging/validate_build_output.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Function to get the OS version
-get_os_version() {
+get_rpm_os_version() {
     if [[ -f /etc/centos-release ]]; then
         cat /etc/centos-release | awk '{print $4}'
     elif [[ -f /etc/oracle-release ]]; then
@@ -29,10 +29,10 @@ git clone -b error_add --depth=1  https://github.com/citusdata/tools.git tools
 python3 -m pip install -r tools/packaging_automation/requirements.txt
 
 echo "Package type: ${package_type}"
-echo "OS version: $(get_os_version)"
+echo "OS version: $(get_rpm_os_version)"
 
  # if os version is centos 7 or oracle linux 7, then remove urllib3 with pip uninstall and install urllib3<2.0.0 with pip install
-if [[ ${package_type} == "rpm" && $(get_os_version) == 7* ]]; then
+if [[ ${package_type} == "rpm" && $(get_rpm_os_version) == 7* ]]; then
     python3 -m pip uninstall -y urllib3
     python3 -m pip install 'urllib3<2'
 fi

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -78,6 +78,7 @@ jobs:
           set -ex
           git config --global --add safe.directory /__w/citus/citus
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
+          exit 1
 
       - name: Make install
         run: |

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -78,7 +78,15 @@ jobs:
           set -ex
           git config --global --add safe.directory /__w/citus/citus
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
-          exit 1
+
+          # Check the exit code of the make command
+          make_exit_code=${PIPESTATUS[0]}
+
+          # If the make command returned a non-zero exit code, exit with the same code
+          if [[ $make_exit_code -ne 0 ]]; then
+              echo "make command failed with exit code $make_exit_code"
+              exit $make_exit_code
+          fi
 
       - name: Make install
         run: |

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Make
         run: |
-          set -e
+          set -ex
           git config --global --add safe.directory ${{ github.workspace }}
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Make
         run: |
-          set -e
+          set -ex
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -153,6 +153,7 @@ jobs:
       - name: Make
         shell: bash
         run: |
+          set -e
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -136,20 +136,24 @@ jobs:
 
       - name: Configure
         run: |
+          set -e
           echo "Current Shell:$0"
           echo "GCC Version: $(gcc --version)"
           ./configure 2>&1 | tee output.log
 
       - name: Make clean
         run: |
+          set -e
           make clean
 
       - name: Make
         run: |
+          set -e
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install
         run: |
+          set -e
           make install 2>&1 | tee -a output.log
 
       - name: Validate output

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Make
         run: |
           set -ex
-          git config --global --add safe.directory /__w/citus/citus
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
           # Check the exit code of the make command
@@ -159,7 +159,7 @@ jobs:
       - name: Make
         run: |
           set -ex
-          git config --global --add safe.directory /__w/citus/citus
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
           # Check the exit code of the make command

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Make
         run: |
           set -ex
-          git config --global --add safe.directory ${{ github.workspace }}
+          git config --global --add safe.directory /__w/citus/citus
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install
@@ -150,6 +150,7 @@ jobs:
       - name: Make
         run: |
           set -ex
+          git config --global --add safe.directory /__w/citus/citus
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
           - oraclelinux-7
           - oraclelinux-8
           - centos-7
-          - centos-8
+          - almalinux-8
           - almalinux-9
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
 

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Make
         run: |
           set -ex
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config --global --add safe.directory /__w/citus/citus
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
           # Check the exit code of the make command

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     needs: get_postgres_versions_from_file
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # While we use separate images for different Postgres versions in rpm
         # based distros
@@ -97,7 +97,7 @@ jobs:
     needs: get_postgres_versions_from_file
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # On deb based distros, we use the same docker image for
         # builds based on different Postgres versions because deb

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Make
         run: |
           set -e
+          git config --global --add safe.directory ${{ github.workspace }}
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -63,19 +63,16 @@ jobs:
 
       - name: Configure
         run: |
-          set -e
           echo "Current Shell:$0"
           echo "GCC Version: $(gcc --version)"
           ./configure 2>&1 | tee output.log
 
       - name: Make clean
         run: |
-          set -e
           make clean
 
       - name: Make
         run: |
-          set -ex
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
@@ -90,7 +87,6 @@ jobs:
 
       - name: Make install
         run: |
-          set -e
           make CFLAGS="-Wno-missing-braces" install 2>&1 | tee -a output.log
 
       - name: Validate output
@@ -146,20 +142,17 @@ jobs:
 
       - name: Configure
         run: |
-          set -e
           echo "Current Shell:$0"
           echo "GCC Version: $(gcc --version)"
           ./configure 2>&1 | tee output.log
 
       - name: Make clean
         run: |
-          set -e
           make clean
 
       - name: Make
         shell: bash
         run: |
-          set -ex
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
@@ -175,7 +168,6 @@ jobs:
 
       - name: Make install
         run: |
-          set -e
           make install 2>&1 | tee -a output.log
 
       - name: Validate output

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Make
         run: |
           set -ex
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
           # Check the exit code of the make command

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     needs: get_postgres_versions_from_file
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # While we use separate images for different Postgres versions in rpm
         # based distros
@@ -63,20 +63,24 @@ jobs:
 
       - name: Configure
         run: |
+          set -e
           echo "Current Shell:$0"
           echo "GCC Version: $(gcc --version)"
           ./configure 2>&1 | tee output.log
 
       - name: Make clean
         run: |
+          set -e
           make clean
 
       - name: Make
         run: |
+          set -e
           make CFLAGS="-Wno-missing-braces" -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
       - name: Make install
         run: |
+          set -e
           make CFLAGS="-Wno-missing-braces" install 2>&1 | tee -a output.log
 
       - name: Validate output
@@ -97,7 +101,7 @@ jobs:
     needs: get_postgres_versions_from_file
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # On deb based distros, we use the same docker image for
         # builds based on different Postgres versions because deb

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -157,9 +157,10 @@ jobs:
           make clean
 
       - name: Make
+        shell: bash
         run: |
           set -ex
-          git config --global --add safe.directory /__w/citus/citus
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
           # Check the exit code of the make command

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -162,6 +162,16 @@ jobs:
           git config --global --add safe.directory /__w/citus/citus
           make -sj$(cat /proc/cpuinfo | grep "core id" | wc -l) 2>&1 | tee -a output.log
 
+          # Check the exit code of the make command
+          make_exit_code=${PIPESTATUS[0]}
+
+          # If the make command returned a non-zero exit code, exit with the same code
+          if [[ $make_exit_code -ne 0 ]]; then
+              echo "make command failed with exit code $make_exit_code"
+              exit $make_exit_code
+          fi
+
+
       - name: Make install
         run: |
           set -e


### PR DESCRIPTION
DESCRIPTION: PR description that will go into the change log, up to 78 characters

There are 4 errors arised recently and I fixed them in this PR. Problems and fixes are as below:
1. When executing make step in packaging pipeline, if it gets error, we can not detect it since there are additional operations after make in one line.
With this fix, now if an error occured after make execution, we can detect and see the step red and failed here,

2. Recently we started to get the error ` fatal: detected dubious ownership in repository at '/__w/citus/citus' ` as  below 
https://github.com/citusdata/citus/actions/runs/5542692968/jobs/10117706723#step:7:9
There is a fix for that one as well.

3. fixed the requirements issue arised related to urllib3 library version
4. Getting errors with centos-8 docker image with the new postgres-dev packages. Now, changed centos-8 image with almalinux-8 and now it works
