### PR TITLE
Fix format attribute and IsLocalReplicationOriginSessionActive errors

### DIFF
--- a/src/backend/distributed/utils/replication_origin_session_utils.c
+++ b/src/backend/distributed/utils/replication_origin_session_utils.c
@@ -20,8 +20,6 @@ static void SetupMemoryContextResetReplicationOriginHandler(void);
 
 static void SetupReplicationOriginSessionHelper(bool isContexResetSetupNeeded);
 
-static inline bool IsLocalReplicationOriginSessionActive(void);
-
 PG_FUNCTION_INFO_V1(citus_internal_start_replication_origin_tracking);
 PG_FUNCTION_INFO_V1(citus_internal_stop_replication_origin_tracking);
 PG_FUNCTION_INFO_V1(citus_internal_is_replication_origin_tracking_active);
@@ -68,6 +66,16 @@ citus_internal_stop_replication_origin_tracking(PG_FUNCTION_ARGS)
 }
 
 
+/* IsLocalReplicationOriginSessionActive checks if the current replication origin
+ * session is active in the local node.
+ */
+static inline bool
+IsLocalReplicationOriginSessionActive(void)
+{
+	return (replorigin_session_origin == DoNotReplicateId);
+}
+
+
 /* citus_internal_is_replication_origin_tracking_active checks if the current replication origin
  * session is active in the local node.
  */
@@ -76,16 +84,6 @@ citus_internal_is_replication_origin_tracking_active(PG_FUNCTION_ARGS)
 {
 	bool result = IsLocalReplicationOriginSessionActive();
 	PG_RETURN_BOOL(result);
-}
-
-
-/* IsLocalReplicationOriginSessionActive checks if the current replication origin
- * session is active in the local node.
- */
-inline bool
-IsLocalReplicationOriginSessionActive(void)
-{
-	return (replorigin_session_origin == DoNotReplicateId);
 }
 
 

--- a/src/include/distributed/citus_safe_lib.h
+++ b/src/include/distributed/citus_safe_lib.h
@@ -26,7 +26,7 @@ extern void SafeQsort(void *ptr, rsize_t count, rsize_t size,
 void * SafeBsearch(const void *key, const void *ptr, rsize_t count, rsize_t size,
 				   int (*comp)(const void *, const void *));
 int SafeSnprintf(char *str, rsize_t count, const char *fmt, ...) pg_attribute_printf(3,
-																					 0);
+																					 4);
 
 #define memset_struct_0(variable) memset(&variable, 0, sizeof(variable))
 


### PR DESCRIPTION
This PR fixes the following:

- in oraclelinux-7 `Make` step
```
/usr/bin/ld: utils/replication_origin_session_utils.o: relocation R_X86_64_PC32 against undefined symbol 
`IsLocalReplicationOriginSessionActive' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```
`IsLocalReplicationOriginSessionActive` function has improper inline declaration, fixed that
- in centos-7 `Make` step
```
utils/background_jobs.c: In function 'StartCitusBackgroundTaskExecutor':
utils/background_jobs.c:1746:6: warning: function might be possible candidate for 'gnu_printf' format attribute
[-Wsuggest-attribute=format]
      database, user, jobId, taskId);
      ^
```
should use `pg_attribute_printf(3,4)` instead of `pg_attribute_printf(3,0)` since the number of arguments varies for `SafeSnprintf(char *str, rsize_t count, const char *fmt, ...)`