### PR TITLE
Fix ScanKeyInit RegProcedure and Datum arguments

### DIFF
--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -707,9 +707,9 @@ ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe, TupleDesc tupleDescri
 	Relation columnarChunk = table_open(columnarChunkOid, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_columnar_chunk_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_chunk_stripe,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripe));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(stripe));
 
 	Oid indexId = ColumnarChunkIndexRelationId();
 	bool indexOk = OidIsValid(indexId);
@@ -915,7 +915,7 @@ StripeMetadataLookupRowNumber(Relation relation, uint64 rowNumber, Snapshot snap
 	uint64 storageId = ColumnarStorageGetStorageId(relation, false);
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 
 	StrategyNumber strategyNumber = InvalidStrategy;
 	RegProcedure procedure = InvalidOid;
@@ -930,7 +930,7 @@ StripeMetadataLookupRowNumber(Relation relation, uint64 rowNumber, Snapshot snap
 		procedure = F_INT8GT;
 	}
 	ScanKeyInit(&scanKey[1], Anum_columnar_stripe_first_row_number,
-				strategyNumber, procedure, UInt64GetDatum(rowNumber));
+				strategyNumber, procedure, Int64GetDatum(rowNumber));
 
 	Relation columnarStripes = table_open(ColumnarStripeRelationId(), AccessShareLock);
 
@@ -1081,7 +1081,7 @@ FindStripeWithHighestRowNumber(Relation relation, Snapshot snapshot)
 	uint64 storageId = ColumnarStorageGetStorageId(relation, false);
 	ScanKeyData scanKey[1];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 
 	Relation columnarStripes = table_open(ColumnarStripeRelationId(), AccessShareLock);
 
@@ -1143,9 +1143,9 @@ ReadChunkGroupRowCounts(uint64 storageId, uint64 stripe, uint32 chunkGroupCount,
 
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_chunkgroup_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_chunkgroup_stripe,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripe));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(stripe));
 
 	Oid indexId = ColumnarChunkGroupIndexRelationId();
 	bool indexOk = OidIsValid(indexId);
@@ -1372,9 +1372,9 @@ UpdateStripeMetadataRow(uint64 storageId, uint64 stripeId, bool *update,
 
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_stripe_stripe,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripeId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(stripeId));
 
 	Oid columnarStripesOid = ColumnarStripeRelationId();
 
@@ -1451,7 +1451,7 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 	HeapTuple heapTuple;
 
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(storageId));
 
 	Oid columnarStripesOid = ColumnarStripeRelationId();
 
@@ -1578,7 +1578,7 @@ DeleteStorageFromColumnarMetadataTable(Oid metadataTableId,
 {
 	ScanKeyData scanKey[1];
 	ScanKeyInit(&scanKey[0], storageIdAtrrNumber, BTEqualStrategyNumber,
-				F_INT8EQ, UInt64GetDatum(storageId));
+				F_INT8EQ, Int64GetDatum(storageId));
 
 	Relation metadataTable = try_relation_open(metadataTableId, AccessShareLock);
 	if (metadataTable == NULL)

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -707,9 +707,9 @@ ReadStripeSkipList(RelFileNode relfilenode, uint64 stripe, TupleDesc tupleDescri
 	Relation columnarChunk = table_open(columnarChunkOid, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_columnar_chunk_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_chunk_stripe,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(stripe));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripe));
 
 	Oid indexId = ColumnarChunkIndexRelationId();
 	bool indexOk = OidIsValid(indexId);
@@ -915,7 +915,7 @@ StripeMetadataLookupRowNumber(Relation relation, uint64 rowNumber, Snapshot snap
 	uint64 storageId = ColumnarStorageGetStorageId(relation, false);
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 
 	StrategyNumber strategyNumber = InvalidStrategy;
 	RegProcedure procedure = InvalidOid;
@@ -1081,7 +1081,7 @@ FindStripeWithHighestRowNumber(Relation relation, Snapshot snapshot)
 	uint64 storageId = ColumnarStorageGetStorageId(relation, false);
 	ScanKeyData scanKey[1];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 
 	Relation columnarStripes = table_open(ColumnarStripeRelationId(), AccessShareLock);
 
@@ -1143,9 +1143,9 @@ ReadChunkGroupRowCounts(uint64 storageId, uint64 stripe, uint32 chunkGroupCount,
 
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_chunkgroup_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, UInt64GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_chunkgroup_stripe,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(stripe));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripe));
 
 	Oid indexId = ColumnarChunkGroupIndexRelationId();
 	bool indexOk = OidIsValid(indexId);
@@ -1372,9 +1372,9 @@ UpdateStripeMetadataRow(uint64 storageId, uint64 stripeId, bool *update,
 
 	ScanKeyData scanKey[2];
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 	ScanKeyInit(&scanKey[1], Anum_columnar_stripe_stripe,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(stripeId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(stripeId));
 
 	Oid columnarStripesOid = ColumnarStripeRelationId();
 
@@ -1451,7 +1451,7 @@ ReadDataFileStripeList(uint64 storageId, Snapshot snapshot)
 	HeapTuple heapTuple;
 
 	ScanKeyInit(&scanKey[0], Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(storageId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(storageId));
 
 	Oid columnarStripesOid = ColumnarStripeRelationId();
 

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -892,7 +892,7 @@ GetConstraintNameList(Oid relationId)
 	Relation pgConstraint = table_open(ConstraintRelationId, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid,
-				BTEqualStrategyNumber, F_OIDEQ, relationId);
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(relationId));
 
 	bool useIndex = true;
 	SysScanDesc scanDescriptor = systable_beginscan(pgConstraint,

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -1227,7 +1227,7 @@ GetForeignKeyOids(Oid relationId, int flags)
 
 	Relation pgConstraint = table_open(ConstraintRelationId, AccessShareLock);
 	ScanKeyInit(&scanKey[0], pgConstraintTargetAttrNumber,
-				BTEqualStrategyNumber, F_OIDEQ, relationId);
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(relationId));
 	SysScanDesc scanDescriptor = systable_beginscan(pgConstraint, indexOid, useIndex,
 													NULL, scanKeyCount, scanKey);
 

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -780,7 +780,7 @@ UpdateFunctionDistributionInfo(const ObjectAddress *distAddress,
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_object_objid, BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(distAddress->objectId));
 	ScanKeyInit(&scanKey[2], Anum_pg_dist_object_objsubid, BTEqualStrategyNumber,
-				F_INT4EQ, ObjectIdGetDatum(distAddress->objectSubId));
+				F_INT4EQ, Int32GetDatum(distAddress->objectSubId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistObjectRel,
 													DistObjectPrimaryKeyIndexId(),

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -369,7 +369,7 @@ SchemaHasDistributedTableWithFKey(char *schemaName)
 	Relation pgClass = table_open(RelationRelationId, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_class_relnamespace, BTEqualStrategyNumber,
-				F_OIDEQ, namespaceOid);
+				F_OIDEQ, ObjectIdGetDatum(namespaceOid));
 	SysScanDesc scanDescriptor = systable_beginscan(pgClass, scanIndexId, useIndex, NULL,
 													scanKeyCount, scanKey);
 

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -249,7 +249,7 @@ GetExplicitTriggerIdList(Oid relationId)
 	ScanKeyData scanKey[1];
 
 	ScanKeyInit(&scanKey[0], Anum_pg_trigger_tgrelid,
-				BTEqualStrategyNumber, F_OIDEQ, relationId);
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(relationId));
 
 	bool useIndex = true;
 	SysScanDesc scanDescriptor = systable_beginscan(pgTrigger, TriggerRelidNameIndexId,

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -1200,7 +1200,7 @@ FirstExtensionWithSchema(Oid schemaId)
 
 	ScanKeyData entry[1];
 	ScanKeyInit(&entry[0], Anum_pg_extension_extnamespace, BTEqualStrategyNumber,
-				F_INT4EQ, schemaId);
+				F_OIDEQ, ObjectIdGetDatum(schemaId));
 
 	SysScanDesc scan = systable_beginscan(relation, InvalidOid, false, NULL, 1, entry);
 	HeapTuple extensionTuple = systable_getnext(scan);

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -510,7 +510,7 @@ UpdateDistributedObjectColocationId(uint32 oldColocationId,
 	/* scan pg_dist_object for colocationId equal to old colocationId */
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_object_colocationid,
 				BTEqualStrategyNumber,
-				F_INT4EQ, UInt32GetDatum(oldColocationId));
+				F_INT4EQ, Int32GetDatum(oldColocationId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistObjectRel,
 													InvalidOid,

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -5610,8 +5610,8 @@ GetPoolinfoViaCatalog(int64 nodeId)
 	char *poolinfo = NULL;
 
 	/* set scan arguments */
-	ScanKeyInit(&scanKey[0], nodeIdIdx, BTEqualStrategyNumber, F_INT4EQ,
-				Int32GetDatum(nodeId));
+	ScanKeyInit(&scanKey[0], nodeIdIdx, BTEqualStrategyNumber, F_INT8EQ,
+				Int64GetDatum(nodeId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPoolinfo, DistPoolinfoIndexId(),
 													indexOK,

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -5600,7 +5600,7 @@ role_exists(PG_FUNCTION_ARGS)
  * Otherwise, this function returns NULL.
  */
 char *
-GetPoolinfoViaCatalog(int64 nodeId)
+GetPoolinfoViaCatalog(int32 nodeId)
 {
 	ScanKeyData scanKey[1];
 	const int scanKeyCount = 1;
@@ -5610,8 +5610,8 @@ GetPoolinfoViaCatalog(int64 nodeId)
 	char *poolinfo = NULL;
 
 	/* set scan arguments */
-	ScanKeyInit(&scanKey[0], nodeIdIdx, BTEqualStrategyNumber, F_INT8EQ,
-				Int64GetDatum(nodeId));
+	ScanKeyInit(&scanKey[0], nodeIdIdx, BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(nodeId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPoolinfo, DistPoolinfoIndexId(),
 													indexOK,

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -1757,8 +1757,8 @@ GetFunctionDependenciesForObjects(ObjectAddress *objectAddress)
 				ObjectIdGetDatum(objectAddress->objectId));
 	ScanKeyInit(&key[2],
 				Anum_pg_depend_objsubid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(objectAddress->objectSubId));
+				BTEqualStrategyNumber, F_INT4EQ,
+				Int32GetDatum(objectAddress->objectSubId));
 
 	SysScanDesc scan = systable_beginscan(depRel, DependDependerIndexId, true,
 										  NULL, 3, key);

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1968,7 +1968,7 @@ DeleteShardRow(uint64 shardId)
 	Relation pgDistShard = table_open(DistShardRelationId(), RowExclusiveLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_shard_shardid,
-				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(shardId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(shardId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistShard,
 													DistShardShardidIndexId(), indexOK,
@@ -2012,7 +2012,7 @@ DeleteShardPlacementRow(uint64 placementId)
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPlacement);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_placement_placementid,
-				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(placementId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(placementId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPlacement,
 													DistPlacementPlacementidIndexId(),
@@ -2062,7 +2062,7 @@ UpdatePlacementGroupId(uint64 placementId, int groupId)
 	Relation pgDistPlacement = table_open(DistPlacementRelationId(), RowExclusiveLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPlacement);
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_placement_placementid,
-				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(placementId));
+				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(placementId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPlacement,
 													DistPlacementPlacementidIndexId(),
@@ -3286,11 +3286,11 @@ BackgroundTaskHasUmnetDependencies(int64 jobId, int64 taskId)
 
 	/* pg_catalog.pg_dist_background_task_depend.job_id = jobId */
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_background_task_depend_job_id,
-				BTEqualStrategyNumber, F_INT8EQ, jobId);
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(jobId));
 
 	/* pg_catalog.pg_dist_background_task_depend.task_id = $taskId */
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_background_task_depend_task_id,
-				BTEqualStrategyNumber, F_INT8EQ, taskId);
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(taskId));
 
 	SysScanDesc scanDescriptor =
 		systable_beginscan(pgDistBackgroundTasksDepend,

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1968,7 +1968,7 @@ DeleteShardRow(uint64 shardId)
 	Relation pgDistShard = table_open(DistShardRelationId(), RowExclusiveLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_shard_shardid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(shardId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(shardId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistShard,
 													DistShardShardidIndexId(), indexOK,
@@ -2012,7 +2012,7 @@ DeleteShardPlacementRow(uint64 placementId)
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPlacement);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_placement_placementid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(placementId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(placementId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPlacement,
 													DistPlacementPlacementidIndexId(),
@@ -2062,7 +2062,7 @@ UpdatePlacementGroupId(uint64 placementId, int groupId)
 	Relation pgDistPlacement = table_open(DistPlacementRelationId(), RowExclusiveLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPlacement);
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_placement_placementid,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(placementId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(placementId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistPlacement,
 													DistPlacementPlacementidIndexId(),

--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1005,7 +1005,7 @@ ListCleanupRecordsForCurrentOperation(void)
 
 	ScanKeyData scanKey[1];
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_operation_id, BTEqualStrategyNumber,
-				F_INT8EQ, UInt64GetDatum(CurrentOperationId));
+				F_INT8EQ, Int64GetDatum(CurrentOperationId));
 
 	int scanKeyCount = 1;
 	Oid scanIndexId = InvalidOid;
@@ -1119,7 +1119,7 @@ CleanupRecordExists(uint64 recordId)
 	bool indexOK = true;
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(recordId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
@@ -1152,7 +1152,7 @@ DeleteCleanupRecordByRecordId(uint64 recordId)
 	bool indexOK = true;
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
-				BTEqualStrategyNumber, F_INT8EQ, UInt64GetDatum(recordId));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -532,7 +532,7 @@ ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType, 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_colocation_distributioncolumntype,
 				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(distributionColumnType));
 	ScanKeyInit(&scanKey[1], Anum_pg_dist_colocation_shardcount,
-				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(shardCount));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(shardCount));
 	ScanKeyInit(&scanKey[2], Anum_pg_dist_colocation_replicationfactor,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(replicationFactor));
 	ScanKeyInit(&scanKey[3], Anum_pg_dist_colocation_distributioncolumncollation,
@@ -1183,7 +1183,7 @@ ColocatedTableId(Oid colocationId)
 	}
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_partition_colocationid,
-				BTEqualStrategyNumber, F_INT4EQ, ObjectIdGetDatum(colocationId));
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(colocationId));
 
 	Relation pgDistPartition = table_open(DistPartitionRelationId(), AccessShareLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPartition);

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -989,7 +989,7 @@ ColocationGroupTableList(uint32 colocationId, uint32 count)
 	}
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_partition_colocationid,
-				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(colocationId));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(colocationId));
 
 	Relation pgDistPartition = table_open(DistPartitionRelationId(), AccessShareLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPartition);
@@ -1166,7 +1166,7 @@ ColocatedNonPartitionShardIntervalList(ShardInterval *shardInterval)
  * guarantee that the table isn't dropped for the remainder of the transaction.
  */
 Oid
-ColocatedTableId(Oid colocationId)
+ColocatedTableId(int32 colocationId)
 {
 	Oid colocatedTableId = InvalidOid;
 	bool indexOK = true;
@@ -1183,7 +1183,7 @@ ColocatedTableId(Oid colocationId)
 	}
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_partition_colocationid,
-				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(colocationId));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(colocationId));
 
 	Relation pgDistPartition = table_open(DistPartitionRelationId(), AccessShareLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(pgDistPartition);
@@ -1292,7 +1292,7 @@ DeleteColocationGroupLocally(uint32 colocationId)
 	Relation pgDistColocation = table_open(DistColocationRelationId(), RowExclusiveLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_colocation_colocationid,
-				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(colocationId));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(colocationId));
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistColocation, InvalidOid, indexOK,
 													NULL, scanKeyCount, scanKey);

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -411,9 +411,9 @@ CheckConstraintNameListForRelation(Oid relationId)
 	Relation pgConstraint = table_open(ConstraintRelationId, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_constraint_conrelid,
-				BTEqualStrategyNumber, F_OIDEQ, relationId);
+				BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(relationId));
 	ScanKeyInit(&scanKey[1], Anum_pg_constraint_contype,
-				BTEqualStrategyNumber, F_CHAREQ, CONSTRAINT_CHECK);
+				BTEqualStrategyNumber, F_CHAREQ, CharGetDatum(CONSTRAINT_CHECK));
 
 	bool useIndex = false;
 	SysScanDesc scanDescriptor = systable_beginscan(pgConstraint, InvalidOid, useIndex,

--- a/src/backend/distributed/utils/tenant_schema_metadata.c
+++ b/src/backend/distributed/utils/tenant_schema_metadata.c
@@ -134,7 +134,7 @@ ColocationIdGetTenantSchemaId(uint32 colocationId)
 											 AccessShareLock);
 	ScanKeyData scanKey[1];
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_schema_colocationid,
-				BTEqualStrategyNumber, F_INT4EQ, UInt32GetDatum(colocationId));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(colocationId));
 
 	bool indexOk = true;
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistTenantSchema,

--- a/src/include/distributed/colocation_utils.h
+++ b/src/include/distributed/colocation_utils.h
@@ -24,7 +24,7 @@ extern bool ShardsColocated(ShardInterval *leftShardInterval,
 extern List * ColocatedTableList(Oid distributedTableId);
 extern List * ColocatedShardIntervalList(ShardInterval *shardInterval);
 extern List * ColocatedNonPartitionShardIntervalList(ShardInterval *shardInterval);
-extern Oid ColocatedTableId(Oid colocationId);
+extern Oid ColocatedTableId(int32 colocationId);
 extern uint64 ColocatedShardIdInRelation(Oid relationId, int shardIndex);
 uint32 ColocationId(int shardCount, int replicationFactor, Oid distributionColumnType,
 					Oid distributionColumnCollation);

--- a/src/include/distributed/metadata_cache.h
+++ b/src/include/distributed/metadata_cache.h
@@ -320,6 +320,6 @@ extern const char * CurrentDatabaseName(void);
 
 /* connection-related functions */
 extern char * GetAuthinfoViaCatalog(const char *roleName, int64 nodeId);
-extern char * GetPoolinfoViaCatalog(int64 nodeId);
+extern char * GetPoolinfoViaCatalog(int32 nodeId);
 
 #endif /* METADATA_CACHE_H */


### PR DESCRIPTION
Index scans in PG16 return empty sets because of extra compatibility enforcement for `ScanKeyInit` arguments.
Could be one of the relevant PG commits: https://github.com/postgres/postgres/commit/c8b2ef05f481ef06326d7b9f3eb14b303f215c7e
This PR fixes all incompatible `RegProcedure` and `Datum` arguments in all `ScanKeyInit` functions used throughout the codebase.
Helpful for #6952 
