### PR TITLE
fix flappyness of shard_rebalancer operations test

### DIFF
--- a/src/test/regress/expected/shard_rebalancer.out
+++ b/src/test/regress/expected/shard_rebalancer.out
@@ -2581,7 +2581,7 @@ SELECT create_distributed_table('test_with_all_shards_excluded', 'a', colocate_w
 
 (1 row)
 
-SELECT shardid FROM pg_dist_shard;
+SELECT shardid FROM pg_dist_shard ORDER BY shardid ASC;
  shardid
 ---------------------------------------------------------------------
   433504

--- a/src/test/regress/sql/shard_rebalancer.sql
+++ b/src/test/regress/sql/shard_rebalancer.sql
@@ -1445,7 +1445,7 @@ DROP TABLE IF EXISTS test_with_all_shards_excluded;
 CREATE TABLE test_with_all_shards_excluded(a int PRIMARY KEY);
 SELECT create_distributed_table('test_with_all_shards_excluded', 'a', colocate_with:='none', shard_count:=4);
 
-SELECT shardid FROM pg_dist_shard;
+SELECT shardid FROM pg_dist_shard ORDER BY shardid ASC;
 
 SELECT rebalance_table_shards('test_with_all_shards_excluded', excluded_shard_list:='{102073, 102074, 102075, 102076}');
 


### PR DESCRIPTION
Fixes flappyness where the order of shards was dependent on the physical layout in the heap. Failed here https://app.circleci.com/pipelines/github/citusdata/citus/33844/workflows/1651f8f5-6e6a-457e-9d35-34b8788ea6d1/jobs/1189836


```diff
--- /home/circleci/project/src/test/regress/expected/shard_rebalancer.out.modified	2023-07-24 12:51:27.126284675 +0000
+++ /home/circleci/project/src/test/regress/results/shard_rebalancer.out.modified	2023-07-24 12:51:27.170285079 +0000
@@ -2571,24 +2571,24 @@
 CREATE TABLE test_with_all_shards_excluded(a int PRIMARY KEY);
 SELECT create_distributed_table('test_with_all_shards_excluded', 'a', colocate_with:='none', shard_count:=4);
  create_distributed_table 
 --------------------------
  
 (1 row)
 
 SELECT shardid FROM pg_dist_shard;
  shardid 
 ---------
-  433504
   433505
   433506
   433507
+  433504
 (4 rows)
 
 SELECT rebalance_table_shards('test_with_all_shards_excluded', excluded_shard_list:='{102073, 102074, 102075, 102076}');
  rebalance_table_shards 
 ------------------------
  
 (1 row)
 
 DROP TABLE test_with_all_shards_excluded;
 SET citus.shard_count TO 2;
```