### PR TITLE
Makes sure to handle NULL constraints for ADD COLUMN commands

### DIFF
--- a/src/backend/distributed/deparser/deparse_table_stmts.c
+++ b/src/backend/distributed/deparser/deparse_table_stmts.c
@@ -627,6 +627,10 @@ AppendAlterTableCmdAddColumn(StringInfo buf, AlterTableCmd *alterTableCmd,
 		{
 			appendStringInfoString(buf, " NOT NULL");
 		}
+		else if (constraint->contype == CONSTR_NULL)
+		{
+			appendStringInfoString(buf, " NULL");
+		}
 		else if (constraint->contype == CONSTR_DEFAULT)
 		{
 			char attgenerated = '\0';

--- a/src/test/regress/expected/alter_table_add_column.out
+++ b/src/test/regress/expected/alter_table_add_column.out
@@ -35,7 +35,7 @@ ALTER TABLE referencing ADD COLUMN test_1 integer DEFAULT (alter_table_add_colum
 ALTER TABLE referencing ADD COLUMN test_2 integer UNIQUE REFERENCES referenced(int_col) ON UPDATE CASCADE ON DELETE SET DEFAULT NOT DEFERRABLE INITIALLY IMMEDIATE;
 ALTER TABLE referencing ADD COLUMN test_3 integer GENERATED ALWAYS AS (test_1 * alter_table_add_column_other_schema.my_random(1)) STORED UNIQUE REFERENCES referenced(int_col) MATCH FULL;
 ALTER TABLE referencing ADD COLUMN test_4 integer PRIMARY KEY WITH (fillfactor=70) NOT NULL REFERENCES referenced(int_col) MATCH SIMPLE ON UPDATE CASCADE ON DELETE SET DEFAULT;
-ALTER TABLE referencing ADD COLUMN test_5 integer CONSTRAINT unique_c UNIQUE WITH (fillfactor=50);
+ALTER TABLE referencing ADD COLUMN test_5 integer CONSTRAINT unique_c UNIQUE WITH (fillfactor=50) NULL;
 ALTER TABLE referencing ADD COLUMN test_6 text COMPRESSION pglz COLLATE caseinsensitive NOT NULL;
 ALTER TABLE referencing ADD COLUMN "test_\'!7" "simple_!\'custom_type";
 -- we give up deparsing ALTER TABLE command if it needs to create a check constraint, and we fallback to legacy behavior

--- a/src/test/regress/sql/alter_table_add_column.sql
+++ b/src/test/regress/sql/alter_table_add_column.sql
@@ -33,7 +33,7 @@ ALTER TABLE referencing ADD COLUMN test_1 integer DEFAULT (alter_table_add_colum
 ALTER TABLE referencing ADD COLUMN test_2 integer UNIQUE REFERENCES referenced(int_col) ON UPDATE CASCADE ON DELETE SET DEFAULT NOT DEFERRABLE INITIALLY IMMEDIATE;
 ALTER TABLE referencing ADD COLUMN test_3 integer GENERATED ALWAYS AS (test_1 * alter_table_add_column_other_schema.my_random(1)) STORED UNIQUE REFERENCES referenced(int_col) MATCH FULL;
 ALTER TABLE referencing ADD COLUMN test_4 integer PRIMARY KEY WITH (fillfactor=70) NOT NULL REFERENCES referenced(int_col) MATCH SIMPLE ON UPDATE CASCADE ON DELETE SET DEFAULT;
-ALTER TABLE referencing ADD COLUMN test_5 integer CONSTRAINT unique_c UNIQUE WITH (fillfactor=50);
+ALTER TABLE referencing ADD COLUMN test_5 integer CONSTRAINT unique_c UNIQUE WITH (fillfactor=50) NULL;
 ALTER TABLE referencing ADD COLUMN test_6 text COMPRESSION pglz COLLATE caseinsensitive NOT NULL;
 ALTER TABLE referencing ADD COLUMN "test_\'!7" "simple_!\'custom_type";
 


### PR DESCRIPTION
DESCRIPTION: Fixes a bug that causes an unexpected error when adding a column with a NULL constraint

Fixes https://github.com/citusdata/citus/issues/7092.