### PR TITLE
PG16 compatibility - Rework PlannedStmt and Query's Permission Info

### DIFF
--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -358,6 +358,11 @@ ConvertRteToSubqueryWithEmptyResult(RangeTblEntry *rte)
 	subquery->jointree = joinTree;
 
 	rte->rtekind = RTE_SUBQUERY;
+#if PG_VERSION_NUM >= PG_VERSION_16
+
+	/* no permission checking for this RTE */
+	rte->perminfoindex = 0;
+#endif
 	rte->subquery = subquery;
 	rte->alias = copyObject(rte->eref);
 }

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1490,9 +1490,10 @@ FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 	/*
 	 * Original range table list is concatenated to final plan's range table list
 	 * therefore all the perminfoindexes should be updated to their value
-	 * PLUS the length of final plan's perminfos.
+	 * PLUS the highest perminfoindex in finalPlan's perminfos, which is exactly
+	 * the list length.
 	 */
-	int list_length_final_permInfos = list_length(finalPlan->permInfos);
+	int finalPlan_highest_perminfoindex = list_length(finalPlan->permInfos);
 
 	ListCell *lc;
 	foreach(lc, localPlan->rtable)
@@ -1500,7 +1501,7 @@ FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 		if (rte->perminfoindex != 0)
 		{
-			rte->perminfoindex = rte->perminfoindex + list_length_final_permInfos;
+			rte->perminfoindex = rte->perminfoindex + finalPlan_highest_perminfoindex;
 		}
 	}
 

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -56,6 +56,9 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/pg_list.h"
+#if PG_VERSION_NUM >= PG_VERSION_16
+#include "parser/parse_relation.h"
+#endif
 #include "parser/parsetree.h"
 #include "parser/parse_type.h"
 #include "optimizer/optimizer.h"
@@ -1482,6 +1485,29 @@ FinalizeNonRouterPlan(PlannedStmt *localPlan, DistributedPlan *distributedPlan,
 	/* add original range table list for access permission checks */
 	finalPlan->rtable = list_concat(finalPlan->rtable, localPlan->rtable);
 
+#if PG_VERSION_NUM >= PG_VERSION_16
+
+	/*
+	 * Original range table list is concatenated to final plan's range table list
+	 * therefore all the perminfoindexes should be updated to their value
+	 * PLUS the length of final plan's perminfos.
+	 */
+	int list_length_final_permInfos = list_length(finalPlan->permInfos);
+
+	ListCell *lc;
+	foreach(lc, localPlan->rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+		if (rte->perminfoindex != 0)
+		{
+			rte->perminfoindex = rte->perminfoindex + list_length_final_permInfos;
+		}
+	}
+
+	/* finally, concatenate perminfos as well */
+	finalPlan->permInfos = list_concat(finalPlan->permInfos, localPlan->permInfos);
+#endif
+
 	return finalPlan;
 }
 
@@ -1518,6 +1544,16 @@ FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 
 	/* add original range table list for access permission checks */
 	routerPlan->rtable = list_concat(routerPlan->rtable, localPlan->rtable);
+
+#if PG_VERSION_NUM >= PG_VERSION_16
+
+	/*
+	 * We know that extra remoteScanRangeTableEntry has perminfoindex 0
+	 * therefore we can simply use the perminfos we had in localplan
+	 */
+	Assert(remoteScanRangeTableEntry->perminfoindex == 0);
+	routerPlan->permInfos = localPlan->permInfos;
+#endif
 
 	routerPlan->canSetTag = true;
 	routerPlan->relationOids = NIL;

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1084,6 +1084,11 @@ CreateDistributedPlan(uint64 planId, bool allowRecursivePlanning, Query *origina
 	/*
 	 * Plan subqueries and CTEs that cannot be pushed down by recursively
 	 * calling the planner and return the resulting plans to subPlanList.
+	 * Note that GenerateSubplansForSubqueriesAndCTEs will reset perminfoindexes
+	 * for some RTEs in originalQuery->rtable list, while not changing
+	 * originalQuery->rteperminfos. That's fine because we will go through
+	 * standard planner again, which will adjust things accordingly in
+	 * add_rte_to_flat_rtable.
 	 */
 	List *subPlanList = GenerateSubplansForSubqueriesAndCTEs(planId, originalQuery,
 															 plannerRestrictionContext);

--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -136,6 +136,9 @@ GeneratePlaceHolderPlannedStmt(Query *parse)
 	result->stmt_len = parse->stmt_len;
 
 	result->rtable = copyObject(parse->rtable);
+#if PG_VERSION_NUM >= PG_VERSION_16
+	result->permInfos = copyObject(parse->rteperminfos);
+#endif
 	result->planTree = (Plan *) plan;
 	result->hasReturning = (parse->returningList != NIL);
 

--- a/src/backend/distributed/planner/merge_planner.c
+++ b/src/backend/distributed/planner/merge_planner.c
@@ -835,13 +835,13 @@ ConvertRelationRTEIntoSubquery(Query *mergeQuery, RangeTblEntry *sourceRte,
 
 #if PG_VERSION_NUM >= PG_VERSION_16
 	sourceResultsQuery->rteperminfos = NIL;
-	if (newRangeTableEntry->perminfoindex)
+	if (sourceRte->perminfoindex)
 	{
 		/* create permission info for newRangeTableEntry */
 		RTEPermissionInfo *perminfo = getRTEPermissionInfo(mergeQuery->rteperminfos,
-														   newRangeTableEntry);
+														   sourceRte);
 
-		/* update the subquery's rteperminfos accordingly */
+		/* update the sourceResultsQuery's rteperminfos accordingly */
 		newRangeTableEntry->perminfoindex = 1;
 		sourceResultsQuery->rteperminfos = list_make1(perminfo);
 	}
@@ -874,12 +874,6 @@ ConvertRelationRTEIntoSubquery(Query *mergeQuery, RangeTblEntry *sourceRte,
 	sourceRte->rtekind = RTE_SUBQUERY;
 #if PG_VERSION_NUM >= PG_VERSION_16
 	sourceRte->perminfoindex = 0;
-
-	/*
-	 * Note: we don't need to remove replaced sourceRte from mergeQuery->rteperminfos to avoid
-	 * crash of Assert(bms_num_members(indexset) == list_length(rteperminfos));
-	 * because mergeQuery->rteperminfos has already gone through ExecCheckPermissions
-	 */
 #endif
 	sourceRte->subquery = sourceResultsQuery;
 	sourceRte->inh = false;

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -91,7 +91,7 @@ CreateColocatedJoinChecker(Query *subquery, PlannerRestrictionContext *restricti
 		}
 		anchorSubquery = WrapRteRelationIntoSubquery(anchorRangeTblEntry, NIL, perminfo);
 #else
-		anchorSubquery = WrapRteRelationIntoSubquery(anchorRangeTblEntry, NIL);
+		anchorSubquery = WrapRteRelationIntoSubquery(anchorRangeTblEntry, NIL, NULL);
 #endif
 	}
 	else if (anchorRangeTblEntry->rtekind == RTE_SUBQUERY)
@@ -276,12 +276,8 @@ SubqueryColocated(Query *subquery, ColocatedJoinChecker *checker)
  */
 Query *
 WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation,
-#if PG_VERSION_NUM >= PG_VERSION_16
 							List *requiredAttributes,
 							RTEPermissionInfo *perminfo)
-#else
-							List * requiredAttributes)
-#endif
 {
 	Query *subquery = makeNode(Query);
 	RangeTblRef *newRangeTableRef = makeNode(RangeTblRef);

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1915,6 +1915,9 @@ SubqueryPushdownMultiNodeTree(Query *originalQuery)
 	pushedDownQuery->targetList = subqueryTargetEntryList;
 	pushedDownQuery->jointree = copyObject(queryTree->jointree);
 	pushedDownQuery->rtable = copyObject(queryTree->rtable);
+#if PG_VERSION_NUM >= PG_VERSION_16
+	pushedDownQuery->rteperminfos = copyObject(queryTree->rteperminfos);
+#endif
 	pushedDownQuery->setOperations = copyObject(queryTree->setOperations);
 	pushedDownQuery->querySource = queryTree->querySource;
 	pushedDownQuery->hasSubLinks = queryTree->hasSubLinks;

--- a/src/backend/distributed/utils/relation_utils.c
+++ b/src/backend/distributed/utils/relation_utils.c
@@ -45,9 +45,6 @@ RelationGetNamespaceName(Relation relation)
  * we are dealing with GetUserId().
  * Currently the following entries are filled like this:
  *      perminfo->checkAsUser = GetUserId();
- *		perminfo->selectedCols = NULL;
- *		perminfo->insertedCols = NULL;
- *		perminfo->updatedCols = NULL;
  */
 RTEPermissionInfo *
 GetFilledPermissionInfo(Oid relid, bool inh, AclMode requiredPerms)
@@ -57,9 +54,6 @@ GetFilledPermissionInfo(Oid relid, bool inh, AclMode requiredPerms)
 	perminfo->inh = inh;
 	perminfo->requiredPerms = requiredPerms;
 	perminfo->checkAsUser = GetUserId();
-	perminfo->selectedCols = NULL;
-	perminfo->insertedCols = NULL;
-	perminfo->updatedCols = NULL;
 	return perminfo;
 }
 

--- a/src/include/distributed/query_colocation_checker.h
+++ b/src/include/distributed/query_colocation_checker.h
@@ -35,12 +35,8 @@ extern ColocatedJoinChecker CreateColocatedJoinChecker(Query *subquery,
 													   restrictionContext);
 extern bool SubqueryColocated(Query *subquery, ColocatedJoinChecker *context);
 extern Query * WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation,
-#if PG_VERSION_NUM >= PG_VERSION_16
 										   List *requiredAttributes,
 										   RTEPermissionInfo *perminfo);
-#else
-										   List *requiredAttributes);
-#endif
 extern List * CreateAllTargetListForRelation(Oid relationId, List *requiredAttributes);
 
 #endif /* QUERY_COLOCATION_CHECKER_H */

--- a/src/include/distributed/query_colocation_checker.h
+++ b/src/include/distributed/query_colocation_checker.h
@@ -35,7 +35,12 @@ extern ColocatedJoinChecker CreateColocatedJoinChecker(Query *subquery,
 													   restrictionContext);
 extern bool SubqueryColocated(Query *subquery, ColocatedJoinChecker *context);
 extern Query * WrapRteRelationIntoSubquery(RangeTblEntry *rteRelation,
+#if PG_VERSION_NUM >= PG_VERSION_16
+										   List *requiredAttributes,
+										   RTEPermissionInfo *perminfo);
+#else
 										   List *requiredAttributes);
+#endif
 extern List * CreateAllTargetListForRelation(Oid relationId, List *requiredAttributes);
 
 #endif /* QUERY_COLOCATION_CHECKER_H */

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -42,12 +42,8 @@ extern bool GeneratingSubplans(void);
 extern bool ContainsLocalTableDistributedTableJoin(List *rangeTableList);
 extern void ReplaceRTERelationWithRteSubquery(RangeTblEntry *rangeTableEntry,
 											  List *requiredAttrNumbers,
-#if PG_VERSION_NUM >= PG_VERSION_16
 											  RecursivePlanningContext *context,
 											  RTEPermissionInfo *perminfo);
-#else
-											  RecursivePlanningContext *context);
-#endif
 extern bool IsRecursivelyPlannableRelation(RangeTblEntry *rangeTableEntry);
 extern bool IsRelationLocalTableOrMatView(Oid relationId);
 extern bool ContainsReferencesToOuterQuery(Query *query);

--- a/src/include/distributed/recursive_planning.h
+++ b/src/include/distributed/recursive_planning.h
@@ -42,7 +42,12 @@ extern bool GeneratingSubplans(void);
 extern bool ContainsLocalTableDistributedTableJoin(List *rangeTableList);
 extern void ReplaceRTERelationWithRteSubquery(RangeTblEntry *rangeTableEntry,
 											  List *requiredAttrNumbers,
+#if PG_VERSION_NUM >= PG_VERSION_16
+											  RecursivePlanningContext *context,
+											  RTEPermissionInfo *perminfo);
+#else
 											  RecursivePlanningContext *context);
+#endif
 extern bool IsRecursivelyPlannableRelation(RangeTblEntry *rangeTableEntry);
 extern bool IsRelationLocalTableOrMatView(Oid relationId);
 extern bool ContainsReferencesToOuterQuery(Query *query);

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -144,6 +144,9 @@ object_aclcheck(Oid classid, Oid objectid, Oid roleid, AclMode mode)
 
 typedef bool TU_UpdateIndexes;
 
+/* dummy definition - variable never used but always passed as NULL/NIL */
+typedef RangeTblEntry RTEPermissionInfo;
+
 #endif
 
 #if PG_VERSION_NUM >= PG_VERSION_15

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -144,7 +144,11 @@ object_aclcheck(Oid classid, Oid objectid, Oid roleid, AclMode mode)
 
 typedef bool TU_UpdateIndexes;
 
-/* dummy definition - variable never used but always passed as NULL/NIL */
+/*
+ * we define RTEPermissionInfo for PG16 compatibility
+ * There are some functions that need to include RTEPermissionInfo in their signature
+ * for PG14/PG15 we pass a NULL argument in these functions
+ */
 typedef RangeTblEntry RTEPermissionInfo;
 
 #endif


### PR DESCRIPTION
The main issue lies in the following entries of PlannedStmt: {
   rtable
   permInfos
}

Each rtable has an int perminfoindex, and its actual permission info is obtained through the following:
permInfos[perminfoindex]

We had a crash because perminfoindexes were not updated in the finalized planned statement after distributed planner hook.

So, basically, everywhere we set a query's or planned statement's rtable entry, we need to set the rteperminfos/permInfos accordingly.

Relevant PG commits:
https://github.com/postgres/postgres/commit/a61b1f74823c9c4f79c95226a461f1e7a367764b a61b1f74823c9c4f79c95226a461f1e7a367764b
https://github.com/postgres/postgres/commit/b803b7d132e3505ab77c29acf91f3d1caa298f95 b803b7d132e3505ab77c29acf91f3d1caa298f95
