### PR TITLE
PG16 compatibility - varnullingrels additions

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
@@ -115,7 +115,7 @@ BEGIN
         SET partkey = (split_part(partkey, 'varlevelsup', 1)
                        || 'varnullingrels (b) :varlevelsup'
                        || split_part(partkey, 'varlevelsup', 2))
-        WHERE partkey IS NOT NULL AND partkey NOT LIKE '%varnullingrels%';
+        WHERE partkey IS NOT NULL AND partkey NOT ILIKE '%varnullingrels%';
     $cmd$;
     END IF;
 

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
@@ -110,10 +110,10 @@ BEGIN
     -- if we are upgrading from PG14/PG15 to PG16+,
     -- we need to regenerate the partkeys because they will include varnullingrels as well.
     UPDATE pg_catalog.pg_dist_partition
-    SET partkey = column_name_to_column(pg_dist_partkeys_pre_upgrade.logicalrelid, col_name)
-    FROM public.pg_dist_partkeys_pre_upgrade
-    WHERE pg_dist_partkeys_pre_upgrade.logicalrelid = pg_dist_partition.logicalrelid;
-    DROP TABLE public.pg_dist_partkeys_pre_upgrade;
+    SET partkey = column_name_to_column(pg_dist_partkeys_pre_16_upgrade.logicalrelid, col_name)
+    FROM public.pg_dist_partkeys_pre_16_upgrade
+    WHERE pg_dist_partkeys_pre_16_upgrade.logicalrelid = pg_dist_partition.logicalrelid;
+    DROP TABLE public.pg_dist_partkeys_pre_16_upgrade;
 
     INSERT INTO pg_catalog.pg_dist_shard SELECT * FROM public.pg_dist_shard;
     INSERT INTO pg_catalog.pg_dist_placement SELECT * FROM public.pg_dist_placement;

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -115,7 +115,7 @@ BEGIN
         SET partkey = (split_part(partkey, 'varlevelsup', 1)
                        || 'varnullingrels (b) :varlevelsup'
                        || split_part(partkey, 'varlevelsup', 2))
-        WHERE partkey IS NOT NULL AND partkey NOT LIKE '%varnullingrels%';
+        WHERE partkey IS NOT NULL AND partkey NOT ILIKE '%varnullingrels%';
     $cmd$;
     END IF;
 

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -110,10 +110,10 @@ BEGIN
     -- if we are upgrading from PG14/PG15 to PG16+,
     -- we need to regenerate the partkeys because they will include varnullingrels as well.
     UPDATE pg_catalog.pg_dist_partition
-    SET partkey = column_name_to_column(pg_dist_partkeys_pre_upgrade.logicalrelid, col_name)
-    FROM public.pg_dist_partkeys_pre_upgrade
-    WHERE pg_dist_partkeys_pre_upgrade.logicalrelid = pg_dist_partition.logicalrelid;
-    DROP TABLE public.pg_dist_partkeys_pre_upgrade;
+    SET partkey = column_name_to_column(pg_dist_partkeys_pre_16_upgrade.logicalrelid, col_name)
+    FROM public.pg_dist_partkeys_pre_16_upgrade
+    WHERE pg_dist_partkeys_pre_16_upgrade.logicalrelid = pg_dist_partition.logicalrelid;
+    DROP TABLE public.pg_dist_partkeys_pre_16_upgrade;
 
     INSERT INTO pg_catalog.pg_dist_shard SELECT * FROM public.pg_dist_shard;
     INSERT INTO pg_catalog.pg_dist_placement SELECT * FROM public.pg_dist_placement;

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/12.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/12.1-1.sql
@@ -88,9 +88,9 @@ BEGIN
     -- if we are upgrading from PG14/PG15 to PG16+,
     -- we will need to regenerate the partkeys because they will include varnullingrels as well.
     -- so we save the partkeys as column names here
-    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_upgrade AS
+    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_16_upgrade AS
     SELECT logicalrelid, column_to_column_name(logicalrelid, partkey) as col_name
-    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL;
+    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL AND partkey NOT ILIKE '%varnullingrels%';
 END;
 $cppu$;
 

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/12.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/12.1-1.sql
@@ -84,6 +84,13 @@ BEGIN
        objects.colocationid
     FROM pg_catalog.pg_dist_object objects,
          pg_catalog.pg_identify_object_as_address(objects.classid, objects.objid, objects.objsubid) address;
+
+    -- if we are upgrading from PG14/PG15 to PG16+,
+    -- we will need to regenerate the partkeys because they will include varnullingrels as well.
+    -- so we save the partkeys as column names here
+    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_upgrade AS
+    SELECT logicalrelid, column_to_column_name(logicalrelid, partkey) as col_name
+    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL;
 END;
 $cppu$;
 

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
@@ -88,9 +88,9 @@ BEGIN
     -- if we are upgrading from PG14/PG15 to PG16+,
     -- we will need to regenerate the partkeys because they will include varnullingrels as well.
     -- so we save the partkeys as column names here
-    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_upgrade AS
+    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_16_upgrade AS
     SELECT logicalrelid, column_to_column_name(logicalrelid, partkey) as col_name
-    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL;
+    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL AND partkey NOT ILIKE '%varnullingrels%';
 END;
 $cppu$;
 

--- a/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_prepare_pg_upgrade/latest.sql
@@ -84,6 +84,13 @@ BEGIN
        objects.colocationid
     FROM pg_catalog.pg_dist_object objects,
          pg_catalog.pg_identify_object_as_address(objects.classid, objects.objid, objects.objsubid) address;
+
+    -- if we are upgrading from PG14/PG15 to PG16+,
+    -- we will need to regenerate the partkeys because they will include varnullingrels as well.
+    -- so we save the partkeys as column names here
+    CREATE TABLE IF NOT EXISTS public.pg_dist_partkeys_pre_upgrade AS
+    SELECT logicalrelid, column_to_column_name(logicalrelid, partkey) as col_name
+    FROM pg_catalog.pg_dist_partition WHERE partkey IS NOT NULL;
 END;
 $cppu$;
 

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -302,5 +302,6 @@ s/(NOTICE:  issuing CREATE EXTENSION IF NOT EXISTS citus_columnar WITH SCHEMA  p
 
 s/, password_required=false//g
 s/provide the file or change sslmode/provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode/g
+s/:varcollid 0 :varlevelsup 0/:varcollid 0 :varnullingrels (b) :varlevelsup 0/g
 
 #endif /* PG_VERSION_NUM < PG_VERSION_16 */

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -302,6 +302,6 @@ s/(NOTICE:  issuing CREATE EXTENSION IF NOT EXISTS citus_columnar WITH SCHEMA  p
 
 s/, password_required=false//g
 s/provide the file or change sslmode/provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode/g
-s/:varcollid 0 :varlevelsup 0/:varcollid 0 :varnullingrels (b) :varlevelsup 0/g
+s/(:varcollid [0-9]+) :varlevelsup 0/\1 :varnullingrels (b) :varlevelsup 0/g
 
 #endif /* PG_VERSION_NUM < PG_VERSION_16 */

--- a/src/test/regress/expected/citus_local_tables.out
+++ b/src/test/regress/expected/citus_local_tables.out
@@ -635,7 +635,7 @@ FROM pg_dist_partition WHERE logicalrelid = 'citus_local_table_4'::regclass;
 SELECT column_name_to_column('citus_local_table_4', 'a');
                                                   column_name_to_column
 ---------------------------------------------------------------------
- {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
+ {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
 (1 row)
 
 SELECT master_update_shard_statistics(shardid)

--- a/src/test/regress/expected/citus_local_tables_mx.out
+++ b/src/test/regress/expected/citus_local_tables_mx.out
@@ -769,8 +769,8 @@ SELECT logicalrelid, partmethod, partkey FROM pg_dist_partition
         ORDER BY logicalrelid;
      logicalrelid     | partmethod |                                                          partkey
 ---------------------------------------------------------------------
- parent_dropped_col   | h          | {VAR :varno 1 :varattno 1 :vartype 1082 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
- parent_dropped_col_2 | h          | {VAR :varno 1 :varattno 5 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 5 :location -1}
+ parent_dropped_col   | h          | {VAR :varno 1 :varattno 1 :vartype 1082 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
+ parent_dropped_col_2 | h          | {VAR :varno 1 :varattno 5 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 5 :location -1}
 (2 rows)
 
 -- some tests for view propagation on citus local tables

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -1289,10 +1289,10 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
     SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
     \gset
     \if :server_version_ge_16
-    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varnullingrels (b) :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 1 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
     \else
-	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 1 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
     \endif
 	SELECT citus_internal_update_relation_colocation('test_2'::regclass, 251);

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -1284,8 +1284,17 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SET application_name to 'citus_internal gpid=10000000001';
 	-- with an ugly trick, update the vartype of table from int to bigint
 	-- so that making two tables colocated fails
-	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+	-- include varnullingrels for PG16
+    SHOW server_version \gset
+    SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
+    \gset
+    \if :server_version_ge_16
+    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varnullingrels (b) :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
+    \else
+	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+	WHERE logicalrelid = 'test_2'::regclass;
+    \endif
 	SELECT citus_internal_update_relation_colocation('test_2'::regclass, 251);
 ERROR:  cannot colocate tables test_2 and test_3
 ROLLBACK;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -986,7 +986,7 @@ DELETE FROM pg_dist_shard WHERE shardid = 1;
 CREATE TABLE e_transactions(order_id varchar(255) NULL, transaction_id int) PARTITION BY LIST(transaction_id);
 CREATE TABLE orders_2020_07_01
 PARTITION OF e_transactions FOR VALUES IN (1,2,3);
-INSERT INTO pg_dist_partition VALUES ('e_transactions'::regclass,'h', '{VAR :varno 1 :varattno 1 :vartype 1043 :vartypmod 259 :varcollid 100 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}', 7, 's');
+INSERT INTO pg_dist_partition VALUES ('e_transactions'::regclass,'h', '{VAR :varno 1 :varattno 1 :vartype 1043 :vartypmod 259 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}', 7, 's');
 SELECT
 	(metadata->>'partitioned_citus_table_exists_pre_11')::boolean as partitioned_citus_table_exists_pre_11,
 	(metadata->>'partitioned_citus_table_exists_pre_11') IS NULL as is_null

--- a/src/test/regress/expected/multi_metadata_sync.out
+++ b/src/test/regress/expected/multi_metadata_sync.out
@@ -533,7 +533,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
- mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
+ mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
 (1 row)
 
 SELECT * FROM pg_dist_shard  WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;
@@ -672,7 +672,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
- mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
+ mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
 (1 row)
 
 SELECT * FROM pg_dist_shard WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;

--- a/src/test/regress/expected/multi_metadata_sync_0.out
+++ b/src/test/regress/expected/multi_metadata_sync_0.out
@@ -533,7 +533,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
- mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
+ mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
 (1 row)
 
 SELECT * FROM pg_dist_shard  WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;
@@ -672,7 +672,7 @@ SELECT * FROM pg_dist_node ORDER BY nodeid;
 SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY logicalrelid::text;
           logicalrelid           | partmethod |                                                         partkey                                                          | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
- mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
+ mx_testing_schema.mx_test_table | h          | {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |            2 | s        | f
 (1 row)
 
 SELECT * FROM pg_dist_shard WHERE logicalrelid::text LIKE 'mx_testing_schema%' ORDER BY shardid;

--- a/src/test/regress/expected/multi_prune_shard_list.out
+++ b/src/test/regress/expected/multi_prune_shard_list.out
@@ -86,7 +86,7 @@ SELECT prune_using_both_values('pruning', 'tomato', 'rose');
 SELECT debug_equality_expression('pruning');
                                                                                                                                                                             debug_equality_expression
 ---------------------------------------------------------------------
- {OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 1 :vartype 25 :vartypmod -1 :varcollid 100 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull true :location -1 :constvalue <>}) :location -1}
+ {OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 1 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull true :location -1 :constvalue <>}) :location -1}
 (1 row)
 
 -- print the initial ordering of shard intervals

--- a/src/test/regress/expected/single_shard_table_udfs.out
+++ b/src/test/regress/expected/single_shard_table_udfs.out
@@ -121,7 +121,7 @@ FROM pg_dist_partition WHERE logicalrelid = 'null_dist_key_table'::regclass;
 SELECT column_name_to_column('null_dist_key_table', 'a');
                                                   column_name_to_column
 ---------------------------------------------------------------------
- {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
+ {VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}
 (1 row)
 
 SELECT master_update_shard_statistics(shardid)

--- a/src/test/regress/expected/start_stop_metadata_sync.out
+++ b/src/test/regress/expected/start_stop_metadata_sync.out
@@ -158,12 +158,12 @@ SELECT * FROM test_matview;
 SELECT * FROM pg_dist_partition WHERE logicalrelid::text LIKE 'events%' ORDER BY logicalrelid::text;
         logicalrelid        | partmethod |                                                          partkey                                                           | colocationid | repmodel | autoconverted
 ---------------------------------------------------------------------
- events                     | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
- events_2021_feb            | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
- events_2021_jan            | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
- events_replicated          | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
- events_replicated_2021_feb | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
- events_replicated_2021_jan | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
+ events                     | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
+ events_2021_feb            | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
+ events_2021_jan            | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980000 | s        | f
+ events_replicated          | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
+ events_replicated_2021_feb | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
+ events_replicated_2021_jan | h          | {VAR :varno 1 :varattno 1 :vartype 1184 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} |       980001 | c        | f
 (6 rows)
 
 SELECT count(*) > 0 FROM pg_dist_node;

--- a/src/test/regress/expected/upgrade_basic_after.out
+++ b/src/test/regress/expected/upgrade_basic_after.out
@@ -400,3 +400,12 @@ SELECT * FROM t_range ORDER BY id;
 (9 rows)
 
 ROLLBACK;
+-- There is a difference in partkey Var representation between PG16 and older versions
+-- Sanity check here that we can properly do column_to_column_name
+SELECT column_to_column_name(logicalrelid, partkey)
+FROM pg_dist_partition WHERE partkey IS NOT NULL ORDER BY 1 LIMIT 1;
+ column_to_column_name
+---------------------------------------------------------------------
+ a
+(1 row)
+

--- a/src/test/regress/expected/upgrade_basic_before.out
+++ b/src/test/regress/expected/upgrade_basic_before.out
@@ -65,3 +65,12 @@ UPDATE pg_dist_shard SET shardminvalue = '1', shardmaxvalue = '3' WHERE shardid 
 UPDATE pg_dist_shard SET shardminvalue = '5', shardmaxvalue = '7' WHERE shardid = :shardid2;
 \copy t_range FROM STDIN with (DELIMITER ',')
 \copy t_range FROM STDIN with (DELIMITER ',')
+-- There is a difference in partkey Var representation between PG16 and older versions
+-- Sanity check here that we can properly do column_to_column_name
+SELECT column_to_column_name(logicalrelid, partkey)
+FROM pg_dist_partition WHERE partkey IS NOT NULL ORDER BY 1 LIMIT 1;
+ column_to_column_name
+---------------------------------------------------------------------
+ a
+(1 row)
+

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -804,10 +804,10 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
     SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
     \gset
     \if :server_version_ge_16
-    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varnullingrels (b) :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 1 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
     \else
-	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 1 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
     \endif
 

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -798,8 +798,19 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SET application_name to 'citus_internal gpid=10000000001';
 	-- with an ugly trick, update the vartype of table from int to bigint
 	-- so that making two tables colocated fails
-	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+
+    -- include varnullingrels for PG16
+    SHOW server_version \gset
+    SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
+    \gset
+    \if :server_version_ge_16
+    UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varnullingrels (b) :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
 	WHERE logicalrelid = 'test_2'::regclass;
+    \else
+	UPDATE pg_dist_partition SET partkey = '{VAR :varno 1 :varattno 1 :vartype 20 :vartypmod -1 :varcollid 1 :varlevelsup 0 :varnoold 1 :varoattno 1 :location -1}'
+	WHERE logicalrelid = 'test_2'::regclass;
+    \endif
+
 	SELECT citus_internal_update_relation_colocation('test_2'::regclass, 251);
 ROLLBACK;
 

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -458,7 +458,7 @@ DELETE FROM pg_dist_shard WHERE shardid = 1;
 CREATE TABLE e_transactions(order_id varchar(255) NULL, transaction_id int) PARTITION BY LIST(transaction_id);
 CREATE TABLE orders_2020_07_01
 PARTITION OF e_transactions FOR VALUES IN (1,2,3);
-INSERT INTO pg_dist_partition VALUES ('e_transactions'::regclass,'h', '{VAR :varno 1 :varattno 1 :vartype 1043 :vartypmod 259 :varcollid 100 :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}', 7, 's');
+INSERT INTO pg_dist_partition VALUES ('e_transactions'::regclass,'h', '{VAR :varno 1 :varattno 1 :vartype 1043 :vartypmod 259 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1}', 7, 's');
 
 SELECT
 	(metadata->>'partitioned_citus_table_exists_pre_11')::boolean as partitioned_citus_table_exists_pre_11,

--- a/src/test/regress/sql/upgrade_basic_after.sql
+++ b/src/test/regress/sql/upgrade_basic_after.sql
@@ -143,3 +143,8 @@ SELECT * FROM t_range ORDER BY id;
 
 
 ROLLBACK;
+
+-- There is a difference in partkey Var representation between PG16 and older versions
+-- Sanity check here that we can properly do column_to_column_name
+SELECT column_to_column_name(logicalrelid, partkey)
+FROM pg_dist_partition WHERE partkey IS NOT NULL ORDER BY 1 LIMIT 1;

--- a/src/test/regress/sql/upgrade_basic_before.sql
+++ b/src/test/regress/sql/upgrade_basic_before.sql
@@ -51,3 +51,8 @@ UPDATE pg_dist_shard SET shardminvalue = '5', shardmaxvalue = '7' WHERE shardid 
 6,3
 7,4
 \.
+
+-- There is a difference in partkey Var representation between PG16 and older versions
+-- Sanity check here that we can properly do column_to_column_name
+SELECT column_to_column_name(logicalrelid, partkey)
+FROM pg_dist_partition WHERE partkey IS NOT NULL ORDER BY 1 LIMIT 1;


### PR DESCRIPTION
PG16 introduced a new entry varnnullingrels to Var, which represents our partkey in pg_dist_partition.
This commit does the necessary changes for this.

Relevant PG commit:
https://github.com/postgres/postgres/commit/2489d76c4906f4461a364ca8ad7e0751ead8aa0d 2489d76c4906f4461a364ca8ad7e0751ead8aa0d

Checkout main PG16 PR for CI tests: particularly the upgrade tests are successful. #6952 