### PR TITLE
PG16 compatibility - one more outer join check

### DIFF
--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1414,6 +1414,12 @@ RelationInfoContainsOnlyRecurringTuples(PlannerInfo *plannerInfo, Relids relids)
 
 	while ((relationId = bms_next_member(relids, relationId)) >= 0)
 	{
+		/* outer join RTE check in PG16 */
+		if (IsRelOptOuterJoin(plannerInfo, relationId))
+		{
+			continue;
+		}
+
 		RangeTblEntry *rangeTableEntry = plannerInfo->simple_rte_array[relationId];
 
 		if (FindNodeMatchingCheckFunctionInRangeTableList(list_make1(rangeTableEntry),

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -171,8 +171,6 @@ static bool FindQueryContainingRTEIdentityInternal(Node *node,
 
 static int ParentCountPriorToAppendRel(List *appendRelList, AppendRelInfo *appendRelInfo);
 
-static bool IsVarRelOptOuterJoin(PlannerInfo *root, Var *varToBeAdded);
-
 
 /*
  * AllDistributionKeysInQueryAreEqual returns true if either
@@ -1241,7 +1239,7 @@ AddToAttributeEquivalenceClass(AttributeEquivalenceClass *attributeEquivalenceCl
 	}
 
 	/* outer join checks in PG16 */
-	if (IsVarRelOptOuterJoin(root, varToBeAdded))
+	if (IsRelOptOuterJoin(root, varToBeAdded->varno))
 	{
 		return;
 	}
@@ -1388,19 +1386,19 @@ GetTargetSubquery(PlannerInfo *root, RangeTblEntry *rangeTableEntry, Var *varToB
 
 
 /*
- * IsVarRelOptOuterJoin returns true if the Var to be added
- * is an outer join, false otherwise.
+ * IsRelOptOuterJoin returns true if the RelOpt referenced
+ * by varNo is an outer join, false otherwise.
  */
-static bool
-IsVarRelOptOuterJoin(PlannerInfo *root, Var *varToBeAdded)
+bool
+IsRelOptOuterJoin(PlannerInfo *root, int varNo)
 {
 #if PG_VERSION_NUM >= PG_VERSION_16
-	if (root->simple_rel_array_size <= varToBeAdded->varno)
+	if (root->simple_rel_array_size <= varNo)
 	{
 		return true;
 	}
 
-	RelOptInfo *rel = root->simple_rel_array[varToBeAdded->varno];
+	RelOptInfo *rel = root->simple_rel_array[varNo];
 	if (rel == NULL)
 	{
 		/* must be an outer join */

--- a/src/include/distributed/relation_restriction_equivalence.h
+++ b/src/include/distributed/relation_restriction_equivalence.h
@@ -20,6 +20,7 @@
 extern bool AllDistributionKeysInQueryAreEqual(Query *originalQuery,
 											   PlannerRestrictionContext *
 											   plannerRestrictionContext);
+extern bool IsRelOptOuterJoin(PlannerInfo *root, int varNo);
 extern bool SafeToPushdownUnionSubquery(Query *originalQuery, PlannerRestrictionContext *
 										plannerRestrictionContext);
 extern bool ContainsUnionSubquery(Query *queryTree);


### PR DESCRIPTION
We already took care of the majority of necessary outer join checks
in https://github.com/citusdata/citus/commit/7c6b4ce1035491ff5a31a9d15bb8b28f3c0dd5b3

In RelationInfoContainsOnlyRecurringTuples, we need to add one more check of whether we
are dealing with an outer join RTE using IsRelOptOuterJoin function.
This fixes an outer join crash in sqlancer_failures.sql test.