### PR TITLE
Add citus.distributed_data_dump to only return results from local shards

### DIFF
--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -315,6 +315,13 @@ PublishDistributedTableChanges(LogicalDecodingContext *ctx, ReorderBufferTXN *tx
 		return;
 	}
 
+	/*
+	 * TODO: consider replicated shards
+	 *
+	 * We should only emit from one of the replicas, and it should align with the
+	 * IsDistributedDataDump logic.
+	 */
+
 	/* translate and publish from shard relation to distributed table relation for CDC. */
 	TranslateAndPublishRelationForCDC(ctx, txn, relation, change, shardId,
 									  distRelationId);

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -92,6 +92,7 @@
 #include "distributed/resource_lock.h"
 #include "distributed/shard_pruning.h"
 #include "distributed/shared_connection_stats.h"
+#include "distributed/task_execution_utils.h"
 #include "distributed/version_compat.h"
 #include "distributed/worker_protocol.h"
 #include "distributed/local_multi_copy.h"
@@ -3010,10 +3011,32 @@ CitusCopyTo(CopyStmt *copyStatement, QueryCompletion *completionTag)
 		ShardInterval *shardInterval = lfirst(shardIntervalCell);
 		List *shardPlacementList = ActiveShardPlacementList(shardInterval->shardId);
 		ListCell *shardPlacementCell = NULL;
-		int placementIndex = 0;
+		int placementIndex = -1;
 
 		StringInfo copyCommand = ConstructCopyStatement(copyStatement,
 														shardInterval->shardId);
+
+		/*
+		 * When citus.distributed_data_dump is enabled, only emit from local shards.
+		 *
+		 * That way, users can run COPY table TO STDOUT on all nodes to get a full
+		 * copy of the data with much higher bandwidth than running it via the
+		 * coordinator. Moreover, each command can use a snapshot that aligns with
+		 * a specific replication slot.
+		 */
+		if (IsDistributedDataDump)
+		{
+			List *newPlacementList =
+				TaskPlacementListForDistributedDataDump(shardPlacementList);
+
+			if (newPlacementList == NIL)
+			{
+				/* shard does not have local placements */
+				continue;
+			}
+
+			shardPlacementList = newPlacementList;
+		}
 
 		foreach(shardPlacementCell, shardPlacementList)
 		{
@@ -3021,6 +3044,8 @@ CitusCopyTo(CopyStmt *copyStatement, QueryCompletion *completionTag)
 			int connectionFlags = 0;
 			char *userName = NULL;
 			const bool raiseErrors = true;
+
+			placementIndex++;
 
 			MultiConnection *connection = GetPlacementConnection(connectionFlags,
 																 shardPlacement,

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1166,6 +1166,22 @@ RegisterCitusConfigVariables(void)
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"citus.distributed_data_dump",
+		gettext_noop("When enabled, queries only return data from local shards"),
+		gettext_noop("When you need a full copy of a set of Citus tables, it can be "
+					 "useful to only return data from local shards, or from the first "
+					 "replica of replicated shards (incl. reference tables). That way, "
+					 "you can pull from all nodes concurrently and construct a complete "
+					 "snapshot. This is also necessary for logical replications "
+					 "scenarios, since the snapshot of the data on each node needs to "
+					 "be aligned with the replication slot on that node."),
+		&IsDistributedDataDump,
+		false,
+		PGC_USERSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
 	DefineCustomRealVariable(
 		"citus.distributed_deadlock_detection_factor",
 		gettext_noop("Sets the time to wait before checking for distributed "

--- a/src/include/distributed/multi_executor.h
+++ b/src/include/distributed/multi_executor.h
@@ -72,6 +72,9 @@ extern int ExecutorSlowStartInterval;
 extern bool SortReturning;
 extern int ExecutorLevel;
 
+/* citus.distributed_data_dump GUC */
+extern bool IsDistributedDataDump;
+
 
 extern void CitusExecutorStart(QueryDesc *queryDesc, int eflags);
 extern void CitusExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,

--- a/src/include/distributed/task_execution_utils.h
+++ b/src/include/distributed/task_execution_utils.h
@@ -2,5 +2,7 @@
 #define TASK_EXECUTION_UTILS_H
 
 extern List * CreateTaskListForJobTree(List *jobTaskList);
+extern List * TaskListForDistributedDataDump(List *taskList);
+extern List * TaskPlacementListForDistributedDataDump(List *taskPlacementList);
 
 #endif /* TASK_EXECUTION_UTILS_H */


### PR DESCRIPTION
DESCRIPTION: Add citus.distributed_data_dump to only return results from local shards

For CDC purposes, it is useful to have a way to get only local data from distributed tables from each node. In particular, logical replication relies on a pairing between snapshot and replication slot that can only be done at a node level. Outside of CDC, it can also be useful to read the table from all nodes at once with higher bandwidth.

Very much a draft still.

TODO:
- [x] Make sure COPY to STDOUT honours the snapshot
- [ ] Consider an option to always do this for walsender, to simplify logical replication configuration
- [ ] Tests