### PR TITLE
Removes ubuntu/bionic from packaging pipelines

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -119,7 +119,8 @@ jobs:
           - debian-buster-all
           - debian-bookworm-all
           - debian-bullseye-all
-          - ubuntu-bionic-all
+          # temporarily disabled since postgres 16 is not available for ubuntu/bionic
+          # - ubuntu-bionic-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
           - ubuntu-kinetic-all

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   get_postgres_versions_from_file:
@@ -119,8 +123,6 @@ jobs:
           - debian-buster-all
           - debian-bookworm-all
           - debian-bullseye-all
-          # temporarily disabled since postgres 16 is not available for ubuntu/bionic
-          # - ubuntu-bionic-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
           - ubuntu-kinetic-all


### PR DESCRIPTION
DESCRIPTION: Removes ubuntu/bionic from packaging pipelines

Since pg16 beta is not available for ubuntu/bionic and ubuntu/bionic
support is EOL, I need to remove this os from pipeline
https://ubuntu.com/blog/ubuntu-18-04-eol-for-devices 

Additionally, added concurrency support for GH Actions Packaging pipeline
