### PR TITLE
get rid of {Push/Pop}OverrideSearchPath

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -53,6 +53,7 @@
 #include "distributed/multi_executor.h"
 #include "distributed/multi_logical_planner.h"
 #include "distributed/multi_partitioning_utils.h"
+#include "distributed/namespace_utils.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/replication_origin_session_utils.h"
@@ -1764,10 +1765,7 @@ CreateMaterializedViewDDLCommand(Oid matViewOid)
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
 	 * schema-prefixed.
 	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	int saveNestLevel = PushEmptySearchPath();
 
 	/*
 	 * Push the transaction snapshot to be able to get vief definition with pg_get_viewdef
@@ -1779,7 +1777,7 @@ CreateMaterializedViewDDLCommand(Oid matViewOid)
 	char *viewDefinition = TextDatumGetCString(viewDefinitionDatum);
 
 	PopActiveSnapshot();
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	appendStringInfo(query, "AS %s", viewDefinition);
 

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -50,7 +50,7 @@ static List * GetAllViews(void);
 static bool ShouldPropagateExtensionCommand(Node *parseTree);
 static bool IsAlterExtensionSetSchemaCitus(Node *parseTree);
 static Node * RecreateExtensionStmt(Oid extensionOid);
-static List * GenerateGrantCommandsOnExtesionDependentFDWs(Oid extensionId);
+static List * GenerateGrantCommandsOnExtensionDependentFDWs(Oid extensionId);
 
 
 /*
@@ -985,7 +985,7 @@ CreateExtensionDDLCommand(const ObjectAddress *extensionAddress)
 
 	/* any privilege granted on FDWs that belong to the extension should be included */
 	List *FDWGrants =
-		GenerateGrantCommandsOnExtesionDependentFDWs(extensionAddress->objectId);
+		GenerateGrantCommandsOnExtensionDependentFDWs(extensionAddress->objectId);
 
 	ddlCommands = list_concat(ddlCommands, FDWGrants);
 
@@ -1048,11 +1048,11 @@ RecreateExtensionStmt(Oid extensionOid)
 
 
 /*
- * GenerateGrantCommandsOnExtesionDependentFDWs returns a list of commands that GRANTs
+ * GenerateGrantCommandsOnExtensionDependentFDWs returns a list of commands that GRANTs
  * the privileges on FDWs that are depending on the given extension.
  */
 static List *
-GenerateGrantCommandsOnExtesionDependentFDWs(Oid extensionId)
+GenerateGrantCommandsOnExtensionDependentFDWs(Oid extensionId)
 {
 	List *commands = NIL;
 	List *FDWOids = GetDependentFDWsToExtension(extensionId);

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -895,7 +895,7 @@ GetForeignConstraintCommandsInternal(Oid relationId, int flags)
 
 	List *foreignKeyCommands = NIL;
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	Oid foreignKeyOid = InvalidOid;
 	foreach_oid(foreignKeyOid, foreignKeyOids)
@@ -906,7 +906,7 @@ GetForeignConstraintCommandsInternal(Oid relationId, int flags)
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	return foreignKeyCommands;
 }

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -909,15 +909,14 @@ GetFunctionDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace)
 	else
 	{
 		Datum sqlTextDatum = (Datum) 0;
-
-		PushOverrideEmptySearchPath(CurrentMemoryContext);
+		int saveNestLevel = PushEmptySearchPath();
 
 		sqlTextDatum = DirectFunctionCall1(pg_get_functiondef,
 										   ObjectIdGetDatum(funcOid));
 		createFunctionSQL = TextDatumGetCString(sqlTextDatum);
 
 		/* revert back to original search_path */
-		PopOverrideSearchPath();
+		PopEmptySearchPath(saveNestLevel);
 	}
 
 	return createFunctionSQL;

--- a/src/backend/distributed/commands/statistics.c
+++ b/src/backend/distributed/commands/statistics.c
@@ -530,7 +530,7 @@ GetExplicitStatisticsCommandList(Oid relationId)
 	RelationClose(relation);
 
 	/* generate fully-qualified names */
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	Oid statisticsId = InvalidOid;
 	foreach_oid(statisticsId, statisticsIdList)
@@ -579,7 +579,7 @@ GetExplicitStatisticsCommandList(Oid relationId)
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	return explicitStatisticsCommandList;
 }

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -74,7 +74,7 @@ GetExplicitTriggerCommandList(Oid relationId)
 {
 	List *createTriggerCommandList = NIL;
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	List *triggerIdList = GetExplicitTriggerIdList(relationId);
 
@@ -116,7 +116,7 @@ GetExplicitTriggerCommandList(Oid relationId)
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	return createTriggerCommandList;
 }

--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -479,10 +479,7 @@ AppendViewDefinitionToCreateViewCommand(StringInfo buf, Oid viewOid)
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
 	 * schema-prefixed.
 	 */
-	OverrideSearchPath *overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	int saveNestLevel = PushEmptySearchPath();
 
 	/*
 	 * Push the transaction snapshot to be able to get vief definition with pg_get_viewdef
@@ -494,7 +491,7 @@ AppendViewDefinitionToCreateViewCommand(StringInfo buf, Oid viewOid)
 	char *viewDefinition = TextDatumGetCString(viewDefinitionDatum);
 
 	PopActiveSnapshot();
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	appendStringInfo(buf, "AS %s ", viewDefinition);
 }

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -818,7 +818,7 @@ deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 	 * Switch to empty search_path to deparse_index_columns to produce fully-
 	 * qualified names in expressions.
 	 */
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	/* index column or expression list begins here */
 	appendStringInfoChar(buffer, '(');
@@ -855,7 +855,7 @@ deparse_shard_index_statement(IndexStmt *origStmt, Oid distrelid, int64 shardid,
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 }
 
 

--- a/src/backend/distributed/deparser/deparse_domain_stmts.c
+++ b/src/backend/distributed/deparser/deparse_domain_stmts.c
@@ -345,9 +345,9 @@ AppendAlterDomainStmtSetDefault(StringInfo buf, AlterDomainStmt *stmt)
 	expr = TransformDefaultExpr(expr, stmt->typeName, baseTypeName);
 
 	/* deparse while the searchpath is cleared to force qualification of identifiers */
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 	char *exprSql = deparse_expression(expr, NIL, true, true);
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	appendStringInfo(buf, "SET DEFAULT %s", exprSql);
 }
@@ -443,9 +443,9 @@ AppendConstraint(StringInfo buf, Constraint *constraint, List *domainName,
 				elog(ERROR, "missing expression for domain constraint");
 			}
 
-			PushOverrideEmptySearchPath(CurrentMemoryContext);
+			int saveNestLevel = PushEmptySearchPath();
 			char *exprSql = deparse_expression(expr, NIL, true, true);
-			PopOverrideSearchPath();
+			PopEmptySearchPath(saveNestLevel);
 
 			appendStringInfo(buf, " CHECK (%s)", exprSql);
 			return;
@@ -469,9 +469,9 @@ AppendConstraint(StringInfo buf, Constraint *constraint, List *domainName,
 				elog(ERROR, "missing expression for domain default");
 			}
 
-			PushOverrideEmptySearchPath(CurrentMemoryContext);
+			int saveNestLevel = PushEmptySearchPath();
 			char *exprSql = deparse_expression(expr, NIL, true, true);
-			PopOverrideSearchPath();
+			PopEmptySearchPath(saveNestLevel);
 
 			appendStringInfo(buf, " DEFAULT %s", exprSql);
 			return;

--- a/src/backend/distributed/deparser/deparse_publication_stmts.c
+++ b/src/backend/distributed/deparser/deparse_publication_stmts.c
@@ -307,11 +307,11 @@ AppendWhereClauseExpression(StringInfo buf, RangeVar *tableName,
 
 	List *relationContext = deparse_context_for(tableName->relname, relation->rd_id);
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 	char *whereClauseString = deparse_expression(whereClause,
 												 relationContext,
 												 true, true);
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	appendStringInfoString(buf, whereClauseString);
 

--- a/src/backend/distributed/deparser/deparse_table_stmts.c
+++ b/src/backend/distributed/deparser/deparse_table_stmts.c
@@ -562,9 +562,9 @@ DeparseRawExprForColumnDefault(Oid relationId, Oid columnTypeId, int32 columnTyp
 
 	List *deparseContext = deparse_context_for(get_rel_name(relationId), relationId);
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 	char *defaultExprStr = deparse_expression(defaultExpr, deparseContext, false, false);
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	RelationClose(relation);
 

--- a/src/backend/distributed/deparser/ruleutils_15.c
+++ b/src/backend/distributed/deparser/ruleutils_15.c
@@ -54,6 +54,7 @@
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/citus_ruleutils.h"
 #include "distributed/multi_router_planner.h"
+#include "distributed/namespace_utils.h"
 #include "executor/spi.h"
 #include "foreign/foreign.h"
 #include "funcapi.h"
@@ -624,18 +625,14 @@ pg_get_rule_expr(Node *expression)
 {
 	bool showImplicitCasts = true;
 	deparse_context context;
-	OverrideSearchPath *overridePath = NULL;
 	StringInfo buffer = makeStringInfo();
 
 	/*
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
 	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
+	 * PushEmptySearchPath(), since we set addCatalog to true;
 	 */
-	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	int saveNestLevel = PushEmptySearchPath();
 
 	context.buf = buffer;
 	context.namespaces = NIL;
@@ -652,7 +649,7 @@ pg_get_rule_expr(Node *expression)
 	get_rule_expr(expression, &context, showImplicitCasts);
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	return buffer->data;
 }
@@ -2038,8 +2035,6 @@ get_query_def_extended(Query *query, StringInfo buf, List *parentnamespace,
 	deparse_context context;
 	deparse_namespace dpns;
 
-	OverrideSearchPath *overridePath = NULL;
-
 	/* Guard against excessively long or deeply-nested queries */
 	CHECK_FOR_INTERRUPTS();
 	check_stack_depth();
@@ -2058,12 +2053,9 @@ get_query_def_extended(Query *query, StringInfo buf, List *parentnamespace,
 	/*
 	 * Set search_path to NIL so that all objects outside of pg_catalog will be
 	 * schema-prefixed. pg_catalog will be added automatically when we call
-	 * PushOverrideSearchPath(), since we set addCatalog to true;
+	 * PushEmptySearchPath().
 	 */
-	overridePath = GetOverrideSearchPath(CurrentMemoryContext);
-	overridePath->schemas = NIL;
-	overridePath->addCatalog = true;
-	PushOverrideSearchPath(overridePath);
+	int saveNestLevel = PushEmptySearchPath();
 
 	context.buf = buf;
 	context.namespaces = lcons(&dpns, list_copy(parentnamespace));
@@ -2118,7 +2110,7 @@ get_query_def_extended(Query *query, StringInfo buf, List *parentnamespace,
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 }
 
 /* ----------

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -612,7 +612,7 @@ GetPreLoadTableCreationCommands(Oid relationId,
 {
 	List *tableDDLEventList = NIL;
 
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	/* fetch table schema and column option definitions */
 	char *tableSchemaDef = pg_get_tableschemadef_string(relationId,
@@ -665,7 +665,7 @@ GetPreLoadTableCreationCommands(Oid relationId,
 	tableDDLEventList = list_concat(tableDDLEventList, policyCommands);
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 
 	return tableDDLEventList;
 }
@@ -754,7 +754,7 @@ GatherIndexAndConstraintDefinitionList(Form_pg_index indexForm, List **indexDDLE
 									   int indexFlags)
 {
 	/* generate fully-qualified names */
-	PushOverrideEmptySearchPath(CurrentMemoryContext);
+	int saveNestLevel = PushEmptySearchPath();
 
 	Oid indexId = indexForm->indexrelid;
 	bool indexImpliedByConstraint = IndexImpliedByAConstraint(indexForm);
@@ -805,7 +805,7 @@ GatherIndexAndConstraintDefinitionList(Form_pg_index indexForm, List **indexDDLE
 	}
 
 	/* revert back to original search_path */
-	PopOverrideSearchPath();
+	PopEmptySearchPath(saveNestLevel);
 }
 
 

--- a/src/backend/distributed/operations/replicate_none_dist_table_shard.c
+++ b/src/backend/distributed/operations/replicate_none_dist_table_shard.c
@@ -158,7 +158,7 @@ NoneDistTableDropCoordinatorPlacementTable(Oid noneDistTableId)
 	 * local session because changes made to shards are allowed for Citus internal
 	 * backends anyway.
 	 */
-	int save_nestlevel = NewGUCNestLevel();
+	int saveNestLevel = NewGUCNestLevel();
 
 	SetLocalEnableLocalReferenceForeignKeys(false);
 	SetLocalEnableManualChangesToShard(true);
@@ -184,7 +184,7 @@ NoneDistTableDropCoordinatorPlacementTable(Oid noneDistTableId)
 	bool localExecutionSupported = true;
 	ExecuteUtilityTaskList(list_make1(task), localExecutionSupported);
 
-	AtEOXact_GUC(true, save_nestlevel);
+	AtEOXact_GUC(true, saveNestLevel);
 }
 
 

--- a/src/include/distributed/namespace_utils.h
+++ b/src/include/distributed/namespace_utils.h
@@ -10,6 +10,7 @@
 #ifndef NAMESPACE_UTILS_H
 #define NAMESPACE_UTILS_H
 
-extern void PushOverrideEmptySearchPath(MemoryContext memoryContext);
+extern int PushEmptySearchPath(void);
+extern void PopEmptySearchPath(int saveNestLevel);
 
 #endif /* NAMESPACE_UTILS_H */


### PR DESCRIPTION
PushOverrideSearchPath suffers from a vulnerability issue reported by
CVE-2023-2454. Postgres fix this by replacing it with set_config_option, see [1]. 
It is recommended that out-of-tree code should also update such code though 
the "override" mechanism remains for compatibility.

The postgres master branch(i.e. PG 17) recently removed 
PushOverrideSearchPath() and PopOverrideSearchPath(), see [2]. So this should
also ease the process when citus decide to support Postgres v17.

This patch also contains some trivial typo fix.

[1]: postgres commit: 681d9e4621aac0a9c71364b6f54f00f6d8c4337f
[2]: postgres commit: 7c5c4e1c0396b0617a6f9b659dd7375fb0bfb9dc
