### PR TITLE
PQputCopyData's return value 0 should be considered fail

### DIFF
--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -716,14 +716,14 @@ PutRemoteCopyData(MultiConnection *connection, const char *buffer, int nbytes)
 	Assert(PQisnonblocking(pgConn));
 
 	int copyState = PQputCopyData(pgConn, buffer, nbytes);
-	if (copyState == -1)
+	if (copyState <= 0)
 	{
 		return false;
 	}
 
 	/*
 	 * PQputCopyData may have queued up part of the data even if it managed
-	 * to send some of it succesfully. We provide back pressure by waiting
+	 * to send some of it successfully. We provide back pressure by waiting
 	 * until the socket is writable to prevent the internal libpq buffers
 	 * from growing excessively.
 	 *


### PR DESCRIPTION
PQputCopyData returns 0 when it failed to expand the output buffer in
nonblock mode. So 0 should be treating as fail.

DESCRIPTION: Fixes a bug that could cause COPY logic to skip data in case of OOM