### PR TITLE
PG16 update GRANT... ADMIN | INHERIT | SET

### DIFF
--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -380,27 +380,30 @@ AppendGrantRoleStmt(StringInfo buf, GrantRoleStmt *stmt)
 	{
 #if PG_VERSION_NUM >= PG_VERSION_16
 		DefElem *opt = NULL;
+		 bool appended_option = false; // To track if any option has been appended
 		foreach_ptr(opt, stmt->opt)
 		{
 			if (strcmp(opt->defname, "admin") == 0)
 			{
-				appendStringInfo(buf, "WITH ADMIN OPTION");
-				// break; // exits after finding "admin" 
+				appendStringInfo(buf, " WITH ADMIN OPTION");
+				appended_option = true;
+				// break; // exits after finding "admin" (is this needed?) 
 			}
-			else if (strcmp(opt->defnamc  e,"inherit")== 0)
+			else if (strcmp(opt->defname,"inherit")==0)
 			{
-            appendStringInfo(buf, "INHERIT TRUE")
-			 appendStringInfo(buf, "GRANT x TO y WITH INHERIT TRUE, SET TRUE;");
+				if (appended_option) appendStringInfo(buf, " ");
+            appendStringInfo(buf, "WITH INHERIT TRUE");
+            appended_option = true;
 			}
-			else if((strcmp(opt->defname, "set") == 0))
-			{
-            appendStringInfo(buf, "SET TRUE")
+			else if((strcmp(opt->defname, "set") == 0)){
+				if (appended_option) appendStringInfo(buf, " ");
+            appendStringInfo(buf, "WITH SET TRUE");
+            appended_option = true;
 			}	
 		}
-#else
-		if (stmt->admin_opt)
+		if (appended_option)
 		{
-			appendStringInfo(buf, " WITH ADMIN OPTION");
+			appendStringInfo(buf, " ");
 		}
 #endif
 

--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -380,30 +380,27 @@ AppendGrantRoleStmt(StringInfo buf, GrantRoleStmt *stmt)
 	{
 #if PG_VERSION_NUM >= PG_VERSION_16
 		DefElem *opt = NULL;
-		 bool appended_option = false; // To track if any option has been appended
 		foreach_ptr(opt, stmt->opt)
 		{
 			if (strcmp(opt->defname, "admin") == 0)
 			{
-				appendStringInfo(buf, " WITH ADMIN OPTION");
-				appended_option = true;
-				// break; // exits after finding "admin" (is this needed?) 
+				appendStringInfo(buf, "WITH ADMIN OPTION");
+				// break; // exits after finding "admin" 
 			}
-			else if (strcmp(opt->defname,"inherit")==0)
+			else if (strcmp(opt->defnamc  e,"inherit")== 0)
 			{
-				if (appended_option) appendStringInfo(buf, " ");
-            appendStringInfo(buf, "WITH INHERIT TRUE");
-            appended_option = true;
+            appendStringInfo(buf, "INHERIT TRUE")
+			 appendStringInfo(buf, "GRANT x TO y WITH INHERIT TRUE, SET TRUE;");
 			}
-			else if((strcmp(opt->defname, "set") == 0)){
-				if (appended_option) appendStringInfo(buf, " ");
-            appendStringInfo(buf, "WITH SET TRUE");
-            appended_option = true;
+			else if((strcmp(opt->defname, "set") == 0))
+			{
+            appendStringInfo(buf, "SET TRUE")
 			}	
 		}
-		if (appended_option)
+#else
+		if (stmt->admin_opt)
 		{
-			appendStringInfo(buf, " ");
+			appendStringInfo(buf, " WITH ADMIN OPTION");
 		}
 #endif
 

--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -380,18 +380,30 @@ AppendGrantRoleStmt(StringInfo buf, GrantRoleStmt *stmt)
 	{
 #if PG_VERSION_NUM >= PG_VERSION_16
 		DefElem *opt = NULL;
+		 bool appended_option = false; // To track if any option has been appended
 		foreach_ptr(opt, stmt->opt)
 		{
 			if (strcmp(opt->defname, "admin") == 0)
 			{
 				appendStringInfo(buf, " WITH ADMIN OPTION");
-				break;
+				appended_option = true;
+				// break; // exits after finding "admin" (is this needed?) 
 			}
+			else if (strcmp(opt->defname,"inherit")==0)
+			{
+				if (appended_option) appendStringInfo(buf, " ");
+            appendStringInfo(buf, "WITH INHERIT TRUE");
+            appended_option = true;
+			}
+			else if((strcmp(opt->defname, "set") == 0)){
+				if (appended_option) appendStringInfo(buf, " ");
+            appendStringInfo(buf, "WITH SET TRUE");
+            appended_option = true;
+			}	
 		}
-#else
-		if (stmt->admin_opt)
+		if (appended_option)
 		{
-			appendStringInfo(buf, " WITH ADMIN OPTION");
+			appendStringInfo(buf, " ");
 		}
 #endif
 

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -10,6 +10,8 @@ SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::t
 
 CREATE ROLE create_role;
 CREATE ROLE create_role_2;
+CREATE ROLE create_role_3;
+CREATE ROLE create_role_4;
 CREATE USER create_user;
 CREATE USER create_user_2;
 CREATE GROUP create_group;
@@ -44,6 +46,8 @@ CREATE ROLE "create_role""edge";
 -- test grant role
 GRANT create_group TO create_role;
 GRANT create_group TO create_role_2 WITH ADMIN OPTION;
+GRANT create_group TO create_role_3 WITH INHERIT;
+GRANT create_group TO create_role_4 WITH SET; 
 
 SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, (rolpassword != '') as pass_not_empty, rolvaliduntil FROM pg_authid WHERE rolname LIKE 'create\_%' ORDER BY rolname;
 SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::text, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE 'create\_%' ORDER BY 1, 2;

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -10,6 +10,8 @@ SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::t
 
 CREATE ROLE create_role;
 CREATE ROLE create_role_2;
+CREATE ROLE create_role_3;
+CREATE ROLE create_role_4;
 CREATE USER create_user;
 CREATE USER create_user_2;
 CREATE GROUP create_group;
@@ -44,7 +46,8 @@ CREATE ROLE "create_role""edge";
 -- test grant role
 GRANT create_group TO create_role;
 GRANT create_group TO create_role_2 WITH ADMIN OPTION;
-
+GRANT create_group TO create_role_3 WITH INHERIT;
+GRANT create_group TO create_role_4 WITH SET; 
 
 SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, (rolpassword != '') as pass_not_empty, rolvaliduntil FROM pg_authid WHERE rolname LIKE 'create\_%' ORDER BY rolname;
 SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::text, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE 'create\_%' ORDER BY 1, 2;

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -10,8 +10,6 @@ SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::t
 
 CREATE ROLE create_role;
 CREATE ROLE create_role_2;
-CREATE ROLE create_role_3;
-CREATE ROLE create_role_4;
 CREATE USER create_user;
 CREATE USER create_user_2;
 CREATE GROUP create_group;
@@ -46,8 +44,7 @@ CREATE ROLE "create_role""edge";
 -- test grant role
 GRANT create_group TO create_role;
 GRANT create_group TO create_role_2 WITH ADMIN OPTION;
-GRANT create_group TO create_role_3 WITH INHERIT;
-GRANT create_group TO create_role_4 WITH SET; 
+
 
 SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, (rolpassword != '') as pass_not_empty, rolvaliduntil FROM pg_authid WHERE rolname LIKE 'create\_%' ORDER BY rolname;
 SELECT roleid::regrole::text AS role, member::regrole::text, grantor::regrole::text, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE 'create\_%' ORDER BY 1, 2;

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -335,34 +335,3 @@ SET search_path TO pg16;
 \set VERBOSITY terse
 SET client_min_messages TO ERROR;
 DROP SCHEMA pg16 CASCADE;
-
---
--- PG16 allows GRANT WITH ADMIN | INHERIT | SET
---
--- GRANT privileges to a role or roles  
-\c - - - :master_port
-CREATE ROLE create_role;
-CREATE ROLE create_role_2;
-CREATE ROLE create_role_3;
-CREATE ROLE create_role_4;
-CREATE USER create_user;
-CREATE USER create_user_2;
-CREATE GROUP create_group;
-CREATE GROUP create_group_2;
-
---test grant role
-GRANT create_group TO create_role;
-GRANT create_group TO create_role_2 WITH ADMIN OPTION;
-GRANT create_group TO create_role_3 WITH INHERIT;
-GRANT create_group TO create_role_4 WITH SET; 
-
--- ADMIN role can perfom administrative tasks 
--- role can now access the data and permissions of the table (owner of table)
--- role can change current user to any other user/role that has access 
-GRANT ADMIN ON DATABASE db_name TO role_name;
-GRANT INHERIT ON TABLE table_name TO role_name;
-GRANT SET SESSION AUTHORIZATION TO role_name;
-
-SELECT * FROM table_name WHERE column_name = 'value';
-
-SELECT COUNT(*) FROM table_name WHERE column_name = 'value';

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -335,3 +335,34 @@ SET search_path TO pg16;
 \set VERBOSITY terse
 SET client_min_messages TO ERROR;
 DROP SCHEMA pg16 CASCADE;
+
+--
+-- PG16 allows GRANT WITH ADMIN | INHERIT | SET
+--
+-- GRANT privileges to a role or roles  
+\c - - - :master_port
+CREATE ROLE create_role;
+CREATE ROLE create_role_2;
+CREATE ROLE create_role_3;
+CREATE ROLE create_role_4;
+CREATE USER create_user;
+CREATE USER create_user_2;
+CREATE GROUP create_group;
+CREATE GROUP create_group_2;
+
+--test grant role
+GRANT create_group TO create_role;
+GRANT create_group TO create_role_2 WITH ADMIN OPTION;
+GRANT create_group TO create_role_3 WITH INHERIT;
+GRANT create_group TO create_role_4 WITH SET; 
+
+-- ADMIN role can perfom administrative tasks 
+-- role can now access the data and permissions of the table (owner of table)
+-- role can change current user to any other user/role that has access 
+GRANT ADMIN ON DATABASE db_name TO role_name;
+GRANT INHERIT ON TABLE table_name TO role_name;
+GRANT SET SESSION AUTHORIZATION TO role_name;
+
+SELECT * FROM table_name WHERE column_name = 'value';
+
+SELECT COUNT(*) FROM table_name WHERE column_name = 'value';


### PR DESCRIPTION

Allowing GRANT ADMIN to now also be INHERIT or SET in support of psql16 

`GRANT role_name [, ...] TO role_specification [, ...]
    [ WITH { ADMIN | INHERIT | SET } { OPTION | TRUE | FALSE } ]
    [ GRANTED BY role_specification ]`