### PR TITLE
avoid rebuilding MetadataCache for each placement insertion

### DIFF
--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1262,19 +1262,21 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 		CreateTruncateTrigger(relationId);
 	}
 
-	/* create shards for hash distributed and reference tables */
 	if (tableType == HASH_DISTRIBUTED)
 	{
+		/* create shards for hash distributed table */
 		CreateHashDistributedTableShards(relationId, distributedTableParams->shardCount,
 										 colocatedTableId,
 										 localTableEmpty);
 	}
 	else if (tableType == REFERENCE_TABLE)
 	{
+		/* create shards for reference table */
 		CreateReferenceTableShard(relationId);
 	}
 	else if (tableType == SINGLE_SHARD_DISTRIBUTED)
 	{
+		/* create the shard of given single-shard distributed table */
 		CreateSingleShardTableShard(relationId, colocatedTableId,
 									colocationId);
 	}
@@ -1900,7 +1902,7 @@ CreateHashDistributedTableShards(Oid relationId, int shardCount,
 
 
 /*
- * CreateHashDistributedTableShards creates the shard of given single-shard
+ * CreateSingleShardTableShard creates the shard of given single-shard
  * distributed table.
  */
 static void

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -383,14 +383,13 @@ CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId,
 
 /*
  * InsertShardPlacementRows inserts shard placements to the metadata table on
- * the coordinator node. Then, returns the list of added shard placements.
+ * the coordinator node.
  */
-List *
+void
 InsertShardPlacementRows(Oid relationId, int64 shardId, List *workerNodeList,
 						 int workerStartIndex, int replicationFactor)
 {
 	int workerNodeCount = list_length(workerNodeList);
-	List *insertedShardPlacements = NIL;
 
 	for (int placementIndex = 0; placementIndex < replicationFactor; placementIndex++)
 	{
@@ -399,13 +398,11 @@ InsertShardPlacementRows(Oid relationId, int64 shardId, List *workerNodeList,
 		uint32 nodeGroupId = workerNode->groupId;
 		const uint64 shardSize = 0;
 
-		uint64 shardPlacementId = InsertShardPlacementRow(shardId, INVALID_PLACEMENT_ID,
-														  shardSize, nodeGroupId);
-		ShardPlacement *shardPlacement = LoadShardPlacement(shardId, shardPlacementId);
-		insertedShardPlacements = lappend(insertedShardPlacements, shardPlacement);
+		InsertShardPlacementRow(shardId,
+								INVALID_PLACEMENT_ID,
+								shardSize,
+								nodeGroupId);
 	}
-
-	return insertedShardPlacements;
 }
 
 

--- a/src/include/distributed/coordinator_protocol.h
+++ b/src/include/distributed/coordinator_protocol.h
@@ -251,9 +251,9 @@ extern void CreateAppendDistributedShardPlacements(Oid relationId, int64 shardId
 												   replicationFactor);
 extern void CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 								  bool useExclusiveConnection);
-extern List * InsertShardPlacementRows(Oid relationId, int64 shardId,
-									   List *workerNodeList, int workerStartIndex,
-									   int replicationFactor);
+extern void InsertShardPlacementRows(Oid relationId, int64 shardId,
+									 List *workerNodeList, int workerStartIndex,
+									 int replicationFactor);
 extern uint64 UpdateShardStatistics(int64 shardId);
 extern void CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 											 int32 replicationFactor,


### PR DESCRIPTION
for reference table and distributed table without colocation field, 
each time we insert a shard placement, it invalidate the metadata cache with the
relation oid, and build it by a following `LoadShardPlacement`, this was partly
fixed by #6722 for CreateColocatedShards, problem still exists for other cases,
this patch fix them all.
