### PR TITLE
Adds PostgreSQL 16 RC1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-v0c8d80c'
+    default: '-v641cdcd'
   pg14_version:
     type: string
     default: '14.9'
@@ -15,10 +15,10 @@ parameters:
     default: '15.4'
   pg16_version:
     type: string
-    default: '16beta3'
+    default: '16rc1'
   upgrade_pg_versions:
     type: string
-    default: '14.9-15.4-16beta3'
+    default: '14.9-15.4-16rc1'
   style_checker_tools_version:
     type: string
     default: '0.8.18'

--- a/src/test/regress/expected/isolation_shard_rebalancer_progress.out
+++ b/src/test/regress/expected/isolation_shard_rebalancer_progress.out
@@ -19,7 +19,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -42,7 +42,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -63,7 +63,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -102,7 +102,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -125,7 +125,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       2|move          |t               |t                   |f                   |Completed
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       2|move          |t               |t                   |f                   |Completed
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
+colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 (4 rows)
 
@@ -141,7 +141,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -184,7 +184,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -207,7 +207,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |f                   |Copying Data
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |f                   |Copying Data
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -228,7 +228,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -271,7 +271,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -294,7 +294,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -315,7 +315,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -358,7 +358,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -381,7 +381,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |t                   |Final Catchup
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -402,7 +402,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -445,7 +445,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -487,7 +487,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -530,7 +530,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -572,7 +572,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -616,7 +616,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -658,7 +658,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -702,7 +702,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -744,7 +744,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -787,7 +787,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -829,7 +829,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -872,7 +872,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -914,7 +914,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -958,7 +958,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -1000,7 +1000,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -1044,7 +1044,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -1086,7 +1086,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -1132,7 +1132,7 @@ step s4-shard-move-sep-block-writes:
  <waiting ...>
 step s7-get-progress-ordered: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,
@@ -1155,7 +1155,7 @@ table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname
 ---------------------------------------------------------------------
 colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f
 colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f
-separate  |1500009|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f
+separate  |1500009|    100000|localhost |     57637|           100000|localhost |     57638|             8000|       1|move          |t               |t                   |f
 (3 rows)
 
 step s5-release-advisory-lock:
@@ -1182,103 +1182,7 @@ step s1-wait:
 step s4-wait:
 step s7-get-progress-ordered:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
- SELECT
-  table_name,
-  shardid,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - shard_size) = (SELECT MIN(ABS(size - shard_size)) FROM possible_sizes )) shard_size,
-  sourcename,
-  sourceport,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - source_shard_size) = (SELECT MIN(ABS(size - source_shard_size)) FROM possible_sizes )) source_shard_size,
-  targetname,
-  targetport,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - target_shard_size) = (SELECT MIN(ABS(size - target_shard_size)) FROM possible_sizes )) target_shard_size,
-  progress,
-  operation_type,
-  target_lsn IS NULL OR source_lsn >= target_lsn AS lsn_sanity_check,
-  source_lsn IS NOT NULL AS source_lsn_available,
-  target_lsn IS NOT NULL AS target_lsn_available
- FROM get_rebalance_progress()
- ORDER BY 1, 2, 3, 4, 5;
-
-table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
----------------------------------------------------------------------
-(0 rows)
-
-
-starting permutation: s6-acquire-advisory-lock-after-copy s1-shard-move-c1-block-writes s4-shard-move-sep-block-writes s7-get-progress-ordered s6-release-advisory-lock s1-wait s4-wait s7-get-progress-ordered
-master_set_node_property
----------------------------------------------------------------------
-
-(1 row)
-
-step s6-acquire-advisory-lock-after-copy:
-    SELECT pg_advisory_lock(44000, 55152);
-
-pg_advisory_lock
----------------------------------------------------------------------
-
-(1 row)
-
-step s1-shard-move-c1-block-writes:
- SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
- <waiting ...>
-step s4-shard-move-sep-block-writes: 
- SELECT citus_move_shard_placement(1500009, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
- <waiting ...>
-step s7-get-progress-ordered: 
- set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
- SELECT
-  table_name,
-  shardid,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - shard_size) = (SELECT MIN(ABS(size - shard_size)) FROM possible_sizes )) shard_size,
-  sourcename,
-  sourceport,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - source_shard_size) = (SELECT MIN(ABS(size - source_shard_size)) FROM possible_sizes )) source_shard_size,
-  targetname,
-  targetport,
-  ( SELECT size FROM possible_sizes WHERE ABS(size - target_shard_size) = (SELECT MIN(ABS(size - target_shard_size)) FROM possible_sizes )) target_shard_size,
-  progress,
-  operation_type,
-  target_lsn IS NULL OR source_lsn >= target_lsn AS lsn_sanity_check,
-  source_lsn IS NOT NULL AS source_lsn_available,
-  target_lsn IS NOT NULL AS target_lsn_available
- FROM get_rebalance_progress()
- ORDER BY 1, 2, 3, 4, 5;
-
-table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
----------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |f
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |f
-separate  |1500009|     50000|localhost |     57637|            50000|localhost |     57638|           200000|       1|move          |t               |t                   |f
-(3 rows)
-
-step s6-release-advisory-lock:
-    SELECT pg_advisory_unlock(44000, 55152);
-
-pg_advisory_unlock
----------------------------------------------------------------------
-t
-(1 row)
-
-step s1-shard-move-c1-block-writes: <... completed>
-citus_move_shard_placement
----------------------------------------------------------------------
-
-(1 row)
-
-step s4-shard-move-sep-block-writes: <... completed>
-citus_move_shard_placement
----------------------------------------------------------------------
-
-(1 row)
-
-step s1-wait:
-step s4-wait:
-step s7-get-progress-ordered:
- set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
  SELECT
   table_name,
   shardid,

--- a/src/test/regress/expected/isolation_shard_rebalancer_progress.out
+++ b/src/test/regress/expected/isolation_shard_rebalancer_progress.out
@@ -19,7 +19,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -40,9 +40,9 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -63,7 +63,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -102,7 +102,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -123,9 +123,9 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       2|move          |t               |t                   |f                   |Completed
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       2|move          |t               |t                   |f                   |Completed
-colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       2|move          |t               |t                   |f                   |Completed
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       2|move          |t               |t                   |f                   |Completed
+colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 (4 rows)
 
@@ -141,7 +141,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -184,7 +184,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -205,9 +205,9 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |f                   |Copying Data
-colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f                   |Copying Data
+colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -228,7 +228,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -271,7 +271,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -292,9 +292,9 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -315,7 +315,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -358,7 +358,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -379,9 +379,9 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated1|1500002|    280000|localhost |     57637|           280000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
 
@@ -402,7 +402,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -445,7 +445,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -466,8 +466,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -487,7 +487,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -530,7 +530,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -551,8 +551,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |f                   |Copying Data
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -572,7 +572,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -616,7 +616,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -637,8 +637,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -658,7 +658,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -702,7 +702,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -723,8 +723,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|copy          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|copy          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -744,7 +744,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -787,7 +787,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -808,8 +808,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -829,7 +829,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -872,7 +872,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -893,8 +893,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |t                   |Final Catchup
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -914,7 +914,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -958,7 +958,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -979,8 +979,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -1000,7 +1000,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -1044,7 +1044,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -1065,8 +1065,8 @@ step s7-get-progress:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|            50000|       1|copy          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|           400000|       1|copy          |t               |t                   |t                   |Final Catchup
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|copy          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|copy          |t               |t                   |t                   |Final Catchup
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -1086,7 +1086,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -1132,7 +1132,7 @@ step s4-shard-move-sep-block-writes:
  <waiting ...>
 step s7-get-progress-ordered: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,
@@ -1153,9 +1153,9 @@ step s7-get-progress-ordered:
 
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
 ---------------------------------------------------------------------
-colocated1|1500001|     50000|localhost |     57637|            50000|localhost |     57638|             8000|       1|move          |t               |t                   |f
-colocated2|1500005|    400000|localhost |     57637|           400000|localhost |     57638|             8000|       1|move          |t               |t                   |f
-separate  |1500009|    100000|localhost |     57637|           100000|localhost |     57638|             8000|       1|move          |t               |t                   |f
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f
+separate  |1500009|    200000|localhost |     57637|           200000|localhost |     57638|             8000|       1|move          |t               |t                   |f
 (3 rows)
 
 step s5-release-advisory-lock:
@@ -1182,7 +1182,103 @@ step s1-wait:
 step s4-wait:
 step s7-get-progress-ordered:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ SELECT
+  table_name,
+  shardid,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - shard_size) = (SELECT MIN(ABS(size - shard_size)) FROM possible_sizes )) shard_size,
+  sourcename,
+  sourceport,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - source_shard_size) = (SELECT MIN(ABS(size - source_shard_size)) FROM possible_sizes )) source_shard_size,
+  targetname,
+  targetport,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - target_shard_size) = (SELECT MIN(ABS(size - target_shard_size)) FROM possible_sizes )) target_shard_size,
+  progress,
+  operation_type,
+  target_lsn IS NULL OR source_lsn >= target_lsn AS lsn_sanity_check,
+  source_lsn IS NOT NULL AS source_lsn_available,
+  target_lsn IS NOT NULL AS target_lsn_available
+ FROM get_rebalance_progress()
+ ORDER BY 1, 2, 3, 4, 5;
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
+---------------------------------------------------------------------
+(0 rows)
+
+
+starting permutation: s6-acquire-advisory-lock-after-copy s1-shard-move-c1-block-writes s4-shard-move-sep-block-writes s7-get-progress-ordered s6-release-advisory-lock s1-wait s4-wait s7-get-progress-ordered
+master_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+step s6-acquire-advisory-lock-after-copy:
+    SELECT pg_advisory_lock(44000, 55152);
+
+pg_advisory_lock
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-shard-move-c1-block-writes:
+ SELECT citus_move_shard_placement(1500001, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s4-shard-move-sep-block-writes: 
+ SELECT citus_move_shard_placement(1500009, 'localhost', 57637, 'localhost', 57638, shard_transfer_mode:='block_writes');
+ <waiting ...>
+step s7-get-progress-ordered: 
+ set LOCAL client_min_messages=NOTICE;
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ SELECT
+  table_name,
+  shardid,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - shard_size) = (SELECT MIN(ABS(size - shard_size)) FROM possible_sizes )) shard_size,
+  sourcename,
+  sourceport,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - source_shard_size) = (SELECT MIN(ABS(size - source_shard_size)) FROM possible_sizes )) source_shard_size,
+  targetname,
+  targetport,
+  ( SELECT size FROM possible_sizes WHERE ABS(size - target_shard_size) = (SELECT MIN(ABS(size - target_shard_size)) FROM possible_sizes )) target_shard_size,
+  progress,
+  operation_type,
+  target_lsn IS NULL OR source_lsn >= target_lsn AS lsn_sanity_check,
+  source_lsn IS NOT NULL AS source_lsn_available,
+  target_lsn IS NOT NULL AS target_lsn_available
+ FROM get_rebalance_progress()
+ ORDER BY 1, 2, 3, 4, 5;
+
+table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
+---------------------------------------------------------------------
+colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f
+colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f
+separate  |1500009|    200000|localhost |     57637|           200000|localhost |     57638|           200000|       1|move          |t               |t                   |f
+(3 rows)
+
+step s6-release-advisory-lock:
+    SELECT pg_advisory_unlock(44000, 55152);
+
+pg_advisory_unlock
+---------------------------------------------------------------------
+t
+(1 row)
+
+step s1-shard-move-c1-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s4-shard-move-sep-block-writes: <... completed>
+citus_move_shard_placement
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-wait:
+step s4-wait:
+step s7-get-progress-ordered:
+ set LOCAL client_min_messages=NOTICE;
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
  SELECT
   table_name,
   shardid,

--- a/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
+++ b/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
@@ -131,7 +131,7 @@ session "s7"
 step "s7-get-progress"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
 	SELECT
 		table_name,
 		shardid,
@@ -157,7 +157,7 @@ step "s7-get-progress"
 step "s7-get-progress-ordered"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
 	SELECT
 		table_name,
 		shardid,
@@ -204,5 +204,4 @@ permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-copy-c1-online" "s7-
 
 // parallel blocking shard move
 permutation "s5-acquire-advisory-lock-before-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s5-release-advisory-lock" "s1-wait" "s4-wait" "s7-get-progress-ordered"
-// Commented out due to flakyness
-// permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s6-release-advisory-lock"  "s1-wait" "s4-wait" "s7-get-progress-ordered"
+permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s6-release-advisory-lock"  "s1-wait" "s4-wait" "s7-get-progress-ordered"

--- a/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
+++ b/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
@@ -131,7 +131,7 @@ session "s7"
 step "s7-get-progress"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
 	SELECT
 		table_name,
 		shardid,
@@ -157,7 +157,7 @@ step "s7-get-progress"
 step "s7-get-progress-ordered"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (200000), (400000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (50000), (100000), (280000), (400000))
 	SELECT
 		table_name,
 		shardid,
@@ -204,4 +204,5 @@ permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-copy-c1-online" "s7-
 
 // parallel blocking shard move
 permutation "s5-acquire-advisory-lock-before-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s5-release-advisory-lock" "s1-wait" "s4-wait" "s7-get-progress-ordered"
-permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s6-release-advisory-lock"  "s1-wait" "s4-wait" "s7-get-progress-ordered"
+// Commented out due to flakyness
+// permutation "s6-acquire-advisory-lock-after-copy" "s1-shard-move-c1-block-writes" "s4-shard-move-sep-block-writes"("s1-shard-move-c1-block-writes") "s7-get-progress-ordered" "s6-release-advisory-lock"  "s1-wait" "s4-wait" "s7-get-progress-ordered"


### PR DESCRIPTION
DESCRIPTION: Adds PostgreSQL 16 RC1 support

#### - Updates CI image to the one with PG16RC1 images

#### - Fixes isolation_shard_rebalancer_progress test
Some shard size calculations were done differently in PG16.
https://app.circleci.com/pipelines/github/citusdata/citus/34532/workflows/857848ad-ac64-475e-8c58-2c8180c4fd6d/jobs/1228286
```diff
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|
 ----------+-------+----------+----------+----------+-----------------+----------+----------+-----------------+
-colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|
+colocated1|1500002|    400000|localhost |     57637|           400000|localhost |     57638|                0|
```
Actual sizes for shard 1500002 are 196608 prePG16 and 335872 in PG16.
In order for 335872 to stay in the 200000 range, I changed 400000 to 480000.

```diff
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|
 ----------+-------+----------+----------+----------+-----------------+----------+----------+-----------------+
-separate  |1500009|     50000|localhost |     57637|            50000|localhost |     57638|             8000|
+separate  |1500009|    200000|localhost |     57637|           200000|localhost |     57638|             8000|
```
Actual sizes for shard 1500009 are 122880 prePG16 and 172032 in PG16.
So I changed the approximation from 50000 to 4000 such that both 122880 and 172032 approximate to 100000.

There was another instance with shard 150009 in which the
target_shard_size was 122880 prePG16 and 196608 in PG16.
These both approximate to 200000.

Citus commit used for reference:
https://github.com/citusdata/citus/commit/aea4964b39497f7482a0781e07b88277b37e0c10
