### PR TITLE
Removes ubuntu:kinetic pipelines since it's EOL

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -125,7 +125,6 @@ jobs:
           - debian-bullseye-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
-          - ubuntu-kinetic-all
 
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
 


### PR DESCRIPTION
ubuntu:kinetic is EOL so removing it's pipeline

https://fridge.ubuntu.com/2023/06/14/ubuntu-22-10-kinetic-kudu-reaches-end-of-life-on-july-20-2023/
