### PR TITLE
Adds PostgreSQL 16.0 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   image_suffix:
     type: string
-    default: '-v641cdcd'
+    default: '-v87fd773'
   pg14_version:
     type: string
     default: '14.9'
@@ -15,10 +15,10 @@ parameters:
     default: '15.4'
   pg16_version:
     type: string
-    default: '16rc1'
+    default: '16.0'
   upgrade_pg_versions:
     type: string
-    default: '14.9-15.4-16rc1'
+    default: '14.9-15.4-16.0'
   style_checker_tools_version:
     type: string
     default: '0.8.18'

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -46,6 +46,8 @@ get_guc_variables_compat(int *gucCount)
 #define object_ownercheck(a, b, c) object_ownercheck(a, b, c)
 #define object_aclcheck(a, b, c, d) object_aclcheck(a, b, c, d)
 
+#define pgstat_fetch_stat_local_beentry(a) pgstat_get_local_beentry_by_index(a)
+
 #else
 
 #include "catalog/pg_class_d.h"


### PR DESCRIPTION
The main PG16 support work has been done for 16beta3 https://github.com/citusdata/citus/pull/6952
There was some extra work needed for 16rc1 https://github.com/citusdata/citus/pull/7173
And this PR yet introduces some extra work needed to 16.0 :)

`pgstat_fetch_stat_local_beentry` has been renamed to `pgstat_get_local_beentry_by_index` in PG16.0

Relevant PG commit:
https://github.com/postgres/postgres/commit/8dfa37b797843a83a5756ea3309055e8953e1a86 8dfa37b797843a83a5756ea3309055e8953e1a86

https://github.com/citusdata/the-process/pull/150