### PR TITLE
Removes centos 7 for PG 16 in packaging pipelines

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -44,7 +44,6 @@ jobs:
         # For this reason, we need to use a "matrix" to generate names of
         # rpm images, e.g. citus/packaging:centos-7-pg12
         packaging_docker_image:
-          - oraclelinux-7
           - oraclelinux-8
           - almalinux-8
           - almalinux-9
@@ -56,6 +55,10 @@ jobs:
           - packaging_docker_image: centos-7
             POSTGRES_VERSION: 14
           - packaging_docker_image: centos-7
+            POSTGRES_VERSION: 15
+          - packaging_docker_image: oraclelinux-7
+            POSTGRES_VERSION: 14
+          - packaging_docker_image: oraclelinux-7
             POSTGRES_VERSION: 15
 
     container:

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
         # Postgres removed support for CentOS 7 in PG 16. Below block is needed to
         # keep the build for CentOS 7 working for PG 14 and PG 15.
-        # Once Marlin drop support for Centos 7, we can remove this block.
+        # Once dependent systems drop support for Centos 7, we can remove this block.
         include:
           - packaging_docker_image: centos-7
             POSTGRES_VERSION: 14

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -46,10 +46,17 @@ jobs:
         packaging_docker_image:
           - oraclelinux-7
           - oraclelinux-8
-          - centos-7
           - almalinux-8
           - almalinux-9
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
+        # Postgres removed support for CentOS 7 in PG 16. Below block is needed to
+        # keep the build for CentOS 7 working for PG 14 and PG 15.
+        # Once Marlin drop support for Centos 7, we can remove this block.
+        include:
+          - packaging_docker_image: centos-7
+            POSTGRES_VERSION: 14
+          - packaging_docker_image: centos-7
+            POSTGRES_VERSION: 15
 
     container:
       image: citus/packaging:${{ matrix.packaging_docker_image }}-pg${{ matrix.POSTGRES_VERSION }}


### PR DESCRIPTION
centos 7 and oracle 7 is not being supported for newer releases by Postgres. Therefore, getting package download errors in packaging pipelines.
This PR removes el/7 and ol/7 Postgres 16 pipelines