### PR TITLE
Remove useless test output

### DIFF
--- a/src/test/regress/expected/citus_non_blocking_split_shards.out
+++ b/src/test/regress/expected/citus_non_blocking_split_shards.out
@@ -639,11 +639,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+SET client_min_messages TO ERROR;
 DROP SCHEMA "citus_split_test_schema" CASCADE;
-NOTICE:  drop cascades to 4 other objects
-DETAIL:  drop cascades to table citus_split_test_schema.sensors
-drop cascades to table citus_split_test_schema.reference_table
-drop cascades to table citus_split_test_schema.colocated_dist_table
-drop cascades to table citus_split_test_schema.table_with_index_rep_identity
 DROP ROLE test_shard_split_role;
 --END : Cleanup

--- a/src/test/regress/sql/citus_non_blocking_split_shards.sql
+++ b/src/test/regress/sql/citus_non_blocking_split_shards.sql
@@ -317,6 +317,7 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_subscription$$);
 
 ALTER SYSTEM RESET citus.defer_shard_delete_interval;
 SELECT pg_reload_conf();
+SET client_min_messages TO ERROR;
 DROP SCHEMA "citus_split_test_schema" CASCADE;
 DROP ROLE test_shard_split_role;
 --END : Cleanup


### PR DESCRIPTION
This was sometimes failing when running locally due to some local shard
still existing due to. This fixes that. We normally silence all
`drop schema cascade` output like this anyway to avoid unnecessary
diffs when modifying a test later on.
