### PR TITLE
Use the $(DLSUFFIX) instead of hard coded extensions for cdc

### DIFF
--- a/src/backend/distributed/cdc/Makefile.decoder
+++ b/src/backend/distributed/cdc/Makefile.decoder
@@ -14,11 +14,6 @@ override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
 
 install: install-cdc
 
-clean: clean-cdc
-
 install-cdc:
 	mkdir -p '$(citus_decoders_dir)'
-	$(INSTALL_SHLIB) citus_$(DECODER).so '$(citus_decoders_dir)/$(DECODER).so'
-
-clean-cdc:
-	rm -f '$(DESTDIR)$(datadir)/$(datamoduledir)/citus_decoders/$(DECODER).so'
+	$(INSTALL_SHLIB) citus_$(DECODER)$(DLSUFFIX) '$(citus_decoders_dir)/$(DECODER)$(DLSUFFIX)'


### PR DESCRIPTION
When cdc got added the makefiles hardcoded the `.so` extension instead of using the platform specifc `$(DLSUFFIX)` variable used by `pgxs.mk`. Also don't remove installed cdc artifacts on `make clean`.