### PR TITLE
Shard moves/isolate report LSN's in lsn format

### DIFF
--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -1882,14 +1882,15 @@ WaitForGroupedLogicalRepTargetsToCatchUp(XLogRecPtr sourcePosition,
 										   GetCurrentTimestamp(),
 										   logicalReplicationProgressReportTimeout))
 			{
-				ereport(LOG, (errmsg(
-								  "The LSN of the target subscriptions on node %s:%d have "
-								  "increased from %ld to %ld at %s where the source LSN is %ld  ",
-								  superuserConnection->hostname,
-								  superuserConnection->port, previousTargetBeforeThisLoop,
-								  targetPosition,
-								  timestamptz_to_str(previousLSNIncrementTime),
-								  sourcePosition)));
+				ereport(LOG, (errmsg("The LSN of the target subscriptions on node %s:%d "
+									 "has increased from %X/%X to %X/%X at %s where the "
+									 "source LSN is %X/%X ",
+									 superuserConnection->hostname,
+									 superuserConnection->port,
+									 LSN_FORMAT_ARGS(previousTargetBeforeThisLoop),
+									 LSN_FORMAT_ARGS(targetPosition),
+									 timestamptz_to_str(previousLSNIncrementTime),
+									 LSN_FORMAT_ARGS(sourcePosition))));
 
 				previousReportTime = GetCurrentTimestamp();
 			}


### PR DESCRIPTION
DESCRIPTION: Shard moves/isolate report LSN's in lsn format

While investigating an issue with our catchup mechanism on certain
postgres versions we noticed we print LSN's in the format of the native
long type. This is an uncommon representation for LSN's in postgres
logs.

This patch changes the output of our log message to go from the long
type representation to the native LSN type representation. Making it
easier for postgres users to recognize and compare LSN's with other
related reports.

example of new output:
```
2023-09-25 17:28:47.544 CEST [11345] LOG:  The LSN of the target subscriptions on node localhost:9701 have increased from 0/0 to 0/E1ED20F8 at 2023-09-25 17:28:47.544165+02 where the source LSN is 1/415DCAD0
```
