### PR TITLE
Send keepalive messages in split decoder periodically to avoid wal receiver timeouts during large shard splits.

### DIFF
--- a/src/backend/distributed/shardsplit/shardsplit_decoder.c
+++ b/src/backend/distributed/shardsplit/shardsplit_decoder.c
@@ -98,7 +98,7 @@ replication_origin_filter_cb(LogicalDecodingContext *ctx, RepOriginId origin_id)
  * reordering phase which is above change_cb. So we do not need to send keepalive in
  * change_cb.
  */
-#if (PG_VERSION_NUM <= PG_VERSION_15)
+#if (PG_VERSION_NUM < PG_VERSION_16)
 static void
 update_replication_progress(LogicalDecodingContext *ctx, bool skipped_xact)
 {
@@ -118,7 +118,7 @@ update_replication_progress(LogicalDecodingContext *ctx, bool skipped_xact)
 	 */
 	if (ctx->end_xact || ++changes_count >= CHANGES_THRESHOLD)
 	{
-#if (PG_VERSION_NUM == PG_VERSION_15)
+#if (PG_VERSION_NUM >= PG_VERSION_15)
 		OutputPluginUpdateProgress(ctx, skipped_xact);
 #else
 		OutputPluginUpdateProgress(ctx);
@@ -148,7 +148,7 @@ shard_split_change_cb(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		return;
 	}
 
-#if (PG_VERSION_NUM <= PG_VERSION_15)
+#if (PG_VERSION_NUM < PG_VERSION_16)
 
 	/* Send replication keepalive. */
 	update_replication_progress(ctx, false);


### PR DESCRIPTION
DESCRIPTION: Send keepalive messages during the logical replication phase of large shard splits to avoid timeouts.

During the logical replication part of  the shard split process, split decoder filters out the wal records produced by the initial copy.  If the number of wal records is big, then split decoder ends up processing for a long time before sending out any wal records through pgoutput. Hence the wal receiver may time out and restarts repeatedly causing our split driver code catch up logic to fail.

Notes: 

1. If the wal_receiver_timeout is set to a very small number e.g. 600ms, it may time out before receiving the keepalives. My tests show that this code works best when the` wal_receiver_timeout `is set to 1minute, which is the default value.

2. Once a logical replication worker time outs, a new one gets launched. The new logical replication worker sets the pg_stat_subscription columns to initial values. E.g. the latest_end_lsn is set to 0.  Our driver logic in `WaitForGroupedLogicalRepTargetsToCatchUp`  can not handle LSN value to go back. This is the main reason for it to get stuck in the infinite loop.
