### PR TITLE
Fix leaking of memory and memory contexts in Foreign Constraint Graphs

### DIFF
--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -339,7 +339,7 @@ CreateForeignConstraintRelationshipGraph()
 			ALLOCSET_DEFAULT_INITSIZE,
 			ALLOCSET_DEFAULT_MAXSIZE);
 	}
-	else 
+	else
 	{
 		MemoryContextReset(ForeignConstraintRelationshipMemoryContext);
 	}

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -28,6 +28,7 @@
 #include "distributed/version_compat.h"
 #include "nodes/pg_list.h"
 #include "storage/lockdefs.h"
+#include "utils/catcache.h"
 #include "utils/fmgroids.h"
 #include "utils/hsearch.h"
 #include "common/hashfn.h"
@@ -332,6 +333,12 @@ CreateForeignConstraintRelationshipGraph()
 	 */
 	if (ForeignConstraintRelationshipMemoryContext == NULL)
 	{
+		/* make sure we've initialized CacheMemoryContext */
+		if (CacheMemoryContext == NULL)
+		{
+			CreateCacheMemoryContext();
+		}
+
 		ForeignConstraintRelationshipMemoryContext = AllocSetContextCreate(
 			CacheMemoryContext,
 			"Foreign Constraint Relationship Graph Context",

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -324,8 +324,6 @@ CreateForeignConstraintRelationshipGraph()
 		return;
 	}
 
-	ClearForeignConstraintRelationshipGraphContext();
-
 	/*
 	 * Lazily create our memory context once and reset on every reuse.
 	 * Since we have cleared and invalidated the fConstraintRelationshipGraph, right
@@ -348,8 +346,11 @@ CreateForeignConstraintRelationshipGraph()
 	}
 	else
 	{
+		fConstraintRelationshipGraph = NULL;
 		MemoryContextReset(ForeignConstraintRelationshipMemoryContext);
 	}
+
+	Assert(fConstraintRelationshipGraph == NULL);
 
 	MemoryContext oldContext = MemoryContextSwitchTo(
 		ForeignConstraintRelationshipMemoryContext);
@@ -651,24 +652,4 @@ CreateOrFindNode(HTAB *adjacencyLists, Oid relid)
 	}
 
 	return node;
-}
-
-
-/*
- * ClearForeignConstraintRelationshipGraphContext clear all the allocated memory obtained
- * for foreign constraint relationship graph. Since all the variables of relationship
- * graph was obtained within the same context, destroying hash map is enough as
- * it deletes the context.
- */
-void
-ClearForeignConstraintRelationshipGraphContext()
-{
-	if (fConstraintRelationshipGraph == NULL)
-	{
-		return;
-	}
-
-	hash_destroy(fConstraintRelationshipGraph->nodeMap);
-	pfree(fConstraintRelationshipGraph);
-	fConstraintRelationshipGraph = NULL;
 }

--- a/src/include/distributed/foreign_key_relationship.h
+++ b/src/include/distributed/foreign_key_relationship.h
@@ -20,7 +20,6 @@ extern bool ShouldUndistributeCitusLocalTable(Oid relationId);
 extern List * ReferencedRelationIdList(Oid relationId);
 extern List * ReferencingRelationIdList(Oid relationId);
 extern void SetForeignConstraintRelationshipGraphInvalid(void);
-extern void ClearForeignConstraintRelationshipGraphContext(void);
 extern bool OidVisited(HTAB *oidVisitedMap, Oid oid);
 extern void VisitOid(HTAB *oidVisitedMap, Oid oid);
 


### PR DESCRIPTION
DESCRIPTION: Fix leaking of memory and memory contexts in Foreign Constraint Graphs

Previously, every time we (re)created the Foreign Constraint Relationship Graph, we created a new Memory Context while loosing a reference to the previous context. This old context could still have left over memory in there causing a memory leak.

With this patch we statically have one memory context that we lazily initialize the first time we create our foreign constraint relationship graph. On every subsequent creation, beside destroying our previous hashmap we also reset our memory context to remove any left over references.
