### PR TITLE
Handle errors better in generate_citus_tarballs.sh

### DIFF
--- a/src/test/regress/citus_tests/upgrade/generate_citus_tarballs.sh
+++ b/src/test/regress/citus_tests/upgrade/generate_citus_tarballs.sh
@@ -3,44 +3,45 @@
 set -euxo pipefail
 
 pg_version=$1
-citus_old_version=$2
+citus_version=$2
 
 base="$(pwd)"
 
-install_citus_and_tar() {
-    # do everything in a subdirectory to avoid clutter in current directory
-    mkdir -p "${builddir}" && cd "${builddir}"
+# If tarball already exsists we're good
+if [ -f "${base}/install-pg${pg_version}-citus${citus_version}.tar" ]; then
+    exit 0
+fi
 
-    "${citus_dir}/configure" --without-libcurl
+basedir="${base}/${citus_version}"
 
-    installdir="${builddir}/install"
-    make "-j$(nproc)" && mkdir -p "${installdir}" && make DESTDIR="${installdir}" install
+rm -rf "${basedir}"
+mkdir -p "${basedir}"
+cd "${basedir}"
+citus_dir=${basedir}/citus_$citus_version
+git clone --branch "$citus_version" https://github.com/citusdata/citus.git --depth 1 citus_"$citus_version"
+builddir="${basedir}/build"
 
-    cd "${installdir}" && find . -type f -print >"${builddir}/files.lst"
+# do everything in a subdirectory to avoid clutter in current directory
+mkdir -p "${builddir}"
+cd "${builddir}"
 
-    tar cvf "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" $(cat "${builddir}"/files.lst)
-    mv "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" "${base}/install-pg${pg_version}-citus${citus_version}.tar"
+"${citus_dir}/configure" --without-libcurl
 
-    cd "${builddir}" && rm -rf install files.lst && make clean
-}
+installdir="${builddir}/install"
+make "-j$(nproc)"
+mkdir -p "${installdir}"
+make DESTDIR="${installdir}" install
 
-build_ext() {
-    citus_version="$1"
-    # If tarball already exsists we're good
-    if [ -f "${base}/install-pg${pg_version}-citus${citus_version}.tar" ]; then
-        return
-    fi
+cd "${installdir}"
 
-    basedir="${base}/${citus_version}"
+find . -type f -print >"${builddir}/files.lst"
 
-    rm -rf "${basedir}"
-    mkdir -p "${basedir}"
-    cd "${basedir}"
-    citus_dir=${basedir}/citus_$citus_version
-    git clone --branch "$citus_version" https://github.com/citusdata/citus.git --depth 1 citus_"$citus_version"
-    builddir="${basedir}/build"
+cd "${builddir}"
 
-    install_citus_and_tar
-}
+tar cvf "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" $(cat "${builddir}"/files.lst)
+mv "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" "${base}/install-pg${pg_version}-citus${citus_version}.tar"
 
-build_ext "${citus_old_version}"
+cd "${builddir}"
+rm -rf install files.lst
+make clean
+

--- a/src/test/regress/citus_tests/upgrade/generate_citus_tarballs.sh
+++ b/src/test/regress/citus_tests/upgrade/generate_citus_tarballs.sh
@@ -36,8 +36,6 @@ cd "${installdir}"
 
 find . -type f -print >"${builddir}/files.lst"
 
-cd "${builddir}"
-
 tar cvf "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" $(cat "${builddir}"/files.lst)
 mv "${basedir}/install-pg${pg_version}-citus${citus_version}.tar" "${base}/install-pg${pg_version}-citus${citus_version}.tar"
 


### PR DESCRIPTION
Normally our bash scripts fail when a command fails because we make sure
they contain `set -e`. In `generate_citus_tarballs.sh` this didn't work
well though due the actual commands being inside of functions and
sometimes being chained using `&&`. This could make us miss certain
errors, and be very confused when it then failed in a different way
later. This happened when debugging the flaky test job in #7218.
