### PR TITLE
Start Maintenance Daemon for Main DB at the server start.

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1821,15 +1821,15 @@ RegisterCitusConfigVariables(void)
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_MS,
 		NULL, NULL, NULL);
 
-      DefineCustomStringVariable(
-                "citus.main_db",
-                gettext_noop("Which database is designated as the controldb"),
-                NULL,
-                &MainDb,
-                "",
-                PGC_POSTMASTER,
-                GUC_STANDARD,
-                NULL, NULL, NULL);
+	DefineCustomStringVariable(
+		"citus.main_db",
+		gettext_noop("Which database is designated as the controldb"),
+		NULL,
+		&MainDb,
+		"",
+		PGC_POSTMASTER,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
 		"citus.max_adaptive_executor_pool_size",

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1023,16 +1023,6 @@ RegisterCitusConfigVariables(void)
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 
-	DefineCustomStringVariable(
-		"citus.main_db",
-		gettext_noop("Which database is designated as the controldb"),
-		NULL,
-		&MainDb,
-		"",
-		PGC_POSTMASTER,
-		GUC_STANDARD,
-		NULL, NULL, NULL);
-
 	DefineCustomEnumVariable(
 		"citus.coordinator_aggregation_strategy",
 		gettext_noop("Sets the strategy for when an aggregate cannot be pushed down. "
@@ -1830,6 +1820,16 @@ RegisterCitusConfigVariables(void)
 		PGC_SIGHUP,
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE | GUC_UNIT_MS,
 		NULL, NULL, NULL);
+
+      DefineCustomStringVariable(
+                "citus.main_db",
+                gettext_noop("Which database is designated as the controldb"),
+                NULL,
+                &MainDb,
+                "",
+                PGC_POSTMASTER,
+                GUC_STANDARD,
+                NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
 		"citus.max_adaptive_executor_pool_size",

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -481,7 +481,7 @@ _PG_init(void)
 #endif
 
 	InitializeMaintenanceDaemon();
-	InitializeMaintenanceDaemonForAdminDB();
+	InitializeMaintenanceDaemonForMainDb();
 
 	/* initialize coordinated transaction management */
 	InitializeTransactionManagement();
@@ -1024,10 +1024,10 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomStringVariable(
-		"citus.controldb_name",
+		"citus.main_db",
 		gettext_noop("Which database is designated as the controldb"),
 		NULL,
-		&ControlDbName,
+		&MainDb,
 		"",
 		PGC_POSTMASTER,
 		GUC_STANDARD,

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1029,7 +1029,7 @@ RegisterCitusConfigVariables(void)
 		NULL,
 		&ControlDbName,
 		"",
-		PGC_SU_BACKEND,
+		PGC_POSTMASTER,
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1823,7 +1823,7 @@ RegisterCitusConfigVariables(void)
 
 	DefineCustomStringVariable(
 		"citus.main_db",
-		gettext_noop("Which database is designated as the controldb"),
+		gettext_noop("Which database is designated as the main_db"),
 		NULL,
 		&MainDb,
 		"",

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -481,6 +481,7 @@ _PG_init(void)
 #endif
 
 	InitializeMaintenanceDaemon();
+	InitializeMaintenanceDaemonForAdminDB();
 
 	/* initialize coordinated transaction management */
 	InitializeTransactionManagement();

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1023,6 +1023,16 @@ RegisterCitusConfigVariables(void)
 		GUC_STANDARD,
 		NULL, NULL, NULL);
 
+	DefineCustomStringVariable(
+		"citus.controldb_name",
+		gettext_noop("Which database is designated as the controldb"),
+		NULL,
+		&ControlDbName,
+		"",
+		PGC_SU_BACKEND,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
 	DefineCustomEnumVariable(
 		"citus.coordinator_aggregation_strategy",
 		gettext_noop("Sets the strategy for when an aggregate cannot be pushed down. "

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -341,7 +341,6 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 
 	if (databaseOid == 0)
 	{
-		/* TODO : Get the admin database name from GUC contro_db*/
 		char *databaseName = ControlDbName;
 
 		BackgroundWorkerInitializeConnection(databaseName, NULL, 0);

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -339,9 +339,12 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 
 	MaintenanceDaemonDBData *myDbData = NULL;
 
+	bool isMainDb = false;
+
 	if (databaseOid == 0)
 	{
 		char *databaseName = MainDb;
+		isMainDb = true;
 
 		BackgroundWorkerInitializeConnection(databaseName, NULL, 0);
 
@@ -422,7 +425,6 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 
 		before_shmem_exit(MaintenanceDaemonShmemExit, main_arg);
 
-		BackgroundWorkerInitializeConnectionByOid(databaseOid, myDbData->userOid, 0);
 	}
 
 	/*
@@ -471,6 +473,10 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 
 	elog(LOG, "starting maintenance daemon on database %u user %u",
 		 databaseOid, myDbData->userOid);
+
+	if (!isMainDb) {
+		BackgroundWorkerInitializeConnectionByOid(databaseOid, myDbData->userOid, 0);
+	}
 
 	/* make worker recognizable in pg_stat_activity */
 	pgstat_report_appname("Citus Maintenance Daemon");

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -361,10 +361,17 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		{
 			/*
 			 * When the database crashes, background workers are restarted, but
-			 * the state in shared memory is lost. In that case, we exit and
-			 * wait for a session to call InitializeMaintenanceDaemonBackend
-			 * to properly add it to the hash.
+			 * the state in shared memory is lost. In that case, we exit and wait
+			 * for Postmaster calling __PG_Init which in turn calls
+			 * InitializeMaintenanceDaemonForAdminDB.
 			 */
+
+			proc_exit(0);
+		}
+
+		if (found && myDbData->workerPid != 0)
+		{
+			/* Another maintenance daemon is running.*/
 
 			proc_exit(0);
 		}

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -99,7 +99,7 @@ int Recover2PCInterval = 60000;
 int DeferShardDeleteInterval = 15000;
 int BackgroundTaskQueueCheckInterval = 5000;
 int MaxBackgroundTaskExecutors = 4;
-char *ControlDbName = "";
+char *MainDb = "";
 
 /* config variables for metadata sync timeout */
 int MetadataSyncInterval = 60000;
@@ -141,15 +141,15 @@ InitializeMaintenanceDaemon(void)
 
 
 /*
- * InitializeMaintenanceDaemonForAdminDB is called in _PG_Init
+ * InitializeMaintenanceDaemonForMainDb is called in _PG_Init
  * at which stage we are not in a transaction or have databaseOid
  */
 void
-InitializeMaintenanceDaemonForAdminDB(void)
+InitializeMaintenanceDaemonForMainDb(void)
 {
-	if (strcmp(ControlDbName, "") == 0)
+	if (strcmp(MainDb, "") == 0)
 	{
-		elog(LOG, "There is no designated control database.");
+		elog(LOG, "There is no designated main database.");
 		return;
 	}
 
@@ -341,7 +341,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 
 	if (databaseOid == 0)
 	{
-		char *databaseName = ControlDbName;
+		char *databaseName = MainDb;
 
 		BackgroundWorkerInitializeConnection(databaseName, NULL, 0);
 

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -99,6 +99,7 @@ int Recover2PCInterval = 60000;
 int DeferShardDeleteInterval = 15000;
 int BackgroundTaskQueueCheckInterval = 5000;
 int MaxBackgroundTaskExecutors = 4;
+char *ControlDbName = "";
 
 /* config variables for metadata sync timeout */
 int MetadataSyncInterval = 60000;
@@ -146,6 +147,12 @@ InitializeMaintenanceDaemon(void)
 void
 InitializeMaintenanceDaemonForAdminDB(void)
 {
+	if (strcmp(ControlDbName, "") == 0)
+	{
+		elog(LOG, "There is no designated control database.");
+		return;
+	}
+
 	BackgroundWorker worker;
 
 	memset(&worker, 0, sizeof(worker));
@@ -335,7 +342,7 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 	if (databaseOid == 0)
 	{
 		/* TODO : Get the admin database name from GUC contro_db*/
-		char *databaseName = "postgres";
+		char *databaseName = ControlDbName;
 
 		BackgroundWorkerInitializeConnection(databaseName, NULL, 0);
 

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -424,7 +424,6 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 		}
 
 		before_shmem_exit(MaintenanceDaemonShmemExit, main_arg);
-
 	}
 
 	/*
@@ -474,7 +473,8 @@ CitusMaintenanceDaemonMain(Datum main_arg)
 	elog(LOG, "starting maintenance daemon on database %u user %u",
 		 databaseOid, myDbData->userOid);
 
-	if (!isMainDb) {
+	if (!isMainDb)
+	{
 		BackgroundWorkerInitializeConnectionByOid(databaseOid, myDbData->userOid, 0);
 	}
 

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -157,9 +157,9 @@ InitializeMaintenanceDaemonForMainDb(void)
 
 	memset(&worker, 0, sizeof(worker));
 
-	SafeSnprintf(worker.bgw_name, sizeof(worker.bgw_name),
-				 "Citus Maintenance Daemon: %u/%u",
-				 0, 0);
+
+	strcpy_s(worker.bgw_name, sizeof(worker.bgw_name),
+			 "Citus Maintenance Daemon for Main DB");
 
 	/* request ability to connect to target database */
 	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -341,11 +341,11 @@ WarnMaintenanceDaemonNotStarted(void)
 /*
  * ConnectToDatabase connects to the database for the given databaseOid.
  * if databaseOid is 0, connects to MainDb and then creates a hash entry.
- * If a hash entry cannot be created for MainDb it exists the process requesting a restart.
+ * If a hash entry cannot be created for MainDb it exits the process requesting a restart.
  * However for regular databases, it exits without requesting a restart since another
- * subsequent backend should be starting the Maintenance Deamon.
- * If a hash entry found has a valid workerPid, it exits
- * without requesting a restart since there is already a deamon running.
+ * subsequent backend is expected to start the Maintenance Daemon.
+ * If the found hash entry has a valid workerPid, it exits
+ * without requesting a restart since there is already a daemon running.
  */
 static MaintenanceDaemonDBData *
 ConnectToDatabase(Oid databaseOid)

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -340,10 +340,12 @@ WarnMaintenanceDaemonNotStarted(void)
 
 /*
  * ConnectToDatabase connects to the database for the given databaseOid.
- * if databaseOid is 0, it connects to MainDb. It returns the hash entry
- * for the database. If there hash entry already has a valid workerPid,
- * it exits the process. If a hash entry cannot be created it exists the
- * process requesting a restart.
+ * if databaseOid is 0, connects to MainDb and then creates a hash entry.
+ * If a hash entry cannot be created for MainDb it exists the process requesting a restart.
+ * However for regular databases, it exits without requesting a restart since another
+ * subsequent backend should be starting the Maintenance Deamon.
+ * If a hash entry found has a valid workerPid, it exits
+ * without requesting a restart since there is already a deamon running.
  */
 static MaintenanceDaemonDBData *
 ConnectToDatabase(Oid databaseOid)
@@ -1072,7 +1074,7 @@ MaintenanceDaemonShmemExit(int code, Datum arg)
 }
 
 
-/* MaintenanceDaemonSigTermHandler calls proc_exit(0) */
+/* MaintenanceDaemonSigTermHandler sets the got_SIGTERM flag.*/
 static void
 MaintenanceDaemonSigTermHandler(SIGNAL_ARGS)
 {

--- a/src/include/distributed/maintenanced.h
+++ b/src/include/distributed/maintenanced.h
@@ -20,6 +20,7 @@
 
 /* config variable for */
 extern double DistributedDeadlockDetectionTimeoutFactor;
+extern char *ControlDbName;
 
 extern void StopMaintenanceDaemon(Oid databaseId);
 extern void TriggerNodeMetadataSync(Oid databaseId);

--- a/src/include/distributed/maintenanced.h
+++ b/src/include/distributed/maintenanced.h
@@ -27,6 +27,7 @@ extern void InitializeMaintenanceDaemon(void);
 extern size_t MaintenanceDaemonShmemSize(void);
 extern void MaintenanceDaemonShmemInit(void);
 extern void InitializeMaintenanceDaemonBackend(void);
+extern void InitializeMaintenanceDaemonForAdminDB(void);
 extern bool LockCitusExtension(void);
 
 extern PGDLLEXPORT void CitusMaintenanceDaemonMain(Datum main_arg);

--- a/src/include/distributed/maintenanced.h
+++ b/src/include/distributed/maintenanced.h
@@ -20,7 +20,7 @@
 
 /* config variable for */
 extern double DistributedDeadlockDetectionTimeoutFactor;
-extern char *ControlDbName;
+extern char *MainDb;
 
 extern void StopMaintenanceDaemon(Oid databaseId);
 extern void TriggerNodeMetadataSync(Oid databaseId);
@@ -28,7 +28,7 @@ extern void InitializeMaintenanceDaemon(void);
 extern size_t MaintenanceDaemonShmemSize(void);
 extern void MaintenanceDaemonShmemInit(void);
 extern void InitializeMaintenanceDaemonBackend(void);
-extern void InitializeMaintenanceDaemonForAdminDB(void);
+extern void InitializeMaintenanceDaemonForMainDb(void);
 extern bool LockCitusExtension(void);
 
 extern PGDLLEXPORT void CitusMaintenanceDaemonMain(Datum main_arg);

--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -753,6 +753,7 @@ class Postgres(QueryRunner):
         self.subscriptions = set()
         self.publications = set()
         self.replication_slots = set()
+        self.databases = set()
         self.schemas = set()
         self.users = set()
 
@@ -993,6 +994,10 @@ class Postgres(QueryRunner):
             args = sql.SQL("")
         self.sql(sql.SQL("CREATE USER {} {}").format(sql.Identifier(name), args))
 
+    def create_database(self, name):
+        self.databases.add(name)
+        self.sql(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(name)))
+
     def create_schema(self, name):
         self.schemas.add(name)
         self.sql(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(name)))
@@ -1019,6 +1024,12 @@ class Postgres(QueryRunner):
     def cleanup_users(self):
         for user in self.users:
             self.sql(sql.SQL("DROP USER IF EXISTS {}").format(sql.Identifier(user)))
+
+    def cleanup_databases(self):
+        for database in self.databases:
+            self.sql(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(database))
+            )
 
     def cleanup_schemas(self):
         for schema in self.schemas:

--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -454,6 +454,9 @@ def cleanup_test_leftovers(nodes):
         node.cleanup_schemas()
 
     for node in nodes:
+        node.cleanup_databases()
+
+    for node in nodes:
         node.cleanup_users()
 
 

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -1,0 +1,21 @@
+def test_set_maindb(coord):
+    with coord.cur() as cur1:
+        cur1.execute("CREATE DATABASE mymaindb;")
+        coord.configure("citus.main_db='mymaindb'")
+        coord.restart()
+
+        assert coord.sql_value("SHOW citus.main_db;") == "mymaindb"
+
+        assert (
+            coord.sql_value(
+                "SELECT count(*) FROM pg_stat_activity WHERE application_name = 'Citus Maintenance Daemon';"
+            )
+            == 2
+        )
+
+        assert (
+            coord.sql_value(
+                "SELECT count(*) FROM pg_stat_activity WHERE application_name = 'Citus Maintenance Daemon' AND datname='mymaindb';"
+            )
+            == 1
+        )

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -1,3 +1,7 @@
+# This test checks that once citus.main_db is set and the
+# server is restarted. A Citus Maintenance Daemon for the main_db
+# is launched. This should happen even if there is no query run
+# in main_db yet.
 def test_set_maindb(coord):
     with coord.cur() as cur1:
         cur1.execute("CREATE DATABASE mymaindb;")

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -4,6 +4,7 @@
 # in main_db yet.
 def test_set_maindb(coord):
     with coord.cur() as cur1:
+        cur1.execute("DROP DATABASE IF EXISTS mymaindb;")
         cur1.execute("CREATE DATABASE mymaindb;")
         coord.configure("citus.main_db='mymaindb'")
         coord.restart()

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -72,5 +72,3 @@ def test_set_maindb(cluster_factory):
         )
         == 0
     )
-
-    cluster.coordinator.cleanup_databases()

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -3,8 +3,9 @@
 # is launched. This should happen even if there is no query run
 # in main_db yet.
 def test_set_maindb(coord):
+    coord.create_database("mymaindb")
+
     with coord.cur() as cur1:
-        cur1.execute("CREATE DATABASE mymaindb;")
         cur1.execute("ALTER SYSTEM SET citus.main_db='mymaindb'")
         cur1.execute("SELECT pg_reload_conf();")
         coord.restart()
@@ -25,4 +26,4 @@ def test_set_maindb(coord):
             == 1
         )
 
-        coord.sql("DROP DATABASE mymaindb;")
+    coord.cleanup_databases()

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -25,4 +25,4 @@ def test_set_maindb(coord):
             == 1
         )
 
-        coord.cleanup_schemas()
+        coord.sql("DROP DATABASE mymaindb;")

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -5,7 +5,7 @@
 import time
 
 
-def wait_until_deamons_start(deamoncount, cluster):
+def wait_until_maintenance_deamons_start(deamoncount, cluster):
     i = 0
     n = 0
 
@@ -26,13 +26,17 @@ def wait_until_deamons_start(deamoncount, cluster):
 def test_set_maindb(cluster_factory):
     cluster = cluster_factory(0)
 
+    # Test that once citus.main_db is set to a database name
+    # there are two maintenance deamons running upon restart.
+    # One maintenance deamon for the database of the current connection
+    # and one for the citus.main_db.
     cluster.coordinator.create_database("mymaindb")
     cluster.coordinator.configure("citus.main_db='mymaindb'")
     cluster.coordinator.restart()
 
     assert cluster.coordinator.sql_value("SHOW citus.main_db;") == "mymaindb"
 
-    wait_until_deamons_start(2, cluster)
+    wait_until_maintenance_deamons_start(2, cluster)
 
     assert (
         cluster.coordinator.sql_value(
@@ -41,10 +45,32 @@ def test_set_maindb(cluster_factory):
         == 1
     )
 
+    # Test that once citus.main_db is set to empty string
+    # there is only one maintenance deamon for the database
+    # of the current connection.
     cluster.coordinator.configure("citus.main_db=''")
     cluster.coordinator.restart()
     assert cluster.coordinator.sql_value("SHOW citus.main_db;") == ""
 
-    wait_until_deamons_start(1, cluster)
+    wait_until_maintenance_deamons_start(1, cluster)
+
+    # Test that after citus.main_db is dropped. The maintenance
+    # deamon for this database is terminated.
+    cluster.coordinator.configure("citus.main_db='mymaindb'")
+    cluster.coordinator.restart()
+    assert cluster.coordinator.sql_value("SHOW citus.main_db;") == "mymaindb"
+
+    wait_until_maintenance_deamons_start(2, cluster)
+
+    cluster.coordinator.sql("DROP DATABASE mymaindb;")
+
+    wait_until_maintenance_deamons_start(1, cluster)
+
+    assert (
+        cluster.coordinator.sql_value(
+            "SELECT count(*) FROM pg_stat_activity WHERE application_name = 'Citus Maintenance Daemon' AND datname='mymaindb';"
+        )
+        == 0
+    )
 
     cluster.coordinator.cleanup_databases()

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -6,7 +6,8 @@ def test_set_maindb(coord):
     with coord.cur() as cur1:
         cur1.execute("DROP DATABASE IF EXISTS mymaindb;")
         cur1.execute("CREATE DATABASE mymaindb;")
-        coord.configure("citus.main_db='mymaindb'")
+        cur1.execute("ALTER SYSTEM SET citus.main_db='mymaindb'")
+        cur1.execute("SELECT pg_reload_conf();")
         coord.restart()
 
         assert coord.sql_value("SHOW citus.main_db;") == "mymaindb"

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -35,5 +35,4 @@ def test_set_maindb(cluster_factory):
         == 1
     )
 
-    
     cluster.coordinator.cleanup_databases()

--- a/src/test/regress/citus_tests/test/test_maintenancedeamon.py
+++ b/src/test/regress/citus_tests/test/test_maintenancedeamon.py
@@ -4,7 +4,6 @@
 # in main_db yet.
 def test_set_maindb(coord):
     with coord.cur() as cur1:
-        cur1.execute("DROP DATABASE IF EXISTS mymaindb;")
         cur1.execute("CREATE DATABASE mymaindb;")
         cur1.execute("ALTER SYSTEM SET citus.main_db='mymaindb'")
         cur1.execute("SELECT pg_reload_conf();")
@@ -25,3 +24,5 @@ def test_set_maindb(coord):
             )
             == 1
         )
+
+        coord.cleanup_schemas()


### PR DESCRIPTION
DESCRIPTION: This change starts a maintenance deamon at the time of server start if there is a designated main database.

This is the code flow:

1. User designated an admin database:
   `ALTER SYSTEM SET citus.main_db =  "myadmindb";`

2. When postmaster starts, in _PG_Init, citus calls 
    `InitializeMaintenanceDaemonForMainDb`
  
    This function registers a background worker to run `CitusMaintenanceDaemonMain `with `databaseOid = 0 `

3. `CitusMaintenanceDaemonMain ` takes some special actions when databaseOid is 0:
     - Gets the citus.main_db  value.
     - Connects to the  citus.main_db
     - Now the `MyDatabaseId `is available, creates a hash entry for it.
     - Then follows the same control flow as for a regular db,
