### PR TITLE
Remove software-properties-common from dev container after use

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,10 @@ RUN apt update && apt install -y \
  && add-apt-repository ppa:deadsnakes/ppa -y \
  && apt install -y \
     python3.9-full \
+ # software properties pulls in pkexec, which makes the debugger unusable in vscode
+ && apt purge -y \
+    software-properties-common \
+ && apt autoremove -y \
  && apt clean
 
 RUN sudo pip3 install pipenv pipenv-shebang
@@ -109,7 +113,7 @@ WORKDIR /uncrustify/uncrustify-uncrustify-0.68.1/
 RUN mkdir build
 WORKDIR /uncrustify/uncrustify-uncrustify-0.68.1/build/
 RUN cmake ..
-RUN make -sj8
+RUN MAKEFLAGS="-j $(nproc)" make -s
 
 RUN make install DESTDIR=/uncrustify
 


### PR DESCRIPTION
During the creation of the devcontainer we need to add a ppa repository, which is easiest done via software-properies-common. As turns out this installes pkexec into the container as a side effect.

When vscode tries to attach a debugger it first checks if pkexec is installed as this gives a nicer popup asking for elevation of rights to attach to the process. However, since dev containers don't have a windowing system running pkexec isn't working as expected and thus prevents the debugger from attaching.

Without pkexec in the container vscode 'falls back' to plain old sudo which we can run passwordless in the container.

For pkexec to be removed we need to first purge software-propertied-common as well as autoremove all packages that were installed due to the installation of said package. By performing this all in one step we minimize the size of the layer we are creating.
