### PR TITLE
Fix flaky test detection job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -439,7 +439,10 @@ jobs:
         else
           echo "Detected tests " $tests
         fi
-        echo tests="$tests" >> "$GITHUB_OUTPUT"
+
+        echo 'tests<<EOF' >> $GITHUB_OUTPUT
+        echo "$tests" >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> $GITHUB_OUTPUT
   test-flakyness:
     if: ${{ needs.test-flakyness-pre.outputs.tests != ''}}
     name: Test flakyness


### PR DESCRIPTION
We were getting such errors in flaky-test detection job:
```
Unable to process file command 'output' successfully
```

Even though we don't seem to be writing multiple lines to $GITHUB_OUTPUT, this seems to be the right fix.
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

Closes https://github.com/citusdata/citus/pull/7258.