### PR TITLE
Fixes tests parameter in GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -463,7 +463,7 @@ jobs:
     - name: Run minimal tests
       run: |-
         tests="${{ needs.test-flakyness-pre.outputs.tests }}"
-        IFS=',' read -ra tests_array <<< "$tests"
+        IFS=',' read -ra tests_array <<< "${tests}"
         for test in "${tests_array[@]}"
         do
             test_name=$(echo "${test}" | sed -r "s/.+\/(.+)\..+/\1/")

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.5.0
     - name: Expose $PG_MAJOR to Github Env
-      run: echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
+      run: echo "PG_MAJOR=${PG_MAJOR}" >> ${GITHUB_ENV}
       shell: bash
     - name: Build
       run: "./ci/build-citus.sh"
@@ -243,10 +243,10 @@ jobs:
             }
             print substr(parts[X], 1, length(parts[X])-1)
         }')
-        echo $TESTS
+        echo ${TESTS}
         gosu circleci \
           make -C src/test/regress \
-            check-arbitrary-configs parallel=4 CONFIGS=$TESTS
+            check-arbitrary-configs parallel=4 CONFIGS=${TESTS}
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
     - uses: "./.github/actions/upload_coverage"
@@ -328,7 +328,7 @@ jobs:
               bindir=/usr/lib/postgresql/${PG_MAJOR}/bin \
               citus-old-version=${citus_version} \
               citus-pre-tar=/install-pg${PG_MAJOR}-citus${citus_version}.tar \
-              citus-post-tar=${GITHUB_WORKSPACE}/install-$PG_MAJOR.tar; \
+              citus-post-tar=${GITHUB_WORKSPACE}/install-${PG_MAJOR}.tar; \
         done;
         # run make check-citus-upgrade-mixed for all citus versions
         # the image has ${CITUS_VERSIONS} set with all verions it contains the binaries of
@@ -339,7 +339,7 @@ jobs:
               citus-old-version=${citus_version} \
               bindir=/usr/lib/postgresql/${PG_MAJOR}/bin \
               citus-pre-tar=/install-pg${PG_MAJOR}-citus${citus_version}.tar \
-              citus-post-tar=${GITHUB_WORKSPACE}/install-$PG_MAJOR.tar; \
+              citus-post-tar=${GITHUB_WORKSPACE}/install-${PG_MAJOR}.tar; \
         done;
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
@@ -432,14 +432,14 @@ jobs:
     - name: Detect regression tests need to be ran
       id: detect-regression-tests
       run: |-
-        detected_changes=$(git diff origin/main... --name-only --diff-filter=AM | (grep 'src/test/regress/sql/.*\.sql\|src/test/regress/spec/.*\.spec\|src/test/regress/citus_tests/test/test_.*\.py' || true))
-        tests=${detected_changes}
-        if [ -z "$tests" ]; then
+        detected_changes=$(git diff origin/main... --name-only --diff-filter=AM | grep 'src/test/regress/sql/.*\.sql\|src/test/regress/spec/.*\.spec\|src/test/regress/citus_tests/test/test_.*\.py' | tr '\n' ',')
+        tests=$(echo "${detected_changes}" | sed 's/,$//')
+        if [ -z "${tests}" ]; then
             echo "No test found."
         else
-          echo "Detected tests " $tests
+          echo "Detected tests " ${tests}
         fi
-        echo tests="$tests" >> "$GITHUB_OUTPUT"
+        echo tests="${tests}" >> "${GITHUB_OUTPUT}"
   test-flakyness:
     if: ${{ needs.test-flakyness-pre.outputs.tests != ''}}
     name: Test flakyness
@@ -463,11 +463,11 @@ jobs:
     - name: Run minimal tests
       run: |-
         tests="${{ needs.test-flakyness-pre.outputs.tests }}"
-        tests_array=($tests)
+        IFS=',' read -ra tests_array <<< "$tests"
         for test in "${tests_array[@]}"
         do
-            test_name=$(echo "$test" | sed -r "s/.+\/(.+)\..+/\1/")
-            gosu circleci src/test/regress/citus_tests/run_test.py $test_name --repeat ${{ env.runs }} --use-base-schedule --use-whole-schedule-line
+            test_name=$(echo "${test}" | sed -r "s/.+\/(.+)\..+/\1/")
+            gosu circleci src/test/regress/citus_tests/run_test.py ${test_name} --repeat ${{ env.runs }} --use-base-schedule --use-whole-schedule-line
         done
       shell: bash
     - uses: "./.github/actions/save_logs_and_results"


### PR DESCRIPTION
Parameters are stored in GITHUB_OUTPUT env variable
in key value format. When value has an empty space, GH Actions
throws an error. In case of multiple tests, I replaced empty space
with comma.
Additionally, used curly braces in parameter usage to make it stable
for various characters in variables
Pipeline execution with problem: https://github.com/citusdata/citus/actions/runs/6510589418/job/17727309270
Pipeline execution with the fix: https://github.com/citusdata/citus/actions/runs/6531699591/job/17734162927

