### PR TITLE
Fix #7242, CALL(@0) crash backend

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -702,6 +702,7 @@ DissuadePlannerFromUsingPlan(PlannedStmt *plan)
 	 * Arbitrarily high cost, but low enough that it can be added up
 	 * without overflowing by choose_custom_plan().
 	 */
+	Assert(plan != NULL);
 	plan->planTree->total_cost = FLT_MAX / 100000000;
 }
 

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -525,7 +525,12 @@ ShardPlacementForFunctionColocatedWithDistTable(DistObjectCacheEntry *procedure,
 
 		if (partitionParam->paramkind == PARAM_EXTERN)
 		{
-			/* Don't log a message, we should end up here again without a parameter */
+			/*
+			 * Don't log a message, we should end up here again without a
+			 * parameter.
+			 * Note that "plan" can be null, for example when a CALL statement
+			 * is prepared.
+			 */
 			if (plan)
 			{
 				DissuadePlannerFromUsingPlan(plan);

--- a/src/backend/distributed/planner/function_call_delegation.c
+++ b/src/backend/distributed/planner/function_call_delegation.c
@@ -526,7 +526,10 @@ ShardPlacementForFunctionColocatedWithDistTable(DistObjectCacheEntry *procedure,
 		if (partitionParam->paramkind == PARAM_EXTERN)
 		{
 			/* Don't log a message, we should end up here again without a parameter */
-			DissuadePlannerFromUsingPlan(plan);
+			if (plan)
+			{
+				DissuadePlannerFromUsingPlan(plan);
+			}
 			return NULL;
 		}
 	}

--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -581,6 +581,14 @@ class QueryRunner(ABC):
         with self.cur(**kwargs) as cur:
             cur.execute(query, params=params)
 
+    def sql_prepared(self, query, params=None, **kwargs):
+        """Run an SQL query, with prepare=True
+
+        This opens a new connection and closes it once the query is done
+        """
+        with self.cur(**kwargs) as cur:
+            cur.execute(query, params=params, prepare=True)
+
     def sql_row(self, query, params=None, allow_empty_result=False, **kwargs):
         """Run an SQL query that returns a single row and returns this row
 

--- a/src/test/regress/citus_tests/test/test_prepared_statements.py
+++ b/src/test/regress/citus_tests/test/test_prepared_statements.py
@@ -1,6 +1,3 @@
-import psycopg
-import pytest
-
 
 def test_call_param(cluster):
     # create a distributed table and an associated distributed procedure

--- a/src/test/regress/citus_tests/test/test_prepared_statements.py
+++ b/src/test/regress/citus_tests/test/test_prepared_statements.py
@@ -1,6 +1,7 @@
 import psycopg
 import pytest
 
+
 def test_call_param(cluster):
     # create a distributed table and an associated distributed procedure
     # to ensure parameterized CALL succeed, even when the param is the
@@ -21,7 +22,9 @@ def test_call_param(cluster):
     coord.sql_prepared(sql, (1,))
 
     coord.sql("SELECT create_distributed_table('test', 'i')")
-    coord.sql("SELECT create_distributed_function('p(int)', distribution_arg_name := '_i', colocate_with := 'test')")
+    coord.sql(
+        "SELECT create_distributed_function('p(int)', distribution_arg_name := '_i', colocate_with := 'test')"
+    )
 
     # prepare/exec after distribution
     coord.sql_prepared(sql, (2,))

--- a/src/test/regress/citus_tests/test/test_prepared_statements.py
+++ b/src/test/regress/citus_tests/test/test_prepared_statements.py
@@ -1,4 +1,3 @@
-
 def test_call_param(cluster):
     # create a distributed table and an associated distributed procedure
     # to ensure parameterized CALL succeed, even when the param is the

--- a/src/test/regress/citus_tests/test/test_prepared_statements.py
+++ b/src/test/regress/citus_tests/test/test_prepared_statements.py
@@ -1,0 +1,31 @@
+import psycopg
+import pytest
+
+def test_call_param(cluster):
+    # create a distributed table and an associated distributed procedure
+    # to ensure parameterized CALL succeed, even when the param is the
+    # distribution key.
+    coord = cluster.coordinator
+    coord.sql("CREATE TABLE test(i int)")
+    coord.sql(
+        """
+        CREATE PROCEDURE p(_i INT) LANGUAGE plpgsql AS $$
+        BEGIN
+        INSERT INTO test(i) VALUES (_i);
+        END; $$
+        """
+    )
+    sql = "CALL p(%s)"
+
+    # prepare/exec before distributing
+    coord.sql_prepared(sql, (1,))
+
+    coord.sql("SELECT create_distributed_table('test', 'i')")
+    coord.sql("SELECT create_distributed_function('p(int)', distribution_arg_name := '_i', colocate_with := 'test')")
+
+    # prepare/exec after distribution
+    coord.sql_prepared(sql, (2,))
+
+    sum_i = coord.sql_value("select sum(i) from test;")
+
+    assert sum_i == 3


### PR DESCRIPTION
When executing a prepared CALL, which is not pure SQL but available with some drivers like npgsql and jpgdbc, Citus entered a code path where a plan is not defined, while trying to increase its cost. Thus SIG11 when plan is a NULL pointer.

Fix by only increasing plan cost when plan is not null.

However, it is a bit suspicious to get here with a NULL plan and maybe a better change will be to not call ShardPlacementForFunctionColocatedWithDistTable() with a NULL plan at all (in call.c:134)

bug hit with for example:
```
CallableStatement proc = con.prepareCall("{CALL p(?)}");
proc.registerOutParameter(1, java.sql.Types.BIGINT);
proc.setInt(1, -100);
proc.execute();
```

where `p(bigint)` is a distributed "function" and the param the distribution key (also in a distributed table), see #7242 for details

Fixes #7242 

