### PR TITLE
Removes use-base-schedule flag from CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -501,7 +501,7 @@ jobs:
         for test in "${tests_array[@]}"
         do
             test_name=$(echo "$test" | sed -r "s/.+\/(.+)\..+/\1/")
-            gosu circleci src/test/regress/citus_tests/run_test.py $test_name --repeat ${{ env.runs }} --use-base-schedule --use-whole-schedule-line
+            gosu circleci src/test/regress/citus_tests/run_test.py $test_name --repeat ${{ env.runs }} --use-whole-schedule-line
         done
       shell: bash
     - uses: "./.github/actions/save_logs_and_results"

--- a/.github/workflows/flaky_test_debugging.yml
+++ b/.github/workflows/flaky_test_debugging.yml
@@ -71,7 +71,7 @@ jobs:
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-
-          gosu circleci src/test/regress/citus_tests/run_test.py ${{ env.test }} --repeat ${{ env.runs }} --use-base-schedule --use-whole-schedule-line
+          gosu circleci src/test/regress/citus_tests/run_test.py ${{ env.test }} --repeat ${{ env.runs }} --use-whole-schedule-line
       shell: bash
     - uses: "./.github/actions/save_logs_and_results"
       if: always()


### PR DESCRIPTION
Normally, tests which are written non-dependent to other tests can use minimal-tests and should use as well. However, in our test settings base-schedule is being used which may cause unnecessary dependencies and so unrelated errors that developers don't see in their local environment
With this change, default setting will be minimal, so that tests will be free of unnecessary dependencies. 
