### PR TITLE
Make some more tests re-runable

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -125,7 +125,6 @@ DEPS = {
     "multi_mx_create_table": TestDeps(
         None,
         [
-            "multi_test_helpers_superuser",
             "multi_mx_node_metadata",
             "multi_cluster_management",
             "multi_mx_function_table_reference",
@@ -182,6 +181,30 @@ DEPS = {
             "multi_extension",
             "multi_test_helpers",
             "multi_test_helpers_superuser",
+        ],
+    ),
+    "multi_mx_function_table_reference": TestDeps(
+        None,
+        [
+            "multi_cluster_management",
+            "remove_coordinator_from_metadata",
+        ],
+        # because it queries node group id and it changes as we add / remove nodes
+        repeatable=False,
+    ),
+    "multi_mx_add_coordinator": TestDeps(
+        None,
+        [
+            "multi_cluster_management",
+            "remove_coordinator_from_metadata",
+            "multi_mx_function_table_reference",
+        ],
+    ),
+    "metadata_sync_helpers": TestDeps(
+        None,
+        [
+            "multi_mx_node_metadata",
+            "multi_cluster_management",
         ],
     ),
 }

--- a/src/test/regress/expected/create_role_propagation.out
+++ b/src/test/regress/expected/create_role_propagation.out
@@ -696,3 +696,4 @@ SELECT rolname FROM pg_authid WHERE rolname LIKE '%existing%' ORDER BY 1;
 (0 rows)
 
 \c - - - :master_port
+DROP ROLE nondist_cascade_1, nondist_cascade_2, nondist_cascade_3, dist_cascade;

--- a/src/test/regress/expected/multi_mx_add_coordinator.out
+++ b/src/test/regress/expected/multi_mx_add_coordinator.out
@@ -124,7 +124,7 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM mx_add_coo
      0
 (1 row)
 
--- test that distributed functions also use local execution
+-- test that distributed functions also use sequential execution
 CREATE OR REPLACE FUNCTION my_group_id()
 RETURNS void
 LANGUAGE plpgsql
@@ -365,5 +365,6 @@ SELECT verify_metadata('localhost', :worker_1_port),
 
 SET client_min_messages TO error;
 DROP SCHEMA mx_add_coordinator CASCADE;
+DROP USER reprefuser;
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/expected/multi_mx_create_table.out
+++ b/src/test/regress/expected/multi_mx_create_table.out
@@ -3,6 +3,7 @@
 --
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1220000;
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1220000;
+SET client_min_messages TO WARNING;
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
  start_metadata_sync_to_node
 ---------------------------------------------------------------------
@@ -15,6 +16,9 @@ SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
 
 (1 row)
 
+-- cannot drop them at the end of the test file as other tests depend on them
+DROP SCHEMA IF EXISTS citus_mx_test_schema, citus_mx_test_schema_join_1, citus_mx_test_schema_join_2 CASCADE;
+DROP TABLE IF EXISTS nation_hash, lineitem_mx, orders_mx, customer_mx, nation_mx, part_mx, supplier_mx, mx_ddl_table, limit_orders_mx, multiple_hash_mx, app_analytics_events_mx, researchers_mx, labs_mx, objects_mx, articles_hash_mx, articles_single_shard_hash_mx, company_employees_mx;
 -- create schema to test schema support
 CREATE SCHEMA citus_mx_test_schema;
 CREATE SCHEMA citus_mx_test_schema_join_1;
@@ -42,7 +46,7 @@ BEGIN
 END;
 $$
 LANGUAGE 'plpgsql' IMMUTABLE;
-CREATE FUNCTION public.immutable_append_mx(old_values int[], new_value int)
+CREATE OR REPLACE FUNCTION public.immutable_append_mx(old_values int[], new_value int)
 RETURNS int[] AS $$ SELECT old_values || new_value $$ LANGUAGE SQL IMMUTABLE;
 CREATE OPERATOR citus_mx_test_schema.=== (
     LEFTARG = int,
@@ -65,14 +69,16 @@ SELECT quote_ident(current_setting('lc_collate')) as current_locale \gset
 \endif
 CREATE COLLATION citus_mx_test_schema.english (LOCALE=:current_locale);
 CREATE TYPE citus_mx_test_schema.new_composite_type as (key1 text, key2 text);
-CREATE TYPE order_side_mx AS ENUM ('buy', 'sell');
+CREATE TYPE citus_mx_test_schema.order_side_mx AS ENUM ('buy', 'sell');
 -- now create required stuff in the worker 1
 \c - - - :worker_1_port
+SET client_min_messages TO WARNING;
 -- show that we do not support creating citus local tables from mx workers for now
 CREATE TABLE citus_local_table(a int);
 SELECT citus_add_local_table_to_metadata('citus_local_table');
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.
+DROP TABLE citus_local_table;
 SET search_path TO citus_mx_test_schema;
 -- create operator
 CREATE OPERATOR citus_mx_test_schema.=== (
@@ -85,6 +91,7 @@ CREATE OPERATOR citus_mx_test_schema.=== (
 );
 -- now create required stuff in the worker 2
 \c - - - :worker_2_port
+SET client_min_messages TO WARNING;
 SET search_path TO citus_mx_test_schema;
 -- create operator
 CREATE OPERATOR citus_mx_test_schema.=== (
@@ -97,6 +104,7 @@ CREATE OPERATOR citus_mx_test_schema.=== (
 );
 -- connect back to the master, and do some more tests
 \c - - - :master_port
+SET client_min_messages TO WARNING;
 SET citus.shard_replication_factor TO 1;
 SET search_path TO public;
 CREATE TABLE nation_hash(
@@ -315,7 +323,7 @@ CREATE TABLE limit_orders_mx (
     symbol text NOT NULL,
     bidder_id bigint NOT NULL,
     placed_at timestamp NOT NULL,
-    kind order_side_mx NOT NULL,
+    kind citus_mx_test_schema.order_side_mx NOT NULL,
     limit_price decimal NOT NULL DEFAULT 0.00 CHECK (limit_price >= 0.00)
 );
 SET citus.shard_count TO 2;
@@ -473,6 +481,7 @@ ORDER BY table_name::text;
 (23 rows)
 
 \c - - - :worker_1_port
+SET client_min_messages TO WARNING;
 SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
 ORDER BY table_name::text;
@@ -978,6 +987,6 @@ SELECT shard_name, table_name, citus_table_type, shard_size FROM citus_shards OR
 (469 rows)
 
 -- Show that altering type name is not supported from worker node
-ALTER TYPE order_side_mx RENAME TO temp_order_side_mx;
+ALTER TYPE citus_mx_test_schema.order_side_mx RENAME TO temp_order_side_mx;
 ERROR:  operation is not allowed on this node
 HINT:  Connect to the coordinator and run it again.

--- a/src/test/regress/expected/text_search.out
+++ b/src/test/regress/expected/text_search.out
@@ -374,12 +374,21 @@ SELECT * FROM run_command_on_workers($$ SELECT 'text_search.config3'::regconfig;
 (2 rows)
 
 -- verify they are all removed locally
-SELECT 'text_search.config1'::regconfig;
-ERROR:  text search configuration "text_search.config1" does not exist
-SELECT 'text_search.config2'::regconfig;
-ERROR:  text search configuration "text_search.config2" does not exist
-SELECT 'text_search.config3'::regconfig;
-ERROR:  text search configuration "text_search.config3" does not exist
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config1' AND cfgnamespace = 'text_search'::regnamespace;
+ ?column?
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config2' AND cfgnamespace = 'text_search'::regnamespace;
+ ?column?
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config3' AND cfgnamespace = 'text_search'::regnamespace;
+ ?column?
+---------------------------------------------------------------------
+(0 rows)
+
 -- verify that indexes created concurrently that would propagate a TEXT SEARCH CONFIGURATION object
 SET citus.enable_ddl_propagation TO off;
 CREATE TEXT SEARCH CONFIGURATION concurrent_index_config ( PARSER = default );
@@ -434,12 +443,12 @@ $$) ORDER BY 1,2;
 CREATE TEXT SEARCH CONFIGURATION text_search.manually_created_wrongly ( copy = french );
 -- now we expect manually_created_wrongly(citus_backup_XXX) to show up when querying the configurations
 SELECT * FROM run_command_on_workers($$
-    SELECT array_agg(cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_wrongly%';
+    SELECT array_agg(cfgname ORDER BY cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_wrongly%';
 $$) ORDER BY 1,2;
  nodename  | nodeport | success |                               result
 ---------------------------------------------------------------------
- localhost |    57637 | t       | {manually_created_wrongly(citus_backup_0),manually_created_wrongly}
- localhost |    57638 | t       | {manually_created_wrongly(citus_backup_0),manually_created_wrongly}
+ localhost |    57637 | t       | {manually_created_wrongly,manually_created_wrongly(citus_backup_0)}
+ localhost |    57638 | t       | {manually_created_wrongly,manually_created_wrongly(citus_backup_0)}
 (2 rows)
 
 -- verify the objects get reused appropriately when the specification is the same
@@ -458,7 +467,7 @@ CREATE TEXT SEARCH CONFIGURATION text_search.manually_created_correct ( copy = f
 -- now we don't expect manually_created_correct(citus_backup_XXX) to show up when querying the configurations as the
 -- original one is reused
 SELECT * FROM run_command_on_workers($$
-    SELECT array_agg(cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_correct%';
+    SELECT array_agg(cfgname ORDER BY cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_correct%';
 $$) ORDER BY 1,2;
  nodename  | nodeport | success |           result
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -277,3 +277,5 @@ SELECT rolname FROM pg_authid WHERE rolname LIKE '%existing%' ORDER BY 1;
 \c - - - :worker_1_port
 SELECT rolname FROM pg_authid WHERE rolname LIKE '%existing%' ORDER BY 1;
 \c - - - :master_port
+
+DROP ROLE nondist_cascade_1, nondist_cascade_2, nondist_cascade_3, dist_cascade;

--- a/src/test/regress/sql/multi_mx_add_coordinator.sql
+++ b/src/test/regress/sql/multi_mx_add_coordinator.sql
@@ -67,7 +67,7 @@ SET client_min_messages TO DEBUG;
 SELECT count(*) FROM ref;
 SELECT count(*) FROM ref;
 
--- test that distributed functions also use local execution
+-- test that distributed functions also use sequential execution
 CREATE OR REPLACE FUNCTION my_group_id()
 RETURNS void
 LANGUAGE plpgsql
@@ -190,5 +190,6 @@ SELECT verify_metadata('localhost', :worker_1_port),
 
 SET client_min_messages TO error;
 DROP SCHEMA mx_add_coordinator CASCADE;
+DROP USER reprefuser;
 SET search_path TO DEFAULT;
 RESET client_min_messages;

--- a/src/test/regress/sql/multi_mx_create_table.sql
+++ b/src/test/regress/sql/multi_mx_create_table.sql
@@ -5,8 +5,14 @@
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 1220000;
 ALTER SEQUENCE pg_catalog.pg_dist_colocationid_seq RESTART 1220000;
 
+SET client_min_messages TO WARNING;
+
 SELECT start_metadata_sync_to_node('localhost', :worker_1_port);
 SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
+
+-- cannot drop them at the end of the test file as other tests depend on them
+DROP SCHEMA IF EXISTS citus_mx_test_schema, citus_mx_test_schema_join_1, citus_mx_test_schema_join_2 CASCADE;
+DROP TABLE IF EXISTS nation_hash, lineitem_mx, orders_mx, customer_mx, nation_mx, part_mx, supplier_mx, mx_ddl_table, limit_orders_mx, multiple_hash_mx, app_analytics_events_mx, researchers_mx, labs_mx, objects_mx, articles_hash_mx, articles_single_shard_hash_mx, company_employees_mx;
 
 -- create schema to test schema support
 CREATE SCHEMA citus_mx_test_schema;
@@ -38,7 +44,7 @@ END;
 $$
 LANGUAGE 'plpgsql' IMMUTABLE;
 
-CREATE FUNCTION public.immutable_append_mx(old_values int[], new_value int)
+CREATE OR REPLACE FUNCTION public.immutable_append_mx(old_values int[], new_value int)
 RETURNS int[] AS $$ SELECT old_values || new_value $$ LANGUAGE SQL IMMUTABLE;
 
 CREATE OPERATOR citus_mx_test_schema.=== (
@@ -67,14 +73,16 @@ SELECT quote_ident(current_setting('lc_collate')) as current_locale \gset
 CREATE COLLATION citus_mx_test_schema.english (LOCALE=:current_locale);
 
 CREATE TYPE citus_mx_test_schema.new_composite_type as (key1 text, key2 text);
-CREATE TYPE order_side_mx AS ENUM ('buy', 'sell');
+CREATE TYPE citus_mx_test_schema.order_side_mx AS ENUM ('buy', 'sell');
 
 -- now create required stuff in the worker 1
 \c - - - :worker_1_port
+SET client_min_messages TO WARNING;
 
 -- show that we do not support creating citus local tables from mx workers for now
 CREATE TABLE citus_local_table(a int);
 SELECT citus_add_local_table_to_metadata('citus_local_table');
+DROP TABLE citus_local_table;
 
 SET search_path TO citus_mx_test_schema;
 -- create operator
@@ -89,6 +97,7 @@ CREATE OPERATOR citus_mx_test_schema.=== (
 
 -- now create required stuff in the worker 2
 \c - - - :worker_2_port
+SET client_min_messages TO WARNING;
 
 SET search_path TO citus_mx_test_schema;
 
@@ -104,6 +113,7 @@ CREATE OPERATOR citus_mx_test_schema.=== (
 
 -- connect back to the master, and do some more tests
 \c - - - :master_port
+SET client_min_messages TO WARNING;
 
 SET citus.shard_replication_factor TO 1;
 SET search_path TO public;
@@ -308,7 +318,7 @@ CREATE TABLE limit_orders_mx (
     symbol text NOT NULL,
     bidder_id bigint NOT NULL,
     placed_at timestamp NOT NULL,
-    kind order_side_mx NOT NULL,
+    kind citus_mx_test_schema.order_side_mx NOT NULL,
     limit_price decimal NOT NULL DEFAULT 0.00 CHECK (limit_price >= 0.00)
 );
 
@@ -386,6 +396,7 @@ FROM citus_tables
 ORDER BY table_name::text;
 
 \c - - - :worker_1_port
+SET client_min_messages TO WARNING;
 
 SELECT table_name, citus_table_type, distribution_column, shard_count, table_owner
 FROM citus_tables
@@ -394,4 +405,4 @@ ORDER BY table_name::text;
 SELECT shard_name, table_name, citus_table_type, shard_size FROM citus_shards ORDER BY shard_name::text;
 
 -- Show that altering type name is not supported from worker node
-ALTER TYPE order_side_mx RENAME TO temp_order_side_mx;
+ALTER TYPE citus_mx_test_schema.order_side_mx RENAME TO temp_order_side_mx;

--- a/src/test/regress/sql/text_search.sql
+++ b/src/test/regress/sql/text_search.sql
@@ -199,9 +199,9 @@ SELECT * FROM run_command_on_workers($$ SELECT 'text_search.config1'::regconfig;
 SELECT * FROM run_command_on_workers($$ SELECT 'text_search.config2'::regconfig; $$) ORDER BY 1,2;
 SELECT * FROM run_command_on_workers($$ SELECT 'text_search.config3'::regconfig; $$) ORDER BY 1,2;
 -- verify they are all removed locally
-SELECT 'text_search.config1'::regconfig;
-SELECT 'text_search.config2'::regconfig;
-SELECT 'text_search.config3'::regconfig;
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config1' AND cfgnamespace = 'text_search'::regnamespace;
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config2' AND cfgnamespace = 'text_search'::regnamespace;
+SELECT 1 FROM pg_ts_config WHERE cfgname = 'config3' AND cfgnamespace = 'text_search'::regnamespace;
 
 -- verify that indexes created concurrently that would propagate a TEXT SEARCH CONFIGURATION object
 SET citus.enable_ddl_propagation TO off;
@@ -235,7 +235,7 @@ CREATE TEXT SEARCH CONFIGURATION text_search.manually_created_wrongly ( copy = f
 
 -- now we expect manually_created_wrongly(citus_backup_XXX) to show up when querying the configurations
 SELECT * FROM run_command_on_workers($$
-    SELECT array_agg(cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_wrongly%';
+    SELECT array_agg(cfgname ORDER BY cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_wrongly%';
 $$) ORDER BY 1,2;
 
 -- verify the objects get reused appropriately when the specification is the same
@@ -249,7 +249,7 @@ CREATE TEXT SEARCH CONFIGURATION text_search.manually_created_correct ( copy = f
 -- now we don't expect manually_created_correct(citus_backup_XXX) to show up when querying the configurations as the
 -- original one is reused
 SELECT * FROM run_command_on_workers($$
-    SELECT array_agg(cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_correct%';
+    SELECT array_agg(cfgname ORDER BY cfgname) FROM pg_ts_config WHERE cfgname LIKE 'manually_created_correct%';
 $$) ORDER BY 1,2;
 
 CREATE SCHEMA "Text Search Requiring Quote's";


### PR DESCRIPTION
* multi_mx_create_table
* multi_mx_function_table_reference
* multi_mx_add_coordinator
* create_role_propagation
* metadata_sync_helpers
* text_search

https://github.com/citusdata/citus/pull/7278 requires this.
