### PR TITLE
Fix flaky isolation_get_all_active_transactions.spec test

### DIFF
--- a/src/test/regress/expected/isolation_get_all_active_transactions.out
+++ b/src/test/regress/expected/isolation_get_all_active_transactions.out
@@ -94,7 +94,7 @@ step s2-commit:
 	COMMIT;
 
 
-starting permutation: s4-record-pid s3-show-activity s5-kill s3-show-activity
+starting permutation: s4-record-pid s3-show-activity s5-kill s3-wait-backend-termination
 step s4-record-pid:
 	SELECT pg_backend_pid() INTO selected_pid;
 
@@ -109,18 +109,34 @@ count
 
 step s5-kill:
 	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
+	SELECT pg_sleep(1); -- sleep for a while to make sure that backend is terminated
 
 pg_terminate_backend
 ---------------------------------------------------------------------
 t
 (1 row)
 
-step s3-show-activity:
-	SET ROLE postgres;
-	select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
-
-count
+pg_sleep
 ---------------------------------------------------------------------
-    0
+
 (1 row)
+
+step s3-wait-backend-termination:
+	SET ROLE postgres;
+	DO $$
+	DECLARE
+		i int;
+	BEGIN
+		i := 0;
+		-- try for 5 sec then timeout
+		WHILE (select count(*) > 0 from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid))
+		LOOP
+			PERFORM pg_sleep(0.1);
+			i := i + 1;
+			IF i > 50 THEN
+				RAISE EXCEPTION 'Timeout while waiting for backend to terminate';
+			END IF;
+		END LOOP;
+	END;
+	$$;
 

--- a/src/test/regress/expected/isolation_get_all_active_transactions.out
+++ b/src/test/regress/expected/isolation_get_all_active_transactions.out
@@ -109,16 +109,10 @@ count
 
 step s5-kill:
 	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
-	SELECT pg_sleep(1); -- sleep for a while to make sure that backend is terminated
 
 pg_terminate_backend
 ---------------------------------------------------------------------
 t
-(1 row)
-
-pg_sleep
----------------------------------------------------------------------
-
 (1 row)
 
 step s3-wait-backend-termination:

--- a/src/test/regress/spec/isolation_get_all_active_transactions.spec
+++ b/src/test/regress/spec/isolation_get_all_active_transactions.spec
@@ -142,7 +142,6 @@ session "s5"
 step "s5-kill"
 {
 	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
-	SELECT pg_sleep(1); -- sleep for a while to make sure that backend is terminated
 }
 
 

--- a/src/test/regress/spec/isolation_get_all_active_transactions.spec
+++ b/src/test/regress/spec/isolation_get_all_active_transactions.spec
@@ -107,6 +107,29 @@ step "s3-show-activity"
 	select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
 }
 
+step "s3-wait-backend-termination"
+{
+	SET ROLE postgres;
+
+	DO $$
+	DECLARE
+		i int;
+	BEGIN
+		i := 0;
+
+		-- try for 5 sec then timeout
+		WHILE (select count(*) > 0 from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid))
+		LOOP
+			PERFORM pg_sleep(0.1);
+			i := i + 1;
+			IF i > 50 THEN
+				RAISE EXCEPTION 'Timeout while waiting for backend to terminate';
+			END IF;
+		END LOOP;
+	END;
+	$$;
+}
+
 session "s4"
 
 step "s4-record-pid"
@@ -119,8 +142,9 @@ session "s5"
 step "s5-kill"
 {
 	SELECT pg_terminate_backend(pg_backend_pid) FROM selected_pid;
+	SELECT pg_sleep(1); -- sleep for a while to make sure that backend is terminated
 }
 
 
 permutation "s1-grant" "s1-begin-insert" "s2-begin-insert" "s3-as-admin" "s3-as-user-1" "s3-as-readonly" "s3-as-monitor" "s1-commit" "s2-commit"
-permutation "s4-record-pid" "s3-show-activity" "s5-kill" "s3-show-activity"
+permutation "s4-record-pid" "s3-show-activity" "s5-kill" "s3-wait-backend-termination"


### PR DESCRIPTION
Fix the flaky test that results in following diff by waiting until the backend that we want to terminate really terminates, until 5secs.

```diff
--- /__w/citus/citus/src/test/regress/expected/isolation_get_all_active_transactions.out.modified	2023-11-01 16:30:57.648749795 +0000
+++ /__w/citus/citus/src/test/regress/results/isolation_get_all_active_transactions.out.modified	2023-11-01 16:30:57.656749877 +0000
@@ -114,13 +114,13 @@
 --------------------
 t                   
 (1 row)
 
 step s3-show-activity: 
  SET ROLE postgres;
  select count(*) from get_all_active_transactions() where process_id IN (SELECT * FROM selected_pid);
 
 count
 -----
-    0
+    1
 (1 row)
```