### PR TITLE
Remove useless variables

### DIFF
--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -978,7 +978,6 @@ GetAggregateDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace)
 	char *argmodes = NULL;
 	int insertorderbyat = -1;
 	int argsprinted = 0;
-	int inputargno = 0;
 
 	HeapTuple proctup = SearchSysCache1(PROCOID, funcOid);
 	if (!HeapTupleIsValid(proctup))
@@ -1058,7 +1057,6 @@ GetAggregateDDLCommand(const RegProcedure funcOid, bool useCreateOrReplace)
 			}
 		}
 
-		inputargno++;       /* this is a 1-based counter */
 		if (argsprinted == insertorderbyat)
 		{
 			appendStringInfoString(&buf, " ORDER BY ");

--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -175,7 +175,6 @@ BuildCreatePublicationStmt(Oid publicationId)
 												PUBLICATION_PART_ROOT :
 												PUBLICATION_PART_LEAF);
 	Oid relationId = InvalidOid;
-	int citusTableCount PG_USED_FOR_ASSERTS_ONLY = 0;
 
 	/* mainly for consistent ordering in test output */
 	relationIds = SortList(relationIds, CompareOids);
@@ -199,11 +198,6 @@ BuildCreatePublicationStmt(Oid publicationId)
 
 		createPubStmt->tables = lappend(createPubStmt->tables, rangeVar);
 #endif
-
-		if (IsCitusTable(relationId))
-		{
-			citusTableCount++;
-		}
 	}
 
 	/* WITH (publish_via_partition_root = true) option */

--- a/src/backend/distributed/commands/vacuum.c
+++ b/src/backend/distributed/commands/vacuum.c
@@ -184,7 +184,6 @@ ExecuteVacuumOnDistributedTables(VacuumStmt *vacuumStmt, List *relationIdList,
 								 CitusVacuumParams vacuumParams)
 {
 	int relationIndex = 0;
-	int executedVacuumCount = 0;
 
 	Oid relationId = InvalidOid;
 	foreach_oid(relationId, relationIdList)
@@ -197,7 +196,6 @@ ExecuteVacuumOnDistributedTables(VacuumStmt *vacuumStmt, List *relationIdList,
 			/* local execution is not implemented for VACUUM commands */
 			bool localExecutionSupported = false;
 			ExecuteUtilityTaskList(taskList, localExecutionSupported);
-			executedVacuumCount++;
 		}
 		relationIndex++;
 	}

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -158,13 +158,6 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 								"replication factor.")));
 	}
 
-	/* if we have enough nodes, add an extra placement attempt for backup */
-	uint32 placementAttemptCount = (uint32) replicationFactor;
-	if (workerNodeCount > replicationFactor)
-	{
-		placementAttemptCount++;
-	}
-
 	/* set shard storage type according to relation type */
 	char shardStorageType = ShardStorageType(distributedTableId);
 


### PR DESCRIPTION
To fix warnings observed when using different compiler versions.