### PR TITLE
Fix VACUUM flakiness in multi_utilities

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -207,6 +207,10 @@ DEPS = {
             "multi_cluster_management",
         ],
     ),
+    "multi_utilities": TestDeps(
+        "minimal_schedule",
+        ["multi_data_types"],
+    ),
 }
 
 

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -350,11 +350,11 @@ delete from local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
-SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
+SELECT CASE WHEN s BETWEEN 20000000 AND 25000000 THEN 22500000 ELSE s END
 FROM pg_total_relation_size('local_vacuum_table') s ;
-   size
+    s
 ---------------------------------------------------------------------
- 35000000
+ 22500000
 (1 row)
 
 -- vacuum full deallocates pages of dead tuples whereas normal vacuum only marks dead tuples on visibility map

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -347,12 +347,24 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- should not propagate because no distributed table is specified
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
+-- sometimes the vacuum doesn't clean up as expected and results in a flaky result
+-- for our tests. For this reason, we re-run the vacuum command once if size of
+-- the table before and after the VACUUM is not as expected
+SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
 VACUUM local_vacuum_table;
-SELECT CASE WHEN s BETWEEN 20000000 AND 25000000 THEN 22500000 ELSE s END
-FROM pg_total_relation_size('local_vacuum_table') s ;
-    s
+SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
+SELECT :size_before_vacuum <= :size_after_vacuum AS re_vacuum_needed \gset
+\if :re_vacuum_needed
+SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
+VACUUM local_vacuum_table;
+VACUUM local_vacuum_table;
+VACUUM local_vacuum_table;
+SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
+\endif
+SELECT :size_before_vacuum > :size_after_vacuum AS vacuum_successful;
+ vacuum_successful
 ---------------------------------------------------------------------
- 22500000
+ t
 (1 row)
 
 -- vacuum full deallocates pages of dead tuples whereas normal vacuum only marks dead tuples on visibility map

--- a/src/test/regress/expected/multi_utilities.out
+++ b/src/test/regress/expected/multi_utilities.out
@@ -347,24 +347,14 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- should not propagate because no distributed table is specified
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
--- sometimes the vacuum doesn't clean up as expected and results in a flaky result
--- for our tests. For this reason, we re-run the vacuum command once if size of
--- the table before and after the VACUUM is not as expected
-SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
-VACUUM local_vacuum_table;
-SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
-SELECT :size_before_vacuum <= :size_after_vacuum AS re_vacuum_needed \gset
-\if :re_vacuum_needed
-SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
-SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
-\endif
-SELECT :size_before_vacuum > :size_after_vacuum AS vacuum_successful;
- vacuum_successful
+SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
+FROM pg_total_relation_size('local_vacuum_table') s ;
+   size
 ---------------------------------------------------------------------
- t
+ 35000000
 (1 row)
 
 -- vacuum full deallocates pages of dead tuples whereas normal vacuum only marks dead tuples on visibility map
@@ -413,6 +403,8 @@ VACUUM (DISABLE_PAGE_SKIPPING false) local_vacuum_table;
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 50000000 AND 70000000 THEN 60000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
    size
@@ -422,6 +414,8 @@ FROM pg_total_relation_size('local_vacuum_table') s ;
 
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
+VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
@@ -434,9 +428,13 @@ FROM pg_total_relation_size('local_vacuum_table') s ;
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 vacuum (TRUNCATE false) local_vacuum_table;
+vacuum (TRUNCATE false) local_vacuum_table;
+vacuum (TRUNCATE false) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size1 \gset
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
+vacuum (TRUNCATE true) local_vacuum_table;
+vacuum (TRUNCATE true) local_vacuum_table;
 vacuum (TRUNCATE true) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size2 \gset
 SELECT :size1 > :size2 as truncate_less_size;

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -231,7 +231,7 @@ delete from local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
-SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
+SELECT CASE WHEN s BETWEEN 20000000 AND 25000000 THEN 22500000 ELSE s END
 FROM pg_total_relation_size('local_vacuum_table') s ;
 
 -- vacuum full deallocates pages of dead tuples whereas normal vacuum only marks dead tuples on visibility map

--- a/src/test/regress/sql/multi_utilities.sql
+++ b/src/test/regress/sql/multi_utilities.sql
@@ -228,24 +228,11 @@ VACUUM;
 -- should not propagate because no distributed table is specified
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
-
--- sometimes the vacuum doesn't clean up as expected and results in a flaky result
--- for our tests. For this reason, we re-run the vacuum command once if size of
--- the table before and after the VACUUM is not as expected
-SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
-VACUUM local_vacuum_table;
-SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
-
-SELECT :size_before_vacuum <= :size_after_vacuum AS re_vacuum_needed \gset
-\if :re_vacuum_needed
-SELECT pg_total_relation_size('local_vacuum_table') AS size_before_vacuum \gset
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
 VACUUM local_vacuum_table;
-SELECT pg_total_relation_size('local_vacuum_table') AS size_after_vacuum \gset
-\endif
-
-SELECT :size_before_vacuum > :size_after_vacuum AS vacuum_successful;
+SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
+FROM pg_total_relation_size('local_vacuum_table') s ;
 
 -- vacuum full deallocates pages of dead tuples whereas normal vacuum only marks dead tuples on visibility map
 VACUUM FULL local_vacuum_table;
@@ -272,11 +259,15 @@ VACUUM (DISABLE_PAGE_SKIPPING false) local_vacuum_table;
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP OFF, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 50000000 AND 70000000 THEN 60000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
 
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
+VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
+VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
@@ -285,10 +276,14 @@ FROM pg_total_relation_size('local_vacuum_table') s ;
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 vacuum (TRUNCATE false) local_vacuum_table;
+vacuum (TRUNCATE false) local_vacuum_table;
+vacuum (TRUNCATE false) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size1 \gset
 
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
+vacuum (TRUNCATE true) local_vacuum_table;
+vacuum (TRUNCATE true) local_vacuum_table;
 vacuum (TRUNCATE true) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size2 \gset
 


### PR DESCRIPTION
When I run this test in my local, the size of the table after the DELETE command is around 58785792. Hence, I assume that the diffs suggest that the Vacuum had no effect.

diff1: https://github.com/citusdata/citus/actions/runs/6721324131/attempts/1#summary-18267028116
```diff
insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
    size   
 ----------
- 35000000
+ 84606976
 (1 row)
```
diff2: https://github.com/citusdata/citus/actions/runs/6722231142/attempts/1#summary-18269870674
```diff
insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 VACUUM local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 20000000 AND 25000000 THEN 22500000 ELSE s END
 FROM pg_total_relation_size('local_vacuum_table') s ;
     s     
 ----------
- 22500000
+ 58785792
 (1 row)
```

Also, ran into another similar flakyness through this PR's tests :)
diff3: https://github.com/citusdata/citus/actions/runs/6812556461/attempts/1#summary-18525495090
```diff
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 VACUUM (INDEX_CLEANUP ON, PARALLEL 1) local_vacuum_table;
 SELECT CASE WHEN s BETWEEN 20000000 AND 49999999 THEN 35000000 ELSE s END size
 FROM pg_total_relation_size('local_vacuum_table') s ;
    size   
 ----------
- 35000000
+ 84606976
 (1 row)
```

diff4: https://app.circleci.com/pipelines/github/citusdata/citus/34279/workflows/df56dd03-925b-475e-9c76-285f89998ffd/jobs/1212694
```diff
delete from local_vacuum_table;
 vacuum (TRUNCATE false) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size1 \gset
 insert into local_vacuum_table select i from generate_series(1,1000000) i;
 delete from local_vacuum_table;
 vacuum (TRUNCATE true) local_vacuum_table;
 SELECT pg_total_relation_size('local_vacuum_table') as size2 \gset
 SELECT :size1 > :size2 as truncate_less_size;
  truncate_less_size 
 --------------------
- t
+ f
 (1 row)
```
The current solution is to run the VACUUM command three times instead of once.

This flaky test is part of #7310 
