### PR TITLE
Bump PG versions to latest minors 14.10, 15.5, 16.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ USER citus
 
 # build postgres versions separately for effective parrallelism and caching of already built versions when changing only certain versions
 FROM base AS pg14
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.9
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.10
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -80,7 +80,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg15
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.4
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.5
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -92,7 +92,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg16
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.0
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.1
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -210,7 +210,7 @@ COPY --chown=citus:citus .psqlrc .
 RUN sudo chown --from=root:root citus:citus -R ~
 
 # sets default pg version
-RUN pgenv switch 16.0
+RUN pgenv switch 16.1
 
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,11 +31,11 @@ jobs:
       pgupgrade_image_name: "citus/pgupgradetester"
       style_checker_image_name: "citus/stylechecker"
       style_checker_tools_version: "0.8.18"
-      image_suffix: "-v9d71045"
-      pg14_version: '{ "major": "14", "full": "14.9" }'
-      pg15_version: '{ "major": "15", "full": "15.4" }'
-      pg16_version: '{ "major": "16", "full": "16.0" }'
-      upgrade_pg_versions: "14.9-15.4-16.0"
+      image_suffix: "-dev-2831cc2"
+      pg14_version: '{ "major": "14", "full": "14.10" }'
+      pg15_version: '{ "major": "15", "full": "15.5" }'
+      pg16_version: '{ "major": "16", "full": "16.1" }'
+      upgrade_pg_versions: "14.10-15.5-16.1"
     steps:
       # Since GHA jobs needs at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
       pgupgrade_image_name: "citus/pgupgradetester"
       style_checker_image_name: "citus/stylechecker"
       style_checker_tools_version: "0.8.18"
-      image_suffix: "-dev-2831cc2"
+      image_suffix: "-vbd8441d"
       pg14_version: '{ "major": "14", "full": "14.10" }'
       pg15_version: '{ "major": "15", "full": "15.5" }'
       pg16_version: '{ "major": "16", "full": "16.1" }'


### PR DESCRIPTION
Postgres got minor updates on Nov9, this starts using the images with the latest
version for our tests, namely 14.10, 15.5 and 16.1.
Sister PR: https://github.com/citusdata/the-process/pull/152