### PR TITLE
Fix wrong PR links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ### citus v12.1.1 (November 9, 2023) ###
 
 * Fixes leaking of memory and memory contexts in Citus foreign key cache
-  (#7219)
+  (#7236)
 
 * Makes sure to disallow creating a replicated distributed table concurrently
-  (#7236)
+  (#7219)
 
 ### citus v12.1.0 (September 12, 2023) ###
 


### PR DESCRIPTION
When preparing changelog for 12.1.1 release, I accidentally swapped the PR numbers for the two commits. This commit fixes the changelog to point to the correct PRs.
