### PR TITLE
Fix redundant variable declaration

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -90,7 +90,6 @@ my $workerCount = 2;
 my $serversAreShutdown = "TRUE";
 my $usingWindows = 0;
 my $mitmPid = 0;
-my $workerCount = 2;
 
 if ($Config{osname} eq "MSWin32")
 {


### PR DESCRIPTION
The `$workerCount` declare twice in src/test/regress/pg_regress_multi.pl.