### PR TITLE
Devcontainer: add code formatting tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -165,10 +165,8 @@ RUN sudo apt update \
 RUN sudo curl -o /root/gdbpg.py https://raw.githubusercontent.com/tvesely/gdbpg/6065eee7872457785f830925eac665aa535caf62/gdbpg.py
 COPY --chown=root:root .gdbinit /root/
 
-# add some common tools to the final container
-# bin directory for user tools
-RUN mkdir .bin
-ENV PATH="/home/citus/.bin:${PATH}"
+# install developer dependencies in the global environment
+RUN --mount=type=bind,source=requirements.txt,target=requirements.txt pip install -r requirements.txt
 
 # for persistent bash history across devcontainers we need to have
 # a) a directory to store the history in
@@ -181,14 +179,16 @@ RUN sudo install -d -o citus -g citus /commandhistory \
 # install citus-dev
 RUN git clone --branch develop https://github.com/citusdata/tools.git citus-tools \
  && ( cd citus-tools/citus_dev && pipenv install ) \
- && ln -s /home/citus/citus-tools/citus_dev/citus_dev-pipenv .bin/citus_dev \
+ && mkdir -p ~/.local/bin \
+ && ln -s /home/citus/citus-tools/citus_dev/citus_dev-pipenv .local/bin/citus_dev \
  && sudo make -C citus-tools/uncrustify install bindir=/usr/local/bin pkgsysconfdir=/usr/local/etc/ \
  && mkdir -p ~/.local/share/bash-completion/completions/ \
  && ln -s ~/citus-tools/citus_dev/bash_completion ~/.local/share/bash-completion/completions/citus_dev
 
 # TODO some LC_ALL errors, possibly solved by locale-gen
 RUN git clone https://github.com/so-fancy/diff-so-fancy.git \
- && ln -s /home/citus/diff-so-fancy/diff-so-fancy .bin/
+ && mkdir -p ~/.local/bin \
+ && ln -s /home/citus/diff-so-fancy/diff-so-fancy .local/bin/
 
 COPY --link --from=uncrustify-builder /uncrustify/usr/ /usr/
 
@@ -211,8 +211,6 @@ RUN sudo chown --from=root:root citus:citus -R ~
 
 # sets default pg version
 RUN pgenv switch 16.1
-
-RUN --mount=type=bind,source=requirements.txt,target=requirements.txt pip install -r requirements.txt
 
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -212,5 +212,7 @@ RUN sudo chown --from=root:root citus:citus -R ~
 # sets default pg version
 RUN pgenv switch 16.1
 
+RUN --mount=type=bind,source=requirements.txt,target=requirements.txt pip install -r requirements.txt
+
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/citusdata/citus-devcontainer:devcontainer-format-tools",
+    "image": "ghcr.io/citusdata/citus-devcontainer:main",
     "runArgs": [
         "--cap-add=SYS_PTRACE",
     ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/citusdata/citus-devcontainer:main",
+    "image": "ghcr.io/citusdata/citus-devcontainer:devcontainer-format-tools",
     "runArgs": [
         "--cap-add=SYS_PTRACE",
     ],

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,9 @@
+black==23.11.0
+click==8.1.7
+isort==5.12.0
+mypy-extensions==1.0.0
+packaging==23.2
+pathspec==0.11.2
+platformdirs==4.0.0
+tomli==2.0.1
+typing_extensions==4.8.0

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -20,7 +20,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/citusdata/citus-devcontainer
@@ -32,14 +32,14 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
       -
         name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:.devcontainer"
           push: true


### PR DESCRIPTION
The devcontainer missed two tools used by code formatting, as done by `ci/fix_style.sh`
The missing tools were both python tools, used for formatting our python scripts.

 - black
 - isort

This change adds both tools. The way it does this is by keeping a `requirements.txt` in `.devcontainer/` containing all python dependencies we need to install. When installing both tools in a clean environment we have exported all installed packages with `pip freeze` into the `requirements.txt` assuming this is all related to the two tools installed.

Since python installs the binaires in `~/.local/bin/` we also move some scripts we manually install from `~/.bin/` to that same directory. At first it seemed like vscode's devcontainers were not having that on the path. However, when the container has that directory when it starts the directory does get added to `$PATH` by `~/.profile`. This makes the whole environment a bit more streamlined.

TODO:
 - [x] revert image back to `main` before merging