### PR TITLE
Run wal2json cdc test for pg16 as well

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
       pgupgrade_image_name: "citus/pgupgradetester"
       style_checker_image_name: "citus/stylechecker"
       style_checker_tools_version: "0.8.18"
-      image_suffix: "-vbd8441d"
+      image_suffix: "-dev-7ee690b"
       pg14_version: '{ "major": "14", "full": "14.10" }'
       pg15_version: '{ "major": "15", "full": "15.5" }'
       pg16_version: '{ "major": "16", "full": "16.1" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
       pgupgrade_image_name: "citus/pgupgradetester"
       style_checker_image_name: "citus/stylechecker"
       style_checker_tools_version: "0.8.18"
-      image_suffix: "-dev-7ee690b"
+      image_suffix: "-v19b671f"
       pg14_version: '{ "major": "14", "full": "14.10" }'
       pg15_version: '{ "major": "15", "full": "15.5" }'
       pg16_version: '{ "major": "16", "full": "16.1" }'

--- a/src/test/cdc/t/016_cdc_wal2json.pl
+++ b/src/test/cdc/t/016_cdc_wal2json.pl
@@ -9,13 +9,6 @@ use cdctestlib;
 
 use threads;
 
-my $pg_major_version =  int($ENV{'pg_major_version'});
-print("working with PG major version : $pg_major_version\n");
-if ($pg_major_version >= 16) {
-	plan skip_all => 'wal2json is not available for PG16 yet';
-    exit 0;
-}
-
 # Initialize co-ordinator node
 my $select_stmt = qq(SELECT * FROM data_100008 ORDER BY id;);
 my $result = 0;


### PR DESCRIPTION
pg16 wal2json package is now available, adding the tests back. Basically reverting https://github.com/citusdata/citus/pull/6952/commits/f253bb32104b54cf96dd8fd05821500af1aba206

Sister PR https://github.com/citusdata/the-process/pull/153