### PR TITLE
Refactors ExtendedTaskList methods

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -729,10 +729,11 @@ static uint64 MicrosecondsBetweenTimestamps(instr_time startTime, instr_time end
 static int WorkerPoolCompare(const void *lhsKey, const void *rhsKey);
 static void SetAttributeInputMetadata(DistributedExecution *execution,
 									  ShardCommandExecution *shardCommandExecution);
-static ExecutionParams * GetExecutionParams(RowModifyLevel modLevel, List *taskList,
-											TupleDestination *tupleDest,
-											bool expectResults,
-											ParamListInfo paramListInfo);
+static ExecutionParams * CreateDefaultExecutionParams(RowModifyLevel modLevel,
+													  List *taskList,
+													  TupleDestination *tupleDest,
+													  bool expectResults,
+													  ParamListInfo paramListInfo);
 
 
 /*
@@ -1023,10 +1024,10 @@ ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
  * bind params (presumably from executor state) with defaults for some of the arguments.
  */
 static ExecutionParams *
-GetExecutionParams(RowModifyLevel modLevel, List *taskList,
-				   TupleDestination *tupleDest,
-				   bool expectResults,
-				   ParamListInfo paramListInfo)
+CreateDefaultExecutionParams(RowModifyLevel modLevel, List *taskList,
+							 TupleDestination *tupleDest,
+							 bool expectResults,
+							 ParamListInfo paramListInfo)
 {
 	int targetPoolSize = MaxAdaptiveExecutorPoolSize;
 	bool localExecutionSupported = true;
@@ -1054,8 +1055,10 @@ ExecuteTaskListIntoTupleDestWithParam(RowModifyLevel modLevel, List *taskList,
 									  bool expectResults,
 									  ParamListInfo paramListInfo)
 {
-	ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
-														  expectResults, paramListInfo);
+	ExecutionParams *executionParams = CreateDefaultExecutionParams(modLevel, taskList,
+																	tupleDest,
+																	expectResults,
+																	paramListInfo);
 	return ExecuteTaskListExtended(executionParams);
 }
 
@@ -1070,8 +1073,10 @@ ExecuteTaskListIntoTupleDest(RowModifyLevel modLevel, List *taskList,
 							 bool expectResults)
 {
 	ParamListInfo paramListInfo = NULL;
-	ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
-														  expectResults, paramListInfo);
+	ExecutionParams *executionParams = CreateDefaultExecutionParams(modLevel, taskList,
+																	tupleDest,
+																	expectResults,
+																	paramListInfo);
 	return ExecuteTaskListExtended(executionParams);
 }
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -729,11 +729,10 @@ static uint64 MicrosecondsBetweenTimestamps(instr_time startTime, instr_time end
 static int WorkerPoolCompare(const void *lhsKey, const void *rhsKey);
 static void SetAttributeInputMetadata(DistributedExecution *execution,
 									  ShardCommandExecution *shardCommandExecution);
-static ExecutionParams *
-GetExecutionParams(RowModifyLevel modLevel, List *taskList,
-                      TupleDestination *tupleDest,
-                      bool expectResults,
-                      ParamListInfo paramListInfo);
+static ExecutionParams * GetExecutionParams(RowModifyLevel modLevel, List *taskList,
+											TupleDestination *tupleDest,
+											bool expectResults,
+											ParamListInfo paramListInfo);
 
 
 /*
@@ -1019,31 +1018,31 @@ ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
 }
 
 
-
 /*
  * Prepare execution parameters for a task list.It is used by the
  * functions that execute task lists.
-*/
+ */
 static ExecutionParams *
 GetExecutionParams(RowModifyLevel modLevel, List *taskList,
-                      TupleDestination *tupleDest,
-                      bool expectResults,
-                      ParamListInfo paramListInfo)
+				   TupleDestination *tupleDest,
+				   bool expectResults,
+				   ParamListInfo paramListInfo)
 {
-    int targetPoolSize = MaxAdaptiveExecutorPoolSize;
-    bool localExecutionSupported = true;
-    ExecutionParams *executionParams = CreateBasicExecutionParams(
-        modLevel, taskList, targetPoolSize, localExecutionSupported
-        );
+	int targetPoolSize = MaxAdaptiveExecutorPoolSize;
+	bool localExecutionSupported = true;
+	ExecutionParams *executionParams = CreateBasicExecutionParams(
+		modLevel, taskList, targetPoolSize, localExecutionSupported
+		);
 
-    executionParams->xactProperties = DecideTransactionPropertiesForTaskList(
-        modLevel, taskList, false);
-    executionParams->expectResults = expectResults;
-    executionParams->tupleDestination = tupleDest;
-    executionParams->paramListInfo = paramListInfo;
+	executionParams->xactProperties = DecideTransactionPropertiesForTaskList(
+		modLevel, taskList, false);
+	executionParams->expectResults = expectResults;
+	executionParams->tupleDestination = tupleDest;
+	executionParams->paramListInfo = paramListInfo;
 
-    return executionParams;
+	return executionParams;
 }
+
 
 /*
  * ExecuteTaskListIntoTupleDestWithParam is a proxy to ExecuteTaskListExtended() which uses
@@ -1051,14 +1050,15 @@ GetExecutionParams(RowModifyLevel modLevel, List *taskList,
  */
 uint64
 ExecuteTaskListIntoTupleDestWithParam(RowModifyLevel modLevel, List *taskList,
-                                      TupleDestination *tupleDest,
-                                      bool expectResults,
-                                      ParamListInfo paramListInfo)
+									  TupleDestination *tupleDest,
+									  bool expectResults,
+									  ParamListInfo paramListInfo)
 {
 	ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
-	                                                         expectResults, paramListInfo);
-    return ExecuteTaskListExtended(executionParams);
+														  expectResults, paramListInfo);
+	return ExecuteTaskListExtended(executionParams);
 }
+
 
 /*
  * ExecuteTaskListIntoTupleDest is a proxy to ExecuteTaskListExtended() with defaults
@@ -1066,12 +1066,12 @@ ExecuteTaskListIntoTupleDestWithParam(RowModifyLevel modLevel, List *taskList,
  */
 uint64
 ExecuteTaskListIntoTupleDest(RowModifyLevel modLevel, List *taskList,
-                             TupleDestination *tupleDest,
-                             bool expectResults)
+							 TupleDestination *tupleDest,
+							 bool expectResults)
 {
-    ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
-	                                                         expectResults, NULL);
-    return ExecuteTaskListExtended(executionParams);
+	ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
+														  expectResults, NULL);
+	return ExecuteTaskListExtended(executionParams);
 }
 
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1019,8 +1019,8 @@ ExecuteTaskListOutsideTransaction(RowModifyLevel modLevel, List *taskList,
 
 
 /*
- * Prepare execution parameters for a task list.It is used by the
- * functions that execute task lists.
+ * CreateDefaultExecutionParams returns execution params based on given (possibly null)
+ * bind params (presumably from executor state) with defaults for some of the arguments.
  */
 static ExecutionParams *
 GetExecutionParams(RowModifyLevel modLevel, List *taskList,
@@ -1069,8 +1069,9 @@ ExecuteTaskListIntoTupleDest(RowModifyLevel modLevel, List *taskList,
 							 TupleDestination *tupleDest,
 							 bool expectResults)
 {
+	ParamListInfo paramListInfo = NULL;
 	ExecutionParams *executionParams = GetExecutionParams(modLevel, taskList, tupleDest,
-														  expectResults, NULL);
+														  expectResults, paramListInfo);
 	return ExecuteTaskListExtended(executionParams);
 }
 


### PR DESCRIPTION
ExecuteTaskListIntoTupleDestWithParam and ExecuteTaskListIntoTupleDest are nearly the same. I parameterized and a made a reusable structure here