### PR TITLE
Fix the incorrect column count after ALTER TABLE

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_15.c
+++ b/src/backend/distributed/deparser/ruleutils_15.c
@@ -1563,8 +1563,15 @@ set_join_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 
 	/* Assert we processed the right number of columns */
 #ifdef USE_ASSERT_CHECKING
-	while (i < colinfo->num_cols && colinfo->colnames[i] == NULL)
-		i++;
+	for (int col_index = 0; col_index < colinfo->num_cols; col_index++)
+	{
+		/*
+		 * In the above processing-loops, "i" advances only if
+		 * the column is not new, check if this is a new column.
+		 */
+		if (colinfo->is_new_col[col_index])
+			i++;
+	}
 	Assert(i == colinfo->num_cols);
 	Assert(j == nnewcolumns);
 #endif

--- a/src/backend/distributed/utils/citus_nodefuncs.c
+++ b/src/backend/distributed/utils/citus_nodefuncs.c
@@ -142,7 +142,17 @@ SetRangeTblExtraData(RangeTblEntry *rte, CitusRTEKind rteKind, char *fragmentSch
 	fauxFunction->funcexpr = (Node *) fauxFuncExpr;
 
 	/* set the column count to pass ruleutils checks, not used elsewhere */
-	fauxFunction->funccolcount = list_length(rte->eref->colnames);
+	if (rte->relid != 0)
+	{
+		Relation rel = RelationIdGetRelation(rte->relid);
+		fauxFunction->funccolcount = RelationGetNumberOfAttributes(rel);
+		RelationClose(rel);
+	}
+	else
+	{
+		fauxFunction->funccolcount = list_length(rte->eref->colnames);
+	}
+
 	fauxFunction->funccolnames = funcColumnNames;
 	fauxFunction->funccoltypes = funcColumnTypes;
 	fauxFunction->funccoltypmods = funcColumnTypeMods;

--- a/src/test/regress/expected/multi_alter_table_statements.out
+++ b/src/test/regress/expected/multi_alter_table_statements.out
@@ -1349,6 +1349,77 @@ SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.p
  (schema,{test_schema_for_sequence_propagation},{})
 (1 row)
 
+-- Bug: https://github.com/citusdata/citus/issues/7378
+-- Create a reference table
+CREATE TABLE tbl_ref(row_id integer primary key);
+INSERT INTO tbl_ref VALUES (1), (2);
+SELECT create_reference_table('tbl_ref');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_alter_table_statements.tbl_ref$$)
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Create a distributed table
+CREATE TABLE tbl_dist(series_id integer);
+INSERT INTO tbl_dist VALUES (1), (1), (2), (2);
+SELECT create_distributed_table('tbl_dist', 'series_id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$multi_alter_table_statements.tbl_dist$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Create a view that joins the distributed table with the reference table on the distribution key.
+CREATE VIEW vw_citus_views as
+SELECT d.series_id FROM tbl_dist d JOIN tbl_ref r ON d.series_id = r.row_id;
+-- The view initially works fine
+SELECT * FROM vw_citus_views ORDER BY 1;
+ series_id
+---------------------------------------------------------------------
+         1
+         1
+         2
+         2
+(4 rows)
+
+-- Now, alter the table
+ALTER TABLE tbl_ref ADD COLUMN category1 varchar(50);
+SELECT * FROM vw_citus_views ORDER BY 1;
+ series_id
+---------------------------------------------------------------------
+         1
+         1
+         2
+         2
+(4 rows)
+
+ALTER TABLE tbl_ref ADD COLUMN category2 varchar(50);
+SELECT * FROM vw_citus_views ORDER BY 1;
+ series_id
+---------------------------------------------------------------------
+         1
+         1
+         2
+         2
+(4 rows)
+
+ALTER TABLE tbl_ref DROP COLUMN category1;
+SELECT * FROM vw_citus_views ORDER BY 1;
+ series_id
+---------------------------------------------------------------------
+         1
+         1
+         2
+         2
+(4 rows)
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA test_schema_for_sequence_propagation CASCADE;
 DROP TABLE table_without_sequence;

--- a/src/test/regress/sql/multi_alter_table_statements.sql
+++ b/src/test/regress/sql/multi_alter_table_statements.sql
@@ -727,6 +727,32 @@ ALTER TABLE table_without_sequence ADD COLUMN x BIGINT DEFAULT nextval('test_sch
 SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object WHERE objid IN ('test_schema_for_sequence_propagation.seq_10'::regclass);
 SELECT pg_identify_object_as_address(classid, objid, objsubid) from pg_catalog.pg_dist_object WHERE objid IN ('test_schema_for_sequence_propagation'::regnamespace);
 
+-- Bug: https://github.com/citusdata/citus/issues/7378
+
+-- Create a reference table
+CREATE TABLE tbl_ref(row_id integer primary key);
+INSERT INTO tbl_ref VALUES (1), (2);
+SELECT create_reference_table('tbl_ref');
+
+-- Create a distributed table
+CREATE TABLE tbl_dist(series_id integer);
+INSERT INTO tbl_dist VALUES (1), (1), (2), (2);
+SELECT create_distributed_table('tbl_dist', 'series_id');
+
+-- Create a view that joins the distributed table with the reference table on the distribution key.
+CREATE VIEW vw_citus_views as
+SELECT d.series_id FROM tbl_dist d JOIN tbl_ref r ON d.series_id = r.row_id;
+
+-- The view initially works fine
+SELECT * FROM vw_citus_views ORDER BY 1;
+-- Now, alter the table
+ALTER TABLE tbl_ref ADD COLUMN category1 varchar(50);
+SELECT * FROM vw_citus_views ORDER BY 1;
+ALTER TABLE tbl_ref ADD COLUMN category2 varchar(50);
+SELECT * FROM vw_citus_views ORDER BY 1;
+ALTER TABLE tbl_ref DROP COLUMN category1;
+SELECT * FROM vw_citus_views ORDER BY 1;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA test_schema_for_sequence_propagation CASCADE;
 DROP TABLE table_without_sequence;


### PR DESCRIPTION
DESCRIPTION: Fix the incorrect column count after ALTER TABLE

Fixes: #7378 


In Citus's query planning process, range table entries are typically mocked as `RTE_FUNCTION` entries, with a `RangeTblFunction` node created to represent them. This node's `funccolcount` is set based on the column count from the view's parse tree, reflecting the column count of the underlying table at the time of the view's creation. However, a runtime issue emerges if the underlying table is altered, particularly when new columns are added. The `funccolcount` in the `RTE_FUNCTION` remains outdated, leading to a mismatch in column counts. This results in an error, specifically "column 2 of relation 'r' does not exist," during runtime when Citus checks if any column is dropped using `get_rte_attribute_is_dropped(curinputrte, aliasvar->varattno)`.

The proposed solution to this bug is to update `funccolcount` during the planning phase to reflect the actual, current column count of the underlying table. By using `RelationGetNumberOfAttributes(rel)` instead of the initial column count from the view’s parse tree, the `funccolcount` accurately represents the up-to-date structure of the underlying table. This fix ensures that any schema changes, such as adding new columns to the table, are accommodated, thereby maintaining query accuracy and consistency in Citus, even in environments with evolving database schemas.
