### PR TITLE
Add pytest test example about connecting to a worker

### DIFF
--- a/src/test/regress/citus_tests/test/README.md
+++ b/src/test/regress/citus_tests/test/README.md
@@ -82,6 +82,7 @@ the name of the fixture. For example:
 ```python
 def test_some_query(cluster):
     cluster.coordinator.sql("SELECT 1")
+	assert cluster.workers[0].sql_value('SELECT 2') == 2
 ```
 
 If you need a cluster of a specific size you can use the `cluster_factory`


### PR DESCRIPTION
I noticed while reviewing #7203 that there as no example of executing sql on a
worker for the pytest README. Since this is a pretty common thing that people
want to do, this PR adds that.
