### PR TITLE
Fix foreign_key_to_reference_shard_rebalance test

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -199,6 +199,9 @@ DEPS = {
         repeatable=False,
     ),
     "multi_prepare_plsql": TestDeps("base_schedule"),
+    "foreign_key_to_reference_shard_rebalance": TestDeps(
+        "minimal_schedule", ["remove_coordinator_from_metadata"]
+    )
 }
 
 

--- a/src/test/regress/expected/foreign_key_to_reference_shard_rebalance.out
+++ b/src/test/regress/expected/foreign_key_to_reference_shard_rebalance.out
@@ -210,6 +210,7 @@ select create_distributed_table('partitioned_tbl_with_fkey','x');
 
 create table partition_1_with_fkey partition of partitioned_tbl_with_fkey for values from ('2022-01-01') to ('2022-12-31');
 create table partition_2_with_fkey partition of partitioned_tbl_with_fkey for values from ('2023-01-01') to ('2023-12-31');
+create table partition_3_with_fkey partition of partitioned_tbl_with_fkey DEFAULT;
 insert into partitioned_tbl_with_fkey (x,y) select s,s%10 from generate_series(1,100) s;
 ALTER TABLE partitioned_tbl_with_fkey ADD CONSTRAINT fkey_to_ref_tbl FOREIGN KEY (y) REFERENCES ref_table_with_fkey(id);
 WITH shardid AS (SELECT shardid FROM pg_dist_shard where logicalrelid = 'partitioned_tbl_with_fkey'::regclass ORDER BY shardid LIMIT 1)

--- a/src/test/regress/sql/foreign_key_to_reference_shard_rebalance.sql
+++ b/src/test/regress/sql/foreign_key_to_reference_shard_rebalance.sql
@@ -84,6 +84,7 @@ create table partitioned_tbl_with_fkey (x int, y int, t timestamptz default now(
 select create_distributed_table('partitioned_tbl_with_fkey','x');
 create table partition_1_with_fkey partition of partitioned_tbl_with_fkey for values from ('2022-01-01') to ('2022-12-31');
 create table partition_2_with_fkey partition of partitioned_tbl_with_fkey for values from ('2023-01-01') to ('2023-12-31');
+create table partition_3_with_fkey partition of partitioned_tbl_with_fkey DEFAULT;
 insert into partitioned_tbl_with_fkey (x,y) select s,s%10 from generate_series(1,100) s;
 
 ALTER TABLE partitioned_tbl_with_fkey ADD CONSTRAINT fkey_to_ref_tbl FOREIGN KEY (y) REFERENCES ref_table_with_fkey(id);


### PR DESCRIPTION
Replaces https://github.com/citusdata/citus/pull/7396 by adding a rule that allows properly testing foreign_key_to_reference_shard_rebalance via run_test.py.

(Making this a separate PR as I cannot push to https://github.com/citusdata/citus/pull/7396 but want to get this in asap)