### PR TITLE
Support running isolation_update_node in flaky test detection

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -153,6 +153,9 @@ DEPS = {
     "isolation_extension_commands": TestDeps(
         None, ["isolation_setup", "isolation_add_remove_node"]
     ),
+    "isolation_update_node": TestDeps(
+        None, ["isolation_setup", "isolation_add_remove_node"]
+    ),
     "schema_based_sharding": TestDeps("minimal_schedule"),
     "multi_sequence_default": TestDeps(
         None, ["multi_test_helpers", "multi_cluster_management", "multi_table_ddl"]

--- a/src/test/regress/expected/isolation_update_node.out
+++ b/src/test/regress/expected/isolation_update_node.out
@@ -93,8 +93,8 @@ nodeid|nodename|nodeport
 starting permutation: s1-begin s1-update-node-1 s2-begin s2-update-node-1 s1-commit s2-abort s1-show-nodes s3-update-node-1-back s3-manually-fix-metadata
 nodeid|nodename |nodeport
 ---------------------------------------------------------------------
-    25|localhost|   57638
-    24|localhost|   57637
+    23|localhost|   57638
+    22|localhost|   57637
 (2 rows)
 
 step s1-begin:
@@ -139,8 +139,8 @@ step s1-show-nodes:
 
 nodeid|nodename |nodeport|isactive
 ---------------------------------------------------------------------
-    25|localhost|   57638|t
-    24|localhost|   58637|t
+    23|localhost|   57638|t
+    22|localhost|   58637|t
 (2 rows)
 
 step s3-update-node-1-back:
@@ -178,8 +178,8 @@ nodeid|nodename|nodeport
 starting permutation: s2-create-table s1-begin s1-update-node-nonexistent s1-prepare-transaction s2-cache-prepared-statement s1-commit-prepared s2-execute-prepared s1-update-node-existent s3-manually-fix-metadata
 nodeid|nodename |nodeport
 ---------------------------------------------------------------------
-    27|localhost|   57638
-    26|localhost|   57637
+    23|localhost|   57638
+    22|localhost|   57637
 (2 rows)
 
 step s2-create-table:

--- a/src/test/regress/spec/isolation_update_node.spec
+++ b/src/test/regress/spec/isolation_update_node.spec
@@ -3,6 +3,8 @@ setup
     -- revert back to pg_isolation_test_session_is_blocked until the tests are fixed
     SELECT citus_internal.restore_isolation_tester_func();
 
+    ALTER SEQUENCE pg_dist_node_nodeid_seq RESTART 22;
+
     SELECT 1 FROM master_add_node('localhost', 57637);
     SELECT 1 FROM master_add_node('localhost', 57638);
 


### PR DESCRIPTION
I noticed in #7423 that `isolation_update_node` could not be run using
flaky test detection. This fixes that.
