### PR TITLE
Generate qualified relation name

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -209,12 +209,9 @@ static void ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommand
 static bool HasAnyGeneratedStoredColumns(Oid relationId);
 static List * GetNonGeneratedStoredColumnNameList(Oid relationId);
 static void CheckAlterDistributedTableConversionParameters(TableConversionState *con);
-static char * CreateWorkerChangeSequenceDependencyCommand(char *sequenceSchemaName,
-														  char *sequenceName,
-														  char *sourceSchemaName,
-														  char *sourceName,
-														  char *targetSchemaName,
-														  char *targetName);
+static char * CreateWorkerChangeSequenceDependencyCommand(char *qualifiedSequeceName,
+														  char *qualifiedSourceName,
+														  char *qualifiedTargetName);
 static void ErrorIfMatViewSizeExceedsTheLimit(Oid matViewOid);
 static char * CreateMaterializedViewDDLCommand(Oid matViewOid);
 static char * GetAccessMethodForMatViewIfExists(Oid viewOid);
@@ -791,13 +788,15 @@ ConvertTableInternal(TableConversionState *con)
 		justBeforeDropCommands = lappend(justBeforeDropCommands, detachFromParentCommand);
 	}
 
+	char *qualifiedRelationName = quote_qualified_identifier(con->schemaName,
+															 con->relationName);
+
 	if (PartitionedTable(con->relationId))
 	{
 		if (!con->suppressNoticeMessages)
 		{
 			ereport(NOTICE, (errmsg("converting the partitions of %s",
-									quote_qualified_identifier(con->schemaName,
-															   con->relationName))));
+									qualifiedRelationName)));
 		}
 
 		List *partitionList = PartitionList(con->relationId);
@@ -870,9 +869,7 @@ ConvertTableInternal(TableConversionState *con)
 
 	if (!con->suppressNoticeMessages)
 	{
-		ereport(NOTICE, (errmsg("creating a new table for %s",
-								quote_qualified_identifier(con->schemaName,
-														   con->relationName))));
+		ereport(NOTICE, (errmsg("creating a new table for %s", qualifiedRelationName)));
 	}
 
 	TableDDLCommand *tableCreationCommand = NULL;
@@ -999,8 +996,6 @@ ConvertTableInternal(TableConversionState *con)
 			{
 				continue;
 			}
-			char *qualifiedRelationName = quote_qualified_identifier(con->schemaName,
-																	 con->relationName);
 
 			TableConversionParameters cascadeParam = {
 				.relationId = colocatedTableId,
@@ -1750,9 +1745,7 @@ CreateMaterializedViewDDLCommand(Oid matViewOid)
 {
 	StringInfo query = makeStringInfo();
 
-	char *viewName = get_rel_name(matViewOid);
-	char *schemaName = get_namespace_name(get_rel_namespace(matViewOid));
-	char *qualifiedViewName = quote_qualified_identifier(schemaName, viewName);
+	char *qualifiedViewName = generate_qualified_relation_name(matViewOid);
 
 	/* here we need to get the access method of the view to recreate it */
 	char *accessMethodName = GetAccessMethodForMatViewIfExists(matViewOid);
@@ -1801,9 +1794,8 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 			 bool suppressNoticeMessages)
 {
 	char *sourceName = get_rel_name(sourceId);
-	char *targetName = get_rel_name(targetId);
-	Oid schemaId = get_rel_namespace(sourceId);
-	char *schemaName = get_namespace_name(schemaId);
+	char *qualifiedSourceName = generate_qualified_relation_name(sourceId);
+	char *qualifiedTargetName = generate_qualified_relation_name(targetId);
 
 	StringInfo query = makeStringInfo();
 
@@ -1811,8 +1803,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 	{
 		if (!suppressNoticeMessages)
 		{
-			ereport(NOTICE, (errmsg("moving the data of %s",
-									quote_qualified_identifier(schemaName, sourceName))));
+			ereport(NOTICE, (errmsg("moving the data of %s", qualifiedSourceName)));
 		}
 
 		if (!HasAnyGeneratedStoredColumns(sourceId))
@@ -1822,8 +1813,7 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 			 * "INSERT INTO .. SELECT *"".
 			 */
 			appendStringInfo(query, "INSERT INTO %s SELECT * FROM %s",
-							 quote_qualified_identifier(schemaName, targetName),
-							 quote_qualified_identifier(schemaName, sourceName));
+							 qualifiedTargetName, qualifiedSourceName);
 		}
 		else
 		{
@@ -1838,9 +1828,8 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 			char *insertColumnString = StringJoin(nonStoredColumnNameList, ',');
 			appendStringInfo(query,
 							 "INSERT INTO %s (%s) OVERRIDING SYSTEM VALUE SELECT %s FROM %s",
-							 quote_qualified_identifier(schemaName, targetName),
-							 insertColumnString, insertColumnString,
-							 quote_qualified_identifier(schemaName, sourceName));
+							 qualifiedTargetName, insertColumnString,
+							 insertColumnString, qualifiedSourceName);
 		}
 
 		ExecuteQueryViaSPI(query->data, SPI_OK_INSERT);
@@ -1864,14 +1853,9 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 		 */
 		if (ShouldSyncTableMetadata(targetId))
 		{
-			Oid sequenceSchemaOid = get_rel_namespace(sequenceOid);
-			char *sequenceSchemaName = get_namespace_name(sequenceSchemaOid);
-			char *sequenceName = get_rel_name(sequenceOid);
+			char *qualifiedSequenceName = generate_qualified_relation_name(sequenceOid);
 			char *workerChangeSequenceDependencyCommand =
-				CreateWorkerChangeSequenceDependencyCommand(sequenceSchemaName,
-															sequenceName,
-															schemaName, sourceName,
-															schemaName, targetName);
+				CreateWorkerChangeSequenceDependencyCommand(qualifiedSequenceName, qualifiedSourceName, qualifiedTargetName);
 			SendCommandToWorkersWithMetadata(workerChangeSequenceDependencyCommand);
 		}
 		else if (ShouldSyncTableMetadata(sourceId))
@@ -1894,25 +1878,23 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 
 	if (!suppressNoticeMessages)
 	{
-		ereport(NOTICE, (errmsg("dropping the old %s",
-								quote_qualified_identifier(schemaName, sourceName))));
+		ereport(NOTICE, (errmsg("dropping the old %s", qualifiedSourceName)));
 	}
 
 	resetStringInfo(query);
 	appendStringInfo(query, "DROP %sTABLE %s CASCADE",
 					 IsForeignTable(sourceId) ? "FOREIGN " : "",
-					 quote_qualified_identifier(schemaName, sourceName));
+					 qualifiedSourceName);
 	ExecuteQueryViaSPI(query->data, SPI_OK_UTILITY);
 
 	if (!suppressNoticeMessages)
 	{
-		ereport(NOTICE, (errmsg("renaming the new table to %s",
-								quote_qualified_identifier(schemaName, sourceName))));
+		ereport(NOTICE, (errmsg("renaming the new table to %s", qualifiedSourceName)));
 	}
 
 	resetStringInfo(query);
 	appendStringInfo(query, "ALTER TABLE %s RENAME TO %s",
-					 quote_qualified_identifier(schemaName, targetName),
+					 qualifiedTargetName,
 					 quote_identifier(sourceName));
 	ExecuteQueryViaSPI(query->data, SPI_OK_UTILITY);
 }
@@ -2172,18 +2154,14 @@ CheckAlterDistributedTableConversionParameters(TableConversionState *con)
  * worker_change_sequence_dependency query with the parameters.
  */
 static char *
-CreateWorkerChangeSequenceDependencyCommand(char *sequenceSchemaName, char *sequenceName,
-											char *sourceSchemaName, char *sourceName,
-											char *targetSchemaName, char *targetName)
+CreateWorkerChangeSequenceDependencyCommand(char *qualifiedSequeceName,
+											char *qualifiedSourceName,
+											char *qualifiedTargetName)
 {
-	char *qualifiedSchemaName = quote_qualified_identifier(sequenceSchemaName,
-														   sequenceName);
-	char *qualifiedSourceName = quote_qualified_identifier(sourceSchemaName, sourceName);
-	char *qualifiedTargetName = quote_qualified_identifier(targetSchemaName, targetName);
 
 	StringInfo query = makeStringInfo();
 	appendStringInfo(query, "SELECT worker_change_sequence_dependency(%s, %s, %s)",
-					 quote_literal_cstr(qualifiedSchemaName),
+					 quote_literal_cstr(qualifiedSequeceName),
 					 quote_literal_cstr(qualifiedSourceName),
 					 quote_literal_cstr(qualifiedTargetName));
 

--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1855,7 +1855,9 @@ ReplaceTable(Oid sourceId, Oid targetId, List *justBeforeDropCommands,
 		{
 			char *qualifiedSequenceName = generate_qualified_relation_name(sequenceOid);
 			char *workerChangeSequenceDependencyCommand =
-				CreateWorkerChangeSequenceDependencyCommand(qualifiedSequenceName, qualifiedSourceName, qualifiedTargetName);
+				CreateWorkerChangeSequenceDependencyCommand(qualifiedSequenceName,
+															qualifiedSourceName,
+															qualifiedTargetName);
 			SendCommandToWorkersWithMetadata(workerChangeSequenceDependencyCommand);
 		}
 		else if (ShouldSyncTableMetadata(sourceId))
@@ -2158,7 +2160,6 @@ CreateWorkerChangeSequenceDependencyCommand(char *qualifiedSequeceName,
 											char *qualifiedSourceName,
 											char *qualifiedTargetName)
 {
-
 	StringInfo query = makeStringInfo();
 	appendStringInfo(query, "SELECT worker_change_sequence_dependency(%s, %s, %s)",
 					 quote_literal_cstr(qualifiedSequeceName),

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -1160,9 +1160,7 @@ DropIdentitiesOnTable(Oid relationId)
 
 		if (attributeForm->attidentity)
 		{
-			char *tableName = get_rel_name(relationId);
-			char *schemaName = get_namespace_name(get_rel_namespace(relationId));
-			char *qualifiedTableName = quote_qualified_identifier(schemaName, tableName);
+			char *qualifiedTableName = generate_qualified_relation_name(relationId);
 
 			StringInfo dropCommand = makeStringInfo();
 
@@ -1222,9 +1220,7 @@ DropViewsOnTable(Oid relationId)
 	Oid viewId = InvalidOid;
 	foreach_oid(viewId, reverseOrderedViews)
 	{
-		char *viewName = get_rel_name(viewId);
-		char *schemaName = get_namespace_name(get_rel_namespace(viewId));
-		char *qualifiedViewName = quote_qualified_identifier(schemaName, viewName);
+		char *qualifiedViewName = generate_qualified_relation_name(viewId);
 
 		StringInfo dropCommand = makeStringInfo();
 		appendStringInfo(dropCommand, "DROP %sVIEW IF EXISTS %s",

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -1323,10 +1323,7 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 	{
 		List *partitionList = PartitionList(relationId);
 		Oid partitionRelationId = InvalidOid;
-		Oid namespaceId = get_rel_namespace(relationId);
-		char *schemaName = get_namespace_name(namespaceId);
-		char *relationName = get_rel_name(relationId);
-		char *parentRelationName = quote_qualified_identifier(schemaName, relationName);
+		char *parentRelationName = generate_qualified_relation_name(relationId);
 
 		/*
 		 * when there are many partitions, each call to CreateDistributedTable

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2548,7 +2548,7 @@ ShardIdForTuple(CitusCopyDestReceiver *copyDest, Datum *columnValues, bool *colu
 		if (columnNulls[partitionColumnIndex])
 		{
 			char *qualifiedTableName = generate_qualified_relation_name(
-										copyDest->distributedRelationId);
+				copyDest->distributedRelationId);
 
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 							errmsg("the partition column of table %s cannot be NULL",

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2547,12 +2547,8 @@ ShardIdForTuple(CitusCopyDestReceiver *copyDest, Datum *columnValues, bool *colu
 
 		if (columnNulls[partitionColumnIndex])
 		{
-			Oid relationId = copyDest->distributedRelationId;
-			char *relationName = get_rel_name(relationId);
-			Oid schemaOid = get_rel_namespace(relationId);
-			char *schemaName = get_namespace_name(schemaOid);
-			char *qualifiedTableName = quote_qualified_identifier(schemaName,
-																  relationName);
+			char *qualifiedTableName = generate_qualified_relation_name(
+										copyDest->distributedRelationId);
 
 			ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 							errmsg("the partition column of table %s cannot be NULL",

--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -392,9 +392,7 @@ CreateViewDDLCommand(Oid viewOid)
 static void
 AppendQualifiedViewNameToCreateViewCommand(StringInfo buf, Oid viewOid)
 {
-	char *viewName = get_rel_name(viewOid);
-	char *schemaName = get_namespace_name(get_rel_namespace(viewOid));
-	char *qualifiedViewName = quote_qualified_identifier(schemaName, viewName);
+	char *qualifiedViewName = generate_qualified_relation_name(viewOid);
 
 	appendStringInfo(buf, "%s ", qualifiedViewName);
 }

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -143,15 +143,10 @@ NonPushableInsertSelectExecScan(CustomScanState *node)
 										targetRelation->partitionColumn);
 			if (distributionColumnIndex == -1)
 			{
-				char *relationName = get_rel_name(targetRelationId);
-				Oid schemaOid = get_rel_namespace(targetRelationId);
-				char *schemaName = get_namespace_name(schemaOid);
-
 				ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 								errmsg(
 									"the partition column of table %s should have a value",
-									quote_qualified_identifier(schemaName,
-															   relationName))));
+									generate_qualified_relation_name(targetRelationId))));
 			}
 
 			TargetEntry *selectPartitionTE = list_nth(selectQuery->targetList,

--- a/src/backend/distributed/operations/shard_transfer.c
+++ b/src/backend/distributed/operations/shard_transfer.c
@@ -1945,11 +1945,7 @@ ConstructQualifiedShardName(ShardInterval *shardInterval)
 static List *
 RecreateTableDDLCommandList(Oid relationId)
 {
-	const char *relationName = get_rel_name(relationId);
-	Oid relationSchemaId = get_rel_namespace(relationId);
-	const char *relationSchemaName = get_namespace_name(relationSchemaId);
-	const char *qualifiedRelationName = quote_qualified_identifier(relationSchemaName,
-																   relationName);
+	const char *qualifiedRelationName = generate_qualified_relation_name(relationId);
 
 	StringInfo dropCommand = makeStringInfo();
 

--- a/src/backend/distributed/worker/worker_drop_protocol.c
+++ b/src/backend/distributed/worker/worker_drop_protocol.c
@@ -170,14 +170,10 @@ WorkerDropDistributedTable(Oid relationId)
 	 */
 	if (!IsAnyObjectAddressOwnedByExtension(list_make1(distributedTableObject), NULL))
 	{
-		char *relName = get_rel_name(relationId);
-		Oid schemaId = get_rel_namespace(relationId);
-		char *schemaName = get_namespace_name(schemaId);
-
 		StringInfo dropCommand = makeStringInfo();
 		appendStringInfo(dropCommand, "DROP%sTABLE %s CASCADE",
 						 IsForeignTable(relationId) ? " FOREIGN " : " ",
-						 quote_qualified_identifier(schemaName, relName));
+						 generate_qualified_relation_name(relationId));
 
 		Node *dropCommandNode = ParseTreeNode(dropCommand->data);
 


### PR DESCRIPTION
This change refactors the code by using generate_qualified_relation_name from id instead of using a sequence of functions to generate the relation name. 


Fixes #6602 