### PR TITLE
Fix behaviour of "citus.select_opens_transaction_block" option

### DIFF
--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -80,7 +80,7 @@ TaskListRequiresRollback(List *taskList)
 
 	if (ReadOnlyTask(task->taskType))
 	{
-		return SelectOpensTransactionBlock &&
+		return SelectOpensTransactionBlock ||
 			   IsTransactionBlock();
 	}
 


### PR DESCRIPTION
It seems "citus.select_opens_transaction_block" option is not working now. Name of this option assumes that new transaction block will be started when "select" query happens.
This well-working option will help to solve issue https://github.com/citusdata/citus/issues/7366 with combination of "repeatable-read" isolation level by default.