### PR TITLE
Fix problems with make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ check-style:
 
 # depend on install-all so that downgrade scripts are installed as well
 check: all install-all
-	$(MAKE) -C src/test/regress check-full
+	# explicetely does not use $(MAKE) to avoid parallelism
+	make -C src/test/regress check
 
 .PHONY: all check clean install install-downgrades install-all


### PR DESCRIPTION
This fixes two problems:
1. Allow `make check -j20` to work, by disabling parallelism. This was
   reported by a user in #7432
2. Actually run all the tests by forwarding to `make check` instead of
   `check-full`, because confusingly `check-full` does not run all the
   tests.
