### PR TITLE
Open transaction block when isolation level uses snapshot

### DIFF
--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -80,8 +80,8 @@ TaskListRequiresRollback(List *taskList)
 
 	if (ReadOnlyTask(task->taskType))
 	{
-		return SelectOpensTransactionBlock &&
-			   IsTransactionBlock();
+		return (SelectOpensTransactionBlock && IsTransactionBlock()) ||
+				IsolationUsesXactSnapshot();
 	}
 
 	if (IsMultiStatementTransaction())

--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -81,7 +81,7 @@ TaskListRequiresRollback(List *taskList)
 	if (ReadOnlyTask(task->taskType))
 	{
 		return (SelectOpensTransactionBlock && IsTransactionBlock()) ||
-				IsolationUsesXactSnapshot();
+			   IsolationUsesXactSnapshot();
 	}
 
 	if (IsMultiStatementTransaction())

--- a/src/test/regress/expected/propagate_set_commands.out
+++ b/src/test/regress/expected/propagate_set_commands.out
@@ -149,11 +149,11 @@ SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
 (1 row)
 
 END;
--- SET is not propagated and plain SELECT does not use transaction blocks
+-- SET is propagated due plain SELECT uses transaction blocks in repeatable read level
 SELECT DISTINCT current_setting('transaction_isolation') FROM test;
  current_setting
 ---------------------------------------------------------------------
- read committed
+ repeatable read
 (1 row)
 
 -- the CTE will trigger transaction blocks

--- a/src/test/regress/sql/propagate_set_commands.sql
+++ b/src/test/regress/sql/propagate_set_commands.sql
@@ -84,7 +84,7 @@ BEGIN;
 SELECT current_setting('transaction_isolation') FROM test WHERE id = 1;
 END;
 
--- SET is not propagated and plain SELECT does not use transaction blocks
+-- SET is propagated due plain SELECT uses transaction blocks in repeatable read level
 SELECT DISTINCT current_setting('transaction_isolation') FROM test;
 
 -- the CTE will trigger transaction blocks


### PR DESCRIPTION

It is offered to always open transaction block when isolation level is repeatable-read or serializable. This will help to solve issue https://github.com/citusdata/citus/issues/7366 when at least "repeatable-read" isolation level is default.