### PR TITLE
Replace spurious strdup with pstrdup

### DIFF
--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -433,7 +433,7 @@ CreateTargetEntryForColumn(Form_pg_attribute attributeTuple, Index rteIndex,
 				attributeTuple->atttypmod, attributeTuple->attcollation, 0);
 	TargetEntry *targetEntry =
 		makeTargetEntry((Expr *) targetColumn, resno,
-						strdup(attributeTuple->attname.data), false);
+						pstrdup(attributeTuple->attname.data), false);
 	return targetEntry;
 }
 


### PR DESCRIPTION
Not sure why we never found this using valgrind, but using strdup will cause memory leaks because the pointer is not tracked in a memory context.