### PR TITLE
Replace more spurious strdups with pstrdups

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -776,7 +776,7 @@ PreprocessCreateExtensionStmtForCitusColumnar(Node *parsetree)
 		/*create extension citus version xxx*/
 		if (newVersionValue)
 		{
-			char *newVersion = strdup(defGetString(newVersionValue));
+			char *newVersion = pstrdup(defGetString(newVersionValue));
 			versionNumber = GetExtensionVersionNumber(newVersion);
 		}
 
@@ -796,7 +796,7 @@ PreprocessCreateExtensionStmtForCitusColumnar(Node *parsetree)
 		Oid citusOid = get_extension_oid("citus", true);
 		if (citusOid != InvalidOid)
 		{
-			char *curCitusVersion = strdup(get_extension_version(citusOid));
+			char *curCitusVersion = pstrdup(get_extension_version(citusOid));
 			int curCitusVersionNum = GetExtensionVersionNumber(curCitusVersion);
 			if (curCitusVersionNum < 1110)
 			{
@@ -891,7 +891,7 @@ PreprocessAlterExtensionCitusStmtForCitusColumnar(Node *parseTree)
 	if (newVersionValue)
 	{
 		char *newVersion = defGetString(newVersionValue);
-		double newVersionNumber = GetExtensionVersionNumber(strdup(newVersion));
+		double newVersionNumber = GetExtensionVersionNumber(pstrdup(newVersion));
 
 		/*alter extension citus update to version >= 11.1-1, and no citus_columnar installed */
 		if (newVersionNumber >= 1110 && citusColumnarOid == InvalidOid)
@@ -935,7 +935,7 @@ PostprocessAlterExtensionCitusStmtForCitusColumnar(Node *parseTree)
 	if (newVersionValue)
 	{
 		char *newVersion = defGetString(newVersionValue);
-		double newVersionNumber = GetExtensionVersionNumber(strdup(newVersion));
+		double newVersionNumber = GetExtensionVersionNumber(pstrdup(newVersion));
 		if (newVersionNumber >= 1110 && citusColumnarOid != InvalidOid)
 		{
 			/*upgrade citus, after "ALTER EXTENSION citus update to xxx" updates citus_columnar Y to version Z. */

--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -123,6 +123,10 @@ AddConnParam(const char *keyword, const char *value)
 						errmsg("ConnParams arrays bound check failed")));
 	}
 
+	/*
+	 * Don't use pstrdup here to avoid being tied to a memory context, we free
+	 * these later using ResetConnParams
+	 */
 	ConnParams.keywords[ConnParams.size] = strdup(keyword);
 	ConnParams.values[ConnParams.size] = strdup(value);
 	ConnParams.size++;

--- a/src/backend/distributed/planner/query_colocation_checker.c
+++ b/src/backend/distributed/planner/query_colocation_checker.c
@@ -449,7 +449,7 @@ CreateTargetEntryForNullCol(Form_pg_attribute attributeTuple, int resno)
 											attributeTuple->attcollation);
 	char *resName = attributeTuple->attname.data;
 	TargetEntry *targetEntry =
-		makeTargetEntry(nullExpr, resno, strdup(resName), false);
+		makeTargetEntry(nullExpr, resno, pstrdup(resName), false);
 	return targetEntry;
 }
 


### PR DESCRIPTION
DESCRIPTION: Remove a few small memory leaks

In #7440 one instance of a strdup was removed. But there were a few
more. This removes the ones that are left over, or adds a comment why
strdup is on purpose.
