### PR TITLE
Replace LOCAL_HOST_NAME with LocalHostName

### DIFF
--- a/src/backend/distributed/connection/connection_configuration.c
+++ b/src/backend/distributed/connection/connection_configuration.c
@@ -445,7 +445,7 @@ GetEffectiveConnKey(ConnectionHashKey *key)
 	if (!IsTransactionState())
 	{
 		/* we're in the task tracker, so should only see loopback */
-		Assert(strncmp(LOCAL_HOST_NAME, key->hostname, MAX_NODE_LENGTH) == 0 &&
+		Assert(strncmp(LocalHostName, key->hostname, MAX_NODE_LENGTH) == 0 &&
 			   PostPortNumber == key->port);
 		return key;
 	}

--- a/src/backend/distributed/test/metadata_sync.c
+++ b/src/backend/distributed/test/metadata_sync.c
@@ -125,7 +125,7 @@ wait_until_metadata_sync(PG_FUNCTION_ARGS)
 
 	/* First we start listening. */
 	MultiConnection *connection = GetNodeConnection(FORCE_NEW_CONNECTION,
-													LOCAL_HOST_NAME, PostPortNumber);
+													LocalHostName, PostPortNumber);
 	ExecuteCriticalRemoteCommand(connection, "LISTEN " METADATA_SYNC_CHANNEL);
 
 	/*

--- a/src/backend/distributed/test/run_from_same_connection.c
+++ b/src/backend/distributed/test/run_from_same_connection.c
@@ -155,7 +155,7 @@ run_commands_on_session_level_connection_to_node(PG_FUNCTION_ARGS)
 
 	StringInfo processStringInfo = makeStringInfo();
 	StringInfo workerProcessStringInfo = makeStringInfo();
-	MultiConnection *localConnection = GetNodeConnection(0, LOCAL_HOST_NAME,
+	MultiConnection *localConnection = GetNodeConnection(0, LocalHostName,
 														 PostPortNumber);
 
 	if (!singleConnection)

--- a/src/include/distributed/connection_management.h
+++ b/src/include/distributed/connection_management.h
@@ -61,14 +61,6 @@
  */
 #define LOCAL_NODE_ID UINT32_MAX
 
-/*
- * If you want to connect to the current node use `LocalHostName`, which is a GUC, instead
- * of the hardcoded loopback hostname. Only if you really need the loopback hostname use
- * this define.
- */
-#define LOCAL_HOST_NAME "localhost"
-
-
 /* forward declare, to avoid forcing large headers on everyone */
 struct pg_conn; /* target of the PGconn typedef */
 struct MemoryContextData;


### PR DESCRIPTION
The only usages of LOCAL_HOST_NAME were in functions that are only used during regression tests and in places where it was used incorrectly.