### PR TITLE
Improve the script that sorts GUCs in alphabetical order

### DIFF
--- a/ci/check_gucs_are_alphabetically_sorted.sh
+++ b/ci/check_gucs_are_alphabetically_sorted.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source ci/ci_helpers.sh
 
-# extract citus gucs in the form of "citus.X"
-grep -o -E "(\.*\"citus\.\w+\")," src/backend/distributed/shared_library_init.c > gucs.out
+# extract citus gucs in the form of <tab><tab>"citus.X"
+grep -P "^[\t][\t]\"citus\.[a-zA-Z_0-9]+\"" src/backend/distributed/shared_library_init.c > gucs.out
 sort -c gucs.out
 rm gucs.out


### PR DESCRIPTION
Soon we will have occurrences of "citus.X" in shared_library_init.c that are not part of GUC defs, so we need to use a more precise regular expression.