### PR TITLE
Create directories and files with pg_file_create_mode and pg_dir_create_mode permissions

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2663,7 +2663,6 @@ CreateLocalColocatedIntermediateFile(CitusCopyDestReceiver *copyDest,
 	CreateIntermediateResultsDirectory();
 
 	const int fileFlags = (O_CREAT | O_RDWR | O_TRUNC);
-	const int fileMode = (S_IRUSR | S_IWUSR);
 
 	StringInfo filePath = makeStringInfo();
 	appendStringInfo(filePath, "%s_%ld", copyDest->colocatedIntermediateResultIdPrefix,
@@ -2671,7 +2670,7 @@ CreateLocalColocatedIntermediateFile(CitusCopyDestReceiver *copyDest,
 
 	const char *fileName = QueryResultFileName(filePath->data);
 	shardState->fileDest =
-		FileCompatFromFileStart(FileOpenForTransmit(fileName, fileFlags, fileMode));
+		FileCompatFromFileStart(FileOpenForTransmit(fileName, fileFlags));
 
 	CopyOutState localFileCopyOutState = shardState->copyOutState;
 	bool isBinaryCopy = localFileCopyOutState->binary;

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -606,7 +606,7 @@ CreateIntermediateResultsDirectory(void)
 {
 	char *resultDirectory = IntermediateResultsDirectory();
 
-	int makeOK = mkdir(resultDirectory, S_IRWXU);
+	int makeOK = MakePGDirectory(resultDirectory);
 	if (makeOK != 0)
 	{
 		if (errno == EEXIST)

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -295,7 +295,6 @@ PrepareIntermediateResultBroadcast(RemoteFileDestReceiver *resultDest)
 	if (resultDest->writeLocalFile)
 	{
 		const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
-		const int fileMode = (S_IRUSR | S_IWUSR);
 
 		/* make sure the directory exists */
 		CreateIntermediateResultsDirectory();
@@ -303,8 +302,7 @@ PrepareIntermediateResultBroadcast(RemoteFileDestReceiver *resultDest)
 		const char *fileName = QueryResultFileName(resultId);
 
 		resultDest->fileCompat = FileCompatFromFileStart(FileOpenForTransmit(fileName,
-																			 fileFlags,
-																			 fileMode));
+																			 fileFlags));
 	}
 
 	WorkerNode *workerNode = NULL;
@@ -976,7 +974,6 @@ FetchRemoteIntermediateResult(MultiConnection *connection, char *resultId)
 
 	StringInfo copyCommand = makeStringInfo();
 	const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
-	const int fileMode = (S_IRUSR | S_IWUSR);
 
 	PGconn *pgConn = connection->pgConn;
 	int socket = PQsocket(pgConn);
@@ -998,7 +995,7 @@ FetchRemoteIntermediateResult(MultiConnection *connection, char *resultId)
 
 	PQclear(result);
 
-	File fileDesc = FileOpenForTransmit(localPath, fileFlags, fileMode);
+	File fileDesc = FileOpenForTransmit(localPath, fileFlags);
 	FileCompat fileCompat = FileCompatFromFileStart(fileDesc);
 
 	while (true)

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -895,22 +895,13 @@ DecrementExternalClientBackendCounterAtExit(int code, Datum arg)
 static void
 CreateRequiredDirectories(void)
 {
-	const char *subdirs[] = {
-		"pg_foreign_file",
-		"pg_foreign_file/cached",
-		("base/" PG_JOB_CACHE_DIR)
-	};
+	const char *subdir = ("base/" PG_JOB_CACHE_DIR);
 
-	for (int dirNo = 0; dirNo < lengthof(subdirs); dirNo++)
+	if (MakePGDirectory(subdir) != 0 && errno != EEXIST)
 	{
-		int ret = MakePGDirectory(subdirs[dirNo]);
-
-		if (ret != 0 && errno != EEXIST)
-		{
-			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("could not create directory \"%s\": %m",
-								   subdirs[dirNo])));
-		}
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not create directory \"%s\": %m",
+							   subdir)));
 	}
 }
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -903,7 +903,7 @@ CreateRequiredDirectories(void)
 
 	for (int dirNo = 0; dirNo < lengthof(subdirs); dirNo++)
 	{
-		int ret = mkdir(subdirs[dirNo], S_IRWXU);
+		int ret = MakePGDirectory(subdirs[dirNo]);
 
 		if (ret != 0 && errno != EEXIST)
 		{

--- a/src/backend/distributed/utils/directory.c
+++ b/src/backend/distributed/utils/directory.c
@@ -29,7 +29,7 @@ static bool FileIsLink(const char *filename, struct stat filestat);
 void
 CitusCreateDirectory(StringInfo directoryName)
 {
-	int makeOK = mkdir(directoryName->data, S_IRWXU);
+	int makeOK = MakePGDirectory(directoryName->data);
 	if (makeOK != 0)
 	{
 		ereport(ERROR, (errcode_for_file_access(),

--- a/src/backend/distributed/worker/worker_sql_task_protocol.c
+++ b/src/backend/distributed/worker/worker_sql_task_protocol.c
@@ -126,7 +126,6 @@ TaskFileDestReceiverStartup(DestReceiver *dest, int operation,
 	const char *nullPrintCharacter = "\\N";
 
 	const int fileFlags = (O_APPEND | O_CREAT | O_RDWR | O_TRUNC | PG_BINARY);
-	const int fileMode = (S_IRUSR | S_IWUSR);
 
 	/* use the memory context that was in place when the DestReceiver was created */
 	MemoryContext oldContext = MemoryContextSwitchTo(taskFileDest->memoryContext);
@@ -148,8 +147,7 @@ TaskFileDestReceiverStartup(DestReceiver *dest, int operation,
 
 	taskFileDest->fileCompat = FileCompatFromFileStart(FileOpenForTransmit(
 														   taskFileDest->filePath,
-														   fileFlags,
-														   fileMode));
+														   fileFlags));
 
 	if (copyOutState->binary)
 	{

--- a/src/include/distributed/transmit.h
+++ b/src/include/distributed/transmit.h
@@ -21,7 +21,8 @@
 /* Function declarations for transmitting files between two nodes */
 extern void RedirectCopyDataToRegularFile(const char *filename);
 extern void SendRegularFile(const char *filename);
-extern File FileOpenForTransmit(const char *filename, int fileFlags, int fileMode);
+extern File FileOpenForTransmit(const char *filename, int fileFlags);
+extern File FileOpenForTransmitPerm(const char *filename, int fileFlags, int fileMode);
 
 
 #endif   /* TRANSMIT_H */


### PR DESCRIPTION
Since da9b580d files and directories are supposed to be created with pg_file_create_mode and pg_dir_create_mode permissions when default permissions are expected.

This fixes a failure of one of the postgres tests:
If we create file add.conf containing
```
shared_preload_libraries='citus'
```
and run postgres tests
```
TEMP_CONFIG=/path/to/add.conf make installcheck -C src/bin/pg_ctl/
```
then 001_start_stop.pl fails with
```
.../data/base/pgsql_job_cache mode must be 0750
```
in the log.