### PR TITLE
Fixes granted by cascade/restrict statements for revoke

### DIFF
--- a/src/backend/distributed/deparser/citus_grantutils.c
+++ b/src/backend/distributed/deparser/citus_grantutils.c
@@ -74,7 +74,7 @@ AppendGrantRestrictAndCascade(StringInfo buf, GrantStmt *stmt)
 void
 AppendGrantedByInGrantForRoleSpec(StringInfo buf, RoleSpec *grantor, bool isGrant)
 {
-	if (isGrant && grantor)
+	if (grantor)
 	{
 		appendStringInfo(buf, " GRANTED BY %s", RoleSpecString(grantor, true));
 	}

--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -486,8 +486,8 @@ AppendGrantRoleStmt(StringInfo buf, GrantRoleStmt *stmt)
 	appendStringInfo(buf, "%s ", stmt->is_grant ? " TO " : " FROM ");
 	AppendRoleList(buf, stmt->grantee_roles);
 	AppendGrantWithAdminOption(buf, stmt);
-	AppendGrantRestrictAndCascadeForRoleSpec(buf, stmt->behavior, stmt->is_grant);
 	AppendGrantedByInGrantForRoleSpec(buf, stmt->grantor, stmt->is_grant);
+	AppendGrantRestrictAndCascadeForRoleSpec(buf, stmt->behavior,stmt->is_grant);
 	appendStringInfo(buf, ";");
 }
 

--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -487,7 +487,7 @@ AppendGrantRoleStmt(StringInfo buf, GrantRoleStmt *stmt)
 	AppendRoleList(buf, stmt->grantee_roles);
 	AppendGrantWithAdminOption(buf, stmt);
 	AppendGrantedByInGrantForRoleSpec(buf, stmt->grantor, stmt->is_grant);
-	AppendGrantRestrictAndCascadeForRoleSpec(buf, stmt->behavior,stmt->is_grant);
+	AppendGrantRestrictAndCascadeForRoleSpec(buf, stmt->behavior, stmt->is_grant);
 	appendStringInfo(buf, ";");
 }
 

--- a/src/test/regress/expected/create_role_propagation.out
+++ b/src/test/regress/expected/create_role_propagation.out
@@ -282,7 +282,7 @@ SELECT objid::regrole FROM pg_catalog.pg_dist_object WHERE classid='pg_authid'::
  non_dist_role_4
 (5 rows)
 
-REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role;
+REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role cascade;
 revoke dist_role_3,dist_role_1 from test_admin_role cascade;
 drop role test_admin_role;
 \c - - - :worker_1_port

--- a/src/test/regress/expected/create_role_propagation.out
+++ b/src/test/regress/expected/create_role_propagation.out
@@ -272,10 +272,8 @@ SELECT result FROM run_command_on_all_nodes(
 ---------------------------------------------------------------------
  [{"member":"non_dist_role_3","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
   {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
- [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false},     +
-  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
- [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false},     +
-  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
 (3 rows)
 
 SELECT roleid::regrole::text AS role, member::regrole::text, (grantor::regrole::text IN ('postgres', 'non_dist_role_1', 'dist_role_1','test_admin_role')) AS grantor, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE '%dist\_%' ORDER BY 1, 2;
@@ -309,13 +307,11 @@ SELECT result FROM run_command_on_all_nodes(
   ) q;
   $$
 );
-                                              result
+                                            result
 ---------------------------------------------------------------------
  [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
- [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
-  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
- [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
-  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
 (3 rows)
 
 revoke dist_role_3,dist_role_1 from test_admin_role cascade;

--- a/src/test/regress/expected/create_role_propagation.out
+++ b/src/test/regress/expected/create_role_propagation.out
@@ -265,6 +265,7 @@ SELECT result FROM run_command_on_all_nodes(
   SELECT json_agg(q.* ORDER BY member) FROM (
     SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
     FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+    order by member::regrole::text
   ) q;
   $$
 );
@@ -304,6 +305,7 @@ SELECT result FROM run_command_on_all_nodes(
   SELECT json_agg(q.* ORDER BY member) FROM (
     SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
     FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+    order by member::regrole::text
   ) q;
   $$
 );

--- a/src/test/regress/expected/create_role_propagation.out
+++ b/src/test/regress/expected/create_role_propagation.out
@@ -259,7 +259,25 @@ SELECT result FROM run_command_on_all_nodes(
   {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
 (3 rows)
 
-REVOKE dist_role_3 from dist_role_4 granted by test_admin_role;
+REVOKE dist_role_3 from dist_role_4 granted by test_admin_role cascade;
+SELECT result FROM run_command_on_all_nodes(
+  $$
+  SELECT json_agg(q.* ORDER BY member) FROM (
+    SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
+    FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+  ) q;
+  $$
+);
+                                                result
+---------------------------------------------------------------------
+ [{"member":"non_dist_role_3","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
+  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false},     +
+  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false},     +
+  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+(3 rows)
+
 SELECT roleid::regrole::text AS role, member::regrole::text, (grantor::regrole::text IN ('postgres', 'non_dist_role_1', 'dist_role_1','test_admin_role')) AS grantor, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE '%dist\_%' ORDER BY 1, 2;
       role       |     member      | grantor | admin_option
 ---------------------------------------------------------------------
@@ -283,6 +301,23 @@ SELECT objid::regrole FROM pg_catalog.pg_dist_object WHERE classid='pg_authid'::
 (5 rows)
 
 REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role cascade;
+SELECT result FROM run_command_on_all_nodes(
+  $$
+  SELECT json_agg(q.* ORDER BY member) FROM (
+    SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
+    FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+  ) q;
+  $$
+);
+                                              result
+---------------------------------------------------------------------
+ [{"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
+  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+ [{"member":"dist_role_4","role":"dist_role_3","grantor":"test_admin_role","admin_option":false}, +
+  {"member":"test_admin_role","role":"dist_role_3","grantor":"postgres","admin_option":true}]
+(3 rows)
+
 revoke dist_role_3,dist_role_1 from test_admin_role cascade;
 drop role test_admin_role;
 \c - - - :worker_1_port

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -139,10 +139,10 @@ SELECT result FROM run_command_on_all_nodes(
   SELECT json_agg(q.* ORDER BY member) FROM (
     SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
     FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+    order by member::regrole::text
   ) q;
   $$
 );
-
 
 SELECT roleid::regrole::text AS role, member::regrole::text, (grantor::regrole::text IN ('postgres', 'non_dist_role_1', 'dist_role_1','test_admin_role')) AS grantor, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE '%dist\_%' ORDER BY 1, 2;
 SELECT objid::regrole FROM pg_catalog.pg_dist_object WHERE classid='pg_authid'::regclass::oid AND objid::regrole::text LIKE '%dist\_%' ORDER BY 1;
@@ -154,6 +154,7 @@ SELECT result FROM run_command_on_all_nodes(
   SELECT json_agg(q.* ORDER BY member) FROM (
     SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
     FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+    order by member::regrole::text
   ) q;
   $$
 );

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -132,12 +132,31 @@ SELECT result FROM run_command_on_all_nodes(
   $$
 );
 
-REVOKE dist_role_3 from dist_role_4 granted by test_admin_role;
+REVOKE dist_role_3 from dist_role_4 granted by test_admin_role cascade;
+
+SELECT result FROM run_command_on_all_nodes(
+  $$
+  SELECT json_agg(q.* ORDER BY member) FROM (
+    SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
+    FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+  ) q;
+  $$
+);
+
 
 SELECT roleid::regrole::text AS role, member::regrole::text, (grantor::regrole::text IN ('postgres', 'non_dist_role_1', 'dist_role_1','test_admin_role')) AS grantor, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE '%dist\_%' ORDER BY 1, 2;
 SELECT objid::regrole FROM pg_catalog.pg_dist_object WHERE classid='pg_authid'::regclass::oid AND objid::regrole::text LIKE '%dist\_%' ORDER BY 1;
 
 REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role cascade;
+
+SELECT result FROM run_command_on_all_nodes(
+  $$
+  SELECT json_agg(q.* ORDER BY member) FROM (
+    SELECT member::regrole::text, roleid::regrole::text AS role, grantor::regrole::text, admin_option
+    FROM pg_auth_members WHERE roleid::regrole::text = 'dist_role_3'
+  ) q;
+  $$
+);
 
 revoke dist_role_3,dist_role_1 from test_admin_role cascade;
 drop role test_admin_role;

--- a/src/test/regress/sql/create_role_propagation.sql
+++ b/src/test/regress/sql/create_role_propagation.sql
@@ -137,7 +137,7 @@ REVOKE dist_role_3 from dist_role_4 granted by test_admin_role;
 SELECT roleid::regrole::text AS role, member::regrole::text, (grantor::regrole::text IN ('postgres', 'non_dist_role_1', 'dist_role_1','test_admin_role')) AS grantor, admin_option FROM pg_auth_members WHERE roleid::regrole::text LIKE '%dist\_%' ORDER BY 1, 2;
 SELECT objid::regrole FROM pg_catalog.pg_dist_object WHERE classid='pg_authid'::regclass::oid AND objid::regrole::text LIKE '%dist\_%' ORDER BY 1;
 
-REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role;
+REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role cascade;
 
 revoke dist_role_3,dist_role_1 from test_admin_role cascade;
 drop role test_admin_role;


### PR DESCRIPTION
DESCRIPTION: Fixes incorrect propagating of `GRANTED BY` and `CASCADE/RESTRICT` clauses for `REVOKE` statements

There are two issues fixed in this PR
1. granted by statement will appear for revoke statements as well
2. revoke/cascade statement will appear after granted by

Since granted by statements does not appear in statements, this bug hasn't been visible until now. However, after activating the granted by statement for revoke, order problem arised and this issue was fixed order problem for cascade/revoke as well
In summary, this PR provides usage of granted by statements properly now with the correct order of statements.
We can verify the both errors, fixed with just single statement
REVOKE dist_role_3 from non_dist_role_3 granted by test_admin_role cascade;
