### PR TITLE
Fix crash caused by some form of ALTER TABLE ADD COLUMN statements.

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -3053,11 +3053,16 @@ ErrorUnsupportedAlterTableAddColumn(Oid relationId, AlterTableCmd *command,
 	else if (constraint->contype == CONSTR_FOREIGN)
 	{
 		RangeVar *referencedTable = constraint->pktable;
-		char *referencedColumn = strVal(lfirst(list_head(constraint->pk_attrs)));
 		Oid referencedRelationId = RangeVarGetRelid(referencedTable, NoLock, false);
 
-		appendStringInfo(errHint, "FOREIGN KEY (%s) REFERENCES %s(%s)", colName,
-						 get_rel_name(referencedRelationId), referencedColumn);
+		appendStringInfo(errHint, "FOREIGN KEY (%s) REFERENCES %s", colName,
+						 get_rel_name(referencedRelationId));
+
+		if (list_length(constraint->pk_attrs) > 0)
+		{
+			char *referencedColumn = strVal(lfirst(list_head(constraint->pk_attrs)));
+			appendStringInfo(errHint, "(%s)", referencedColumn);
+		}
 
 		if (constraint->fk_del_action == FKCONSTR_ACTION_SETNULL)
 		{

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -3060,8 +3060,7 @@ ErrorUnsupportedAlterTableAddColumn(Oid relationId, AlterTableCmd *command,
 
 		if (list_length(constraint->pk_attrs) > 0)
 		{
-			char *referencedColumn = strVal(lfirst(list_head(constraint->pk_attrs)));
-			appendStringInfo(errHint, "(%s)", referencedColumn);
+			AppendColumnNameList(errHint, constraint->pk_attrs);
 		}
 
 		if (constraint->fk_del_action == FKCONSTR_ACTION_SETNULL)

--- a/src/backend/distributed/deparser/deparse_table_stmts.c
+++ b/src/backend/distributed/deparser/deparse_table_stmts.c
@@ -121,7 +121,7 @@ AppendAlterTableStmt(StringInfo buf, AlterTableStmt *stmt)
  * AppendColumnNameList converts a list of columns into comma separated string format
  * (colname_1, colname_2, .., colname_n).
  */
-static void
+void
 AppendColumnNameList(StringInfo buf, List *columns)
 {
 	appendStringInfoString(buf, " (");

--- a/src/include/distributed/deparser.h
+++ b/src/include/distributed/deparser.h
@@ -121,6 +121,8 @@ extern void AppendGrantedByInGrant(StringInfo buf, GrantStmt *stmt);
 extern void AppendGrantSharedPrefix(StringInfo buf, GrantStmt *stmt);
 extern void AppendGrantSharedSuffix(StringInfo buf, GrantStmt *stmt);
 
+extern void AppendColumnNameList(StringInfo buf, List *columns);
+
 /* Common deparser utils */
 
 typedef struct DefElemOptionFormat

--- a/src/test/regress/expected/alter_table_add_column.out
+++ b/src/test/regress/expected/alter_table_add_column.out
@@ -49,6 +49,10 @@ ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCE
 ERROR:  cannot execute ADD COLUMN command with PRIMARY KEY, UNIQUE, FOREIGN and CHECK constraints
 DETAIL:  Adding a column with a constraint in one command is not supported because all constraints in Citus must have explicit names
 HINT:  You can issue each command separately such as ALTER TABLE referencing ADD COLUMN test_10 data_type; ALTER TABLE referencing ADD CONSTRAINT constraint_name FOREIGN KEY (test_10) REFERENCES referenced;
+ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCES referenced(int_col);
+ERROR:  cannot execute ADD COLUMN command with PRIMARY KEY, UNIQUE, FOREIGN and CHECK constraints
+DETAIL:  Adding a column with a constraint in one command is not supported because all constraints in Citus must have explicit names
+HINT:  You can issue each command separately such as ALTER TABLE referencing ADD COLUMN test_10 data_type; ALTER TABLE referencing ADD CONSTRAINT constraint_name FOREIGN KEY (test_10) REFERENCES referenced (int_col );
 -- try to add test_6 again, but with IF NOT EXISTS
 ALTER TABLE referencing ADD COLUMN IF NOT EXISTS test_6 text;
 NOTICE:  column "test_6" of relation "referencing" already exists, skipping

--- a/src/test/regress/expected/alter_table_add_column.out
+++ b/src/test/regress/expected/alter_table_add_column.out
@@ -44,6 +44,11 @@ ERROR:  cannot execute ADD COLUMN command with PRIMARY KEY, UNIQUE, FOREIGN and 
 DETAIL:  Adding a column with a constraint in one command is not supported because all constraints in Citus must have explicit names
 HINT:  You can issue each command separately such as ALTER TABLE referencing ADD COLUMN test_8 data_type; ALTER TABLE referencing ADD CONSTRAINT constraint_name CHECK (check_expression);
 ALTER TABLE referencing ADD COLUMN test_8 integer CONSTRAINT check_test_8 CHECK (test_8 > 0);
+-- error out properly even if the REFERENCES does not include the column list of the referenced table
+ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCES referenced;
+ERROR:  cannot execute ADD COLUMN command with PRIMARY KEY, UNIQUE, FOREIGN and CHECK constraints
+DETAIL:  Adding a column with a constraint in one command is not supported because all constraints in Citus must have explicit names
+HINT:  You can issue each command separately such as ALTER TABLE referencing ADD COLUMN test_10 data_type; ALTER TABLE referencing ADD CONSTRAINT constraint_name FOREIGN KEY (test_10) REFERENCES referenced;
 -- try to add test_6 again, but with IF NOT EXISTS
 ALTER TABLE referencing ADD COLUMN IF NOT EXISTS test_6 text;
 NOTICE:  column "test_6" of relation "referencing" already exists, skipping

--- a/src/test/regress/sql/alter_table_add_column.sql
+++ b/src/test/regress/sql/alter_table_add_column.sql
@@ -41,6 +41,9 @@ ALTER TABLE referencing ADD COLUMN "test_\'!7" "simple_!\'custom_type";
 ALTER TABLE referencing ADD COLUMN test_8 integer CHECK (test_8 > 0);
 ALTER TABLE referencing ADD COLUMN test_8 integer CONSTRAINT check_test_8 CHECK (test_8 > 0);
 
+-- error out properly even if the REFERENCES does not include the column list of the referenced table
+ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCES referenced;
+
 -- try to add test_6 again, but with IF NOT EXISTS
 ALTER TABLE referencing ADD COLUMN IF NOT EXISTS test_6 text;
 ALTER TABLE referencing ADD COLUMN IF NOT EXISTS test_6 integer;

--- a/src/test/regress/sql/alter_table_add_column.sql
+++ b/src/test/regress/sql/alter_table_add_column.sql
@@ -43,6 +43,7 @@ ALTER TABLE referencing ADD COLUMN test_8 integer CONSTRAINT check_test_8 CHECK 
 
 -- error out properly even if the REFERENCES does not include the column list of the referenced table
 ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCES referenced;
+ALTER TABLE referencing ADD COLUMN test_9 bool, ADD COLUMN test_10 int REFERENCES referenced(int_col);
 
 -- try to add test_6 again, but with IF NOT EXISTS
 ALTER TABLE referencing ADD COLUMN IF NOT EXISTS test_6 text;


### PR DESCRIPTION
DESCRIPTION:  Fixes a crash caused by some form of ALTER TABLE ADD COLUMN statements. When adding multiple columns, if one of the ADD COLUMN statements contains a FOREIGN constraint ommitting the referenced columns in the statement, a SEGFAULT occurs.

For instance, the following statement results in a crash:

```
  ALTER TABLE lt ADD COLUMN new_col1 bool,
                          ADD COLUMN new_col2 int references rt;

```                      


Fixes #7520.