### PR TITLE
Test that we check unsupported options for CREATE DATABASE from non-main dbs

### DIFF
--- a/src/backend/distributed/deparser/deparse_database_stmts.c
+++ b/src/backend/distributed/deparser/deparse_database_stmts.c
@@ -277,6 +277,11 @@ AppendCreateDatabaseStmt(StringInfo buf, CreatedbStmt *stmt)
 	/*
 	 * Make sure that we don't try to deparse something that this
 	 * function doesn't expect.
+	 *
+	 * This is also useful to throw an error for unsupported CREATE
+	 * DATABASE options when the command is issued from non-main dbs
+	 * because we use the same function to deparse CREATE DATABASE
+	 * commands there too.
 	 */
 	EnsureSupportedCreateDatabaseCommand(stmt);
 

--- a/src/test/regress/expected/create_drop_database_propagation_pg15.out
+++ b/src/test/regress/expected/create_drop_database_propagation_pg15.out
@@ -83,5 +83,6 @@ set citus.enable_create_database_propagation to on;
 create database unsupported_option_from_non_main_db with oid = 12345;
 ERROR:  CREATE DATABASE option "oid" is not supported
 \c regression - - :master_port
+set citus.enable_create_database_propagation to on;
 drop database test_locale_provider;
 \c - - - :master_port

--- a/src/test/regress/expected/create_drop_database_propagation_pg15.out
+++ b/src/test/regress/expected/create_drop_database_propagation_pg15.out
@@ -78,5 +78,10 @@ SELECT * FROM public.check_database_on_all_nodes('test_locale_provider') ORDER B
  worker node (remote) | {"database_properties": {"datacl": null, "datname": "test_locale_provider", "datctype": "C", "encoding": "UTF8", "datcollate": "C", "tablespace": "pg_default", "daticurules": null, "datallowconn": true, "datconnlimit": -1, "daticulocale": null, "datistemplate": false, "database_owner": "postgres", "datcollversion": null, "datlocprovider": "c"}, "pg_dist_object_record_for_db_exists": true, "stale_pg_dist_object_record_for_a_db_exists": false}
 (3 rows)
 
+\c test_locale_provider - - :worker_2_port
+set citus.enable_create_database_propagation to on;
+create database unsupported_option_from_non_main_db with oid = 12345;
+ERROR:  CREATE DATABASE option "oid" is not supported
+\c regression - - :master_port
 drop database test_locale_provider;
 \c - - - :master_port

--- a/src/test/regress/sql/create_drop_database_propagation_pg15.sql
+++ b/src/test/regress/sql/create_drop_database_propagation_pg15.sql
@@ -67,6 +67,7 @@ create database unsupported_option_from_non_main_db with oid = 12345;
 
 \c regression - - :master_port
 
+set citus.enable_create_database_propagation to on;
 drop database test_locale_provider;
 
 \c - - - :master_port

--- a/src/test/regress/sql/create_drop_database_propagation_pg15.sql
+++ b/src/test/regress/sql/create_drop_database_propagation_pg15.sql
@@ -60,6 +60,13 @@ CREATE DATABASE test_locale_provider
 
 SELECT * FROM public.check_database_on_all_nodes('test_locale_provider') ORDER BY node_type;
 
+\c test_locale_provider - - :worker_2_port
+
+set citus.enable_create_database_propagation to on;
+create database unsupported_option_from_non_main_db with oid = 12345;
+
+\c regression - - :master_port
+
 drop database test_locale_provider;
 
 \c - - - :master_port


### PR DESCRIPTION
When adding CREATE/DROP DATABASE propagation in #7240, luckily
we've added EnsureSupportedCreateDatabaseCommand() check into
deparser too just to be on the safe side. That way, today CREATE
DATABASE commands from non-main dbs don't silently allow unsupported
options.

I wasn't aware of this when merging #7439 and hence wanted to add
a test so that we don't mistakenly remove that check from deparser
in future.