### PR TITLE
Fix: store the previous shard cost for order verification

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -384,6 +384,7 @@ CheckRebalanceStateInvariants(const RebalanceState *state)
 				Assert(shardCost->cost <= prevShardCost->cost);
 			}
 			totalCost += shardCost->cost;
+			prevShardCost = shardCost;
 		}
 
 		/* Check that utilization field is up to date. */


### PR DESCRIPTION

Store the previous shard cost so that the invariant checking performs as expected.