### PR TITLE
Use expecteddir option in _run_pg_regress()

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -294,6 +294,9 @@ def _run_pg_regress(
         output_dir,
         "--use-existing",
     ]
+    if PG_MAJOR_VERSION >= 16:
+        command.append("--expecteddir")
+        command.append(output_dir)
     if extra_tests != "":
         command.append(extra_tests)
 


### PR DESCRIPTION
Fix check-arbitrary-configs tests failure with current REL_16_STABLE.
This is the same problem as described in #7573. I missed pg_regress call in _run_pg_regress() in that PR.