### PR TITLE
Fix parameter resolving issues with procedure calls when auto_explain is enabled.

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -816,8 +816,11 @@ AdaptiveExecutor(CitusScanState *scanState)
 		 * be part of the same transaction.
 		 */
 		UseCoordinatedTransaction();
+
+		ParamListInfo boundParams = copyParamList(paramListInfo);
+
 		taskList = ExplainAnalyzeTaskList(taskList, defaultTupleDest, tupleDescriptor,
-										  paramListInfo);
+										  boundParams);
 
 		/*
 		 * Multiple queries per task is not supported with local execution. See the Assert in

--- a/src/test/regress/expected/multi_explain.out
+++ b/src/test/regress/expected/multi_explain.out
@@ -3225,6 +3225,19 @@ SET auto_explain.log_min_duration = 0;
 set auto_explain.log_analyze to true;
 -- the following should not be locally executed since explain analyze is on
 select * from test_ref_table;
+CREATE TABLE test_auto_explain.test_params
+( coll1 int8 NULL,
+  coll2 int4 NOT NULL);
+SELECT create_distributed_table('test_auto_explain.test_params', 'coll1');
+
+CREATE OR REPLACE PROCEDURE test_auto_explain.test_delete_from(p_coll2 int)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+DELETE FROM test_auto_explain.test_params
+WHERE coll2 = p_coll2;
+END;$$;
+CALL test_auto_explain.test_delete_from(20240401);
 DROP SCHEMA test_auto_explain CASCADE;
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;

--- a/src/test/regress/expected/multi_explain_0.out
+++ b/src/test/regress/expected/multi_explain_0.out
@@ -3214,6 +3214,19 @@ SET auto_explain.log_min_duration = 0;
 set auto_explain.log_analyze to true;
 -- the following should not be locally executed since explain analyze is on
 select * from test_ref_table;
+CREATE TABLE test_auto_explain.test_params
+( coll1 int8 NULL,
+  coll2 int4 NOT NULL);
+SELECT create_distributed_table('test_auto_explain.test_params', 'coll1');
+
+CREATE OR REPLACE PROCEDURE test_auto_explain.test_delete_from(p_coll2 int)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+DELETE FROM test_auto_explain.test_params
+WHERE coll2 = p_coll2;
+END;$$;
+CALL test_auto_explain.test_delete_from(20240401);
 DROP SCHEMA test_auto_explain CASCADE;
 SET client_min_messages TO ERROR;
 DROP SCHEMA multi_explain CASCADE;

--- a/src/test/regress/sql/multi_explain.sql
+++ b/src/test/regress/sql/multi_explain.sql
@@ -1168,6 +1168,22 @@ set auto_explain.log_analyze to true;
 -- the following should not be locally executed since explain analyze is on
 select * from test_ref_table;
 
+CREATE TABLE test_auto_explain.test_params
+( coll1 int8 NULL,
+  coll2 int4 NOT NULL);
+
+SELECT create_distributed_table('test_auto_explain.test_params', 'coll1');
+
+CREATE OR REPLACE PROCEDURE test_auto_explain.test_delete_from(p_coll2 int)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+DELETE FROM test_auto_explain.test_params
+WHERE coll2 = p_coll2;
+END;$$;
+
+CALL test_auto_explain.test_delete_from(20240401);
+
 DROP SCHEMA test_auto_explain CASCADE;
 
 SET client_min_messages TO ERROR;


### PR DESCRIPTION
There are two ways to generate explain resullts:

1. Run the EXPLAIN command with query
2. Turn on auto_explain, to quitely explain queries in the logs.

Citus follows different code paths in those two cases.

It runs out that auto_explain code path cannot handle parameters to procedures when explaining the procedure calls.

I am not highly confident in this change, expecially the part where I had to skip  parameters with type 0, to make the code work, but the solution should be similar to this.