### PR TITLE
Updates github checkout actions to v4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ needs.params.outputs.build_image_name }}:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -61,7 +61,7 @@ jobs:
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Check C Style
@@ -117,7 +117,7 @@ jobs:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"
       options: --user root
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - name: Expose $PG_MAJOR to Github Env
       run: echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
       shell: bash
@@ -227,7 +227,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run Test
       run: gosu circleci make -C src/test/${{ matrix.suite }} ${{ matrix.make }}
@@ -261,7 +261,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
         parallel: [0,1,2,3,4,5] # workaround for running 6 parallel jobs
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Test arbitrary configs
       run: |-
@@ -311,7 +311,7 @@ jobs:
       old_pg_major: ${{ matrix.old_pg_major }}
       new_pg_major: ${{ matrix.new_pg_major }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
       with:
         pg_major: "${{ env.old_pg_major }}"
@@ -349,7 +349,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
       with:
         skip_installation: true
@@ -413,7 +413,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -431,7 +431,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -450,7 +450,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -463,7 +463,7 @@ jobs:
     outputs:
       tests: ${{ steps.detect-regression-tests.outputs.tests }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Detect regression tests need to be ran
@@ -514,7 +514,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix_32.outputs.json) }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ needs.params.outputs.build_image_name }}:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -61,7 +61,7 @@ jobs:
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
       with:
         fetch-depth: 0
     - name: Check C Style
@@ -117,7 +117,7 @@ jobs:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"
       options: --user root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - name: Expose $PG_MAJOR to Github Env
       run: echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
       shell: bash
@@ -227,7 +227,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
     - name: Run Test
       run: gosu circleci make -C src/test/${{ matrix.suite }} ${{ matrix.make }}
@@ -261,7 +261,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
         parallel: [0,1,2,3,4,5] # workaround for running 6 parallel jobs
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
     - name: Test arbitrary configs
       run: |-
@@ -311,7 +311,7 @@ jobs:
       old_pg_major: ${{ matrix.old_pg_major }}
       new_pg_major: ${{ matrix.new_pg_major }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
       with:
         pg_major: "${{ env.old_pg_major }}"
@@ -349,7 +349,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
       with:
         skip_installation: true
@@ -413,7 +413,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -431,7 +431,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -450,7 +450,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.0
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -463,7 +463,7 @@ jobs:
     outputs:
       tests: ${{ steps.detect-regression-tests.outputs.tests }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
       with:
         fetch-depth: 0
     - name: Detect regression tests need to be ran
@@ -514,7 +514,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix_32.outputs.json) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ needs.params.outputs.build_image_name }}:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -61,7 +61,7 @@ jobs:
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Check C Style
@@ -117,7 +117,7 @@ jobs:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"
       options: --user root
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - name: Expose $PG_MAJOR to Github Env
       run: echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
       shell: bash
@@ -227,7 +227,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run Test
       run: gosu circleci make -C src/test/${{ matrix.suite }} ${{ matrix.make }}
@@ -261,7 +261,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
         parallel: [0,1,2,3,4,5] # workaround for running 6 parallel jobs
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Test arbitrary configs
       run: |-
@@ -311,7 +311,7 @@ jobs:
       old_pg_major: ${{ matrix.old_pg_major }}
       new_pg_major: ${{ matrix.new_pg_major }}
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
       with:
         pg_major: "${{ env.old_pg_major }}"
@@ -349,7 +349,7 @@ jobs:
     - params
     - build
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
       with:
         skip_installation: true
@@ -413,7 +413,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -431,7 +431,7 @@ jobs:
     needs:
     - build
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -450,7 +450,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v4.0
+      - uses: actions/checkout@v4
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -463,7 +463,7 @@ jobs:
     outputs:
       tests: ${{ steps.detect-regression-tests.outputs.tests }}
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Detect regression tests need to be ran
@@ -514,7 +514,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix_32.outputs.json) }}
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
       image: ${{ needs.params.outputs.build_image_name }}:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3.5.0
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.0
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.0
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/flaky_test_debugging.yml
+++ b/.github/workflows/flaky_test_debugging.yml
@@ -28,7 +28,7 @@ jobs:
       image: ${{ vars.build_image_name }}:${{ vars.pg15_version  }}${{ vars.image_suffix }}
       options: --user root
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - name: Configure, Build, and Install
       run: |
         echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
@@ -46,7 +46,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix.outputs.json) }}
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/flaky_test_debugging.yml
+++ b/.github/workflows/flaky_test_debugging.yml
@@ -28,7 +28,7 @@ jobs:
       image: ${{ vars.build_image_name }}:${{ vars.pg15_version  }}${{ vars.image_suffix }}
       options: --user root
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - name: Configure, Build, and Install
       run: |
         echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
@@ -46,7 +46,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v4.0
+      - uses: actions/checkout@v4
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix.outputs.json) }}
     steps:
-    - uses: actions/checkout@v4.0
+    - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/flaky_test_debugging.yml
+++ b/.github/workflows/flaky_test_debugging.yml
@@ -28,7 +28,7 @@ jobs:
       image: ${{ vars.build_image_name }}:${{ vars.pg15_version  }}${{ vars.image_suffix }}
       options: --user root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - name: Configure, Build, and Install
       run: |
         echo "PG_MAJOR=${PG_MAJOR}" >> $GITHUB_ENV
@@ -46,7 +46,7 @@ jobs:
     outputs:
       json: ${{ steps.parallelization.outputs.json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.0
       - uses: "./.github/actions/parallelization"
         id: parallelization
         with:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare_parallelization_matrix.outputs.json) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.0
     - uses: "./.github/actions/setup_extension"
     - name: Run minimal tests
       run: |-

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       pg_versions: ${{ steps.get-postgres-versions.outputs.pg_versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.0
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Get Postgres Versions
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0
+        uses: actions/checkout@v3
 
       - name: Set Postgres and python parameters for rpm based distros
         run: |
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0
+        uses: actions/checkout@v3
 
       - name: Set pg_config path and python parameters for deb based distros
         run: |

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       pg_versions: ${{ steps.get-postgres-versions.outputs.pg_versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Get Postgres Versions
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Postgres and python parameters for rpm based distros
         run: |
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set pg_config path and python parameters for deb based distros
         run: |

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       pg_versions: ${{ steps.get-postgres-versions.outputs.pg_versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.0
         with:
           fetch-depth: 2
       - name: Get Postgres Versions
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.0
 
       - name: Set Postgres and python parameters for rpm based distros
         run: |
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.0
 
       - name: Set pg_config path and python parameters for deb based distros
         run: |


### PR DESCRIPTION
Updates checkout plugin for github actions to v4. Can not update the version for check-sql-snapshots since new plugin causes below error in the docker image this step is using . Please refer to: https://github.com/citusdata/citus/actions/runs/9286197994/job/25552373953
Error: 
```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```