### PR TITLE
fix: wrong GUC context for skip_advisory_lock_permission_checks

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2401,7 +2401,7 @@ RegisterCitusConfigVariables(void)
 		NULL,
 		&SkipAdvisoryLockPermissionChecks,
 		false,
-		GUC_SUPERUSER_ONLY,
+		PGC_SUSET,
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);
 


### PR DESCRIPTION
According to the desired sementic, PGC_SUSET should be used for citus.skip_advisory_lock_permission_checks instead of GUC_SUPERUSER_ONLY flag.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
