### PR TITLE
Fix CI issues after Github Actions networking changes

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -296,10 +296,12 @@ sub generate_hba
 
     open(my $fh, ">", catfile($TMP_CHECKDIR, $nodename, "data", "pg_hba.conf"))
         or die "could not open pg_hba.conf";
-    print $fh "host all         alice,bob localhost      md5\n";
+    print $fh "host all         alice,bob 127.0.0.1/32 md5\n";
+    print $fh "host all         alice,bob ::1/128      md5\n";
     print $fh "host all         all       127.0.0.1/32 trust\n";
     print $fh "host all         all       ::1/128      trust\n";
-    print $fh "host replication postgres  localhost    trust\n";
+    print $fh "host replication postgres  127.0.0.1/32 trust\n";
+    print $fh "host replication postgres  ::1/128      trust\n";
     close $fh;
 }
 


### PR DESCRIPTION
For some reason using localhost in our hba file doesn't have the
intended effect anymore in our Github Actions runners. Probably because
of some networking change (IPv6 maybe) or some change in the
`/etc/hosts` file.

Replacing localhost with the equivalent loopback IPv4 and IPv6 addresses
resolved this issue.
