### PR TITLE
update outdated actions

### DIFF
--- a/.github/actions/save_logs_and_results/action.yml
+++ b/.github/actions/save_logs_and_results/action.yml
@@ -6,7 +6,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/upload-artifact@v3.1.1
+  - uses: actions/upload-artifact@v4
     name: Upload logs
     with:
       name: ${{ inputs.folder }}

--- a/.github/actions/setup_extension/action.yml
+++ b/.github/actions/setup_extension/action.yml
@@ -17,7 +17,7 @@ runs:
           echo "PG_MAJOR=${{ inputs.pg_major }}" >> $GITHUB_ENV
         fi
     shell: bash
-  - uses: actions/download-artifact@v3.0.1
+  - uses: actions/download-artifact@v4
     with:
       name: build-${{ env.PG_MAJOR }}
   - name: Install Extension

--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -24,4 +24,4 @@ runs:
   - uses: actions/upload-artifact@v4
     with:
       path: "/tmp/codeclimate/*.json"
-      name: codeclimate
+      name: codeclimate-${{ inputs.flags }}

--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: codecov/codecov-action@v3
+  - uses: codecov/codecov-action@v4
     with:
       flags: ${{ inputs.flags }}
       token: ${{ inputs.codecov_token }}
@@ -21,7 +21,7 @@ runs:
       mkdir -p /tmp/codeclimate
       cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/${{ inputs.flags }}.json lcov.info
     shell: bash
-  - uses: actions/upload-artifact@v3.1.1
+  - uses: actions/upload-artifact@v4
     with:
       path: "/tmp/codeclimate/*.json"
       name: codeclimate

--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -12,7 +12,7 @@ runs:
       flags: ${{ inputs.flags }}
       token: ${{ inputs.codecov_token }}
       verbose: true
-      gcov: true
+      plugin: gcov
   - name: Create codeclimate coverage
     run: |-
       lcov --directory . --capture --output-file lcov.info

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -284,6 +284,8 @@ jobs:
             check-arbitrary-configs parallel=4 CONFIGS=$TESTS
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
+      with:
+        folder: arbitrary_config_logs_pg_${{ matrix.pg_version }}_${{ matrix.parallel }}
     - uses: "./.github/actions/upload_coverage"
       if: always()
       with:
@@ -335,6 +337,8 @@ jobs:
       if: failure()
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
+      with:
+        folder: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade_logs
     - uses: "./.github/actions/upload_coverage"
       if: always()
       with:
@@ -529,4 +533,5 @@ jobs:
         done
       shell: bash
     - uses: "./.github/actions/save_logs_and_results"
+      # TODO this section also needs a with.folder based on the matrix
       if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -401,8 +401,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: "codeclimate"
-          path: "codeclimate"
+          path: codeclimate
+          pattern: codeclimate-*
+          merge-multiple: true
       - name: Upload coverage results to Code Climate
         run: |-
           cc-test-reporter sum-coverage codeclimate/*.json -o total.json

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
       image: ${{ needs.params.outputs.build_image_name }}:${{ needs.params.outputs.sql_snapshot_pg_version }}${{ needs.params.outputs.image_suffix }}
       options: --user root
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4
     - name: Check Snapshots
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -125,7 +125,7 @@ jobs:
     - name: Build
       run: "./ci/build-citus.sh"
       shell: bash
-    - uses: actions/upload-artifact@v3.1.1
+    - uses: actions/upload-artifact@v4
       with:
         name: build-${{ env.PG_MAJOR }}
         path: |-
@@ -399,7 +399,7 @@ jobs:
       - test-citus-upgrade
       - test-pg-upgrade
     steps:
-      - uses: actions/download-artifact@v3.0.1
+      - uses: actions/download-artifact@v4
         with:
           name: "codeclimate"
           path: "codeclimate"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -387,7 +387,7 @@ jobs:
     - uses: "./.github/actions/upload_coverage"
       if: always()
       with:
-        flags: ${{ env.pg_major }}_upgrade
+        flags: pg${{ fromJson(needs.params.outputs.pg14_version).major }}_citus_upgrade
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
   upload-coverage:
     if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -285,11 +285,11 @@ jobs:
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
       with:
-        folder: arbitrary_config_logs_pg_${{ matrix.pg_version }}_${{ matrix.parallel }}
+        folder: arbitrary_config_logs_pg_${{ fromJson(matrix.pg_version).major }}_${{ matrix.parallel }}
     - uses: "./.github/actions/upload_coverage"
       if: always()
       with:
-        flags: ${{ env.pg_major }}_arbitrary_configs_${{ matrix.parallel }}
+        flags: ${{ fromJson(matrix.pg_version).major }}_arbitrary_configs_${{ matrix.parallel }}
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -287,7 +287,7 @@ jobs:
     - uses: "./.github/actions/upload_coverage"
       if: always()
       with:
-        flags: ${{ env.pg_major }}_upgrade
+        flags: ${{ env.pg_major }}_arbitrary_configs_${{ matrix.parallel }}
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade


### PR DESCRIPTION
There is a wall of warnings on our Build & Test actions due to outdated nodejs versions being used by older github actions. This PR update these actions to newer versions to make the annotations on the summary more actionable.

Example: https://github.com/citusdata/citus/actions/runs/9906966082