### PR TITLE
Avoid using backslash in SQL string literals

### DIFF
--- a/src/backend/columnar/sql/citus_columnar--11.1-1.sql
+++ b/src/backend/columnar/sql/citus_columnar--11.1-1.sql
@@ -71,7 +71,7 @@ BEGIN
 -- from version 12 and up we have support for tableam's if installed on pg11 we can't
 -- create the objects here. Instead we rely on citus_finish_pg_upgrade to be called by the
 -- user instead to add the missing objects
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
   EXECUTE $$
 --#include "udfs/columnar_handler/10.0-1.sql"
 CREATE OR REPLACE FUNCTION columnar.columnar_handler(internal)

--- a/src/backend/columnar/sql/columnar--10.0-3--10.1-1.sql
+++ b/src/backend/columnar/sql/columnar--10.0-3--10.1-1.sql
@@ -4,7 +4,7 @@
 -- Postgres assigns different names to those foreign keys in PG11, so act accordingly.
 DO $proc$
 BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
   EXECUTE $$
 ALTER TABLE columnar.chunk DROP CONSTRAINT chunk_storage_id_stripe_num_chunk_group_num_fkey;
 ALTER TABLE columnar.chunk_group DROP CONSTRAINT chunk_group_storage_id_stripe_num_fkey;

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -67,7 +67,7 @@ BEGIN
 -- from version 12 and up we have support for tableam's if installed on pg11 we can't
 -- create the objects here. Instead we rely on citus_finish_pg_upgrade to be called by the
 -- user instead to add the missing objects
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
   EXECUTE $$
 #include "udfs/columnar_handler/10.0-1.sql"
 #include "udfs/alter_columnar_table_set/10.0-1.sql"

--- a/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--10.0-1--9.5-1.sql
@@ -5,7 +5,7 @@ SET search_path TO columnar;
 DO $proc$
 BEGIN
 
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
   EXECUTE $$
     DROP FUNCTION pg_catalog.alter_columnar_table_reset(
         table_name regclass,

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/10.0-1.sql
@@ -15,7 +15,7 @@ BEGIN
 
 -- when postgres is version 12 or above we need to create the tableam. If the tableam
 -- exist we assume all objects have been created.
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
 IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
 
 #include "../columnar_handler/10.0-1.sql"

--- a/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
+++ b/src/backend/columnar/sql/udfs/columnar_ensure_objects_exist/latest.sql
@@ -15,7 +15,7 @@ BEGIN
 
 -- when postgres is version 12 or above we need to create the tableam. If the tableam
 -- exist we assume all objects have been created.
-IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 12 THEN
 IF NOT EXISTS (SELECT 1 FROM pg_am WHERE amname = 'columnar') THEN
 
 #include "../columnar_handler/10.0-1.sql"

--- a/src/backend/distributed/sql/citus--8.0-1.sql
+++ b/src/backend/distributed/sql/citus--8.0-1.sql
@@ -323,7 +323,7 @@ CREATE TRIGGER dist_shard_cache_invalidate
 
 DO $proc$
 BEGIN
-IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $$
 CREATE AGGREGATE array_cat_agg(anycompatiblearray) (SFUNC = array_cat, STYPE = anycompatiblearray);
 COMMENT ON AGGREGATE array_cat_agg(anycompatiblearray)

--- a/src/backend/distributed/sql/udfs/any_value/9.1-1.sql
+++ b/src/backend/distributed/sql/udfs/any_value/9.1-1.sql
@@ -1,7 +1,7 @@
 DO $proc$
 BEGIN
 -- PG16 has its own any_value, so only create it pre PG16.
-IF substring(current_Setting('server_version'), '\d+')::int < 16 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int < 16 THEN
     EXECUTE $$
 
 CREATE OR REPLACE FUNCTION pg_catalog.any_value_agg ( anyelement, anyelement )

--- a/src/backend/distributed/sql/udfs/any_value/latest.sql
+++ b/src/backend/distributed/sql/udfs/any_value/latest.sql
@@ -1,7 +1,7 @@
 DO $proc$
 BEGIN
 -- PG16 has its own any_value, so only create it pre PG16.
-IF substring(current_Setting('server_version'), '\d+')::int < 16 THEN
+IF substring(current_Setting('server_version'), '[0-9]+')::int < 16 THEN
     EXECUTE $$
 
 CREATE OR REPLACE FUNCTION pg_catalog.any_value_agg ( anyelement, anyelement )

--- a/src/backend/distributed/sql/udfs/citus_finish_citus_upgrade/11.0-2.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_citus_upgrade/11.0-2.sql
@@ -18,7 +18,7 @@ BEGIN
 	FROM pg_dist_node_metadata;
 
 	SELECT r[1], r[2], r[3]
-	FROM regexp_matches(last_upgrade_version_string,'([0-9]+)\.([0-9]+)-([0-9]+)','') r
+	FROM regexp_matches(last_upgrade_version_string,'([0-9]+)[.]([0-9]+)-([0-9]+)','') r
 	INTO last_upgrade_major_version, last_upgrade_minor_version, last_upgrade_sqlpatch_version;
 
 	IF last_upgrade_major_version IS NULL OR last_upgrade_minor_version IS NULL OR last_upgrade_sqlpatch_version IS NULL THEN

--- a/src/backend/distributed/sql/udfs/citus_finish_citus_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_citus_upgrade/latest.sql
@@ -18,7 +18,7 @@ BEGIN
 	FROM pg_dist_node_metadata;
 
 	SELECT r[1], r[2], r[3]
-	FROM regexp_matches(last_upgrade_version_string,'([0-9]+)\.([0-9]+)-([0-9]+)','') r
+	FROM regexp_matches(last_upgrade_version_string,'([0-9]+)[.]([0-9]+)-([0-9]+)','') r
 	INTO last_upgrade_major_version, last_upgrade_minor_version, last_upgrade_sqlpatch_version;
 
 	IF last_upgrade_major_version IS NULL OR last_upgrade_minor_version IS NULL OR last_upgrade_sqlpatch_version IS NULL THEN

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         CREATE AGGREGATE array_cat_agg(anycompatiblearray) (SFUNC = array_cat, STYPE = anycompatiblearray);
         COMMENT ON AGGREGATE array_cat_agg(anycompatiblearray)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-4.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-4.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         CREATE AGGREGATE array_cat_agg(anycompatiblearray) (SFUNC = array_cat, STYPE = anycompatiblearray);
         COMMENT ON AGGREGATE array_cat_agg(anycompatiblearray)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-5.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/10.2-5.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         CREATE AGGREGATE array_cat_agg(anycompatiblearray) (SFUNC = array_cat, STYPE = anycompatiblearray);
         COMMENT ON AGGREGATE array_cat_agg(anycompatiblearray)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.0-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.0-4.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.0-4.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.1-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/11.2-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.0-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.1-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)
@@ -53,7 +53,7 @@ BEGIN
 
     -- PG16 has its own any_value, so only create it pre PG16.
     -- We can remove this part when we drop support for PG16
-    IF substring(current_Setting('server_version'), '\d+')::int < 16 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int < 16 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/12.2-1.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)
@@ -53,7 +53,7 @@ BEGIN
 
     -- PG16 has its own any_value, so only create it pre PG16.
     -- We can remove this part when we drop support for PG16
-    IF substring(current_Setting('server_version'), '\d+')::int < 16 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int < 16 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finish_pg_upgrade/latest.sql
@@ -10,7 +10,7 @@ DECLARE
 BEGIN
 
 
-    IF substring(current_Setting('server_version'), '\d+')::int >= 14 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int >= 14 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)
@@ -53,7 +53,7 @@ BEGIN
 
     -- PG16 has its own any_value, so only create it pre PG16.
     -- We can remove this part when we drop support for PG16
-    IF substring(current_Setting('server_version'), '\d+')::int < 16 THEN
+    IF substring(current_Setting('server_version'), '[0-9]+')::int < 16 THEN
     EXECUTE $cmd$
         -- disable propagation to prevent EnsureCoordinator errors
         -- the aggregate created here does not depend on Citus extension (yet)

--- a/src/backend/distributed/sql/udfs/citus_shards/10.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_shards/10.1-1.sql
@@ -23,7 +23,7 @@ JOIN
 ON
    pg_dist_partition.logicalrelid = pg_dist_shard.logicalrelid
 LEFT JOIN
-   (SELECT (regexp_matches(table_name,'_(\d+)$'))[1]::int as shard_id, max(size) as size from citus_shard_sizes() GROUP BY shard_id) as shard_sizes
+   (SELECT (regexp_matches(table_name,'_([0-9]+)$'))[1]::int as shard_id, max(size) as size from citus_shard_sizes() GROUP BY shard_id) as shard_sizes
 ON
     pg_dist_shard.shardid = shard_sizes.shard_id
 WHERE

--- a/src/backend/distributed/sql/udfs/citus_shards/11.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_shards/11.1-1.sql
@@ -23,7 +23,7 @@ JOIN
 ON
    pg_dist_partition.logicalrelid = pg_dist_shard.logicalrelid
 LEFT JOIN
-   (SELECT (regexp_matches(table_name,'_(\d+)$'))[1]::int as shard_id, max(size) as size from citus_shard_sizes() GROUP BY shard_id) as shard_sizes
+   (SELECT (regexp_matches(table_name,'_([0-9]+)$'))[1]::int as shard_id, max(size) as size from citus_shard_sizes() GROUP BY shard_id) as shard_sizes
 ON
     pg_dist_shard.shardid = shard_sizes.shard_id
 WHERE

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -474,7 +474,7 @@ PendingWorkerTransactionList(MultiConnection *connection)
 	int32 coordinatorId = GetLocalGroupId();
 
 	appendStringInfo(command, "SELECT gid FROM pg_prepared_xacts "
-							  "WHERE gid LIKE 'citus\\_%d\\_%%' and database = current_database()",
+							  "WHERE gid LIKE 'citus/_%d/_%%' ESCAPE '/' and database = current_database()",
 					 coordinatorId);
 
 	int querySent = SendRemoteCommand(connection, command->data);


### PR DESCRIPTION
If parameter `standard_conforming_strings` is off, backslashes in ordinary string literals ('...') are treated as escape characters causing problems. In particular `CREATE EXTENSION citus;` is failing when `standard_conforming_strings=off`:
```
postgres=# CREATE EXTENSION citus;
WARNING:  nonstandard use of escape in a string literal
LINE 6: IF substring(current_Setting('server_version'), '\d+')::int ...
                                                        ^
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
QUERY:  
BEGIN
-- from version 12 and up we have support for tableam's if installed on pg11 we can't
-- create the objects here. Instead we rely on citus_finish_pg_upgrade to be called by the
-- user instead to add the missing objects
IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
  EXECUTE $$
--#include "udfs/columnar_handler/10.0-1.sql"
CREATE OR REPLACE FUNCTION columnar.columnar_handler(internal)
    RETURNS table_am_handler
    LANGUAGE C
AS '$libdir/citus_columnar', 'columnar_handler';
COMMENT ON FUNCTION columnar.columnar_handler(internal)
    IS 'internal function returning the handler for columnar tables';
-- postgres 11.8 does not support the syntax for table am, also it is seemingly trying
-- to parse the upgrade file and erroring on unknown syntax.
-- normally this section would not execute on postgres 11 anyway. To trick it to pass on
-- 11.8 we wrap the statement in a plpgsql block together with an EXECUTE. This is valid
-- syntax on 11.8 and will execute correctly in 12
DO $create_table_am$
BEGIN
  EXECUTE 'CREATE ACCESS METHOD columnar TYPE TABLE HANDLER columnar.columnar_handler';
END $create_table_am$;
--#include "udfs/alter_columnar_table_set/10.0-1.sql"
CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
    table_name regclass,
    chunk_group_row_limit int DEFAULT NULL,
    stripe_row_limit int DEFAULT NULL,
    compression name DEFAULT null,
    compression_level int DEFAULT NULL)
    RETURNS void
    LANGUAGE C
AS '$libdir/citus_columnar', 'alter_columnar_table_set';
COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
    table_name regclass,
    chunk_group_row_limit int,
    stripe_row_limit int,
    compression name,
    compression_level int)
IS 'set one or more options on a columnar table, when set to NULL no change is made';
--#include "udfs/alter_columnar_table_reset/10.0-1.sql"
CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
    table_name regclass,
    chunk_group_row_limit bool DEFAULT false,
    stripe_row_limit bool DEFAULT false,
    compression bool DEFAULT false,
    compression_level bool DEFAULT false)
    RETURNS void
    LANGUAGE C
AS '$libdir/citus_columnar', 'alter_columnar_table_reset';
COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
    table_name regclass,
    chunk_group_row_limit bool,
    stripe_row_limit bool,
    compression bool,
    compression_level bool)
IS 'reset on or more options on a columnar table to the system defaults';
  $$;
END IF;
END
WARNING:  nonstandard use of escape in a string literal
LINE 1: substring(current_Setting('server_version'), '\d+')::int >= ...
                                                     ^
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
QUERY:  substring(current_Setting('server_version'), '\d+')::int >= 12
ERROR:  null value in column "objid" of relation "pg_depend" violates not-null constraint
DETAIL:  Failing row contains (2601, null, 0, 1259, 16387, 0, n).
CONTEXT:  SQL statement "INSERT INTO pg_depend
  WITH columnar_schema_members(relid) AS (
    SELECT pg_class.oid AS relid FROM pg_class
      WHERE relnamespace =
            COALESCE(
        (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = 'columnar_internal'),
        (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = 'columnar')
     )
        AND relname IN ('chunk',
                        'chunk_group',
                        'chunk_group_pkey',
                        'chunk_pkey',
                        'options',
                        'options_pkey',
                        'storageid_seq',
                        'stripe',
                        'stripe_first_row_number_idx',
                        'stripe_pkey')
  )
  SELECT -- Define a dependency edge from "columnar table access method" ..
         'pg_am'::regclass::oid as classid,
         (select oid from pg_am where amname = 'columnar') as objid,
         0 as objsubid,
         -- ... to each object that is registered to pg_class and that lives
         -- in "columnar" schema. That contains catalog tables, indexes
         -- created on them and the sequences created in "columnar" schema.
         --
         -- Given the possibility of user might have created their own objects
         -- in columnar schema, we explicitly specify list of objects that we
         -- are interested in.
         'pg_class'::regclass::oid as refclassid,
         columnar_schema_members.relid as refobjid,
         0 as refobjsubid,
         'n' as deptype
  FROM columnar_schema_members
  -- Avoid inserting duplicate entries into pg_depend.
  EXCEPT TABLE pg_depend"
PL/pgSQL function columnar_internal.columnar_ensure_am_depends_catalog() line 3 at SQL statement
```
This PR eliminates usages of backslashes in SQL string literals, therefore allowing using Citus when `standard_conforming_strings=off`.