### PR TITLE
Add Debugging Instructions to Devcontainer Setup in CONTRIBUTING.md

### DIFF
--- a/.devcontainer/.psqlrc
+++ b/.devcontainer/.psqlrc
@@ -3,5 +3,5 @@
 \pset border 2
 \setenv PAGER 'pspg --no-mouse -bX --no-commandbar --no-topbar'
 \set HISTSIZE 100000
-\set PROMPT1 '\n%[%033[1m%]%M %n@%/:%>-%p%R%[%033[0m%]%# '
+\set PROMPT1 '\n%[%033[1m%]%M %n@%/:%> (PID: %p)%R%[%033[0m%]%# '
 \set PROMPT2 '  '

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ To get citus installed from source we run `make install -s` in the first termina
 
 With the Citus cluster running you can connect to the coordinator in the first terminal via `psql -p9700`. Because the coordinator is the most common entrypoint the `PGPORT` environment is set accordingly, so a simple `psql` will connect directly to the coordinator.
 
-#### Debugging in the devcontainer
-Debugging within the devcontainer setup is straightforward and fully integrated with Visual Studio Code's debugging tools.
+### Debugging in the VS code
+
 1. Start Debugging: Press F5 to start debugging. You'll be prompted to select the running PostgreSQL process to attach the debugger to. Typically, if you're executing a psql command, you'll want to attach to a process named something like:
 ```
 postgres: citus citus [local] idle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,16 @@ To get citus installed from source we run `make install -s` in the first termina
 
 With the Citus cluster running you can connect to the coordinator in the first terminal via `psql -p9700`. Because the coordinator is the most common entrypoint the `PGPORT` environment is set accordingly, so a simple `psql` will connect directly to the coordinator.
 
+#### Debugging in the devcontainer
+Debugging within the devcontainer setup is straightforward and fully integrated with Visual Studio Code's debugging tools.
+1. Start Debugging: Press F5 to start debugging. You'll be prompted to select the running PostgreSQL process to attach the debugger to. Typically, if you're executing a psql command, you'll want to attach to a process named something like:
+```
+postgres: citus citus [local] idle
+```
+2. Set Breakpoints and Debug: Once the debugger attaches to the correct process, you can set breakpoints within the code. From here, you'll be able to step through the code execution, inspect variables, and fully debug the PostgreSQL instance running within the devcontainer.
+
+This setup provides a seamless way to troubleshoot and optimize the Citus extension by taking advantage of the integrated debugging features in VS Code.
+
 ### Getting and building
 
 [PostgreSQL documentation](https://www.postgresql.org/support/versioning/) has a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,25 @@ With the Citus cluster running you can connect to the coordinator in the first t
 
 ### Debugging in the VS code
 
-1. Start Debugging: Press F5 to start debugging. You'll be prompted to select the running PostgreSQL process to attach the debugger to. Typically, if you're executing a psql command, you'll want to attach to a process named something like:
-```
-postgres: citus citus [local] idle
-```
-2. Set Breakpoints and Debug: Once the debugger attaches to the correct process, you can set breakpoints within the code. From here, you'll be able to step through the code execution, inspect variables, and fully debug the PostgreSQL instance running within the devcontainer.
+1. Start Debugging: Press F5 in VS Code to start debugging. When prompted, you'll need to attach the debugger to the appropriate PostgreSQL process.
 
-This setup provides a seamless way to troubleshoot and optimize the Citus extension by taking advantage of the integrated debugging features in VS Code.
+2. Identify the Process: If you're running a psql command, take note of the PID that appears in your psql prompt. For example:
+```
+[local] citus@citus:9700 (PID: 5436)=#
+```
+This PID (5436 in this case) indicates the process that you should attach the debugger to.
+If you are uncertain about which process to attach, you can list all running PostgreSQL processes using the following command:
+```
+ps aux | grep postgres
+```
+
+Look for the process associated with the PID you noted. For example:
+```
+citus      5436  0.0  0.0  0  0 ?        S    14:00   0:00 postgres: citus citus
+```
+4. Attach the Debugger: Once you've identified the correct PID, select that process when prompted in VS Code to attach the debugger. You should now be able to debug the PostgreSQL session tied to the psql command.
+
+5. Set Breakpoints and Debug: With the debugger attached, you can set breakpoints within the code. This allows you to step through the code execution, inspect variables, and fully debug the PostgreSQL instance running in your container.
 
 ### Getting and building
 


### PR DESCRIPTION
**Description:**
This PR adds a section to CONTRIBUTING.md that explains how to set up debugging in the devcontainer using VS Code.

**Changes:**

- **New Debugging Section**: Clear instructions on starting the debugger, selecting the appropriate PostgreSQL process, and setting breakpoints for easier troubleshooting.

**Purpose:**

- **Improved Contributor Workflow**: Enables contributors to debug the Citus extension within the devcontainer, enhancing productivity and making it easier to resolve issues.
