### PR TITLE
Remove warnings on some builds

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -3021,6 +3021,8 @@ AvailableExtensionVersionColumnar(void)
 
 	ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					errmsg("citus extension is not found")));
+
+	return NULL; /* keep compiler happy */
 }
 
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -2522,6 +2522,8 @@ AvailableExtensionVersion(void)
 
 	ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					errmsg("citus extension is not found")));
+
+	return NULL; /* keep compiler happy */
 }
 
 

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -1810,6 +1810,8 @@ CastExpr(Expr *expr, Oid sourceType, Oid targetType, Oid targetCollation,
 		ereport(ERROR, (errmsg("could not find a conversion path from type %d to %d",
 							   sourceType, targetType)));
 	}
+
+	return NULL; /* keep compiler happy */
 }
 
 


### PR DESCRIPTION
We have a product where the warning Werror=return-type is enabled and is treated as an error for the entire build process. So our build process stops. Of course, we can do tricks in the build script, but I guess this commit will be useful because it removes one excluded warning.