### PR TITLE
fix: typo runnnig -> running

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-1.sql
@@ -96,7 +96,7 @@ END;
 
         IF all_nodes_can_connect_to_each_other != True THEN
                   RAISE EXCEPTION 'There are unhealth primary nodes, you need to ensure all '
-                                  'nodes are up and runnnig. Also, make sure that all nodes can connect '
+                                  'nodes are up and running. Also, make sure that all nodes can connect '
                                   'to each other. Use SELECT * FROM citus_check_cluster_node_health(); '
                                   'to check the cluster health';
         ELSE

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-2.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-2.sql
@@ -96,7 +96,7 @@ END;
 
         IF all_nodes_can_connect_to_each_other != True THEN
                   RAISE EXCEPTION 'There are unhealth primary nodes, you need to ensure all '
-                                  'nodes are up and runnnig. Also, make sure that all nodes can connect '
+                                  'nodes are up and running. Also, make sure that all nodes can connect '
                                   'to each other. Use SELECT * FROM citus_check_cluster_node_health(); '
                                   'to check the cluster health';
         ELSE

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-3.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/11.0-3.sql
@@ -96,7 +96,7 @@ END;
 
         IF all_nodes_can_connect_to_each_other != True THEN
                   RAISE EXCEPTION 'There are unhealth primary nodes, you need to ensure all '
-                                  'nodes are up and runnnig. Also, make sure that all nodes can connect '
+                                  'nodes are up and running. Also, make sure that all nodes can connect '
                                   'to each other. Use SELECT * FROM citus_check_cluster_node_health(); '
                                   'to check the cluster health';
         ELSE

--- a/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/latest.sql
@@ -96,7 +96,7 @@ END;
 
         IF all_nodes_can_connect_to_each_other != True THEN
                   RAISE EXCEPTION 'There are unhealth primary nodes, you need to ensure all '
-                                  'nodes are up and runnnig. Also, make sure that all nodes can connect '
+                                  'nodes are up and running. Also, make sure that all nodes can connect '
                                   'to each other. Use SELECT * FROM citus_check_cluster_node_health(); '
                                   'to check the cluster health';
         ELSE


### PR DESCRIPTION
Very small PR, no changes to behaviour. Just a typo fix :-)

Under `src/backend/distributed/sql/udfs/citus_finalize_upgrade_to_citus11/` the sql has a typo "runnnig", which will be displayed to the user if the `citus_check_cluster_node_health()` fails when calling `citus_finish_citus_upgrade();`