### PR TITLE
Rename foreach_ macros to foreach_declared_ macros

### DIFF
--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -363,7 +363,7 @@ ColumnarGetRelationInfoHook(PlannerInfo *root, Oid relationObjectId,
 
 		/* disable index-only scan */
 		IndexOptInfo *indexOptInfo = NULL;
-		foreach_ptr(indexOptInfo, rel->indexlist)
+		foreach_declared_ptr(indexOptInfo, rel->indexlist)
 		{
 			memset(indexOptInfo->canreturn, false, indexOptInfo->ncolumns * sizeof(bool));
 		}
@@ -381,7 +381,7 @@ RemovePathsByPredicate(RelOptInfo *rel, PathPredicate removePathPredicate)
 	List *filteredPathList = NIL;
 
 	Path *path = NULL;
-	foreach_ptr(path, rel->pathlist)
+	foreach_declared_ptr(path, rel->pathlist)
 	{
 		if (!removePathPredicate(path))
 		{
@@ -428,7 +428,7 @@ static void
 CostColumnarPaths(PlannerInfo *root, RelOptInfo *rel, Oid relationId)
 {
 	Path *path = NULL;
-	foreach_ptr(path, rel->pathlist)
+	foreach_declared_ptr(path, rel->pathlist)
 	{
 		if (IsA(path, IndexPath))
 		{
@@ -783,7 +783,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 		List *pushdownableArgs = NIL;
 
 		Node *boolExprArg = NULL;
-		foreach_ptr(boolExprArg, boolExpr->args)
+		foreach_declared_ptr(boolExprArg, boolExpr->args)
 		{
 			Expr *pushdownableArg = ExtractPushdownClause(root, rel,
 														  (Node *) boolExprArg);
@@ -1550,7 +1550,7 @@ ColumnarPerStripeScanCost(RelOptInfo *rel, Oid relationId, int numberOfColumnsRe
 	uint32 maxColumnCount = 0;
 	uint64 totalStripeSize = 0;
 	StripeMetadata *stripeMetadata = NULL;
-	foreach_ptr(stripeMetadata, stripeList)
+	foreach_declared_ptr(stripeMetadata, stripeList)
 	{
 		totalStripeSize += stripeMetadata->dataLength;
 		maxColumnCount = Max(maxColumnCount, stripeMetadata->columnCount);

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -2042,7 +2042,7 @@ GetHighestUsedRowNumber(uint64 storageId)
 	List *stripeMetadataList = ReadDataFileStripeList(storageId,
 													  GetTransactionSnapshot());
 	StripeMetadata *stripeMetadata = NULL;
-	foreach_ptr(stripeMetadata, stripeMetadataList)
+	foreach_declared_ptr(stripeMetadata, stripeMetadataList)
 	{
 		highestRowNumber = Max(highestRowNumber,
 							   StripeGetHighestRowNumber(stripeMetadata));

--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -880,7 +880,7 @@ ReadChunkGroupNextRow(ChunkGroupReadState *chunkGroupReadState, Datum *columnVal
 	memset(columnNulls, true, sizeof(bool) * chunkGroupReadState->columnCount);
 
 	int attno;
-	foreach_int(attno, chunkGroupReadState->projectedColumnList)
+	foreach_declared_int(attno, chunkGroupReadState->projectedColumnList)
 	{
 		const ChunkData *chunkGroupData = chunkGroupReadState->chunkGroupData;
 		const int rowIndex = chunkGroupReadState->currentRow;
@@ -1489,7 +1489,7 @@ ProjectedColumnMask(uint32 columnCount, List *projectedColumnList)
 	bool *projectedColumnMask = palloc0(columnCount * sizeof(bool));
 	int attno;
 
-	foreach_int(attno, projectedColumnList)
+	foreach_declared_int(attno, projectedColumnList)
 	{
 		/* attno is 1-indexed; projectedColumnMask is 0-indexed */
 		int columnIndex = attno - 1;

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -3083,7 +3083,7 @@ DefElem *
 GetExtensionOption(List *extensionOptions, const char *defname)
 {
 	DefElem *defElement = NULL;
-	foreach_ptr(defElement, extensionOptions)
+	foreach_declared_ptr(defElement, extensionOptions)
 	{
 		if (IsA(defElement, DefElem) &&
 			strncmp(defElement->defname, defname, NAMEDATALEN) == 0)

--- a/src/backend/distributed/clock/causal_clock.c
+++ b/src/backend/distributed/clock/causal_clock.c
@@ -328,7 +328,7 @@ GetHighestClockInTransaction(List *nodeConnectionList)
 {
 	MultiConnection *connection = NULL;
 
-	foreach_ptr(connection, nodeConnectionList)
+	foreach_declared_ptr(connection, nodeConnectionList)
 	{
 		int querySent =
 			SendRemoteCommand(connection, "SELECT citus_get_node_clock();");
@@ -349,7 +349,7 @@ GetHighestClockInTransaction(List *nodeConnectionList)
 							globalClockValue->counter)));
 
 	/* fetch the results and pick the highest clock value of all the nodes */
-	foreach_ptr(connection, nodeConnectionList)
+	foreach_declared_ptr(connection, nodeConnectionList)
 	{
 		bool raiseInterrupts = true;
 

--- a/src/backend/distributed/commands/begin.c
+++ b/src/backend/distributed/commands/begin.c
@@ -33,7 +33,7 @@ SaveBeginCommandProperties(TransactionStmt *transactionStmt)
 	 *
 	 * While BEGIN can be quite frequent it will rarely have options set.
 	 */
-	foreach_ptr(item, transactionStmt->options)
+	foreach_declared_ptr(item, transactionStmt->options)
 	{
 		A_Const *constant = (A_Const *) item->arg;
 

--- a/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
+++ b/src/backend/distributed/commands/cascade_table_operation_for_connected_relations.c
@@ -168,7 +168,7 @@ GetPartitionRelationIds(List *relationIdList)
 	List *partitionRelationIdList = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (PartitionTable(relationId))
 		{
@@ -189,7 +189,7 @@ LockRelationsWithLockMode(List *relationIdList, LOCKMODE lockMode)
 {
 	Oid relationId;
 	relationIdList = SortList(relationIdList, CompareOids);
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		LockRelationOid(relationId, lockMode);
 	}
@@ -207,7 +207,7 @@ static void
 ErrorIfConvertingMultiLevelPartitionedTable(List *relationIdList)
 {
 	Oid relationId;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (PartitionedTable(relationId) && PartitionTable(relationId))
 		{
@@ -236,7 +236,7 @@ void
 ErrorIfAnyPartitionRelationInvolvedInNonInheritedFKey(List *relationIdList)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (!PartitionTable(relationId))
 		{
@@ -300,7 +300,7 @@ bool
 RelationIdListHasReferenceTable(List *relationIdList)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
@@ -322,7 +322,7 @@ GetFKeyCreationCommandsForRelationIdList(List *relationIdList)
 	List *fKeyCreationCommands = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		List *relationFKeyCreationCommands =
 			GetReferencingForeignConstaintCommands(relationId);
@@ -342,7 +342,7 @@ static void
 DropRelationIdListForeignKeys(List *relationIdList, int fKeyFlags)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		DropRelationForeignKeys(relationId, fKeyFlags);
 	}
@@ -399,7 +399,7 @@ GetRelationDropFkeyCommands(Oid relationId, int fKeyFlags)
 	List *relationFKeyIdList = GetForeignKeyOids(relationId, fKeyFlags);
 
 	Oid foreignKeyId;
-	foreach_oid(foreignKeyId, relationFKeyIdList)
+	foreach_declared_oid(foreignKeyId, relationFKeyIdList)
 	{
 		char *dropFkeyCascadeCommand = GetDropFkeyCascadeCommand(foreignKeyId);
 		dropFkeyCascadeCommandList = lappend(dropFkeyCascadeCommandList,
@@ -450,7 +450,7 @@ ExecuteCascadeOperationForRelationIdList(List *relationIdList,
 										 cascadeOperationType)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		/*
 		 * The reason behind skipping certain table types in below loop is
@@ -531,7 +531,7 @@ ExecuteAndLogUtilityCommandListInTableTypeConversionViaSPI(List *utilityCommandL
 	PG_TRY();
 	{
 		char *utilityCommand = NULL;
-		foreach_ptr(utilityCommand, utilityCommandList)
+		foreach_declared_ptr(utilityCommand, utilityCommandList)
 		{
 			/*
 			 * CREATE MATERIALIZED VIEW commands need to be parsed/transformed,
@@ -569,7 +569,7 @@ void
 ExecuteAndLogUtilityCommandList(List *utilityCommandList)
 {
 	char *utilityCommand = NULL;
-	foreach_ptr(utilityCommand, utilityCommandList)
+	foreach_declared_ptr(utilityCommand, utilityCommandList)
 	{
 		ExecuteAndLogUtilityCommand(utilityCommand);
 	}
@@ -597,7 +597,7 @@ void
 ExecuteForeignKeyCreateCommandList(List *ddlCommandList, bool skip_validation)
 {
 	char *ddlCommand = NULL;
-	foreach_ptr(ddlCommand, ddlCommandList)
+	foreach_declared_ptr(ddlCommand, ddlCommandList)
 	{
 		ExecuteForeignKeyCreateCommand(ddlCommand, skip_validation);
 	}

--- a/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
+++ b/src/backend/distributed/commands/citus_add_local_table_to_metadata.c
@@ -588,7 +588,7 @@ ErrorIfOptionListHasNoTableName(List *optionList)
 {
 	char *table_nameString = "table_name";
 	DefElem *option = NULL;
-	foreach_ptr(option, optionList)
+	foreach_declared_ptr(option, optionList)
 	{
 		char *optionName = option->defname;
 		if (strcmp(optionName, table_nameString) == 0)
@@ -613,7 +613,7 @@ ForeignTableDropsTableNameOption(List *optionList)
 {
 	char *table_nameString = "table_name";
 	DefElem *option = NULL;
-	foreach_ptr(option, optionList)
+	foreach_declared_ptr(option, optionList)
 	{
 		char *optionName = option->defname;
 		DefElemAction optionAction = option->defaction;
@@ -732,7 +732,7 @@ UpdateAutoConvertedForConnectedRelations(List *relationIds, bool autoConverted)
 
 	List *relationIdList = NIL;
 	Oid relid = InvalidOid;
-	foreach_oid(relid, relationIds)
+	foreach_declared_oid(relid, relationIds)
 	{
 		List *connectedRelations = GetForeignKeyConnectedRelationIdList(relid);
 		relationIdList = list_concat_unique_oid(relationIdList, connectedRelations);
@@ -740,7 +740,7 @@ UpdateAutoConvertedForConnectedRelations(List *relationIds, bool autoConverted)
 
 	relationIdList = SortList(relationIdList, CompareOids);
 
-	foreach_oid(relid, relationIdList)
+	foreach_declared_oid(relid, relationIdList)
 	{
 		UpdatePgDistPartitionAutoConverted(relid, autoConverted);
 	}
@@ -776,7 +776,7 @@ GetShellTableDDLEventsForCitusLocalTable(Oid relationId)
 
 	List *shellTableDDLEvents = NIL;
 	TableDDLCommand *tableDDLCommand = NULL;
-	foreach_ptr(tableDDLCommand, tableDDLCommands)
+	foreach_declared_ptr(tableDDLCommand, tableDDLCommands)
 	{
 		Assert(CitusIsA(tableDDLCommand, TableDDLCommand));
 		shellTableDDLEvents = lappend(shellTableDDLEvents,
@@ -863,7 +863,7 @@ RenameShardRelationConstraints(Oid shardRelationId, uint64 shardId)
 	List *constraintNameList = GetConstraintNameList(shardRelationId);
 
 	char *constraintName = NULL;
-	foreach_ptr(constraintName, constraintNameList)
+	foreach_declared_ptr(constraintName, constraintNameList)
 	{
 		const char *commandString =
 			GetRenameShardConstraintCommand(shardRelationId, constraintName, shardId);
@@ -958,7 +958,7 @@ RenameShardRelationIndexes(Oid shardRelationId, uint64 shardId)
 	List *indexOidList = GetExplicitIndexOidList(shardRelationId);
 
 	Oid indexOid = InvalidOid;
-	foreach_oid(indexOid, indexOidList)
+	foreach_declared_oid(indexOid, indexOidList)
 	{
 		const char *commandString = GetRenameShardIndexCommand(indexOid, shardId);
 		ExecuteAndLogUtilityCommand(commandString);
@@ -1008,7 +1008,7 @@ RenameShardRelationStatistics(Oid shardRelationId, uint64 shardId)
 	List *statsCommandList = GetRenameStatsCommandList(statsOidList, shardId);
 
 	char *command = NULL;
-	foreach_ptr(command, statsCommandList)
+	foreach_declared_ptr(command, statsCommandList)
 	{
 		ExecuteAndLogUtilityCommand(command);
 	}
@@ -1044,7 +1044,7 @@ RenameShardRelationNonTruncateTriggers(Oid shardRelationId, uint64 shardId)
 	List *triggerIdList = GetExplicitTriggerIdList(shardRelationId);
 
 	Oid triggerId = InvalidOid;
-	foreach_oid(triggerId, triggerIdList)
+	foreach_declared_oid(triggerId, triggerIdList)
 	{
 		bool missingOk = false;
 		HeapTuple triggerTuple = GetTriggerTupleById(triggerId, missingOk);
@@ -1097,7 +1097,7 @@ DropRelationTruncateTriggers(Oid relationId)
 	List *triggerIdList = GetExplicitTriggerIdList(relationId);
 
 	Oid triggerId = InvalidOid;
-	foreach_oid(triggerId, triggerIdList)
+	foreach_declared_oid(triggerId, triggerIdList)
 	{
 		bool missingOk = false;
 		HeapTuple triggerTuple = GetTriggerTupleById(triggerId, missingOk);
@@ -1177,7 +1177,7 @@ DropIdentitiesOnTable(Oid relationId)
 	relation_close(relation, NoLock);
 
 	char *dropCommand = NULL;
-	foreach_ptr(dropCommand, dropCommandList)
+	foreach_declared_ptr(dropCommand, dropCommandList)
 	{
 		/*
 		 * We need to disable/enable ddl propagation for this command, to prevent
@@ -1220,7 +1220,7 @@ DropViewsOnTable(Oid relationId)
 	List *reverseOrderedViews = ReversedOidList(views);
 
 	Oid viewId = InvalidOid;
-	foreach_oid(viewId, reverseOrderedViews)
+	foreach_declared_oid(viewId, reverseOrderedViews)
 	{
 		char *viewName = get_rel_name(viewId);
 		char *schemaName = get_namespace_name(get_rel_namespace(viewId));
@@ -1245,7 +1245,7 @@ ReversedOidList(List *oidList)
 {
 	List *reversed = NIL;
 	Oid oid = InvalidOid;
-	foreach_oid(oid, oidList)
+	foreach_declared_oid(oid, oidList)
 	{
 		reversed = lcons_oid(oid, reversed);
 	}
@@ -1297,7 +1297,7 @@ GetRenameStatsCommandList(List *statsOidList, uint64 shardId)
 {
 	List *statsCommandList = NIL;
 	Oid statsOid;
-	foreach_oid(statsOid, statsOidList)
+	foreach_declared_oid(statsOid, statsOidList)
 	{
 		HeapTuple tup = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(statsOid));
 

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -115,7 +115,7 @@ static bool
 IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt)
 {
 	DefElem *opt = NULL;
-	foreach_ptr(opt, clusterStmt->params)
+	foreach_declared_ptr(opt, clusterStmt->params)
 	{
 		if (strcmp(opt->defname, "verbose") == 0)
 		{

--- a/src/backend/distributed/commands/common.c
+++ b/src/backend/distributed/commands/common.c
@@ -235,7 +235,7 @@ PreprocessDropDistributedObjectStmt(Node *node, const char *queryString,
 	List *distributedObjects = NIL;
 	List *distributedObjectAddresses = NIL;
 	Node *object = NULL;
-	foreach_ptr(object, stmt->objects)
+	foreach_declared_ptr(object, stmt->objects)
 	{
 		/* TODO understand if the lock should be sth else */
 		Relation rel = NULL; /* not used, but required to pass to get_object_address */
@@ -267,7 +267,7 @@ PreprocessDropDistributedObjectStmt(Node *node, const char *queryString,
 	 * remove the entries for the distributed objects on dropping
 	 */
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, distributedObjectAddresses)
+	foreach_declared_ptr(address, distributedObjectAddresses)
 	{
 		UnmarkObjectDistributed(address);
 	}
@@ -303,7 +303,7 @@ DropTextSearchDictObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 	List *objectAddresses = NIL;
 
 	List *objNameList = NIL;
-	foreach_ptr(objNameList, stmt->objects)
+	foreach_declared_ptr(objNameList, stmt->objects)
 	{
 		Oid tsdictOid = get_ts_dict_oid(objNameList, missing_ok);
 
@@ -328,7 +328,7 @@ DropTextSearchConfigObjectAddress(Node *node, bool missing_ok, bool isPostproces
 	List *objectAddresses = NIL;
 
 	List *objNameList = NIL;
-	foreach_ptr(objNameList, stmt->objects)
+	foreach_declared_ptr(objNameList, stmt->objects)
 	{
 		Oid tsconfigOid = get_ts_config_oid(objNameList, missing_ok);
 

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -834,7 +834,7 @@ HashSplitPointsForShardList(List *shardList)
 	List *splitPointList = NIL;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		int32 shardMaxValue = DatumGetInt32(shardInterval->maxValue);
 
@@ -890,7 +890,7 @@ WorkerNodesForShardList(List *shardList)
 	List *nodeIdList = NIL;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		WorkerNode *workerNode = ActiveShardPlacementWorkerNode(shardInterval->shardId);
 		nodeIdList = lappend_int(nodeIdList, workerNode->nodeId);
@@ -1340,7 +1340,7 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 								  ALLOCSET_DEFAULT_SIZES);
 		MemoryContext oldContext = MemoryContextSwitchTo(citusPartitionContext);
 
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			MemoryContextReset(citusPartitionContext);
 
@@ -1554,7 +1554,7 @@ ConvertCitusLocalTableToTableType(Oid relationId, CitusTableType tableType,
 		MemoryContext oldContext = MemoryContextSwitchTo(citusPartitionContext);
 
 		Oid partitionRelationId = InvalidOid;
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			MemoryContextReset(citusPartitionContext);
 
@@ -1704,7 +1704,7 @@ EnsureSequenceTypeSupported(Oid seqOid, Oid attributeTypeId, Oid ownerRelationId
 	Oid attrDefOid;
 	List *attrDefOids = GetAttrDefsFromSequence(seqOid);
 
-	foreach_oid(attrDefOid, attrDefOids)
+	foreach_declared_oid(attrDefOid, attrDefOids)
 	{
 		ObjectAddress columnAddress = GetAttrDefaultColumnAddress(attrDefOid);
 
@@ -1786,7 +1786,7 @@ static void
 EnsureDistributedSequencesHaveOneType(Oid relationId, List *seqInfoList)
 {
 	SequenceInfo *seqInfo = NULL;
-	foreach_ptr(seqInfo, seqInfoList)
+	foreach_declared_ptr(seqInfo, seqInfoList)
 	{
 		if (!seqInfo->isNextValDefault)
 		{

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -69,7 +69,7 @@ EnsureDependenciesExistOnAllNodes(const ObjectAddress *target)
 	/* collect all dependencies in creation order and get their ddl commands */
 	List *dependencies = GetDependenciesForObject(target);
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		List *dependencyCommands = GetDependencyCreateDDLCommands(dependency);
 		ddlCommands = list_concat(ddlCommands, dependencyCommands);
@@ -108,7 +108,7 @@ EnsureDependenciesExistOnAllNodes(const ObjectAddress *target)
 	 */
 	List *addressSortedDependencies = SortList(dependenciesWithCommands,
 											   ObjectAddressComparator);
-	foreach_ptr(dependency, addressSortedDependencies)
+	foreach_declared_ptr(dependency, addressSortedDependencies)
 	{
 		LockDatabaseObject(dependency->classId, dependency->objectId,
 						   dependency->objectSubId, ExclusiveLock);
@@ -134,7 +134,7 @@ EnsureDependenciesExistOnAllNodes(const ObjectAddress *target)
 	else
 	{
 		WorkerNode *workerNode = NULL;
-		foreach_ptr(workerNode, workerNodeList)
+		foreach_declared_ptr(workerNode, workerNodeList)
 		{
 			const char *nodeName = workerNode->workerName;
 			uint32 nodePort = workerNode->workerPort;
@@ -150,7 +150,7 @@ EnsureDependenciesExistOnAllNodes(const ObjectAddress *target)
 	 * that objects have been created on worker nodes before marking them
 	 * distributed, so MarkObjectDistributed wouldn't fail.
 	 */
-	foreach_ptr(dependency, dependenciesWithCommands)
+	foreach_declared_ptr(dependency, dependenciesWithCommands)
 	{
 		/*
 		 * pg_dist_object entries must be propagated with the super user, since
@@ -173,7 +173,7 @@ void
 EnsureAllObjectDependenciesExistOnAllNodes(const List *targets)
 {
 	ObjectAddress *target = NULL;
-	foreach_ptr(target, targets)
+	foreach_declared_ptr(target, targets)
 	{
 		EnsureDependenciesExistOnAllNodes(target);
 	}
@@ -230,7 +230,7 @@ DeferErrorIfCircularDependencyExists(const ObjectAddress *objectAddress)
 	List *dependencies = GetAllDependenciesForObject(objectAddress);
 
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		if (dependency->classId == objectAddress->classId &&
 			dependency->objectId == objectAddress->objectId &&
@@ -318,7 +318,7 @@ GetDistributableDependenciesForObject(const ObjectAddress *target)
 
 	/* filter the ones that can be distributed */
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		/*
 		 * TODO: maybe we can optimize the logic applied in below line. Actually we
@@ -402,7 +402,7 @@ GetDependencyCreateDDLCommands(const ObjectAddress *dependency)
 																		  INCLUDE_IDENTITY,
 																		  creatingShellTableOnRemoteNode);
 					TableDDLCommand *tableDDLCommand = NULL;
-					foreach_ptr(tableDDLCommand, tableDDLCommands)
+					foreach_declared_ptr(tableDDLCommand, tableDDLCommands)
 					{
 						Assert(CitusIsA(tableDDLCommand, TableDDLCommand));
 						commandList = lappend(commandList, GetTableDDLCommand(
@@ -564,7 +564,7 @@ GetAllDependencyCreateDDLCommands(const List *dependencies)
 	List *commands = NIL;
 
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		commands = list_concat(commands, GetDependencyCreateDDLCommands(dependency));
 	}
@@ -712,7 +712,7 @@ bool
 ShouldPropagateAnyObject(List *addresses)
 {
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, addresses)
+	foreach_declared_ptr(address, addresses)
 	{
 		if (ShouldPropagateObject(address))
 		{
@@ -734,7 +734,7 @@ FilterObjectAddressListByPredicate(List *objectAddressList, AddressPredicate pre
 	List *result = NIL;
 
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, objectAddressList)
+	foreach_declared_ptr(address, objectAddressList)
 	{
 		if (predicate(address))
 		{

--- a/src/backend/distributed/commands/domain.c
+++ b/src/backend/distributed/commands/domain.c
@@ -210,7 +210,7 @@ MakeCollateClauseFromOid(Oid collationOid)
 	getObjectIdentityParts(&collateAddress, &objName, &objArgs, false);
 
 	char *name = NULL;
-	foreach_ptr(name, objName)
+	foreach_declared_ptr(name, objName)
 	{
 		collateClause->collname = lappend(collateClause->collname, makeString(name));
 	}

--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -274,7 +274,7 @@ PreprocessDropExtensionStmt(Node *node, const char *queryString,
 
 	/* unmark each distributed extension */
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, distributedExtensionAddresses)
+	foreach_declared_ptr(address, distributedExtensionAddresses)
 	{
 		UnmarkObjectDistributed(address);
 	}
@@ -313,7 +313,7 @@ FilterDistributedExtensions(List *extensionObjectList)
 	List *extensionNameList = NIL;
 
 	String *objectName = NULL;
-	foreach_ptr(objectName, extensionObjectList)
+	foreach_declared_ptr(objectName, extensionObjectList)
 	{
 		const char *extensionName = strVal(objectName);
 		const bool missingOk = true;
@@ -351,7 +351,7 @@ ExtensionNameListToObjectAddressList(List *extensionObjectList)
 	List *extensionObjectAddressList = NIL;
 
 	String *objectName;
-	foreach_ptr(objectName, extensionObjectList)
+	foreach_declared_ptr(objectName, extensionObjectList)
 	{
 		/*
 		 * We set missingOk to false as we assume all the objects in
@@ -527,7 +527,7 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	List *citusTableIdList = CitusTableTypeIdList(ANY_CITUS_TABLE_TYPE);
 
 	Oid citusTableId = InvalidOid;
-	foreach_oid(citusTableId, citusTableIdList)
+	foreach_declared_oid(citusTableId, citusTableIdList)
 	{
 		if (!ShouldMarkRelationDistributed(citusTableId))
 		{
@@ -571,7 +571,7 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	 */
 	List *viewList = GetAllViews();
 	Oid viewOid = InvalidOid;
-	foreach_oid(viewOid, viewList)
+	foreach_declared_oid(viewOid, viewList)
 	{
 		if (!ShouldMarkRelationDistributed(viewOid))
 		{
@@ -605,7 +605,7 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	List *distributedObjectAddressList = GetDistributedObjectAddressList();
 
 	ObjectAddress *distributedObjectAddress = NULL;
-	foreach_ptr(distributedObjectAddress, distributedObjectAddressList)
+	foreach_declared_ptr(distributedObjectAddress, distributedObjectAddressList)
 	{
 		List *distributableDependencyObjectAddresses =
 			GetDistributableDependenciesForObject(distributedObjectAddress);
@@ -627,7 +627,7 @@ MarkExistingObjectDependenciesDistributedIfSupported()
 	SetLocalEnableMetadataSync(false);
 
 	ObjectAddress *objectAddress = NULL;
-	foreach_ptr(objectAddress, uniqueObjectAddresses)
+	foreach_declared_ptr(objectAddress, uniqueObjectAddresses)
 	{
 		MarkObjectDistributed(objectAddress);
 	}
@@ -831,7 +831,7 @@ IsDropCitusExtensionStmt(Node *parseTree)
 
 	/* now that we have a DropStmt, check if citus extension is among the objects to dropped */
 	String *objectName;
-	foreach_ptr(objectName, dropStmt->objects)
+	foreach_declared_ptr(objectName, dropStmt->objects)
 	{
 		const char *extensionName = strVal(objectName);
 
@@ -1061,7 +1061,7 @@ GenerateGrantCommandsOnExtensionDependentFDWs(Oid extensionId)
 	List *FDWOids = GetDependentFDWsToExtension(extensionId);
 
 	Oid FDWOid = InvalidOid;
-	foreach_oid(FDWOid, FDWOids)
+	foreach_declared_oid(FDWOid, FDWOids)
 	{
 		Acl *aclEntry = GetPrivilegesForFDW(FDWOid);
 

--- a/src/backend/distributed/commands/foreign_constraint.c
+++ b/src/backend/distributed/commands/foreign_constraint.c
@@ -202,7 +202,7 @@ ErrorIfUnsupportedForeignConstraintExists(Relation relation, char referencingDis
 	List *foreignKeyOids = GetForeignKeyOids(referencingTableId, flags);
 
 	Oid foreignKeyOid = InvalidOid;
-	foreach_oid(foreignKeyOid, foreignKeyOids)
+	foreach_declared_oid(foreignKeyOid, foreignKeyOids)
 	{
 		HeapTuple heapTuple = SearchSysCache1(CONSTROID, ObjectIdGetDatum(foreignKeyOid));
 
@@ -414,7 +414,7 @@ ForeignKeySetsNextValColumnToDefault(HeapTuple pgConstraintTuple)
 
 	List *setDefaultAttrs = ForeignKeyGetDefaultingAttrs(pgConstraintTuple);
 	AttrNumber setDefaultAttr = InvalidAttrNumber;
-	foreach_int(setDefaultAttr, setDefaultAttrs)
+	foreach_declared_int(setDefaultAttr, setDefaultAttrs)
 	{
 		if (ColumnDefaultsToNextVal(pgConstraintForm->conrelid, setDefaultAttr))
 		{
@@ -727,7 +727,7 @@ ColumnAppearsInForeignKeyToReferenceTable(char *columnName, Oid relationId)
 		GetForeignKeyIdsForColumn(columnName, relationId, searchForeignKeyColumnFlags);
 
 	Oid foreignKeyId = InvalidOid;
-	foreach_oid(foreignKeyId, foreignKeyIdsColumnAppeared)
+	foreach_declared_oid(foreignKeyId, foreignKeyIdsColumnAppeared)
 	{
 		Oid referencedTableId = GetReferencedTableId(foreignKeyId);
 		if (IsCitusTableType(referencedTableId, REFERENCE_TABLE))
@@ -901,7 +901,7 @@ GetForeignConstraintCommandsInternal(Oid relationId, int flags)
 	int saveNestLevel = PushEmptySearchPath();
 
 	Oid foreignKeyOid = InvalidOid;
-	foreach_oid(foreignKeyOid, foreignKeyOids)
+	foreach_declared_oid(foreignKeyOid, foreignKeyOids)
 	{
 		char *statementDef = pg_get_constraintdef_command(foreignKeyOid);
 
@@ -1157,7 +1157,7 @@ static Oid
 FindForeignKeyOidWithName(List *foreignKeyOids, const char *inputConstraintName)
 {
 	Oid foreignKeyOid = InvalidOid;
-	foreach_oid(foreignKeyOid, foreignKeyOids)
+	foreach_declared_oid(foreignKeyOid, foreignKeyOids)
 	{
 		char *constraintName = get_constraint_name(foreignKeyOid);
 
@@ -1472,7 +1472,7 @@ RelationInvolvedInAnyNonInheritedForeignKeys(Oid relationId)
 	List *foreignKeysRelationInvolved = list_concat(referencingForeignKeys,
 													referencedForeignKeys);
 	Oid foreignKeyId = InvalidOid;
-	foreach_oid(foreignKeyId, foreignKeysRelationInvolved)
+	foreach_declared_oid(foreignKeyId, foreignKeysRelationInvolved)
 	{
 		HeapTuple heapTuple = SearchSysCache1(CONSTROID, ObjectIdGetDatum(foreignKeyId));
 		if (!HeapTupleIsValid(heapTuple))

--- a/src/backend/distributed/commands/foreign_data_wrapper.c
+++ b/src/backend/distributed/commands/foreign_data_wrapper.c
@@ -86,7 +86,7 @@ static bool
 NameListHasFDWOwnedByDistributedExtension(List *FDWNames)
 {
 	String *FDWValue = NULL;
-	foreach_ptr(FDWValue, FDWNames)
+	foreach_declared_ptr(FDWValue, FDWNames)
 	{
 		/* captures the extension address during lookup */
 		ObjectAddress *extensionAddress = palloc0(sizeof(ObjectAddress));

--- a/src/backend/distributed/commands/foreign_server.c
+++ b/src/backend/distributed/commands/foreign_server.c
@@ -229,7 +229,7 @@ RecreateForeignServerStmt(Oid serverId)
 
 	int location = -1;
 	DefElem *option = NULL;
-	foreach_ptr(option, server->options)
+	foreach_declared_ptr(option, server->options)
 	{
 		DefElem *copyOption = makeDefElem(option->defname, option->arg, location);
 		createStmt->options = lappend(createStmt->options, copyOption);
@@ -247,7 +247,7 @@ static bool
 NameListHasDistributedServer(List *serverNames)
 {
 	String *serverValue = NULL;
-	foreach_ptr(serverValue, serverNames)
+	foreach_declared_ptr(serverValue, serverNames)
 	{
 		List *addresses = GetObjectAddressByServerName(strVal(serverValue), false);
 

--- a/src/backend/distributed/commands/function.c
+++ b/src/backend/distributed/commands/function.c
@@ -256,7 +256,7 @@ create_distributed_function(PG_FUNCTION_ARGS)
 						 createFunctionSQL, alterFunctionOwnerSQL);
 		List *grantDDLCommands = GrantOnFunctionDDLCommands(funcOid);
 		char *grantOnFunctionSQL = NULL;
-		foreach_ptr(grantOnFunctionSQL, grantDDLCommands)
+		foreach_declared_ptr(grantOnFunctionSQL, grantDDLCommands)
 		{
 			appendStringInfo(&ddlCommand, ";%s", grantOnFunctionSQL);
 		}
@@ -370,7 +370,7 @@ ErrorIfAnyNodeDoesNotHaveMetadata(void)
 		ActivePrimaryNonCoordinatorNodeList(ShareLock);
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if (!workerNode->hasMetadata)
 		{
@@ -1477,7 +1477,7 @@ CreateFunctionStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 	objectWithArgs->objname = stmt->funcname;
 
 	FunctionParameter *funcParam = NULL;
-	foreach_ptr(funcParam, stmt->parameters)
+	foreach_declared_ptr(funcParam, stmt->parameters)
 	{
 		if (ShouldAddFunctionSignature(funcParam->mode))
 		{
@@ -1520,7 +1520,7 @@ DefineAggregateStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess
 	if (stmt->args != NIL)
 	{
 		FunctionParameter *funcParam = NULL;
-		foreach_ptr(funcParam, linitial(stmt->args))
+		foreach_declared_ptr(funcParam, linitial(stmt->args))
 		{
 			objectWithArgs->objargs = lappend(objectWithArgs->objargs,
 											  funcParam->argType);
@@ -1529,7 +1529,7 @@ DefineAggregateStmtObjectAddress(Node *node, bool missing_ok, bool isPostprocess
 	else
 	{
 		DefElem *defItem = NULL;
-		foreach_ptr(defItem, stmt->definition)
+		foreach_declared_ptr(defItem, stmt->definition)
 		{
 			/*
 			 * If no explicit args are given, pg includes basetype in the signature.
@@ -1934,7 +1934,7 @@ static void
 ErrorIfUnsupportedAlterFunctionStmt(AlterFunctionStmt *stmt)
 {
 	DefElem *action = NULL;
-	foreach_ptr(action, stmt->actions)
+	foreach_declared_ptr(action, stmt->actions)
 	{
 		if (strcmp(action->defname, "set") == 0)
 		{
@@ -2041,7 +2041,7 @@ PreprocessGrantOnFunctionStmt(Node *node, const char *queryString,
 
 	List *grantFunctionList = NIL;
 	ObjectAddress *functionAddress = NULL;
-	foreach_ptr(functionAddress, distributedFunctions)
+	foreach_declared_ptr(functionAddress, distributedFunctions)
 	{
 		ObjectWithArgs *distFunction = ObjectWithArgsFromOid(
 			functionAddress->objectId);
@@ -2084,7 +2084,7 @@ PostprocessGrantOnFunctionStmt(Node *node, const char *queryString)
 	}
 
 	ObjectAddress *functionAddress = NULL;
-	foreach_ptr(functionAddress, distributedFunctions)
+	foreach_declared_ptr(functionAddress, distributedFunctions)
 	{
 		EnsureAllObjectDependenciesExistOnAllNodes(list_make1(functionAddress));
 	}
@@ -2121,7 +2121,7 @@ FilterDistributedFunctions(GrantStmt *grantStmt)
 
 		/* iterate over all namespace names provided to get their oid's */
 		String *namespaceValue = NULL;
-		foreach_ptr(namespaceValue, grantStmt->objects)
+		foreach_declared_ptr(namespaceValue, grantStmt->objects)
 		{
 			char *nspname = strVal(namespaceValue);
 			bool missing_ok = false;
@@ -2133,7 +2133,7 @@ FilterDistributedFunctions(GrantStmt *grantStmt)
 		 * iterate over all distributed functions to filter the ones
 		 * that belong to one of the namespaces from above
 		 */
-		foreach_ptr(distributedFunction, distributedFunctionList)
+		foreach_declared_ptr(distributedFunction, distributedFunctionList)
 		{
 			Oid namespaceOid = get_func_namespace(distributedFunction->objectId);
 
@@ -2152,7 +2152,7 @@ FilterDistributedFunctions(GrantStmt *grantStmt)
 	{
 		bool missingOk = false;
 		ObjectWithArgs *objectWithArgs = NULL;
-		foreach_ptr(objectWithArgs, grantStmt->objects)
+		foreach_declared_ptr(objectWithArgs, grantStmt->objects)
 		{
 			ObjectAddress *functionAddress = palloc0(sizeof(ObjectAddress));
 			functionAddress->classId = ProcedureRelationId;

--- a/src/backend/distributed/commands/index.c
+++ b/src/backend/distributed/commands/index.c
@@ -334,7 +334,7 @@ ExecuteFunctionOnEachTableIndex(Oid relationId, PGIndexProcessor pgIndexProcesso
 
 	List *indexIdList = RelationGetIndexList(relation);
 	Oid indexId = InvalidOid;
-	foreach_oid(indexId, indexIdList)
+	foreach_declared_oid(indexId, indexIdList)
 	{
 		HeapTuple indexTuple = SearchSysCache1(INDEXRELID, ObjectIdGetDatum(indexId));
 		if (!HeapTupleIsValid(indexTuple))
@@ -703,7 +703,7 @@ PreprocessDropIndexStmt(Node *node, const char *dropIndexCommand,
 
 	/* check if any of the indexes being dropped belong to a distributed table */
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, dropIndexStatement->objects)
+	foreach_declared_ptr(objectNameList, dropIndexStatement->objects)
 	{
 		struct DropRelationCallbackState state;
 		uint32 rvrFlags = RVR_MISSING_OK;
@@ -874,7 +874,7 @@ ErrorIfUnsupportedAlterIndexStmt(AlterTableStmt *alterTableStatement)
 	/* error out if any of the subcommands are unsupported */
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -926,7 +926,7 @@ CreateIndexTaskList(IndexStmt *indexStmt)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 
@@ -971,7 +971,7 @@ CreateReindexTaskList(Oid relationId, ReindexStmt *reindexStmt)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 
@@ -1220,7 +1220,7 @@ ErrorIfUnsupportedIndexStmt(IndexStmt *createIndexStatement)
 		Var *partitionKey = DistPartitionKeyOrError(relationId);
 		List *indexParameterList = createIndexStatement->indexParams;
 		IndexElem *indexElement = NULL;
-		foreach_ptr(indexElement, indexParameterList)
+		foreach_declared_ptr(indexElement, indexParameterList)
 		{
 			const char *columnName = indexElement->name;
 
@@ -1289,7 +1289,7 @@ DropIndexTaskList(Oid relationId, Oid indexId, DropStmt *dropStmt)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		char *shardIndexName = pstrdup(indexName);

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -1957,7 +1957,7 @@ ShardIntervalListHasLocalPlacements(List *shardIntervalList)
 {
 	int32 localGroupId = GetLocalGroupId();
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		if (ActiveShardPlacementOnGroup(localGroupId, shardInterval->shardId) != NULL)
 		{
@@ -2452,7 +2452,7 @@ ProcessAppendToShardOption(Oid relationId, CopyStmt *copyStatement)
 	bool appendToShardSet = false;
 
 	DefElem *defel = NULL;
-	foreach_ptr(defel, copyStatement->options)
+	foreach_declared_ptr(defel, copyStatement->options)
 	{
 		if (strncmp(defel->defname, APPEND_TO_SHARD_OPTION, NAMEDATALEN) == 0)
 		{

--- a/src/backend/distributed/commands/policy.c
+++ b/src/backend/distributed/commands/policy.c
@@ -48,7 +48,7 @@ CreatePolicyCommands(Oid relationId)
 	List *policyList = GetPolicyListForRelation(relationId);
 
 	RowSecurityPolicy *policy;
-	foreach_ptr(policy, policyList)
+	foreach_declared_ptr(policy, policyList)
 	{
 		char *createPolicyCommand = CreatePolicyCommandForPolicy(relationId, policy);
 		commands = lappend(commands, makeTableDDLCommandString(createPolicyCommand));
@@ -88,7 +88,7 @@ GetPolicyListForRelation(Oid relationId)
 	List *policyList = NIL;
 
 	RowSecurityPolicy *policy;
-	foreach_ptr(policy, relation->rd_rsdesc->policies)
+	foreach_declared_ptr(policy, relation->rd_rsdesc->policies)
 	{
 		policyList = lappend(policyList, policy);
 	}
@@ -310,7 +310,7 @@ GetPolicyByName(Oid relationId, const char *policyName)
 	List *policyList = GetPolicyListForRelation(relationId);
 
 	RowSecurityPolicy *policy = NULL;
-	foreach_ptr(policy, policyList)
+	foreach_declared_ptr(policy, policyList)
 	{
 		if (strncmp(policy->policy_name, policyName, NAMEDATALEN) == 0)
 		{

--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -158,7 +158,7 @@ BuildCreatePublicationStmt(Oid publicationId)
 	List *schemaIds = GetPublicationSchemas(publicationId);
 	Oid schemaId = InvalidOid;
 
-	foreach_oid(schemaId, schemaIds)
+	foreach_declared_oid(schemaId, schemaIds)
 	{
 		char *schemaName = get_namespace_name(schemaId);
 
@@ -182,7 +182,7 @@ BuildCreatePublicationStmt(Oid publicationId)
 	/* mainly for consistent ordering in test output */
 	relationIds = SortList(relationIds, CompareOids);
 
-	foreach_oid(relationId, relationIds)
+	foreach_declared_oid(relationId, relationIds)
 	{
 #if (PG_VERSION_NUM >= PG_VERSION_15)
 		bool tableOnly = false;
@@ -420,7 +420,7 @@ GetAlterPublicationDDLCommandsForTable(Oid relationId, bool isAdd)
 	List *publicationIds = GetRelationPublications(relationId);
 	Oid publicationId = InvalidOid;
 
-	foreach_oid(publicationId, publicationIds)
+	foreach_declared_oid(publicationId, publicationIds)
 	{
 		char *command = GetAlterPublicationTableDDLCommand(publicationId,
 														   relationId, isAdd);

--- a/src/backend/distributed/commands/role.c
+++ b/src/backend/distributed/commands/role.c
@@ -161,7 +161,7 @@ PostprocessAlterRoleStmt(Node *node, const char *queryString)
 	AlterRoleStmt *stmt = castNode(AlterRoleStmt, node);
 
 	DefElem *option = NULL;
-	foreach_ptr(option, stmt->options)
+	foreach_declared_ptr(option, stmt->options)
 	{
 		if (strcasecmp(option->defname, "password") == 0)
 		{
@@ -562,7 +562,7 @@ GenerateCreateOrAlterRoleCommand(Oid roleOid)
 	{
 		List *grantRoleStmts = GenerateGrantRoleStmtsOfRole(roleOid);
 		Node *stmt = NULL;
-		foreach_ptr(stmt, grantRoleStmts)
+		foreach_declared_ptr(stmt, grantRoleStmts)
 		{
 			completeRoleList = lappend(completeRoleList, DeparseTreeNode(stmt));
 		}
@@ -760,7 +760,7 @@ MakeSetStatementArguments(char *configurationName, char *configurationValue)
 				}
 
 				char *configuration = NULL;
-				foreach_ptr(configuration, configurationList)
+				foreach_declared_ptr(configuration, configurationList)
 				{
 					Node *arg = makeStringConst(configuration, -1);
 					args = lappend(args, arg);
@@ -796,7 +796,7 @@ GenerateGrantRoleStmtsFromOptions(RoleSpec *roleSpec, List *options)
 	List *stmts = NIL;
 
 	DefElem *option = NULL;
-	foreach_ptr(option, options)
+	foreach_declared_ptr(option, options)
 	{
 		if (strcmp(option->defname, "adminmembers") != 0 &&
 			strcmp(option->defname, "rolemembers") != 0 &&
@@ -938,7 +938,7 @@ PreprocessCreateRoleStmt(Node *node, const char *queryString,
 
 	/* deparse all grant statements and add them to the commands list */
 	Node *stmt = NULL;
-	foreach_ptr(stmt, grantRoleStmts)
+	foreach_declared_ptr(stmt, grantRoleStmts)
 	{
 		commands = lappend(commands, DeparseTreeNode(stmt));
 	}
@@ -1064,7 +1064,7 @@ void
 UnmarkRolesDistributed(List *roles)
 {
 	Node *roleNode = NULL;
-	foreach_ptr(roleNode, roles)
+	foreach_declared_ptr(roleNode, roles)
 	{
 		RoleSpec *role = castNode(RoleSpec, roleNode);
 		ObjectAddress roleAddress = { 0 };
@@ -1094,7 +1094,7 @@ FilterDistributedRoles(List *roles)
 {
 	List *distributedRoles = NIL;
 	Node *roleNode = NULL;
-	foreach_ptr(roleNode, roles)
+	foreach_declared_ptr(roleNode, roles)
 	{
 		RoleSpec *role = castNode(RoleSpec, roleNode);
 		Oid roleOid = get_rolespec_oid(role, true);
@@ -1189,7 +1189,7 @@ PostprocessGrantRoleStmt(Node *node, const char *queryString)
 	GrantRoleStmt *stmt = castNode(GrantRoleStmt, node);
 
 	RoleSpec *role = NULL;
-	foreach_ptr(role, stmt->grantee_roles)
+	foreach_declared_ptr(role, stmt->grantee_roles)
 	{
 		Oid roleOid = get_rolespec_oid(role, false);
 		ObjectAddress *roleAddress = palloc0(sizeof(ObjectAddress));
@@ -1213,7 +1213,7 @@ IsGrantRoleWithInheritOrSetOption(GrantRoleStmt *stmt)
 {
 #if PG_VERSION_NUM >= PG_VERSION_16
 	DefElem *opt = NULL;
-	foreach_ptr(opt, stmt->opt)
+	foreach_declared_ptr(opt, stmt->opt)
 	{
 		if (strcmp(opt->defname, "inherit") == 0 || strcmp(opt->defname, "set") == 0)
 		{

--- a/src/backend/distributed/commands/schema.c
+++ b/src/backend/distributed/commands/schema.c
@@ -162,7 +162,7 @@ PreprocessDropSchemaStmt(Node *node, const char *queryString,
 	EnsureSequentialMode(OBJECT_SCHEMA);
 
 	String *schemaVal = NULL;
-	foreach_ptr(schemaVal, distributedSchemas)
+	foreach_declared_ptr(schemaVal, distributedSchemas)
 	{
 		if (SchemaHasDistributedTableWithFKey(strVal(schemaVal)))
 		{
@@ -322,7 +322,7 @@ FilterDistributedSchemas(List *schemas)
 	List *distributedSchemas = NIL;
 
 	String *schemaValue = NULL;
-	foreach_ptr(schemaValue, schemas)
+	foreach_declared_ptr(schemaValue, schemas)
 	{
 		const char *schemaName = strVal(schemaValue);
 		Oid schemaOid = get_namespace_oid(schemaName, true);
@@ -443,7 +443,7 @@ GetGrantCommandsFromCreateSchemaStmt(Node *node)
 	CreateSchemaStmt *stmt = castNode(CreateSchemaStmt, node);
 
 	Node *element = NULL;
-	foreach_ptr(element, stmt->schemaElts)
+	foreach_declared_ptr(element, stmt->schemaElts)
 	{
 		if (!IsA(element, GrantStmt))
 		{
@@ -480,7 +480,7 @@ static bool
 CreateSchemaStmtCreatesTable(CreateSchemaStmt *stmt)
 {
 	Node *element = NULL;
-	foreach_ptr(element, stmt->schemaElts)
+	foreach_declared_ptr(element, stmt->schemaElts)
 	{
 		/*
 		 * CREATE TABLE AS and CREATE FOREIGN TABLE commands cannot be

--- a/src/backend/distributed/commands/schema_based_sharding.c
+++ b/src/backend/distributed/commands/schema_based_sharding.c
@@ -174,7 +174,7 @@ EnsureTableKindSupportedForTenantSchema(Oid relationId)
 		List *partitionList = PartitionList(relationId);
 
 		Oid partitionRelationId = InvalidOid;
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			ErrorIfIllegalPartitioningInTenantSchema(relationId, partitionRelationId);
 		}
@@ -199,7 +199,7 @@ EnsureFKeysForTenantTable(Oid relationId)
 	int fKeyReferencingFlags = INCLUDE_REFERENCING_CONSTRAINTS | INCLUDE_ALL_TABLE_TYPES;
 	List *referencingForeignKeys = GetForeignKeyOids(relationId, fKeyReferencingFlags);
 	Oid foreignKeyId = InvalidOid;
-	foreach_oid(foreignKeyId, referencingForeignKeys)
+	foreach_declared_oid(foreignKeyId, referencingForeignKeys)
 	{
 		Oid referencingTableId = GetReferencingTableId(foreignKeyId);
 		Oid referencedTableId = GetReferencedTableId(foreignKeyId);
@@ -232,7 +232,7 @@ EnsureFKeysForTenantTable(Oid relationId)
 
 	int fKeyReferencedFlags = INCLUDE_REFERENCED_CONSTRAINTS | INCLUDE_ALL_TABLE_TYPES;
 	List *referencedForeignKeys = GetForeignKeyOids(relationId, fKeyReferencedFlags);
-	foreach_oid(foreignKeyId, referencedForeignKeys)
+	foreach_declared_oid(foreignKeyId, referencedForeignKeys)
 	{
 		Oid referencingTableId = GetReferencingTableId(foreignKeyId);
 		Oid referencedTableId = GetReferencedTableId(foreignKeyId);
@@ -429,7 +429,7 @@ EnsureSchemaCanBeDistributed(Oid schemaId, List *schemaTableIdList)
 	}
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, schemaTableIdList)
+	foreach_declared_oid(relationId, schemaTableIdList)
 	{
 		EnsureTenantTable(relationId, "citus_schema_distribute");
 	}
@@ -637,7 +637,7 @@ citus_schema_distribute(PG_FUNCTION_ARGS)
 	List *tableIdListInSchema = SchemaGetNonShardTableIdList(schemaId);
 	List *tableIdListToConvert = NIL;
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, tableIdListInSchema)
+	foreach_declared_oid(relationId, tableIdListInSchema)
 	{
 		/* prevent concurrent drop of the relation */
 		LockRelationOid(relationId, AccessShareLock);
@@ -675,7 +675,7 @@ citus_schema_distribute(PG_FUNCTION_ARGS)
 	 * tables.
 	 */
 	List *originalForeignKeyRecreationCommands = NIL;
-	foreach_oid(relationId, tableIdListToConvert)
+	foreach_declared_oid(relationId, tableIdListToConvert)
 	{
 		List *fkeyCommandsForRelation =
 			GetFKeyCreationCommandsRelationInvolvedWithTableType(relationId,
@@ -741,7 +741,7 @@ citus_schema_undistribute(PG_FUNCTION_ARGS)
 	List *tableIdListInSchema = SchemaGetNonShardTableIdList(schemaId);
 	List *tableIdListToConvert = NIL;
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, tableIdListInSchema)
+	foreach_declared_oid(relationId, tableIdListInSchema)
 	{
 		/* prevent concurrent drop of the relation */
 		LockRelationOid(relationId, AccessShareLock);
@@ -883,7 +883,7 @@ TenantSchemaPickAnchorShardId(Oid schemaId)
 	}
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, tablesInSchema)
+	foreach_declared_oid(relationId, tablesInSchema)
 	{
 		/*
 		 * Make sure the relation isn't dropped for the remainder of

--- a/src/backend/distributed/commands/sequence.c
+++ b/src/backend/distributed/commands/sequence.c
@@ -123,7 +123,7 @@ static bool
 OptionsSpecifyOwnedBy(List *optionList, Oid *ownedByTableId)
 {
 	DefElem *defElem = NULL;
-	foreach_ptr(defElem, optionList)
+	foreach_declared_ptr(defElem, optionList)
 	{
 		if (strcmp(defElem->defname, "owned_by") == 0)
 		{
@@ -202,7 +202,7 @@ ExtractDefaultColumnsAndOwnedSequences(Oid relationId, List **columnNameList,
 		}
 
 		Oid ownedSequenceId = InvalidOid;
-		foreach_oid(ownedSequenceId, columnOwnedSequences)
+		foreach_declared_oid(ownedSequenceId, columnOwnedSequences)
 		{
 			/*
 			 * A column might have multiple sequences one via OWNED BY one another
@@ -288,7 +288,7 @@ PreprocessDropSequenceStmt(Node *node, const char *queryString,
 	 */
 	List *deletingSequencesList = stmt->objects;
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, deletingSequencesList)
+	foreach_declared_ptr(objectNameList, deletingSequencesList)
 	{
 		RangeVar *seq = makeRangeVarFromNameList(objectNameList);
 
@@ -322,7 +322,7 @@ PreprocessDropSequenceStmt(Node *node, const char *queryString,
 
 	/* remove the entries for the distributed objects on dropping */
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, distributedSequenceAddresses)
+	foreach_declared_ptr(address, distributedSequenceAddresses)
 	{
 		UnmarkObjectDistributed(address);
 	}
@@ -356,7 +356,7 @@ SequenceDropStmtObjectAddress(Node *stmt, bool missing_ok, bool isPostprocess)
 
 	List *droppingSequencesList = dropSeqStmt->objects;
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, droppingSequencesList)
+	foreach_declared_ptr(objectNameList, droppingSequencesList)
 	{
 		RangeVar *seq = makeRangeVarFromNameList(objectNameList);
 
@@ -476,7 +476,7 @@ PreprocessAlterSequenceStmt(Node *node, const char *queryString,
 	{
 		List *options = stmt->options;
 		DefElem *defel = NULL;
-		foreach_ptr(defel, options)
+		foreach_declared_ptr(defel, options)
 		{
 			if (strcmp(defel->defname, "as") == 0)
 			{
@@ -511,7 +511,7 @@ SequenceUsedInDistributedTable(const ObjectAddress *sequenceAddress, char depTyp
 	Oid relationId;
 	List *relations = GetDependentRelationsWithSequence(sequenceAddress->objectId,
 														depType);
-	foreach_oid(relationId, relations)
+	foreach_declared_oid(relationId, relations)
 	{
 		if (IsCitusTable(relationId))
 		{
@@ -930,7 +930,7 @@ PostprocessGrantOnSequenceStmt(Node *node, const char *queryString)
 	EnsureCoordinator();
 
 	RangeVar *sequence = NULL;
-	foreach_ptr(sequence, distributedSequences)
+	foreach_declared_ptr(sequence, distributedSequences)
 	{
 		ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));
 		Oid sequenceOid = RangeVarGetRelid(sequence, NoLock, false);
@@ -1014,7 +1014,7 @@ FilterDistributedSequences(GrantStmt *stmt)
 		/* iterate over all namespace names provided to get their oid's */
 		List *namespaceOidList = NIL;
 		String *namespaceValue = NULL;
-		foreach_ptr(namespaceValue, stmt->objects)
+		foreach_declared_ptr(namespaceValue, stmt->objects)
 		{
 			char *nspname = strVal(namespaceValue);
 			bool missing_ok = false;
@@ -1028,7 +1028,7 @@ FilterDistributedSequences(GrantStmt *stmt)
 		 */
 		List *distributedSequenceList = DistributedSequenceList();
 		ObjectAddress *sequenceAddress = NULL;
-		foreach_ptr(sequenceAddress, distributedSequenceList)
+		foreach_declared_ptr(sequenceAddress, distributedSequenceList)
 		{
 			Oid namespaceOid = get_rel_namespace(sequenceAddress->objectId);
 
@@ -1052,7 +1052,7 @@ FilterDistributedSequences(GrantStmt *stmt)
 	{
 		bool missing_ok = false;
 		RangeVar *sequenceRangeVar = NULL;
-		foreach_ptr(sequenceRangeVar, stmt->objects)
+		foreach_declared_ptr(sequenceRangeVar, stmt->objects)
 		{
 			Oid sequenceOid = RangeVarGetRelid(sequenceRangeVar, NoLock, missing_ok);
 			ObjectAddress *sequenceAddress = palloc0(sizeof(ObjectAddress));

--- a/src/backend/distributed/commands/statistics.c
+++ b/src/backend/distributed/commands/statistics.c
@@ -184,7 +184,7 @@ PreprocessDropStatisticsStmt(Node *node, const char *queryString,
 	List *ddlJobs = NIL;
 	List *processedStatsOids = NIL;
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, dropStatisticsStmt->objects)
+	foreach_declared_ptr(objectNameList, dropStatisticsStmt->objects)
 	{
 		Oid statsOid = get_statistics_object_oid(objectNameList,
 												 dropStatisticsStmt->missing_ok);
@@ -234,7 +234,7 @@ DropStatisticsObjectAddress(Node *node, bool missing_ok, bool isPostprocess)
 	List *objectAddresses = NIL;
 
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, dropStatisticsStmt->objects)
+	foreach_declared_ptr(objectNameList, dropStatisticsStmt->objects)
 	{
 		Oid statsOid = get_statistics_object_oid(objectNameList,
 												 dropStatisticsStmt->missing_ok);
@@ -535,7 +535,7 @@ GetExplicitStatisticsCommandList(Oid relationId)
 	int saveNestLevel = PushEmptySearchPath();
 
 	Oid statisticsId = InvalidOid;
-	foreach_oid(statisticsId, statisticsIdList)
+	foreach_declared_oid(statisticsId, statisticsIdList)
 	{
 		/* we need create commands for already created stats before distribution */
 		Datum commandText = DirectFunctionCall1(pg_get_statisticsobjdef,
@@ -606,7 +606,7 @@ GetExplicitStatisticsSchemaIdList(Oid relationId)
 	RelationClose(relation);
 
 	Oid statsId = InvalidOid;
-	foreach_oid(statsId, statsIdList)
+	foreach_declared_oid(statsId, statsIdList)
 	{
 		HeapTuple heapTuple = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(statsId));
 		if (!HeapTupleIsValid(heapTuple))

--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -154,7 +154,7 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 	Assert(dropTableStatement->removeType == OBJECT_TABLE);
 
 	List *tableNameList = NULL;
-	foreach_ptr(tableNameList, dropTableStatement->objects)
+	foreach_declared_ptr(tableNameList, dropTableStatement->objects)
 	{
 		RangeVar *tableRangeVar = makeRangeVarFromNameList(tableNameList);
 		bool missingOK = true;
@@ -202,7 +202,7 @@ PreprocessDropTableStmt(Node *node, const char *queryString,
 		SendCommandToWorkersWithMetadata(DISABLE_DDL_PROPAGATION);
 
 		Oid partitionRelationId = InvalidOid;
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			char *detachPartitionCommand =
 				GenerateDetachPartitionCommand(partitionRelationId);
@@ -263,7 +263,7 @@ PostprocessCreateTableStmt(CreateStmt *createStatement, const char *queryString)
 			}
 
 			RangeVar *parentRelation = NULL;
-			foreach_ptr(parentRelation, createStatement->inhRelations)
+			foreach_declared_ptr(parentRelation, createStatement->inhRelations)
 			{
 				Oid parentRelationId = RangeVarGetRelid(parentRelation, NoLock,
 														missingOk);
@@ -480,7 +480,7 @@ PreprocessAlterTableStmtAttachPartition(AlterTableStmt *alterTableStatement,
 {
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *alterTableCommand = NULL;
-	foreach_ptr(alterTableCommand, commandList)
+	foreach_declared_ptr(alterTableCommand, commandList)
 	{
 		if (alterTableCommand->subtype == AT_AttachPartition)
 		{
@@ -792,7 +792,7 @@ ChooseForeignKeyConstraintNameAddition(List *columnNames)
 
 	String *columnNameString = NULL;
 
-	foreach_ptr(columnNameString, columnNames)
+	foreach_declared_ptr(columnNameString, columnNames)
 	{
 		const char *name = strVal(columnNameString);
 
@@ -1314,7 +1314,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 	AlterTableCmd *newCmd = makeNode(AlterTableCmd);
 
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -1418,7 +1418,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 			List *columnConstraints = columnDefinition->constraints;
 
 			Constraint *constraint = NULL;
-			foreach_ptr(constraint, columnConstraints)
+			foreach_declared_ptr(constraint, columnConstraints)
 			{
 				if (constraint->contype == CONSTR_FOREIGN)
 				{
@@ -1442,7 +1442,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 				deparseAT = true;
 
 				constraint = NULL;
-				foreach_ptr(constraint, columnConstraints)
+				foreach_declared_ptr(constraint, columnConstraints)
 				{
 					if (ConstrTypeCitusCanDefaultName(constraint->contype))
 					{
@@ -1467,7 +1467,7 @@ PreprocessAlterTableStmt(Node *node, const char *alterTableCommand,
 			 */
 			constraint = NULL;
 			int constraintIdx = 0;
-			foreach_ptr(constraint, columnConstraints)
+			foreach_declared_ptr(constraint, columnConstraints)
 			{
 				if (constraint->contype == CONSTR_DEFAULT)
 				{
@@ -1696,7 +1696,7 @@ DeparserSupportsAlterTableAddColumn(AlterTableStmt *alterTableStatement,
 	{
 		ColumnDef *columnDefinition = (ColumnDef *) addColumnSubCommand->def;
 		Constraint *constraint = NULL;
-		foreach_ptr(constraint, columnDefinition->constraints)
+		foreach_declared_ptr(constraint, columnDefinition->constraints)
 		{
 			if (constraint->contype == CONSTR_CHECK)
 			{
@@ -1792,7 +1792,7 @@ static bool
 RelationIdListContainsCitusTableType(List *relationIdList, CitusTableType citusTableType)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (IsCitusTableType(relationId, citusTableType))
 		{
@@ -1812,7 +1812,7 @@ static bool
 RelationIdListContainsPostgresTable(List *relationIdList)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (OidIsValid(relationId) && !IsCitusTable(relationId))
 		{
@@ -1851,7 +1851,7 @@ ConvertPostgresLocalTablesToCitusLocalTables(AlterTableStmt *alterTableStatement
 	 * change in below loop due to CreateCitusLocalTable.
 	 */
 	RangeVar *relationRangeVar;
-	foreach_ptr(relationRangeVar, relationRangeVarList)
+	foreach_declared_ptr(relationRangeVar, relationRangeVarList)
 	{
 		List *commandList = alterTableStatement->cmds;
 		LOCKMODE lockMode = AlterTableGetLockLevel(commandList);
@@ -1979,7 +1979,7 @@ RangeVarListHasLocalRelationConvertedByUser(List *relationRangeVarList,
 											AlterTableStmt *alterTableStatement)
 {
 	RangeVar *relationRangeVar;
-	foreach_ptr(relationRangeVar, relationRangeVarList)
+	foreach_declared_ptr(relationRangeVar, relationRangeVarList)
 	{
 		/*
 		 * Here we iterate the relation list, and if at least one of the relations
@@ -2076,7 +2076,7 @@ GetAlterTableAddFKeyConstraintList(AlterTableStmt *alterTableStatement)
 
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		List *commandForeignKeyConstraintList =
 			GetAlterTableCommandFKeyConstraintList(command);
@@ -2116,7 +2116,7 @@ GetAlterTableCommandFKeyConstraintList(AlterTableCmd *command)
 		List *columnConstraints = columnDefinition->constraints;
 
 		Constraint *constraint = NULL;
-		foreach_ptr(constraint, columnConstraints)
+		foreach_declared_ptr(constraint, columnConstraints)
 		{
 			if (constraint->contype == CONSTR_FOREIGN)
 			{
@@ -2139,7 +2139,7 @@ GetRangeVarListFromFKeyConstraintList(List *fKeyConstraintList)
 	List *rightRelationRangeVarList = NIL;
 
 	Constraint *fKeyConstraint = NULL;
-	foreach_ptr(fKeyConstraint, fKeyConstraintList)
+	foreach_declared_ptr(fKeyConstraint, fKeyConstraintList)
 	{
 		RangeVar *rightRelationRangeVar = fKeyConstraint->pktable;
 		rightRelationRangeVarList = lappend(rightRelationRangeVarList,
@@ -2160,7 +2160,7 @@ GetRelationIdListFromRangeVarList(List *rangeVarList, LOCKMODE lockMode, bool mi
 	List *relationIdList = NIL;
 
 	RangeVar *rangeVar = NULL;
-	foreach_ptr(rangeVar, rangeVarList)
+	foreach_declared_ptr(rangeVar, rangeVarList)
 	{
 		Oid rightRelationId = RangeVarGetRelid(rangeVar, lockMode, missingOk);
 		relationIdList = lappend_oid(relationIdList, rightRelationId);
@@ -2234,7 +2234,7 @@ AlterTableDropsForeignKey(AlterTableStmt *alterTableStatement)
 	Oid relationId = AlterTableLookupRelation(alterTableStatement, lockmode);
 
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, alterTableStatement->cmds)
+	foreach_declared_ptr(command, alterTableStatement->cmds)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -2296,7 +2296,7 @@ AnyForeignKeyDependsOnIndex(Oid indexId)
 		GetPgDependTuplesForDependingObjects(dependentObjectClassId, dependentObjectId);
 
 	HeapTuple dependencyTuple = NULL;
-	foreach_ptr(dependencyTuple, dependencyTupleList)
+	foreach_declared_ptr(dependencyTuple, dependencyTupleList)
 	{
 		Form_pg_depend dependencyForm = (Form_pg_depend) GETSTRUCT(dependencyTuple);
 		Oid dependingClassId = dependencyForm->classid;
@@ -2484,7 +2484,7 @@ SkipForeignKeyValidationIfConstraintIsFkey(AlterTableStmt *alterTableStatement,
 	 * shards anyway.
 	 */
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, alterTableStatement->cmds)
+	foreach_declared_ptr(command, alterTableStatement->cmds)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -2565,7 +2565,7 @@ ErrorIfAlterDropsPartitionColumn(AlterTableStmt *alterTableStatement)
 	/* then check if any of subcommands drop partition column.*/
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 		if (alterTableType == AT_DropColumn)
@@ -2634,7 +2634,7 @@ PostprocessAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -2670,7 +2670,7 @@ PostprocessAlterTableStmt(AlterTableStmt *alterTableStatement)
 			}
 
 			Constraint *constraint = NULL;
-			foreach_ptr(constraint, columnConstraints)
+			foreach_declared_ptr(constraint, columnConstraints)
 			{
 				if (constraint->conname == NULL &&
 					(constraint->contype == CONSTR_PRIMARY ||
@@ -2690,7 +2690,7 @@ PostprocessAlterTableStmt(AlterTableStmt *alterTableStatement)
 			 * that sequence is supported
 			 */
 			constraint = NULL;
-			foreach_ptr(constraint, columnConstraints)
+			foreach_declared_ptr(constraint, columnConstraints)
 			{
 				if (constraint->contype == CONSTR_DEFAULT)
 				{
@@ -2802,7 +2802,7 @@ FixAlterTableStmtIndexNames(AlterTableStmt *alterTableStatement)
 
 	List *commandList = alterTableStatement->cmds;
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -3165,7 +3165,7 @@ ErrorIfUnsupportedConstraint(Relation relation, char distributionMethod,
 	List *indexOidList = RelationGetIndexList(relation);
 
 	Oid indexOid = InvalidOid;
-	foreach_oid(indexOid, indexOidList)
+	foreach_declared_oid(indexOid, indexOidList)
 	{
 		Relation indexDesc = index_open(indexOid, RowExclusiveLock);
 		bool hasDistributionColumn = false;
@@ -3310,7 +3310,7 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 	/* error out if any of the subcommands are unsupported */
 	AlterTableCmd *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		AlterTableType alterTableType = command->subtype;
 
@@ -3385,7 +3385,7 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 
 					Constraint *columnConstraint = NULL;
-					foreach_ptr(columnConstraint, column->constraints)
+					foreach_declared_ptr(columnConstraint, column->constraints)
 					{
 						if (columnConstraint->contype == CONSTR_IDENTITY)
 						{
@@ -3417,7 +3417,7 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 					List *columnConstraints = column->constraints;
 
 					Constraint *constraint = NULL;
-					foreach_ptr(constraint, columnConstraints)
+					foreach_declared_ptr(constraint, columnConstraints)
 					{
 						if (constraint->contype == CONSTR_DEFAULT)
 						{
@@ -3770,7 +3770,7 @@ SetupExecutionModeForAlterTable(Oid relationId, AlterTableCmd *command)
 		List *columnConstraints = columnDefinition->constraints;
 
 		Constraint *constraint = NULL;
-		foreach_ptr(constraint, columnConstraints)
+		foreach_declared_ptr(constraint, columnConstraints)
 		{
 			if (constraint->contype == CONSTR_FOREIGN)
 			{
@@ -3970,10 +3970,10 @@ SetInterShardDDLTaskPlacementList(Task *task, ShardInterval *leftShardInterval,
 	List *intersectedPlacementList = NIL;
 
 	ShardPlacement *leftShardPlacement = NULL;
-	foreach_ptr(leftShardPlacement, leftShardPlacementList)
+	foreach_declared_ptr(leftShardPlacement, leftShardPlacementList)
 	{
 		ShardPlacement *rightShardPlacement = NULL;
-		foreach_ptr(rightShardPlacement, rightShardPlacementList)
+		foreach_declared_ptr(rightShardPlacement, rightShardPlacementList)
 		{
 			if (leftShardPlacement->nodeId == rightShardPlacement->nodeId)
 			{

--- a/src/backend/distributed/commands/trigger.c
+++ b/src/backend/distributed/commands/trigger.c
@@ -81,7 +81,7 @@ GetExplicitTriggerCommandList(Oid relationId)
 	List *triggerIdList = GetExplicitTriggerIdList(relationId);
 
 	Oid triggerId = InvalidOid;
-	foreach_oid(triggerId, triggerIdList)
+	foreach_declared_oid(triggerId, triggerIdList)
 	{
 		bool prettyOutput = false;
 		Datum commandText = DirectFunctionCall2(pg_get_triggerdef_ext,
@@ -742,7 +742,7 @@ ErrorIfRelationHasUnsupportedTrigger(Oid relationId)
 	List *relationTriggerList = GetExplicitTriggerIdList(relationId);
 
 	Oid triggerId = InvalidOid;
-	foreach_oid(triggerId, relationTriggerList)
+	foreach_declared_oid(triggerId, relationTriggerList)
 	{
 		ObjectAddress triggerObjectAddress = InvalidObjectAddress;
 		ObjectAddressSet(triggerObjectAddress, TriggerRelationId, triggerId);

--- a/src/backend/distributed/commands/truncate.c
+++ b/src/backend/distributed/commands/truncate.c
@@ -135,7 +135,7 @@ TruncateTaskList(Oid relationId)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		char *shardRelationName = pstrdup(relationName);
@@ -264,7 +264,7 @@ ErrorIfUnsupportedTruncateStmt(TruncateStmt *truncateStatement)
 {
 	List *relationList = truncateStatement->relations;
 	RangeVar *rangeVar = NULL;
-	foreach_ptr(rangeVar, relationList)
+	foreach_declared_ptr(rangeVar, relationList)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 
@@ -294,7 +294,7 @@ static void
 EnsurePartitionTableNotReplicatedForTruncate(TruncateStmt *truncateStatement)
 {
 	RangeVar *rangeVar = NULL;
-	foreach_ptr(rangeVar, truncateStatement->relations)
+	foreach_declared_ptr(rangeVar, truncateStatement->relations)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 
@@ -322,7 +322,7 @@ ExecuteTruncateStmtSequentialIfNecessary(TruncateStmt *command)
 	bool failOK = false;
 
 	RangeVar *rangeVar = NULL;
-	foreach_ptr(rangeVar, relationList)
+	foreach_declared_ptr(rangeVar, relationList)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, failOK);
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -436,7 +436,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 			bool analyze = false;
 
 			DefElem *option = NULL;
-			foreach_ptr(option, explainStmt->options)
+			foreach_declared_ptr(option, explainStmt->options)
 			{
 				if (strcmp(option->defname, "analyze") == 0)
 				{
@@ -677,7 +677,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 	{
 		AlterTableStmt *alterTableStmt = (AlterTableStmt *) parsetree;
 		AlterTableCmd *command = NULL;
-		foreach_ptr(command, alterTableStmt->cmds)
+		foreach_declared_ptr(command, alterTableStmt->cmds)
 		{
 			AlterTableType alterTableType = command->subtype;
 
@@ -876,7 +876,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		}
 
 		DDLJob *ddlJob = NULL;
-		foreach_ptr(ddlJob, ddlJobs)
+		foreach_declared_ptr(ddlJob, ddlJobs)
 		{
 			ExecuteDistributedDDLJob(ddlJob);
 		}
@@ -936,7 +936,7 @@ ProcessUtilityInternal(PlannedStmt *pstmt,
 		{
 			List *addresses = GetObjectAddressListFromParseTree(parsetree, false, true);
 			ObjectAddress *address = NULL;
-			foreach_ptr(address, addresses)
+			foreach_declared_ptr(address, addresses)
 			{
 				MarkObjectDistributed(address);
 				TrackPropagatedObject(address);
@@ -959,7 +959,7 @@ UndistributeDisconnectedCitusLocalTables(void)
 	citusLocalTableIdList = SortList(citusLocalTableIdList, CompareOids);
 
 	Oid citusLocalTableId = InvalidOid;
-	foreach_oid(citusLocalTableId, citusLocalTableIdList)
+	foreach_declared_oid(citusLocalTableId, citusLocalTableIdList)
 	{
 		/* acquire ShareRowExclusiveLock to prevent concurrent foreign key creation */
 		LOCKMODE lockMode = ShareRowExclusiveLock;
@@ -1341,7 +1341,7 @@ CurrentSearchPath(void)
 	bool schemaAdded = false;
 
 	Oid searchPathOid = InvalidOid;
-	foreach_oid(searchPathOid, searchPathList)
+	foreach_declared_oid(searchPathOid, searchPathList)
 	{
 		char *schemaName = get_namespace_name(searchPathOid);
 
@@ -1475,7 +1475,7 @@ DDLTaskList(Oid relationId, const char *commandString)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		StringInfo applyCommand = makeStringInfo();
@@ -1529,7 +1529,7 @@ NodeDDLTaskList(TargetWorkerSet targets, List *commands)
 		SetTaskQueryStringList(task, commands);
 
 		WorkerNode *workerNode = NULL;
-		foreach_ptr(workerNode, workerNodes)
+		foreach_declared_ptr(workerNode, workerNodes)
 		{
 			ShardPlacement *targetPlacement = CitusMakeNode(ShardPlacement);
 			targetPlacement->nodeName = workerNode->workerName;

--- a/src/backend/distributed/commands/vacuum.c
+++ b/src/backend/distributed/commands/vacuum.c
@@ -135,7 +135,7 @@ VacuumRelationIdList(VacuumStmt *vacuumStmt, CitusVacuumParams vacuumParams)
 	List *relationIdList = NIL;
 
 	RangeVar *vacuumRelation = NULL;
-	foreach_ptr(vacuumRelation, vacuumRelationList)
+	foreach_declared_ptr(vacuumRelation, vacuumRelationList)
 	{
 		/*
 		 * If skip_locked option is enabled, we are skipping that relation
@@ -164,7 +164,7 @@ static bool
 IsDistributedVacuumStmt(List *vacuumRelationIdList)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, vacuumRelationIdList)
+	foreach_declared_oid(relationId, vacuumRelationIdList)
 	{
 		if (OidIsValid(relationId) && IsCitusTable(relationId))
 		{
@@ -188,7 +188,7 @@ ExecuteVacuumOnDistributedTables(VacuumStmt *vacuumStmt, List *relationIdList,
 	int executedVacuumCount = 0;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (IsCitusTable(relationId))
 		{
@@ -254,7 +254,7 @@ VacuumTaskList(Oid relationId, CitusVacuumParams vacuumParams, List *vacuumColum
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		char *shardRelationName = pstrdup(relationName);
@@ -475,7 +475,7 @@ DeparseVacuumColumnNames(List *columnNameList)
 	appendStringInfoString(columnNames, " (");
 
 	String *columnName = NULL;
-	foreach_ptr(columnName, columnNameList)
+	foreach_declared_ptr(columnName, columnNameList)
 	{
 		appendStringInfo(columnNames, "%s,", strVal(columnName));
 	}
@@ -510,7 +510,7 @@ ExtractVacuumTargetRels(VacuumStmt *vacuumStmt)
 	List *vacuumList = NIL;
 
 	VacuumRelation *vacuumRelation = NULL;
-	foreach_ptr(vacuumRelation, vacuumStmt->rels)
+	foreach_declared_ptr(vacuumRelation, vacuumStmt->rels)
 	{
 		vacuumList = lappend(vacuumList, vacuumRelation->relation);
 	}
@@ -554,7 +554,7 @@ VacuumStmtParams(VacuumStmt *vacstmt)
 
 	/* Parse options list */
 	DefElem *opt = NULL;
-	foreach_ptr(opt, vacstmt->options)
+	foreach_declared_ptr(opt, vacstmt->options)
 	{
 		/* Parse common options for VACUUM and ANALYZE */
 		if (strcmp(opt->defname, "verbose") == 0)
@@ -727,7 +727,7 @@ ExecuteUnqualifiedVacuumTasks(VacuumStmt *vacuumStmt, CitusVacuumParams vacuumPa
 	int32 localNodeGroupId = GetLocalGroupId();
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodes)
+	foreach_declared_ptr(workerNode, workerNodes)
 	{
 		if (workerNode->groupId != localNodeGroupId)
 		{

--- a/src/backend/distributed/commands/view.c
+++ b/src/backend/distributed/commands/view.c
@@ -69,7 +69,7 @@ ViewHasDistributedRelationDependency(ObjectAddress *viewObjectAddress)
 	List *dependencies = GetAllDependenciesForObject(viewObjectAddress);
 	ObjectAddress *dependency = NULL;
 
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		if (dependency->classId == RelationRelationId && IsAnyObjectDistributed(
 				list_make1(dependency)))
@@ -304,7 +304,7 @@ DropViewStmtObjectAddress(Node *stmt, bool missing_ok, bool isPostprocess)
 	List *objectAddresses = NIL;
 
 	List *possiblyQualifiedViewName = NULL;
-	foreach_ptr(possiblyQualifiedViewName, dropStmt->objects)
+	foreach_declared_ptr(possiblyQualifiedViewName, dropStmt->objects)
 	{
 		RangeVar *viewRangeVar = makeRangeVarFromNameList(possiblyQualifiedViewName);
 		Oid viewOid = RangeVarGetRelid(viewRangeVar, AccessShareLock,
@@ -332,7 +332,7 @@ FilterNameListForDistributedViews(List *viewNamesList, bool missing_ok)
 	List *distributedViewNames = NIL;
 
 	List *possiblyQualifiedViewName = NULL;
-	foreach_ptr(possiblyQualifiedViewName, viewNamesList)
+	foreach_declared_ptr(possiblyQualifiedViewName, viewNamesList)
 	{
 		char *viewName = NULL;
 		char *schemaName = NULL;

--- a/src/backend/distributed/connection/connection_management.c
+++ b/src/backend/distributed/connection/connection_management.c
@@ -879,7 +879,7 @@ WaitEventSetFromMultiConnectionStates(List *connections, int *waitCount)
 	numEventsAdded += 2;
 
 	MultiConnectionPollState *connectionState = NULL;
-	foreach_ptr(connectionState, connections)
+	foreach_declared_ptr(connectionState, connections)
 	{
 		if (numEventsAdded >= eventSetSize)
 		{
@@ -961,7 +961,7 @@ FinishConnectionListEstablishment(List *multiConnectionList)
 	int waitCount = 0;
 
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, multiConnectionList)
+	foreach_declared_ptr(connection, multiConnectionList)
 	{
 		MultiConnectionPollState *connectionState =
 			palloc0(sizeof(MultiConnectionPollState));
@@ -1160,7 +1160,7 @@ static void
 CloseNotReadyMultiConnectionStates(List *connectionStates)
 {
 	MultiConnectionPollState *connectionState = NULL;
-	foreach_ptr(connectionState, connectionStates)
+	foreach_declared_ptr(connectionState, connectionStates)
 	{
 		MultiConnection *connection = connectionState->connection;
 

--- a/src/backend/distributed/connection/locally_reserved_shared_connections.c
+++ b/src/backend/distributed/connection/locally_reserved_shared_connections.c
@@ -360,7 +360,7 @@ EnsureConnectionPossibilityForNodeList(List *nodeList)
 	nodeList = SortList(nodeList, CompareWorkerNodes);
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, nodeList)
+	foreach_declared_ptr(workerNode, nodeList)
 	{
 		bool waitForConnection = true;
 		EnsureConnectionPossibilityForNode(workerNode, waitForConnection);

--- a/src/backend/distributed/connection/placement_connection.c
+++ b/src/backend/distributed/connection/placement_connection.c
@@ -370,7 +370,7 @@ AssignPlacementListToConnection(List *placementAccessList, MultiConnection *conn
 	const char *userName = connection->user;
 
 	ShardPlacementAccess *placementAccess = NULL;
-	foreach_ptr(placementAccess, placementAccessList)
+	foreach_declared_ptr(placementAccess, placementAccessList)
 	{
 		ShardPlacement *placement = placementAccess->placement;
 		ShardPlacementAccessType accessType = placementAccess->accessType;
@@ -533,7 +533,7 @@ FindPlacementListConnection(int flags, List *placementAccessList, const char *us
 	 * suitable connection found for a placement in the placementAccessList.
 	 */
 	ShardPlacementAccess *placementAccess = NULL;
-	foreach_ptr(placementAccess, placementAccessList)
+	foreach_declared_ptr(placementAccess, placementAccessList)
 	{
 		ShardPlacement *placement = placementAccess->placement;
 		ShardPlacementAccessType accessType = placementAccess->accessType;

--- a/src/backend/distributed/connection/remote_commands.c
+++ b/src/backend/distributed/connection/remote_commands.c
@@ -392,7 +392,7 @@ void
 ExecuteCriticalRemoteCommandList(MultiConnection *connection, List *commandList)
 {
 	const char *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		ExecuteCriticalRemoteCommand(connection, command);
 	}
@@ -435,7 +435,7 @@ ExecuteRemoteCommandInConnectionList(List *nodeConnectionList, const char *comma
 {
 	MultiConnection *connection = NULL;
 
-	foreach_ptr(connection, nodeConnectionList)
+	foreach_declared_ptr(connection, nodeConnectionList)
 	{
 		int querySent = SendRemoteCommand(connection, command);
 
@@ -446,7 +446,7 @@ ExecuteRemoteCommandInConnectionList(List *nodeConnectionList, const char *comma
 	}
 
 	/* Process the result */
-	foreach_ptr(connection, nodeConnectionList)
+	foreach_declared_ptr(connection, nodeConnectionList)
 	{
 		bool raiseInterrupts = true;
 		PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
@@ -887,7 +887,7 @@ WaitForAllConnections(List *connectionList, bool raiseInterrupts)
 
 	/* convert connection list to an array such that we can move items around */
 	MultiConnection *connectionItem = NULL;
-	foreach_ptr(connectionItem, connectionList)
+	foreach_declared_ptr(connectionItem, connectionList)
 	{
 		allConnections[connectionIndex] = connectionItem;
 		connectionReady[connectionIndex] = false;

--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -938,7 +938,7 @@ bool
 IsReindexWithParam_compat(ReindexStmt *reindexStmt, char *param)
 {
 	DefElem *opt = NULL;
-	foreach_ptr(opt, reindexStmt->params)
+	foreach_declared_ptr(opt, reindexStmt->params)
 	{
 		if (strcmp(opt->defname, param) == 0)
 		{
@@ -963,7 +963,7 @@ AddVacuumParams(ReindexStmt *reindexStmt, StringInfo buffer)
 
 	char *tableSpaceName = NULL;
 	DefElem *opt = NULL;
-	foreach_ptr(opt, reindexStmt->params)
+	foreach_declared_ptr(opt, reindexStmt->params)
 	{
 		if (strcmp(opt->defname, "tablespace") == 0)
 		{

--- a/src/backend/distributed/deparser/deparse.c
+++ b/src/backend/distributed/deparser/deparse.c
@@ -47,7 +47,7 @@ DeparseTreeNodes(List *stmts)
 {
 	List *sqls = NIL;
 	Node *stmt = NULL;
-	foreach_ptr(stmt, stmts)
+	foreach_declared_ptr(stmt, stmts)
 	{
 		sqls = lappend(sqls, DeparseTreeNode(stmt));
 	}

--- a/src/backend/distributed/deparser/deparse_domain_stmts.c
+++ b/src/backend/distributed/deparser/deparse_domain_stmts.c
@@ -70,7 +70,7 @@ DeparseCreateDomainStmt(Node *node)
 	}
 
 	Constraint *constraint = NULL;
-	foreach_ptr(constraint, stmt->constraints)
+	foreach_declared_ptr(constraint, stmt->constraints)
 	{
 		AppendConstraint(&buf, constraint, stmt->domainname, stmt->typeName);
 	}
@@ -117,7 +117,7 @@ DeparseDropDomainStmt(Node *node)
 
 	TypeName *domainName = NULL;
 	bool first = true;
-	foreach_ptr(domainName, stmt->objects)
+	foreach_declared_ptr(domainName, stmt->objects)
 	{
 		if (!first)
 		{

--- a/src/backend/distributed/deparser/deparse_extension_stmts.c
+++ b/src/backend/distributed/deparser/deparse_extension_stmts.c
@@ -40,7 +40,7 @@ DefElem *
 GetExtensionOption(List *extensionOptions, const char *defname)
 {
 	DefElem *defElement = NULL;
-	foreach_ptr(defElement, extensionOptions)
+	foreach_declared_ptr(defElement, extensionOptions)
 	{
 		if (IsA(defElement, DefElem) &&
 			strncmp(defElement->defname, defname, NAMEDATALEN) == 0)
@@ -112,7 +112,7 @@ AppendCreateExtensionStmtOptions(StringInfo buf, List *options)
 
 	/* Add the options to the statement */
 	DefElem *defElem = NULL;
-	foreach_ptr(defElem, options)
+	foreach_declared_ptr(defElem, options)
 	{
 		if (strcmp(defElem->defname, "schema") == 0)
 		{
@@ -181,7 +181,7 @@ AppendAlterExtensionStmt(StringInfo buf, AlterExtensionStmt *alterExtensionStmt)
 	 * the options.
 	 */
 	DefElem *option = NULL;
-	foreach_ptr(option, optionsList)
+	foreach_declared_ptr(option, optionsList)
 	{
 		if (strcmp(option->defname, "new_version") == 0)
 		{

--- a/src/backend/distributed/deparser/deparse_foreign_server_stmts.c
+++ b/src/backend/distributed/deparser/deparse_foreign_server_stmts.c
@@ -176,7 +176,7 @@ AppendAlterForeignServerOptions(StringInfo buf, AlterForeignServerStmt *stmt)
 
 	DefElemAction action = DEFELEM_UNSPEC;
 	DefElem *def = NULL;
-	foreach_ptr(def, stmt->options)
+	foreach_declared_ptr(def, stmt->options)
 	{
 		if (def->defaction != DEFELEM_UNSPEC)
 		{
@@ -242,7 +242,7 @@ static void
 AppendServerNames(StringInfo buf, DropStmt *stmt)
 {
 	String *serverValue = NULL;
-	foreach_ptr(serverValue, stmt->objects)
+	foreach_declared_ptr(serverValue, stmt->objects)
 	{
 		const char *serverString = quote_identifier(strVal(serverValue));
 		appendStringInfo(buf, "%s", serverString);

--- a/src/backend/distributed/deparser/deparse_publication_stmts.c
+++ b/src/backend/distributed/deparser/deparse_publication_stmts.c
@@ -118,7 +118,7 @@ AppendCreatePublicationStmt(StringInfo buf, CreatePublicationStmt *stmt,
 		 * Check whether there are objects to propagate, mainly to know whether
 		 * we should include "FOR".
 		 */
-		foreach_ptr(publicationObject, stmt->pubobjects)
+		foreach_declared_ptr(publicationObject, stmt->pubobjects)
 		{
 			if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE)
 			{
@@ -156,7 +156,7 @@ AppendCreatePublicationStmt(StringInfo buf, CreatePublicationStmt *stmt,
 		 * Check whether there are tables to propagate, mainly to know whether
 		 * we should include "FOR".
 		 */
-		foreach_ptr(rangeVar, stmt->tables)
+		foreach_declared_ptr(rangeVar, stmt->tables)
 		{
 			if (includeLocalTables || IsCitusTableRangeVar(rangeVar, NoLock, false))
 			{
@@ -198,7 +198,7 @@ AppendPublicationObjects(StringInfo buf, List *publicationObjects,
 	PublicationObjSpec *publicationObject = NULL;
 	bool appendedObject = false;
 
-	foreach_ptr(publicationObject, publicationObjects)
+	foreach_declared_ptr(publicationObject, publicationObjects)
 	{
 		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE)
 		{
@@ -334,7 +334,7 @@ AppendTables(StringInfo buf, List *tables, bool includeLocalTables)
 	RangeVar *rangeVar = NULL;
 	bool appendedObject = false;
 
-	foreach_ptr(rangeVar, tables)
+	foreach_declared_ptr(rangeVar, tables)
 	{
 		if (!includeLocalTables &&
 			!IsCitusTableRangeVar(rangeVar, NoLock, false))

--- a/src/backend/distributed/deparser/deparse_role_stmts.c
+++ b/src/backend/distributed/deparser/deparse_role_stmts.c
@@ -359,7 +359,7 @@ AppendRevokeAdminOptionFor(StringInfo buf, GrantRoleStmt *stmt)
 	if (!stmt->is_grant)
 	{
 		DefElem *opt = NULL;
-		foreach_ptr(opt, stmt->opt)
+		foreach_declared_ptr(opt, stmt->opt)
 		{
 			if (strcmp(opt->defname, "admin") == 0)
 			{
@@ -384,7 +384,7 @@ AppendGrantWithAdminOption(StringInfo buf, GrantRoleStmt *stmt)
 	{
 #if PG_VERSION_NUM >= PG_VERSION_16
 		DefElem *opt = NULL;
-		foreach_ptr(opt, stmt->opt)
+		foreach_declared_ptr(opt, stmt->opt)
 		{
 			bool admin_option = false;
 			char *optval = defGetString(opt);

--- a/src/backend/distributed/deparser/deparse_schema_stmts.c
+++ b/src/backend/distributed/deparser/deparse_schema_stmts.c
@@ -152,7 +152,7 @@ AppendDropSchemaStmt(StringInfo buf, DropStmt *stmt)
 	}
 
 	String *schemaValue = NULL;
-	foreach_ptr(schemaValue, stmt->objects)
+	foreach_declared_ptr(schemaValue, stmt->objects)
 	{
 		const char *schemaString = quote_identifier(strVal(schemaValue));
 		appendStringInfo(buf, "%s", schemaString);

--- a/src/backend/distributed/deparser/deparse_statistics_stmts.c
+++ b/src/backend/distributed/deparser/deparse_statistics_stmts.c
@@ -216,7 +216,7 @@ AppendStatTypes(StringInfo buf, CreateStatsStmt *stmt)
 	appendStringInfoString(buf, " (");
 
 	String *statType = NULL;
-	foreach_ptr(statType, stmt->stat_types)
+	foreach_declared_ptr(statType, stmt->stat_types)
 	{
 		appendStringInfoString(buf, strVal(statType));
 
@@ -235,7 +235,7 @@ AppendColumnNames(StringInfo buf, CreateStatsStmt *stmt)
 {
 	StatsElem *column = NULL;
 
-	foreach_ptr(column, stmt->exprs)
+	foreach_declared_ptr(column, stmt->exprs)
 	{
 		if (!column->name)
 		{

--- a/src/backend/distributed/deparser/deparse_text_search.c
+++ b/src/backend/distributed/deparser/deparse_text_search.c
@@ -86,7 +86,7 @@ AppendDefElemList(StringInfo buf, List *defelems, char *objectName)
 {
 	DefElem *defelem = NULL;
 	bool first = true;
-	foreach_ptr(defelem, defelems)
+	foreach_declared_ptr(defelem, defelems)
 	{
 		if (!first)
 		{
@@ -133,7 +133,7 @@ DeparseDropTextSearchConfigurationStmt(Node *node)
 	appendStringInfoString(&buf, "DROP TEXT SEARCH CONFIGURATION ");
 	List *nameList = NIL;
 	bool first = true;
-	foreach_ptr(nameList, stmt->objects)
+	foreach_declared_ptr(nameList, stmt->objects)
 	{
 		if (!first)
 		{
@@ -171,7 +171,7 @@ DeparseDropTextSearchDictionaryStmt(Node *node)
 	appendStringInfoString(&buf, "DROP TEXT SEARCH DICTIONARY ");
 	List *nameList = NIL;
 	bool first = true;
-	foreach_ptr(nameList, stmt->objects)
+	foreach_declared_ptr(nameList, stmt->objects)
 	{
 		if (!first)
 		{
@@ -466,7 +466,7 @@ AppendStringInfoTokentypeList(StringInfo buf, List *tokentypes)
 {
 	String *tokentype = NULL;
 	bool first = true;
-	foreach_ptr(tokentype, tokentypes)
+	foreach_declared_ptr(tokentype, tokentypes)
 	{
 		if (nodeTag(tokentype) != T_String)
 		{
@@ -494,7 +494,7 @@ AppendStringInfoDictnames(StringInfo buf, List *dicts)
 {
 	List *dictNames = NIL;
 	bool first = true;
-	foreach_ptr(dictNames, dicts)
+	foreach_declared_ptr(dictNames, dicts)
 	{
 		if (!first)
 		{

--- a/src/backend/distributed/deparser/deparse_view_stmts.c
+++ b/src/backend/distributed/deparser/deparse_view_stmts.c
@@ -88,7 +88,7 @@ AppendViewNameList(StringInfo buf, List *viewNamesList)
 {
 	bool isFirstView = true;
 	List *qualifiedViewName = NULL;
-	foreach_ptr(qualifiedViewName, viewNamesList)
+	foreach_declared_ptr(qualifiedViewName, viewNamesList)
 	{
 		char *quotedQualifiedVieName = NameListToQuotedString(qualifiedViewName);
 		if (!isFirstView)

--- a/src/backend/distributed/deparser/qualify_collation_stmt.c
+++ b/src/backend/distributed/deparser/qualify_collation_stmt.c
@@ -83,7 +83,7 @@ QualifyDropCollationStmt(Node *node)
 	List *names = NIL;
 	List *name = NIL;
 
-	foreach_ptr(name, stmt->objects)
+	foreach_declared_ptr(name, stmt->objects)
 	{
 		names = lappend(names, QualifyCollationName(name));
 	}

--- a/src/backend/distributed/deparser/qualify_domain.c
+++ b/src/backend/distributed/deparser/qualify_domain.c
@@ -67,7 +67,7 @@ QualifyDropDomainStmt(Node *node)
 	DropStmt *stmt = castNode(DropStmt, node);
 
 	TypeName *domainName = NULL;
-	foreach_ptr(domainName, stmt->objects)
+	foreach_declared_ptr(domainName, stmt->objects)
 	{
 		QualifyTypeName(domainName, stmt->missing_ok);
 	}
@@ -249,7 +249,7 @@ QualifyCollate(CollateClause *collClause, bool missing_ok)
 
 	collClause->collname = NIL;
 	char *name = NULL;
-	foreach_ptr(name, objName)
+	foreach_declared_ptr(name, objName)
 	{
 		collClause->collname = lappend(collClause->collname, makeString(name));
 	}

--- a/src/backend/distributed/deparser/qualify_publication_stmt.c
+++ b/src/backend/distributed/deparser/qualify_publication_stmt.c
@@ -55,7 +55,7 @@ QualifyPublicationObjects(List *publicationObjects)
 {
 	PublicationObjSpec *publicationObject = NULL;
 
-	foreach_ptr(publicationObject, publicationObjects)
+	foreach_declared_ptr(publicationObject, publicationObjects)
 	{
 		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE)
 		{
@@ -78,7 +78,7 @@ QualifyTables(List *tables)
 {
 	RangeVar *rangeVar = NULL;
 
-	foreach_ptr(rangeVar, tables)
+	foreach_declared_ptr(rangeVar, tables)
 	{
 		QualifyPublicationRangeVar(rangeVar);
 	}

--- a/src/backend/distributed/deparser/qualify_sequence_stmt.c
+++ b/src/backend/distributed/deparser/qualify_sequence_stmt.c
@@ -148,7 +148,7 @@ QualifyDropSequenceStmt(Node *node)
 
 	List *objectNameListWithSchema = NIL;
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, stmt->objects)
+	foreach_declared_ptr(objectNameList, stmt->objects)
 	{
 		RangeVar *seq = makeRangeVarFromNameList(objectNameList);
 
@@ -192,7 +192,7 @@ QualifyGrantOnSequenceStmt(Node *node)
 	}
 	List *qualifiedSequenceRangeVars = NIL;
 	RangeVar *sequenceRangeVar = NULL;
-	foreach_ptr(sequenceRangeVar, stmt->objects)
+	foreach_declared_ptr(sequenceRangeVar, stmt->objects)
 	{
 		if (sequenceRangeVar->schemaname == NULL)
 		{

--- a/src/backend/distributed/deparser/qualify_statistics_stmt.c
+++ b/src/backend/distributed/deparser/qualify_statistics_stmt.c
@@ -73,7 +73,7 @@ QualifyDropStatisticsStmt(Node *node)
 
 	List *objectNameListWithSchema = NIL;
 	List *objectNameList = NULL;
-	foreach_ptr(objectNameList, dropStatisticsStmt->objects)
+	foreach_declared_ptr(objectNameList, dropStatisticsStmt->objects)
 	{
 		RangeVar *stat = makeRangeVarFromNameList(objectNameList);
 

--- a/src/backend/distributed/deparser/qualify_text_search_stmts.c
+++ b/src/backend/distributed/deparser/qualify_text_search_stmts.c
@@ -46,7 +46,7 @@ QualifyDropTextSearchConfigurationStmt(Node *node)
 	List *qualifiedObjects = NIL;
 	List *objName = NIL;
 
-	foreach_ptr(objName, stmt->objects)
+	foreach_declared_ptr(objName, stmt->objects)
 	{
 		char *schemaName = NULL;
 		char *tsconfigName = NULL;
@@ -87,7 +87,7 @@ QualifyDropTextSearchDictionaryStmt(Node *node)
 	List *qualifiedObjects = NIL;
 	List *objName = NIL;
 
-	foreach_ptr(objName, stmt->objects)
+	foreach_declared_ptr(objName, stmt->objects)
 	{
 		char *schemaName = NULL;
 		char *tsdictName = NULL;
@@ -141,7 +141,7 @@ QualifyAlterTextSearchConfigurationStmt(Node *node)
 	bool useNewDicts = false;
 	List *dicts = NULL;
 	List *dictName = NIL;
-	foreach_ptr(dictName, stmt->dicts)
+	foreach_declared_ptr(dictName, stmt->dicts)
 	{
 		DeconstructQualifiedName(dictName, &schemaName, &objName);
 

--- a/src/backend/distributed/deparser/qualify_view_stmt.c
+++ b/src/backend/distributed/deparser/qualify_view_stmt.c
@@ -31,7 +31,7 @@ QualifyDropViewStmt(Node *node)
 	List *qualifiedViewNames = NIL;
 
 	List *possiblyQualifiedViewName = NULL;
-	foreach_ptr(possiblyQualifiedViewName, stmt->objects)
+	foreach_declared_ptr(possiblyQualifiedViewName, stmt->objects)
 	{
 		char *viewName = NULL;
 		char *schemaName = NULL;

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -1415,7 +1415,7 @@ AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution)
 	List *taskList = execution->remoteTaskList;
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		bool placementExecutionReady = true;
 		int placementExecutionIndex = 0;
@@ -1438,7 +1438,7 @@ AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution)
 
 		SetAttributeInputMetadata(execution, shardCommandExecution);
 		ShardPlacement *taskPlacement = NULL;
-		foreach_ptr(taskPlacement, task->taskPlacementList)
+		foreach_declared_ptr(taskPlacement, task->taskPlacementList)
 		{
 			int connectionFlags = 0;
 			char *nodeName = NULL;
@@ -1583,7 +1583,7 @@ AssignTasksToConnectionsOrWorkerPool(DistributedExecution *execution)
 	 * connection may be be returned multiple times by GetPlacementListConnectionIfCached.
 	 */
 	WorkerSession *session = NULL;
-	foreach_ptr(session, execution->sessionList)
+	foreach_declared_ptr(session, execution->sessionList)
 	{
 		MultiConnection *connection = session->connection;
 
@@ -1706,7 +1706,7 @@ static WorkerPool *
 FindOrCreateWorkerPool(DistributedExecution *execution, char *nodeName, int nodePort)
 {
 	WorkerPool *workerPool = NULL;
-	foreach_ptr(workerPool, execution->workerList)
+	foreach_declared_ptr(workerPool, execution->workerList)
 	{
 		if (strncmp(nodeName, workerPool->nodeName, WORKER_LENGTH) == 0 &&
 			nodePort == workerPool->nodePort)
@@ -1753,7 +1753,7 @@ FindOrCreateWorkerSession(WorkerPool *workerPool, MultiConnection *connection)
 	static uint64 sessionId = 1;
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, workerPool->sessionList)
+	foreach_declared_ptr(session, workerPool->sessionList)
 	{
 		if (session->connection == connection)
 		{
@@ -1856,7 +1856,7 @@ SequentialRunDistributedExecution(DistributedExecution *execution)
 	 */
 	MultiShardConnectionType = SEQUENTIAL_CONNECTION;
 	Task *taskToExecute = NULL;
-	foreach_ptr(taskToExecute, taskList)
+	foreach_declared_ptr(taskToExecute, taskList)
 	{
 		execution->remoteAndLocalTaskList = list_make1(taskToExecute);
 		execution->remoteTaskList = list_make1(taskToExecute);
@@ -1896,7 +1896,7 @@ RunDistributedExecution(DistributedExecution *execution)
 	{
 		/* Preemptively step state machines in case of immediate errors */
 		WorkerSession *session = NULL;
-		foreach_ptr(session, execution->sessionList)
+		foreach_declared_ptr(session, execution->sessionList)
 		{
 			ConnectionStateMachine(session);
 		}
@@ -1928,7 +1928,7 @@ RunDistributedExecution(DistributedExecution *execution)
 				HasIncompleteConnectionEstablishment(execution)))
 		{
 			WorkerPool *workerPool = NULL;
-			foreach_ptr(workerPool, execution->workerList)
+			foreach_declared_ptr(workerPool, execution->workerList)
 			{
 				ManageWorkerPool(workerPool);
 			}
@@ -2013,7 +2013,7 @@ ProcessSessionsWithFailedWaitEventSetOperations(DistributedExecution *execution)
 {
 	bool foundFailedSession = false;
 	WorkerSession *session = NULL;
-	foreach_ptr(session, execution->sessionList)
+	foreach_declared_ptr(session, execution->sessionList)
 	{
 		if (session->waitEventSetIndex == WAIT_EVENT_SET_INDEX_FAILED)
 		{
@@ -2057,7 +2057,7 @@ HasIncompleteConnectionEstablishment(DistributedExecution *execution)
 	}
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, execution->sessionList)
+	foreach_declared_ptr(session, execution->sessionList)
 	{
 		MultiConnection *connection = session->connection;
 		if (connection->connectionState == MULTI_CONNECTION_INITIAL ||
@@ -2535,7 +2535,7 @@ AvgTaskExecutionTimeApproximation(WorkerPool *workerPool)
 	INSTR_TIME_SET_CURRENT(now);
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, workerPool->sessionList)
+	foreach_declared_ptr(session, workerPool->sessionList)
 	{
 		/*
 		 * Involve the tasks that are currently running. We do this to
@@ -2573,7 +2573,7 @@ AvgConnectionEstablishmentTime(WorkerPool *workerPool)
 	int sessionCount = 0;
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, workerPool->sessionList)
+	foreach_declared_ptr(session, workerPool->sessionList)
 	{
 		MultiConnection *connection = session->connection;
 
@@ -2729,7 +2729,7 @@ OpenNewConnections(WorkerPool *workerPool, int newConnectionCount,
 #endif
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, newSessionsList)
+	foreach_declared_ptr(session, newSessionsList)
 	{
 		/* immediately run the state machine to handle potential failure */
 		ConnectionStateMachine(session);
@@ -2847,7 +2847,7 @@ static void
 MarkEstablishingSessionsTimedOut(WorkerPool *workerPool)
 {
 	WorkerSession *session = NULL;
-	foreach_ptr(session, workerPool->sessionList)
+	foreach_declared_ptr(session, workerPool->sessionList)
 	{
 		MultiConnection *connection = session->connection;
 
@@ -2899,7 +2899,7 @@ NextEventTimeout(DistributedExecution *execution)
 	long eventTimeout = 1000; /* milliseconds */
 
 	WorkerPool *workerPool = NULL;
-	foreach_ptr(workerPool, execution->workerList)
+	foreach_declared_ptr(workerPool, execution->workerList)
 	{
 		if (workerPool->failureState == WORKER_POOL_FAILED)
 		{
@@ -4240,7 +4240,7 @@ WorkerPoolFailed(WorkerPool *workerPool)
 	}
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, workerPool->sessionList)
+	foreach_declared_ptr(session, workerPool->sessionList)
 	{
 		WorkerSessionFailed(session);
 	}
@@ -4265,7 +4265,7 @@ WorkerPoolFailed(WorkerPool *workerPool)
 		List *workerList = workerPool->distributedExecution->workerList;
 
 		WorkerPool *pool = NULL;
-		foreach_ptr(pool, workerList)
+		foreach_declared_ptr(pool, workerList)
 		{
 			/* failed pools or pools without any connection attempts ignored */
 			if (pool->failureState == WORKER_POOL_FAILED ||
@@ -4618,7 +4618,7 @@ PlacementExecutionReady(TaskPlacementExecution *placementExecution)
 
 		/* wake up an idle connection by checking whether the connection is writeable */
 		WorkerSession *session = NULL;
-		foreach_ptr(session, workerPool->sessionList)
+		foreach_declared_ptr(session, workerPool->sessionList)
 		{
 			MultiConnection *connection = session->connection;
 			RemoteTransaction *transaction = &(connection->remoteTransaction);
@@ -4743,7 +4743,7 @@ BuildWaitEventSet(List *sessionList)
 		CreateWaitEventSet(CurrentMemoryContext, eventSetSize);
 
 	WorkerSession *session = NULL;
-	foreach_ptr(session, sessionList)
+	foreach_declared_ptr(session, sessionList)
 	{
 		AddSessionToWaitEventSet(session, waitEventSet);
 	}
@@ -4841,7 +4841,7 @@ static void
 RebuildWaitEventSetFlags(WaitEventSet *waitEventSet, List *sessionList)
 {
 	WorkerSession *session = NULL;
-	foreach_ptr(session, sessionList)
+	foreach_declared_ptr(session, sessionList)
 	{
 		MultiConnection *connection = session->connection;
 		int waitEventSetIndex = session->waitEventSetIndex;
@@ -4897,7 +4897,7 @@ CleanUpSessions(DistributedExecution *execution)
 
 	/* always trigger wait event set in the first round */
 	WorkerSession *session = NULL;
-	foreach_ptr(session, sessionList)
+	foreach_declared_ptr(session, sessionList)
 	{
 		MultiConnection *connection = session->connection;
 
@@ -4978,7 +4978,7 @@ static void
 UnclaimAllSessionConnections(List *sessionList)
 {
 	WorkerSession *session = NULL;
-	foreach_ptr(session, sessionList)
+	foreach_declared_ptr(session, sessionList)
 	{
 		MultiConnection *connection = session->connection;
 

--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -524,7 +524,7 @@ static bool
 AnchorShardsInTaskListExist(List *taskList)
 {
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		if (!ShardExists(task->anchorShardId))
 		{

--- a/src/backend/distributed/executor/directed_acyclic_graph_execution.c
+++ b/src/backend/distributed/executor/directed_acyclic_graph_execution.c
@@ -94,7 +94,7 @@ FindExecutableTasks(List *allTasks, HTAB *completedTasks)
 	List *curTasks = NIL;
 
 	Task *task = NULL;
-	foreach_ptr(task, allTasks)
+	foreach_declared_ptr(task, allTasks)
 	{
 		if (IsAllDependencyCompleted(task, completedTasks) &&
 			!IsTaskAlreadyCompleted(task, completedTasks))
@@ -118,7 +118,7 @@ RemoveMergeTasks(List *taskList)
 	List *prunedTaskList = NIL;
 	Task *task = NULL;
 
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		if (task->taskType != MERGE_TASK)
 		{
@@ -139,7 +139,7 @@ AddCompletedTasks(List *curCompletedTasks, HTAB *completedTasks)
 	bool found;
 
 	Task *task = NULL;
-	foreach_ptr(task, curCompletedTasks)
+	foreach_declared_ptr(task, curCompletedTasks)
 	{
 		TaskHashKey taskKey = { task->jobId, task->taskId };
 		hash_search(completedTasks, &taskKey, HASH_ENTER, &found);
@@ -172,7 +172,7 @@ IsAllDependencyCompleted(Task *targetTask, HTAB *completedTasks)
 	bool found = false;
 
 	Task *task = NULL;
-	foreach_ptr(task, targetTask->dependentTaskList)
+	foreach_declared_ptr(task, targetTask->dependentTaskList)
 	{
 		TaskHashKey taskKey = { task->jobId, task->taskId };
 

--- a/src/backend/distributed/executor/distributed_execution_locks.c
+++ b/src/backend/distributed/executor/distributed_execution_locks.c
@@ -198,7 +198,7 @@ AcquireExecutorShardLocksForExecution(RowModifyLevel modLevel, List *taskList)
 	List *requiresConsistentSnapshotRelationShardList = NIL;
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		ShardInterval *anchorShardInterval = LoadShardInterval(task->anchorShardId);
 		anchorShardIntervalList = lappend(anchorShardIntervalList, anchorShardInterval);
@@ -344,7 +344,7 @@ AcquireMetadataLocks(List *taskList)
 	 */
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		LockShardDistributionMetadata(task->anchorShardId, ShareLock);
 	}
@@ -379,7 +379,7 @@ AcquireExecutorShardLocksForRelationRowLockList(List *relationRowLockList)
 	 * them.
 	 */
 	RelationRowLock *relationRowLock = NULL;
-	foreach_ptr(relationRowLock, relationRowLockList)
+	foreach_declared_ptr(relationRowLock, relationRowLockList)
 	{
 		LockClauseStrength rowLockStrength = relationRowLock->rowLockStrength;
 		Oid relationId = relationRowLock->relationId;
@@ -412,7 +412,7 @@ void
 LockPartitionsInRelationList(List *relationIdList, LOCKMODE lockmode)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (PartitionedTable(relationId))
 		{
@@ -437,7 +437,7 @@ LockPartitionRelations(Oid relationId, LOCKMODE lockMode)
 	 */
 	List *partitionList = PartitionList(relationId);
 	Oid partitionRelationId = InvalidOid;
-	foreach_oid(partitionRelationId, partitionList)
+	foreach_declared_oid(partitionRelationId, partitionList)
 	{
 		LockRelationOid(partitionRelationId, lockMode);
 	}

--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -206,7 +206,7 @@ WrapTasksForPartitioning(const char *resultIdPrefix, List *selectTaskList,
 													 intervalTypeMod);
 
 	Task *selectTask = NULL;
-	foreach_ptr(selectTask, selectTaskList)
+	foreach_declared_ptr(selectTask, selectTaskList)
 	{
 		char *taskPrefix = SourceShardPrefix(resultIdPrefix, selectTask->anchorShardId);
 		char *partitionMethodString = targetRelation->partitionMethod == 'h' ?
@@ -490,7 +490,7 @@ ColocateFragmentsWithRelation(List *fragmentList, CitusTableCacheEntry *targetRe
 	List **shardResultIdList = palloc0(shardCount * sizeof(List *));
 
 	DistributedResultFragment *sourceFragment = NULL;
-	foreach_ptr(sourceFragment, fragmentList)
+	foreach_declared_ptr(sourceFragment, fragmentList)
 	{
 		int shardIndex = sourceFragment->targetShardIndex;
 
@@ -520,11 +520,11 @@ ColocationTransfers(List *fragmentList, CitusTableCacheEntry *targetRelation)
 									 HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 
 	DistributedResultFragment *fragment = NULL;
-	foreach_ptr(fragment, fragmentList)
+	foreach_declared_ptr(fragment, fragmentList)
 	{
 		List *placementList = ActiveShardPlacementList(fragment->targetShardId);
 		ShardPlacement *placement = NULL;
-		foreach_ptr(placement, placementList)
+		foreach_declared_ptr(placement, placementList)
 		{
 			NodePair transferKey = {
 				.sourceNodeId = fragment->nodeId,
@@ -576,7 +576,7 @@ FragmentTransferTaskList(List *fragmentListTransfers)
 	List *fetchTaskList = NIL;
 
 	NodeToNodeFragmentsTransfer *fragmentsTransfer = NULL;
-	foreach_ptr(fragmentsTransfer, fragmentListTransfers)
+	foreach_declared_ptr(fragmentsTransfer, fragmentListTransfers)
 	{
 		uint32 targetNodeId = fragmentsTransfer->nodes.targetNodeId;
 
@@ -629,7 +629,7 @@ QueryStringForFragmentsTransfer(NodeToNodeFragmentsTransfer *fragmentsTransfer)
 	appendStringInfoString(fragmentNamesArrayString, "ARRAY[");
 
 	DistributedResultFragment *fragment = NULL;
-	foreach_ptr(fragment, fragmentsTransfer->fragmentList)
+	foreach_declared_ptr(fragment, fragmentsTransfer->fragmentList)
 	{
 		const char *fragmentName = fragment->resultId;
 

--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -163,7 +163,7 @@ bool
 TaskListCannotBeExecutedInTransaction(List *taskList)
 {
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		if (task->cannotBeExecutedInTransction)
 		{
@@ -190,7 +190,7 @@ SelectForUpdateOnReferenceTable(List *taskList)
 
 	Task *task = (Task *) linitial(taskList);
 	RelationRowLock *relationRowLock = NULL;
-	foreach_ptr(relationRowLock, task->relationRowLockList)
+	foreach_declared_ptr(relationRowLock, task->relationRowLockList)
 	{
 		Oid relationId = relationRowLock->relationId;
 
@@ -239,7 +239,7 @@ bool
 ModifiedTableReplicated(List *taskList)
 {
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		int64 shardId = task->anchorShardId;
 

--- a/src/backend/distributed/executor/insert_select_executor.c
+++ b/src/backend/distributed/executor/insert_select_executor.c
@@ -244,7 +244,7 @@ NonPushableInsertSelectExecScan(CustomScanState *node)
 			 * on shards with connections.
 			 */
 			Task *task = NULL;
-			foreach_ptr(task, taskList)
+			foreach_declared_ptr(task, taskList)
 			{
 				uint64 shardId = task->anchorShardId;
 				bool shardModified = false;
@@ -381,7 +381,7 @@ BuildColumnNameListFromTargetList(Oid targetRelationId, List *insertTargetList)
 
 	/* build the list of column names for the COPY statement */
 	TargetEntry *insertTargetEntry = NULL;
-	foreach_ptr(insertTargetEntry, insertTargetList)
+	foreach_declared_ptr(insertTargetEntry, insertTargetList)
 	{
 		columnNameList = lappend(columnNameList, insertTargetEntry->resname);
 	}
@@ -402,7 +402,7 @@ PartitionColumnIndexFromColumnList(Oid relationId, List *columnNameList)
 	int partitionColumnIndex = 0;
 
 	const char *columnName = NULL;
-	foreach_ptr(columnName, columnNameList)
+	foreach_declared_ptr(columnName, columnNameList)
 	{
 		AttrNumber attrNumber = get_attnum(relationId, columnName);
 
@@ -428,7 +428,7 @@ DistributionColumnIndex(List *insertTargetList, Var *distributionColumn)
 {
 	TargetEntry *insertTargetEntry = NULL;
 	int targetEntryIndex = 0;
-	foreach_ptr(insertTargetEntry, insertTargetList)
+	foreach_declared_ptr(insertTargetEntry, insertTargetList)
 	{
 		if (insertTargetEntry->resno == distributionColumn->varattno)
 		{
@@ -452,7 +452,7 @@ WrapTaskListForProjection(List *taskList, List *projectedTargetEntries)
 	StringInfo projectedColumnsString = makeStringInfo();
 	int entryIndex = 0;
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, projectedTargetEntries)
+	foreach_declared_ptr(targetEntry, projectedTargetEntries)
 	{
 		if (entryIndex != 0)
 		{
@@ -467,7 +467,7 @@ WrapTaskListForProjection(List *taskList, List *projectedTargetEntries)
 	}
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		StringInfo wrappedQuery = makeStringInfo();
 		appendStringInfo(wrappedQuery, "SELECT %s FROM (%s) subquery",

--- a/src/backend/distributed/executor/intermediate_results.c
+++ b/src/backend/distributed/executor/intermediate_results.c
@@ -308,7 +308,7 @@ PrepareIntermediateResultBroadcast(RemoteFileDestReceiver *resultDest)
 	}
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, initialNodeList)
+	foreach_declared_ptr(workerNode, initialNodeList)
 	{
 		int flags = 0;
 
@@ -328,7 +328,7 @@ PrepareIntermediateResultBroadcast(RemoteFileDestReceiver *resultDest)
 	RemoteTransactionsBeginIfNecessary(connectionList);
 
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		StringInfo copyCommand = ConstructCopyResultStatement(resultId);
 
@@ -339,7 +339,7 @@ PrepareIntermediateResultBroadcast(RemoteFileDestReceiver *resultDest)
 		}
 	}
 
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		bool raiseInterrupts = true;
 
@@ -518,7 +518,7 @@ static void
 BroadcastCopyData(StringInfo dataBuffer, List *connectionList)
 {
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		SendCopyDataOverConnection(dataBuffer, connection);
 	}
@@ -714,7 +714,7 @@ void
 RemoveIntermediateResultsDirectories(void)
 {
 	char *directoryElement = NULL;
-	foreach_ptr(directoryElement, CreatedResultsDirectories)
+	foreach_declared_ptr(directoryElement, CreatedResultsDirectories)
 	{
 		/*
 		 * The shared directory is renamed before deleting it. Otherwise it

--- a/src/backend/distributed/executor/local_executor.c
+++ b/src/backend/distributed/executor/local_executor.c
@@ -253,7 +253,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 													  ALLOCSET_DEFAULT_SIZES);
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		MemoryContext oldContext = MemoryContextSwitchTo(loopContext);
 
@@ -304,7 +304,7 @@ ExecuteLocalTaskListExtended(List *taskList,
 			LOCKMODE lockMode = GetQueryLockMode(jobQuery);
 
 			Oid relationId = InvalidOid;
-			foreach_oid(relationId, localPlan->relationOids)
+			foreach_declared_oid(relationId, localPlan->relationOids)
 			{
 				LockRelationOid(relationId, lockMode);
 			}
@@ -393,7 +393,7 @@ SetColocationIdAndPartitionKeyValueForTasks(List *taskList, Job *workerJob)
 	if (workerJob->colocationId != INVALID_COLOCATION_ID)
 	{
 		Task *task = NULL;
-		foreach_ptr(task, taskList)
+		foreach_declared_ptr(task, taskList)
 		{
 			task->colocationId = workerJob->colocationId;
 			task->partitionKeyValue = workerJob->partitionKeyValue;
@@ -412,7 +412,7 @@ LocallyPlanAndExecuteMultipleQueries(List *queryStrings, TupleDestination *tuple
 {
 	char *queryString = NULL;
 	uint64 totalProcessedRows = 0;
-	foreach_ptr(queryString, queryStrings)
+	foreach_declared_ptr(queryString, queryStrings)
 	{
 		Query *shardQuery = ParseQueryString(queryString,
 											 NULL,
@@ -490,7 +490,7 @@ ExecuteUtilityCommand(const char *taskQueryCommand)
 	List *parseTreeList = pg_parse_query(taskQueryCommand);
 	RawStmt *taskRawStmt = NULL;
 
-	foreach_ptr(taskRawStmt, parseTreeList)
+	foreach_declared_ptr(taskRawStmt, parseTreeList)
 	{
 		Node *taskRawParseTree = taskRawStmt->stmt;
 
@@ -580,7 +580,7 @@ ExtractLocalAndRemoteTasks(bool readOnly, List *taskList, List **localTaskList,
 	*localTaskList = NIL;
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		List *localTaskPlacementList = NULL;
 		List *remoteTaskPlacementList = NULL;
@@ -645,7 +645,7 @@ SplitLocalAndRemotePlacements(List *taskPlacementList, List **localTaskPlacement
 	*remoteTaskPlacementList = NIL;
 
 	ShardPlacement *taskPlacement = NULL;
-	foreach_ptr(taskPlacement, taskPlacementList)
+	foreach_declared_ptr(taskPlacement, taskPlacementList)
 	{
 		if (taskPlacement->groupId == localGroupId)
 		{
@@ -817,7 +817,7 @@ RecordNonDistTableAccessesForTask(Task *task)
 	List *placementAccessList = PlacementAccessListForTask(task, taskPlacement);
 
 	ShardPlacementAccess *placementAccess = NULL;
-	foreach_ptr(placementAccess, placementAccessList)
+	foreach_declared_ptr(placementAccess, placementAccessList)
 	{
 		uint64 placementAccessShardId = placementAccess->placement->shardId;
 		if (placementAccessShardId == INVALID_SHARD_ID)
@@ -968,7 +968,7 @@ AnyTaskAccessesLocalNode(List *taskList)
 {
 	Task *task = NULL;
 
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		if (TaskAccessesLocalNode(task))
 		{
@@ -990,7 +990,7 @@ TaskAccessesLocalNode(Task *task)
 	int32 localGroupId = GetLocalGroupId();
 
 	ShardPlacement *taskPlacement = NULL;
-	foreach_ptr(taskPlacement, task->taskPlacementList)
+	foreach_declared_ptr(taskPlacement, task->taskPlacementList)
 	{
 		if (taskPlacement->groupId == localGroupId)
 		{

--- a/src/backend/distributed/executor/merge_executor.c
+++ b/src/backend/distributed/executor/merge_executor.c
@@ -258,7 +258,7 @@ ExecuteSourceAtCoordAndRedistribution(CitusScanState *scanState)
 	 * on shards with connections.
 	 */
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		uint64 shardId = task->anchorShardId;
 		bool shardModified = false;

--- a/src/backend/distributed/executor/multi_executor.c
+++ b/src/backend/distributed/executor/multi_executor.c
@@ -224,7 +224,7 @@ CitusExecutorRun(QueryDesc *queryDesc,
 			 */
 			List *citusCustomScanStates = FindCitusCustomScanStates(queryDesc->planstate);
 			CitusScanState *citusScanState = NULL;
-			foreach_ptr(citusScanState, citusCustomScanStates)
+			foreach_declared_ptr(citusScanState, citusCustomScanStates)
 			{
 				if (citusScanState->PreExecScan)
 				{
@@ -512,7 +512,7 @@ SortTupleStore(CitusScanState *scanState)
 	 * for sorting the tuples.
 	 */
 	TargetEntry *returningEntry = NULL;
-	foreach_ptr(returningEntry, targetList)
+	foreach_declared_ptr(returningEntry, targetList)
 	{
 		Oid sortop = InvalidOid;
 

--- a/src/backend/distributed/executor/placement_access.c
+++ b/src/backend/distributed/executor/placement_access.c
@@ -126,7 +126,7 @@ BuildPlacementAccessList(int32 groupId, List *relationShardList,
 	List *placementAccessList = NIL;
 
 	RelationShard *relationShard = NULL;
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		ShardPlacement *placement = ActiveShardPlacementOnGroup(groupId,
 																relationShard->shardId);

--- a/src/backend/distributed/executor/repartition_join_execution.c
+++ b/src/backend/distributed/executor/repartition_join_execution.c
@@ -93,7 +93,7 @@ TraverseJobTree(Job *curJob, List **jobIds)
 	*jobIds = lappend(*jobIds, jobIdPointer);
 
 	Job *childJob = NULL;
-	foreach_ptr(childJob, curJob->dependentJobList)
+	foreach_declared_ptr(childJob, curJob->dependentJobList)
 	{
 		TraverseJobTree(childJob, jobIds);
 	}

--- a/src/backend/distributed/executor/subplan_execution.c
+++ b/src/backend/distributed/executor/subplan_execution.c
@@ -59,7 +59,7 @@ ExecuteSubPlans(DistributedPlan *distributedPlan)
 	UseCoordinatedTransaction();
 
 	DistributedSubPlan *subPlan = NULL;
-	foreach_ptr(subPlan, subPlanList)
+	foreach_declared_ptr(subPlan, subPlanList)
 	{
 		PlannedStmt *plannedStmt = subPlan->plan;
 		uint32 subPlanId = subPlan->subPlanId;

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -207,7 +207,7 @@ GetUniqueDependenciesList(List *objectAddressesList)
 	InitObjectAddressCollector(&objectAddressCollector);
 
 	ObjectAddress *objectAddress = NULL;
-	foreach_ptr(objectAddress, objectAddressesList)
+	foreach_declared_ptr(objectAddress, objectAddressesList)
 	{
 		if (IsObjectAddressCollected(*objectAddress, &objectAddressCollector))
 		{
@@ -334,7 +334,7 @@ OrderObjectAddressListInDependencyOrder(List *objectAddressList)
 	InitObjectAddressCollector(&collector);
 
 	ObjectAddress *objectAddress = NULL;
-	foreach_ptr(objectAddress, objectAddressList)
+	foreach_declared_ptr(objectAddress, objectAddressList)
 	{
 		if (IsObjectAddressCollected(*objectAddress, &collector))
 		{
@@ -403,7 +403,7 @@ RecurseObjectDependencies(ObjectAddress target, expandFn expand, followFn follow
 
 	/* iterate all entries and recurse depth first */
 	DependencyDefinition *dependencyDefinition = NULL;
-	foreach_ptr(dependencyDefinition, dependenyDefinitionList)
+	foreach_declared_ptr(dependencyDefinition, dependenyDefinitionList)
 	{
 		if (follow == NULL || !follow(collector, dependencyDefinition))
 		{
@@ -870,7 +870,7 @@ bool
 ErrorOrWarnIfAnyObjectHasUnsupportedDependency(List *objectAddresses)
 {
 	ObjectAddress *objectAddress = NULL;
-	foreach_ptr(objectAddress, objectAddresses)
+	foreach_declared_ptr(objectAddress, objectAddresses)
 	{
 		if (ErrorOrWarnIfObjectHasUnsupportedDependency(objectAddress))
 		{
@@ -963,7 +963,7 @@ DeferErrorIfAnyObjectHasUnsupportedDependency(const List *objectAddresses)
 {
 	DeferredErrorMessage *deferredErrorMessage = NULL;
 	ObjectAddress *objectAddress = NULL;
-	foreach_ptr(objectAddress, objectAddresses)
+	foreach_declared_ptr(objectAddress, objectAddresses)
 	{
 		deferredErrorMessage = DeferErrorIfHasUnsupportedDependency(objectAddress);
 		if (deferredErrorMessage)
@@ -996,7 +996,7 @@ GetUndistributableDependency(const ObjectAddress *objectAddress)
 		return NULL;
 	}
 
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		/*
 		 * Objects with the id smaller than FirstNormalObjectId should be created within
@@ -1173,7 +1173,7 @@ IsAnyObjectAddressOwnedByExtension(const List *targets,
 								   ObjectAddress *extensionAddress)
 {
 	ObjectAddress *target = NULL;
-	foreach_ptr(target, targets)
+	foreach_declared_ptr(target, targets)
 	{
 		if (IsObjectAddressOwnedByExtension(target, extensionAddress))
 		{
@@ -1564,7 +1564,7 @@ ExpandCitusSupportedTypes(ObjectAddressCollector *collector, ObjectAddress targe
 			List *FDWOids = GetDependentFDWsToExtension(extensionId);
 
 			Oid FDWOid = InvalidOid;
-			foreach_oid(FDWOid, FDWOids)
+			foreach_declared_oid(FDWOid, FDWOids)
 			{
 				List *dependentRoleIds = GetDependentRoleIdsFDW(FDWOid);
 				List *dependencies =
@@ -1850,7 +1850,7 @@ GetViewRuleReferenceDependencyList(Oid viewId)
 	List *nonInternalDependenciesOfDependingRules = NIL;
 
 	HeapTuple depTup = NULL;
-	foreach_ptr(depTup, dependencyTupleList)
+	foreach_declared_ptr(depTup, dependencyTupleList)
 	{
 		Form_pg_depend pg_depend = (Form_pg_depend) GETSTRUCT(depTup);
 
@@ -1873,7 +1873,7 @@ GetViewRuleReferenceDependencyList(Oid viewId)
 			List *ruleDependencies = DependencyDefinitionFromPgDepend(ruleAddress);
 
 			DependencyDefinition *dependencyDef = NULL;
-			foreach_ptr(dependencyDef, ruleDependencies)
+			foreach_declared_ptr(dependencyDef, ruleDependencies)
 			{
 				/*
 				 * Follow all dependencies of the internally dependent rule dependencies
@@ -1908,7 +1908,7 @@ GetRelationSequenceDependencyList(Oid relationId)
 
 	List *seqIdList = NIL;
 	SequenceInfo *seqInfo = NULL;
-	foreach_ptr(seqInfo, seqInfoList)
+	foreach_declared_ptr(seqInfo, seqInfoList)
 	{
 		seqIdList = lappend_oid(seqIdList, seqInfo->sequenceOid);
 	}
@@ -1981,7 +1981,7 @@ GetRelationTriggerFunctionDependencyList(Oid relationId)
 
 	List *triggerIdList = GetExplicitTriggerIdList(relationId);
 	Oid triggerId = InvalidOid;
-	foreach_oid(triggerId, triggerIdList)
+	foreach_declared_oid(triggerId, triggerIdList)
 	{
 		Oid functionId = GetTriggerFunctionId(triggerId);
 		DependencyDefinition *dependency =
@@ -2006,7 +2006,7 @@ GetPublicationRelationsDependencyList(Oid publicationId)
 
 	Oid relationId = InvalidOid;
 
-	foreach_oid(relationId, allRelationIds)
+	foreach_declared_oid(relationId, allRelationIds)
 	{
 		if (!IsCitusTable(relationId))
 		{
@@ -2088,7 +2088,7 @@ CreateObjectAddressDependencyDefList(Oid classId, List *objectIdList)
 {
 	List *dependencyList = NIL;
 	Oid objectId = InvalidOid;
-	foreach_oid(objectId, objectIdList)
+	foreach_declared_oid(objectId, objectIdList)
 	{
 		DependencyDefinition *dependency =
 			CreateObjectAddressDependencyDef(classId, objectId);
@@ -2162,7 +2162,7 @@ BuildViewDependencyGraph(Oid relationId, HTAB *nodeMap)
 																	 targetObjectId);
 
 	HeapTuple depTup = NULL;
-	foreach_ptr(depTup, dependencyTupleList)
+	foreach_declared_ptr(depTup, dependencyTupleList)
 	{
 		Form_pg_depend pg_depend = (Form_pg_depend) GETSTRUCT(depTup);
 
@@ -2241,7 +2241,7 @@ GetDependingViews(Oid relationId)
 	foreach_ptr_append(node, nodeQueue)
 	{
 		ViewDependencyNode *dependingNode = NULL;
-		foreach_ptr(dependingNode, node->dependingNodes)
+		foreach_declared_ptr(dependingNode, node->dependingNodes)
 		{
 			ObjectAddress relationAddress = { 0 };
 			ObjectAddressSet(relationAddress, RelationRelationId, dependingNode->id);

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -433,7 +433,7 @@ bool
 IsAnyObjectDistributed(const List *addresses)
 {
 	ObjectAddress *address = NULL;
-	foreach_ptr(address, addresses)
+	foreach_declared_ptr(address, addresses)
 	{
 		if (IsObjectDistributed(address))
 		{

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -919,7 +919,7 @@ CitusTableList(void)
 	List *citusTableIdList = CitusTableTypeIdList(ANY_CITUS_TABLE_TYPE);
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, citusTableIdList)
+	foreach_declared_oid(relationId, citusTableIdList)
 	{
 		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
@@ -1890,7 +1890,7 @@ BuildCachedShardList(CitusTableCacheEntry *cacheEntry)
 								   sizeof(int));
 
 		HeapTuple shardTuple = NULL;
-		foreach_ptr(shardTuple, distShardTupleList)
+		foreach_declared_ptr(shardTuple, distShardTupleList)
 		{
 			ShardInterval *shardInterval = TupleToShardInterval(shardTuple,
 																distShardTupleDesc,
@@ -2028,7 +2028,7 @@ BuildCachedShardList(CitusTableCacheEntry *cacheEntry)
 		GroupShardPlacement *placementArray = palloc0(numberOfPlacements *
 													  sizeof(GroupShardPlacement));
 		GroupShardPlacement *srcPlacement = NULL;
-		foreach_ptr(srcPlacement, placementList)
+		foreach_declared_ptr(srcPlacement, placementList)
 		{
 			placementArray[placementOffset] = *srcPlacement;
 			placementOffset++;
@@ -4332,7 +4332,7 @@ InitializeWorkerNodeCache(void)
 
 	/* iterate over the worker node list */
 	WorkerNode *currentNode = NULL;
-	foreach_ptr(currentNode, workerNodeList)
+	foreach_declared_ptr(currentNode, workerNodeList)
 	{
 		bool handleFound = false;
 
@@ -4509,7 +4509,7 @@ GetLocalNodeId(void)
 	List *workerNodeList = ReadDistNode(includeNodesFromOtherClusters);
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if (workerNode->groupId == localGroupId &&
 			workerNode->isActive)
@@ -5097,7 +5097,7 @@ CitusTableCacheFlushInvalidatedEntries()
 	if (DistTableCacheHash != NULL && DistTableCacheExpired != NIL)
 	{
 		CitusTableCacheEntry *cacheEntry = NULL;
-		foreach_ptr(cacheEntry, DistTableCacheExpired)
+		foreach_declared_ptr(cacheEntry, DistTableCacheExpired)
 		{
 			ResetCitusTableCacheEntry(cacheEntry);
 		}

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -301,7 +301,7 @@ CreateDependingViewsOnWorkers(Oid relationId)
 	SendCommandToWorkersWithMetadata(DISABLE_DDL_PROPAGATION);
 
 	Oid viewOid = InvalidOid;
-	foreach_oid(viewOid, views)
+	foreach_declared_oid(viewOid, views)
 	{
 		if (!ShouldMarkRelationDistributed(viewOid))
 		{
@@ -341,7 +341,7 @@ AddTableToPublications(Oid relationId)
 
 	SendCommandToWorkersWithMetadata(DISABLE_DDL_PROPAGATION);
 
-	foreach_oid(publicationId, publicationIds)
+	foreach_declared_oid(publicationId, publicationIds)
 	{
 		ObjectAddress *publicationAddress = palloc0(sizeof(ObjectAddress));
 		ObjectAddressSet(*publicationAddress, PublicationRelationId, publicationId);
@@ -824,7 +824,7 @@ NodeListInsertCommand(List *workerNodeList)
 
 	/* iterate over the worker nodes, add the values */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		char *hasMetadataString = workerNode->hasMetadata ? "TRUE" : "FALSE";
 		char *metadataSyncedString = workerNode->metadataSynced ? "TRUE" : "FALSE";
@@ -935,7 +935,7 @@ MarkObjectsDistributedCreateCommand(List *addresses,
 
 		char *name = NULL;
 		bool firstInNameLoop = true;
-		foreach_ptr(name, names)
+		foreach_declared_ptr(name, names)
 		{
 			if (!firstInNameLoop)
 			{
@@ -950,7 +950,7 @@ MarkObjectsDistributedCreateCommand(List *addresses,
 
 		char *arg;
 		bool firstInArgLoop = true;
-		foreach_ptr(arg, args)
+		foreach_declared_ptr(arg, args)
 		{
 			if (!firstInArgLoop)
 			{
@@ -1206,13 +1206,13 @@ ShardListInsertCommand(List *shardIntervalList)
 
 	ShardInterval *shardInterval = NULL;
 	bool firstPlacementProcessed = false;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		List *shardPlacementList = ActiveShardPlacementList(shardId);
 
 		ShardPlacement *placement = NULL;
-		foreach_ptr(placement, shardPlacementList)
+		foreach_declared_ptr(placement, shardPlacementList)
 		{
 			if (firstPlacementProcessed)
 			{
@@ -1246,7 +1246,7 @@ ShardListInsertCommand(List *shardIntervalList)
 					 "WITH shard_data(relationname, shardid, storagetype, "
 					 "shardminvalue, shardmaxvalue)  AS (VALUES ");
 
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		Oid distributedRelationId = shardInterval->relationId;
@@ -1683,7 +1683,7 @@ GetDependentRelationsWithSequence(Oid sequenceOid, char depType)
 		Oid attrDefOid;
 		List *attrDefOids = GetAttrDefsFromSequence(sequenceOid);
 
-		foreach_oid(attrDefOid, attrDefOids)
+		foreach_declared_oid(attrDefOid, attrDefOids)
 		{
 			ObjectAddress columnAddress = GetAttrDefaultColumnAddress(attrDefOid);
 			relations = lappend_oid(relations, columnAddress.objectId);
@@ -1879,7 +1879,7 @@ GetDependentFunctionsWithRelation(Oid relationId)
 	table_close(depRel, AccessShareLock);
 
 	ObjectAddress *referencingObject = NULL;
-	foreach_ptr(referencingObject, referencingObjects)
+	foreach_declared_ptr(referencingObject, referencingObjects)
 	{
 		functionOids = list_concat(functionOids,
 								   GetFunctionDependenciesForObjects(referencingObject));
@@ -2669,7 +2669,7 @@ HasMetadataWorkers(void)
 	List *workerNodeList = ActiveReadableNonCoordinatorNodeList();
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if (workerNode->hasMetadata)
 		{
@@ -2702,7 +2702,7 @@ CreateInterTableRelationshipOfRelationOnWorkers(Oid relationId)
 	SendCommandToWorkersWithMetadata(DISABLE_DDL_PROPAGATION);
 
 	const char *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		SendCommandToWorkersWithMetadata(command);
 	}
@@ -2755,14 +2755,14 @@ CreateShellTableOnWorkers(Oid relationId)
 														  creatingShellTableOnRemoteNode);
 
 	TableDDLCommand *tableDDLCommand = NULL;
-	foreach_ptr(tableDDLCommand, tableDDLCommands)
+	foreach_declared_ptr(tableDDLCommand, tableDDLCommands)
 	{
 		Assert(CitusIsA(tableDDLCommand, TableDDLCommand));
 		commandList = lappend(commandList, GetTableDDLCommand(tableDDLCommand));
 	}
 
 	const char *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		SendCommandToWorkersWithMetadata(command);
 	}
@@ -2786,7 +2786,7 @@ CreateTableMetadataOnWorkers(Oid relationId)
 
 	/* send the commands one by one */
 	const char *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		SendCommandToWorkersWithMetadata(command);
 	}
@@ -2810,7 +2810,7 @@ DetachPartitionCommandList(void)
 
 	/* we iterate over all distributed partitioned tables and DETACH their partitions */
 	CitusTableCacheEntry *cacheEntry = NULL;
-	foreach_ptr(cacheEntry, distributedTableList)
+	foreach_declared_ptr(cacheEntry, distributedTableList)
 	{
 		if (!PartitionedTable(cacheEntry->relationId))
 		{
@@ -2874,7 +2874,7 @@ SyncNodeMetadataToNodesOptional(void)
 	List *syncedWorkerList = NIL;
 	List *workerList = ActivePrimaryNonCoordinatorNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerList)
+	foreach_declared_ptr(workerNode, workerList)
 	{
 		if (workerNode->hasMetadata && !workerNode->metadataSynced)
 		{
@@ -2894,7 +2894,7 @@ SyncNodeMetadataToNodesOptional(void)
 		}
 	}
 
-	foreach_ptr(workerNode, syncedWorkerList)
+	foreach_declared_ptr(workerNode, syncedWorkerList)
 	{
 		SetWorkerColumnOptional(workerNode, Anum_pg_dist_node_metadatasynced,
 								BoolGetDatum(true));
@@ -2939,7 +2939,7 @@ SyncNodeMetadataToNodes(void)
 
 	List *workerList = ActivePrimaryNonCoordinatorNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerList)
+	foreach_declared_ptr(workerNode, workerList)
 	{
 		if (workerNode->hasMetadata)
 		{
@@ -3178,7 +3178,7 @@ ShouldInitiateMetadataSync(bool *lockFailure)
 
 	List *workerList = ActivePrimaryNonCoordinatorNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerList)
+	foreach_declared_ptr(workerNode, workerList)
 	{
 		if (workerNode->hasMetadata && !workerNode->metadataSynced)
 		{
@@ -3542,7 +3542,7 @@ EnsureShardMetadataIsSane(Oid relationId, int64 shardId, char storageType,
 			GetFunctionInfo(intervalTypeId, BTREE_AM_OID, BTORDER_PROC);
 
 		HeapTuple shardTuple = NULL;
-		foreach_ptr(shardTuple, distShardTupleList)
+		foreach_declared_ptr(shardTuple, distShardTupleList)
 		{
 			ShardInterval *shardInterval =
 				TupleToShardInterval(shardTuple, distShardTupleDesc,
@@ -3838,7 +3838,7 @@ citus_internal_delete_shard_metadata(PG_FUNCTION_ARGS)
 
 	List *shardPlacementList = ShardPlacementList(shardId);
 	ShardPlacement *shardPlacement = NULL;
-	foreach_ptr(shardPlacement, shardPlacementList)
+	foreach_declared_ptr(shardPlacement, shardPlacementList)
 	{
 		DeleteShardPlacementRow(shardPlacement->placementId);
 	}
@@ -4343,7 +4343,7 @@ SetMetadataSyncNodesFromNodeList(MetadataSyncContext *context, List *nodeList)
 	List *activatedWorkerNodeList = NIL;
 
 	WorkerNode *node = NULL;
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		if (NodeIsPrimary(node))
 		{
@@ -4378,7 +4378,7 @@ EstablishAndSetMetadataSyncBareConnections(MetadataSyncContext *context)
 	/* establish bare connections to activated worker nodes */
 	List *bareConnectionList = NIL;
 	WorkerNode *node = NULL;
-	foreach_ptr(node, context->activatedWorkerNodeList)
+	foreach_declared_ptr(node, context->activatedWorkerNodeList)
 	{
 		MultiConnection *connection = GetNodeUserDatabaseConnection(connectionFlags,
 																	node->workerName,
@@ -4987,7 +4987,7 @@ SendDependencyCreationCommands(MetadataSyncContext *context)
 														  ALLOCSET_DEFAULT_SIZES);
 	MemoryContextSwitchTo(commandsContext);
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		if (!MetadataSyncCollectsCommands(context))
 		{

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -415,7 +415,7 @@ OpenConnectionToNodes(List *workerNodeList)
 {
 	List *connectionList = NIL;
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -439,7 +439,7 @@ GenerateShardStatisticsQueryList(List *workerNodeList, List *citusTableIds)
 {
 	List *shardStatisticsQueryList = NIL;
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		char *shardStatisticsQuery =
 			GenerateAllShardStatisticsQueryForNode(workerNode, citusTableIds);
@@ -460,7 +460,7 @@ ReceiveShardIdAndSizeResults(List *connectionList, Tuplestorestate *tupleStore,
 							 TupleDesc tupleDescriptor)
 {
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		bool raiseInterrupts = true;
 		Datum values[SHARD_SIZES_COLUMN_COUNT];
@@ -551,7 +551,7 @@ DistributedTableSize(Oid relationId, SizeQueryType sizeQueryType, bool failOnErr
 
 	List *workerNodeList = ActiveReadableNodeList();
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		uint64 relationSizeOnNode = 0;
 
@@ -754,7 +754,7 @@ GenerateSizeQueryOnMultiplePlacements(List *shardIntervalList,
 	List *nonPartitionedShardNames = NIL;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		if (optimizePartitionCalculations && PartitionTable(shardInterval->relationId))
 		{
@@ -829,7 +829,7 @@ GenerateSizeQueryForRelationNameList(List *quotedShardNames, char *sizeFunction)
 
 	bool addComma = false;
 	char *quotedShardName = NULL;
-	foreach_ptr(quotedShardName, quotedShardNames)
+	foreach_declared_ptr(quotedShardName, quotedShardNames)
 	{
 		if (addComma)
 		{
@@ -930,7 +930,7 @@ GenerateAllShardStatisticsQueryForNode(WorkerNode *workerNode, List *citusTableI
 	appendStringInfoString(allShardStatisticsQuery, " FROM (VALUES ");
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, citusTableIds)
+	foreach_declared_oid(relationId, citusTableIds)
 	{
 		/*
 		 * Ensure the table still exists by trying to acquire a lock on it
@@ -977,7 +977,7 @@ GenerateShardIdNameValuesForShardList(List *shardIntervalList, bool firstValue)
 	StringInfo selectQuery = makeStringInfo();
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		if (!firstValue)
 		{
@@ -1096,7 +1096,7 @@ TableShardReplicationFactor(Oid relationId)
 
 	List *shardIntervalList = LoadShardIntervalList(relationId);
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 
@@ -1187,7 +1187,7 @@ LoadUnsortedShardIntervalListViaCatalog(Oid relationId)
 						&intervalTypeMod);
 
 	HeapTuple distShardTuple = NULL;
-	foreach_ptr(distShardTuple, distShardTuples)
+	foreach_declared_ptr(distShardTuple, distShardTuples)
 	{
 		ShardInterval *interval = TupleToShardInterval(distShardTuple,
 													   distShardTupleDesc,
@@ -1436,7 +1436,7 @@ FilterShardPlacementList(List *shardPlacementList, bool (*filter)(ShardPlacement
 	List *filteredShardPlacementList = NIL;
 	ShardPlacement *shardPlacement = NULL;
 
-	foreach_ptr(shardPlacement, shardPlacementList)
+	foreach_declared_ptr(shardPlacement, shardPlacementList)
 	{
 		if (filter(shardPlacement))
 		{
@@ -1460,7 +1460,7 @@ FilterActiveShardPlacementListByNode(List *shardPlacementList, WorkerNode *worke
 	List *filteredShardPlacementList = NIL;
 	ShardPlacement *shardPlacement = NULL;
 
-	foreach_ptr(shardPlacement, activeShardPlacementList)
+	foreach_declared_ptr(shardPlacement, activeShardPlacementList)
 	{
 		if (IsPlacementOnWorkerNode(shardPlacement, workerNode))
 		{
@@ -1484,7 +1484,7 @@ ActiveShardPlacementListOnGroup(uint64 shardId, int32 groupId)
 
 	List *activePlacementList = ActiveShardPlacementList(shardId);
 	ShardPlacement *shardPlacement = NULL;
-	foreach_ptr(shardPlacement, activePlacementList)
+	foreach_declared_ptr(shardPlacement, activePlacementList)
 	{
 		if (shardPlacement->groupId == groupId)
 		{
@@ -3280,7 +3280,7 @@ ResetRunningBackgroundTasks(void)
 
 		/* there are tasks that need to release their lock before we can continue */
 		int64 *taskId = NULL;
-		foreach_ptr(taskId, taskIdsToWait)
+		foreach_declared_ptr(taskId, taskIdsToWait)
 		{
 			LOCKTAG locktag = { 0 };
 			SET_LOCKTAG_BACKGROUND_TASK(locktag, *taskId);

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -987,7 +987,7 @@ MarkNodesNotSyncedInLoopBackConnection(MetadataSyncContext *context,
 
 	List *commandList = NIL;
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, context->activatedWorkerNodeList)
+	foreach_declared_ptr(workerNode, context->activatedWorkerNodeList)
 	{
 		/*
 		 * We need to prevent self deadlock when we access pg_dist_node using separate
@@ -1020,7 +1020,7 @@ SetNodeMetadata(MetadataSyncContext *context, bool localOnly)
 		List *updatedActivatedNodeList = NIL;
 
 		WorkerNode *node = NULL;
-		foreach_ptr(node, context->activatedWorkerNodeList)
+		foreach_declared_ptr(node, context->activatedWorkerNodeList)
 		{
 			node = SetWorkerColumnLocalOnly(node, Anum_pg_dist_node_isactive,
 											BoolGetDatum(true));
@@ -1039,7 +1039,7 @@ SetNodeMetadata(MetadataSyncContext *context, bool localOnly)
 	if (!localOnly && EnableMetadataSync)
 	{
 		WorkerNode *node = NULL;
-		foreach_ptr(node, context->activatedWorkerNodeList)
+		foreach_declared_ptr(node, context->activatedWorkerNodeList)
 		{
 			SetNodeStateViaMetadataContext(context, node, BoolGetDatum(true));
 		}
@@ -1835,7 +1835,7 @@ FindNodeAnyClusterByNodeId(uint32 nodeId)
 	List *nodeList = ReadDistNode(includeNodesFromOtherClusters);
 	WorkerNode *node = NULL;
 
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		if (node->nodeId == nodeId)
 		{
@@ -1857,7 +1857,7 @@ FindNodeWithNodeId(int nodeId, bool missingOk)
 	List *nodeList = ActiveReadableNodeList();
 	WorkerNode *node = NULL;
 
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		if (node->nodeId == nodeId)
 		{
@@ -1885,7 +1885,7 @@ FindCoordinatorNodeId()
 	List *nodeList = ReadDistNode(includeNodesFromOtherClusters);
 	WorkerNode *node = NULL;
 
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		if (NodeIsCoordinator(node))
 		{
@@ -2015,7 +2015,7 @@ ErrorIfNodeContainsNonRemovablePlacements(WorkerNode *workerNode)
 	shardPlacements = SortList(shardPlacements, CompareGroupShardPlacements);
 
 	GroupShardPlacement *placement = NULL;
-	foreach_ptr(placement, shardPlacements)
+	foreach_declared_ptr(placement, shardPlacements)
 	{
 		if (!PlacementHasActivePlacementOnAnotherGroup(placement))
 		{
@@ -2051,7 +2051,7 @@ PlacementHasActivePlacementOnAnotherGroup(GroupShardPlacement *sourcePlacement)
 
 	bool foundActivePlacementOnAnotherGroup = false;
 	ShardPlacement *activePlacement = NULL;
-	foreach_ptr(activePlacement, activePlacementList)
+	foreach_declared_ptr(activePlacement, activePlacementList)
 	{
 		if (activePlacement->groupId != sourcePlacement->groupId)
 		{
@@ -2402,7 +2402,7 @@ SetWorkerColumnOptional(WorkerNode *workerNode, int columnIndex, Datum value)
 
 	/* open connections in parallel */
 	WorkerNode *worker = NULL;
-	foreach_ptr(worker, workerNodeList)
+	foreach_declared_ptr(worker, workerNodeList)
 	{
 		bool success = SendOptionalMetadataCommandListToWorkerInCoordinatedTransaction(
 			worker->workerName, worker->workerPort,
@@ -3104,7 +3104,7 @@ static void
 ErrorIfAnyNodeNotExist(List *nodeList)
 {
 	WorkerNode *node = NULL;
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		/*
 		 * First, locally mark the node is active, if everything goes well,
@@ -3153,7 +3153,7 @@ static void
 SendDeletionCommandsForReplicatedTablePlacements(MetadataSyncContext *context)
 {
 	WorkerNode *node = NULL;
-	foreach_ptr(node, context->activatedWorkerNodeList)
+	foreach_declared_ptr(node, context->activatedWorkerNodeList)
 	{
 		if (!node->isActive)
 		{

--- a/src/backend/distributed/operations/citus_create_restore_point.c
+++ b/src/backend/distributed/operations/citus_create_restore_point.c
@@ -122,7 +122,7 @@ OpenConnectionsToAllWorkerNodes(LOCKMODE lockMode)
 	List *workerNodeList = ActivePrimaryNonCoordinatorNodeList(lockMode);
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		MultiConnection *connection = StartNodeConnection(connectionFlags,
 														  workerNode->workerName,
@@ -164,7 +164,7 @@ CreateRemoteRestorePoints(char *restoreName, List *connectionList)
 	const char *parameterValues[1] = { restoreName };
 
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		int querySent = SendRemoteCommandParams(connection, CREATE_RESTORE_POINT_COMMAND,
 												parameterCount, parameterTypes,
@@ -175,7 +175,7 @@ CreateRemoteRestorePoints(char *restoreName, List *connectionList)
 		}
 	}
 
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		PGresult *result = GetRemoteCommandResult(connection, true);
 		if (!IsResponseOK(result))

--- a/src/backend/distributed/operations/create_shards.c
+++ b/src/backend/distributed/operations/create_shards.c
@@ -207,7 +207,7 @@ CreateShardsWithRoundRobinPolicy(Oid distributedTableId, int32 shardCount,
 	 * each placement insertion.
 	 */
 	uint64 *shardIdPtr;
-	foreach_ptr(shardIdPtr, insertedShardIds)
+	foreach_declared_ptr(shardIdPtr, insertedShardIds)
 	{
 		List *placementsForShard = ShardPlacementList(*shardIdPtr);
 		insertedShardPlacements = list_concat(insertedShardPlacements,
@@ -265,7 +265,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
 	char targetShardStorageType = ShardStorageType(targetRelationId);
 
 	ShardInterval *sourceShardInterval = NULL;
-	foreach_ptr(sourceShardInterval, sourceShardIntervalList)
+	foreach_declared_ptr(sourceShardInterval, sourceShardIntervalList)
 	{
 		uint64 sourceShardId = sourceShardInterval->shardId;
 		uint64 *newShardIdPtr = (uint64 *) palloc0(sizeof(uint64));
@@ -293,7 +293,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
 					   shardMinValueText, shardMaxValueText);
 
 		ShardPlacement *sourcePlacement = NULL;
-		foreach_ptr(sourcePlacement, sourceShardPlacementList)
+		foreach_declared_ptr(sourcePlacement, sourceShardPlacementList)
 		{
 			int32 groupId = sourcePlacement->groupId;
 			const uint64 shardSize = 0;
@@ -311,7 +311,7 @@ CreateColocatedShards(Oid targetRelationId, Oid sourceRelationId, bool
 	 * each placement insertion.
 	 */
 	uint64 *shardIdPtr;
-	foreach_ptr(shardIdPtr, insertedShardIds)
+	foreach_declared_ptr(shardIdPtr, insertedShardIds)
 	{
 		List *placementsForShard = ShardPlacementList(*shardIdPtr);
 		insertedShardPlacements = list_concat(insertedShardPlacements,

--- a/src/backend/distributed/operations/delete_protocol.c
+++ b/src/backend/distributed/operations/delete_protocol.c
@@ -250,12 +250,12 @@ DropShards(Oid relationId, char *schemaName, char *relationName,
 	bool shouldExecuteTasksLocally = ShouldExecuteTasksLocally(dropTaskList);
 
 	Task *task = NULL;
-	foreach_ptr(task, dropTaskList)
+	foreach_declared_ptr(task, dropTaskList)
 	{
 		uint64 shardId = task->anchorShardId;
 
 		ShardPlacement *shardPlacement = NULL;
-		foreach_ptr(shardPlacement, task->taskPlacementList)
+		foreach_declared_ptr(shardPlacement, task->taskPlacementList)
 		{
 			uint64 shardPlacementId = shardPlacement->placementId;
 			int32 shardPlacementGroupId = shardPlacement->groupId;
@@ -350,7 +350,7 @@ DropTaskList(Oid relationId, char *schemaName, char *relationName,
 	int taskId = 1;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, deletableShardIntervalList)
+	foreach_declared_ptr(shardInterval, deletableShardIntervalList)
 	{
 		Assert(shardInterval->relationId == relationId);
 

--- a/src/backend/distributed/operations/health_check.c
+++ b/src/backend/distributed/operations/health_check.c
@@ -119,11 +119,11 @@ StoreAllConnectivityChecks(Tuplestorestate *tupleStore, TupleDesc tupleDescripto
 
 	/*
 	 * We iterate over the workerNodeList twice, for source and target worker nodes. This
-	 * operation is safe for foreach_ptr macro, as long as we use different variables for
+	 * operation is safe for foreach_declared_ptr macro, as long as we use different variables for
 	 * each iteration.
 	 */
 	WorkerNode *sourceWorkerNode = NULL;
-	foreach_ptr(sourceWorkerNode, workerNodeList)
+	foreach_declared_ptr(sourceWorkerNode, workerNodeList)
 	{
 		const char *sourceNodeName = sourceWorkerNode->workerName;
 		const int sourceNodePort = sourceWorkerNode->workerPort;
@@ -135,7 +135,7 @@ StoreAllConnectivityChecks(Tuplestorestate *tupleStore, TupleDesc tupleDescripto
 
 		/* the second iteration over workerNodeList for the target worker nodes. */
 		WorkerNode *targetWorkerNode = NULL;
-		foreach_ptr(targetWorkerNode, workerNodeList)
+		foreach_declared_ptr(targetWorkerNode, workerNodeList)
 		{
 			const char *targetNodeName = targetWorkerNode->workerName;
 			const int targetNodePort = targetWorkerNode->workerPort;

--- a/src/backend/distributed/operations/node_protocol.c
+++ b/src/backend/distributed/operations/node_protocol.c
@@ -645,7 +645,7 @@ GetPreLoadTableCreationCommands(Oid relationId,
 	if (tableACLList != NIL)
 	{
 		char *tableACLCommand = NULL;
-		foreach_ptr(tableACLCommand, tableACLList)
+		foreach_declared_ptr(tableACLCommand, tableACLList)
 		{
 			tableDDLEventList = lappend(tableDDLEventList,
 										makeTableDDLCommandString(tableACLCommand));
@@ -822,7 +822,7 @@ GetTableRowLevelSecurityCommands(Oid relationId)
 	List *rowLevelSecurityEnableCommands = pg_get_row_level_security_commands(relationId);
 
 	char *rowLevelSecurityCommand = NULL;
-	foreach_ptr(rowLevelSecurityCommand, rowLevelSecurityEnableCommands)
+	foreach_declared_ptr(rowLevelSecurityCommand, rowLevelSecurityEnableCommands)
 	{
 		rowLevelSecurityCommandList = lappend(
 			rowLevelSecurityCommandList,

--- a/src/backend/distributed/operations/replicate_none_dist_table_shard.c
+++ b/src/backend/distributed/operations/replicate_none_dist_table_shard.c
@@ -63,7 +63,7 @@ NoneDistTableReplicateCoordinatorPlacement(Oid noneDistTableId,
 	/* insert new placements to pg_dist_placement */
 	List *insertedPlacementList = NIL;
 	WorkerNode *targetNode = NULL;
-	foreach_ptr(targetNode, targetNodeList)
+	foreach_declared_ptr(targetNode, targetNodeList)
 	{
 		ShardPlacement *shardPlacement =
 			InsertShardPlacementRowGlobally(shardId, GetNextPlacementId(),
@@ -215,7 +215,7 @@ CreateForeignKeysFromReferenceTablesOnShards(Oid noneDistTableId)
 	List *taskList = NIL;
 
 	char *command = NULL;
-	foreach_ptr(command, ddlCommandList)
+	foreach_declared_ptr(command, ddlCommandList)
 	{
 		List *commandTaskList = InterShardDDLTaskList(
 			ForeignConstraintGetReferencingTableId(command),

--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -264,7 +264,7 @@ DropOrphanedResourcesForCleanup()
 	int failedResourceCountForCleanup = 0;
 	CleanupRecord *record = NULL;
 
-	foreach_ptr(record, cleanupRecordList)
+	foreach_declared_ptr(record, cleanupRecordList)
 	{
 		if (!PrimaryNodeForGroup(record->nodeGroupId, NULL))
 		{
@@ -374,7 +374,7 @@ FinalizeOperationNeedingCleanupOnSuccess(const char *operationName)
 	int failedShardCountOnComplete = 0;
 
 	CleanupRecord *record = NULL;
-	foreach_ptr(record, currentOperationRecordList)
+	foreach_declared_ptr(record, currentOperationRecordList)
 	{
 		if (record->policy == CLEANUP_ALWAYS)
 		{

--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -357,7 +357,7 @@ CheckRebalanceStateInvariants(const RebalanceState *state)
 
 	Assert(state != NULL);
 	Assert(list_length(state->fillStateListAsc) == list_length(state->fillStateListDesc));
-	foreach_ptr(fillState, state->fillStateListAsc)
+	foreach_declared_ptr(fillState, state->fillStateListAsc)
 	{
 		float4 totalCost = 0;
 		ShardCost *shardCost = NULL;
@@ -376,7 +376,7 @@ CheckRebalanceStateInvariants(const RebalanceState *state)
 			   fillState);
 
 
-		foreach_ptr(shardCost, fillState->shardCostListDesc)
+		foreach_declared_ptr(shardCost, fillState->shardCostListDesc)
 		{
 			if (prevShardCost != NULL)
 			{
@@ -520,7 +520,7 @@ GetRebalanceSteps(RebalanceOptions *options)
 	List *activeWorkerList = SortedActiveWorkers();
 	int shardAllowedNodeCount = 0;
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, activeWorkerList)
+	foreach_declared_ptr(workerNode, activeWorkerList)
 	{
 		if (workerNode->shouldHaveShards)
 		{
@@ -539,7 +539,7 @@ GetRebalanceSteps(RebalanceOptions *options)
 	List *unbalancedShards = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, options->relationIdList)
+	foreach_declared_oid(relationId, options->relationIdList)
 	{
 		List *shardPlacementList = FullShardPlacementList(relationId,
 														  options->excludedShardArray);
@@ -1335,7 +1335,7 @@ get_rebalance_progress(PG_FUNCTION_ARGS)
 													 &segmentList);
 
 	ProgressMonitorData *monitor = NULL;
-	foreach_ptr(monitor, rebalanceMonitorList)
+	foreach_declared_ptr(monitor, rebalanceMonitorList)
 	{
 		PlacementUpdateEventProgress *placementUpdateEvents = ProgressMonitorSteps(
 			monitor);
@@ -1846,7 +1846,7 @@ NonColocatedDistRelationIdList(void)
 
 	HTAB *alreadySelectedColocationIds = hash_create("RebalanceColocationIdSet",
 													 capacity, &info, flags);
-	foreach_oid(tableId, allCitusTablesList)
+	foreach_declared_oid(tableId, allCitusTablesList)
 	{
 		bool foundInSet = false;
 		CitusTableCacheEntry *citusTableCacheEntry = GetCitusTableCacheEntry(
@@ -1912,7 +1912,7 @@ RebalanceTableShards(RebalanceOptions *options, Oid shardReplicationModeOid)
 		 * is required for logical replication to replicate UPDATE and DELETE commands.
 		 */
 		PlacementUpdateEvent *placementUpdate = NULL;
-		foreach_ptr(placementUpdate, placementUpdateList)
+		foreach_declared_ptr(placementUpdate, placementUpdateList)
 		{
 			Oid relationId = RelationIdForShard(placementUpdate->shardId);
 			List *colocatedTableList = ColocatedTableList(relationId);
@@ -1947,7 +1947,7 @@ static void
 ErrorOnConcurrentRebalance(RebalanceOptions *options)
 {
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, options->relationIdList)
+	foreach_declared_oid(relationId, options->relationIdList)
 	{
 		/* this provides the legacy error when the lock can't be acquired */
 		AcquireRebalanceColocationLock(relationId, options->operationName);
@@ -2038,7 +2038,7 @@ GenerateTaskMoveDependencyList(PlacementUpdateEvent *move, int64 colocationId,
 	if (found)
 	{
 		int64 *taskId = NULL;
-		foreach_ptr(taskId, shardMoveSourceNodeHashEntry->taskIds)
+		foreach_declared_ptr(taskId, shardMoveSourceNodeHashEntry->taskIds)
 		{
 			hash_search(dependsList, taskId, HASH_ENTER, NULL);
 		}
@@ -2122,13 +2122,13 @@ RebalanceTableShardsBackground(RebalanceOptions *options, Oid shardReplicationMo
 	const char shardTransferMode = LookupShardTransferMode(shardReplicationModeOid);
 	List *colocatedTableList = NIL;
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, options->relationIdList)
+	foreach_declared_oid(relationId, options->relationIdList)
 	{
 		colocatedTableList = list_concat(colocatedTableList,
 										 ColocatedTableList(relationId));
 	}
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		EnsureTableOwner(colocatedTableId);
 	}
@@ -2150,7 +2150,7 @@ RebalanceTableShardsBackground(RebalanceOptions *options, Oid shardReplicationMo
 		 * is required for logical replication to replicate UPDATE and DELETE commands.
 		 */
 		PlacementUpdateEvent *placementUpdate = NULL;
-		foreach_ptr(placementUpdate, placementUpdateList)
+		foreach_declared_ptr(placementUpdate, placementUpdateList)
 		{
 			relationId = RelationIdForShard(placementUpdate->shardId);
 			List *colocatedTables = ColocatedTableList(relationId);
@@ -2203,7 +2203,7 @@ RebalanceTableShardsBackground(RebalanceOptions *options, Oid shardReplicationMo
 
 	ShardMoveDependencies shardMoveDependencies = InitializeShardMoveDependencies();
 
-	foreach_ptr(move, placementUpdateList)
+	foreach_declared_ptr(move, placementUpdateList)
 	{
 		resetStringInfo(&buf);
 
@@ -2360,7 +2360,7 @@ ExecuteRebalancerCommandInSeparateTransaction(char *command)
 		List *setCommands = GetSetCommandListForNewConnections();
 		char *setCommand = NULL;
 
-		foreach_ptr(setCommand, setCommands)
+		foreach_declared_ptr(setCommand, setCommands)
 		{
 			commandList = lappend(commandList, setCommand);
 		}
@@ -2428,14 +2428,14 @@ RebalancePlacementUpdates(List *workerNodeList, List *activeShardPlacementListLi
 	List *shardPlacementList = NIL;
 	List *placementUpdateList = NIL;
 
-	foreach_ptr(shardPlacementList, activeShardPlacementListList)
+	foreach_declared_ptr(shardPlacementList, activeShardPlacementListList)
 	{
 		state = InitRebalanceState(workerNodeList, shardPlacementList,
 								   functions);
 		rebalanceStates = lappend(rebalanceStates, state);
 	}
 
-	foreach_ptr(state, rebalanceStates)
+	foreach_declared_ptr(state, rebalanceStates)
 	{
 		state->placementUpdateList = placementUpdateList;
 		MoveShardsAwayFromDisallowedNodes(state);
@@ -2444,7 +2444,7 @@ RebalancePlacementUpdates(List *workerNodeList, List *activeShardPlacementListLi
 
 	if (!drainOnly)
 	{
-		foreach_ptr(state, rebalanceStates)
+		foreach_declared_ptr(state, rebalanceStates)
 		{
 			state->placementUpdateList = placementUpdateList;
 
@@ -2476,13 +2476,13 @@ RebalancePlacementUpdates(List *workerNodeList, List *activeShardPlacementListLi
 		}
 	}
 
-	foreach_ptr(state, rebalanceStates)
+	foreach_declared_ptr(state, rebalanceStates)
 	{
 		hash_destroy(state->placementsHash);
 	}
 
 	int64 ignoredMoves = 0;
-	foreach_ptr(state, rebalanceStates)
+	foreach_declared_ptr(state, rebalanceStates)
 	{
 		ignoredMoves += state->ignoredMoves;
 	}
@@ -2537,7 +2537,7 @@ InitRebalanceState(List *workerNodeList, List *shardPlacementList,
 	state->placementsHash = ShardPlacementsListToHash(shardPlacementList);
 
 	/* create empty fill state for all of the worker nodes */
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		NodeFillState *fillState = palloc0(sizeof(NodeFillState));
 		fillState->node = workerNode;
@@ -2620,7 +2620,7 @@ FindFillStateForPlacement(RebalanceState *state, ShardPlacement *placement)
 	NodeFillState *fillState = NULL;
 
 	/* Find the correct fill state to add the placement to and do that */
-	foreach_ptr(fillState, state->fillStateListAsc)
+	foreach_declared_ptr(fillState, state->fillStateListAsc)
 	{
 		if (IsPlacementOnWorkerNode(placement, fillState->node))
 		{
@@ -2732,7 +2732,7 @@ MoveShardsAwayFromDisallowedNodes(RebalanceState *state)
 											  CompareDisallowedPlacementDesc);
 
 	/* Move shards off of nodes they are not allowed on */
-	foreach_ptr(disallowedPlacement, state->disallowedPlacementList)
+	foreach_declared_ptr(disallowedPlacement, state->disallowedPlacementList)
 	{
 		NodeFillState *targetFillState = FindAllowedTargetFillState(
 			state, disallowedPlacement->shardCost->shardId);
@@ -2787,7 +2787,7 @@ static NodeFillState *
 FindAllowedTargetFillState(RebalanceState *state, uint64 shardId)
 {
 	NodeFillState *targetFillState = NULL;
-	foreach_ptr(targetFillState, state->fillStateListAsc)
+	foreach_declared_ptr(targetFillState, state->fillStateListAsc)
 	{
 		bool hasShard = PlacementsHashFind(
 			state->placementsHash,
@@ -2913,7 +2913,7 @@ FindAndMoveShardCost(float4 utilizationLowerBound,
 	 * find a source node for the move, starting at the node with the highest
 	 * utilization
 	 */
-	foreach_ptr(sourceFillState, state->fillStateListDesc)
+	foreach_declared_ptr(sourceFillState, state->fillStateListDesc)
 	{
 		/* Don't move shards away from nodes that are already too empty, we're
 		 * done searching */
@@ -2924,7 +2924,7 @@ FindAndMoveShardCost(float4 utilizationLowerBound,
 
 		/* find a target node for the move, starting at the node with the
 		 * lowest utilization */
-		foreach_ptr(targetFillState, state->fillStateListAsc)
+		foreach_declared_ptr(targetFillState, state->fillStateListAsc)
 		{
 			ShardCost *shardCost = NULL;
 
@@ -2947,7 +2947,7 @@ FindAndMoveShardCost(float4 utilizationLowerBound,
 
 			/* find a shardcost that can be moved between between nodes that
 			 * makes the cost distribution more equal */
-			foreach_ptr(shardCost, sourceFillState->shardCostListDesc)
+			foreach_declared_ptr(shardCost, sourceFillState->shardCostListDesc)
 			{
 				bool targetHasShard = PlacementsHashFind(state->placementsHash,
 														 shardCost->shardId,

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -302,7 +302,7 @@ ErrorIfCannotSplitShardExtended(SplitOperation splitOperation,
 
 	NullableDatum lastShardSplitPoint = { 0, true /*isnull*/ };
 	Datum shardSplitPoint;
-	foreach_int(shardSplitPoint, shardSplitPointsList)
+	foreach_declared_int(shardSplitPoint, shardSplitPointsList)
 	{
 		int32 shardSplitPointValue = DatumGetInt32(shardSplitPoint);
 
@@ -399,7 +399,7 @@ GetWorkerNodesFromWorkerIds(List *nodeIdsForPlacementList)
 {
 	List *workersForPlacementList = NIL;
 	int32 nodeId;
-	foreach_int(nodeId, nodeIdsForPlacementList)
+	foreach_declared_int(nodeId, nodeIdsForPlacementList)
 	{
 		uint32 nodeIdValue = (uint32) nodeId;
 		WorkerNode *workerNode = LookupNodeByNodeId(nodeIdValue);
@@ -464,7 +464,7 @@ SplitShard(SplitMode splitMode,
 	/* sort the tables to avoid deadlocks */
 	colocatedTableList = SortList(colocatedTableList, CompareOids);
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		/*
 		 * Block concurrent DDL / TRUNCATE commands on the relation. Similarly,
@@ -694,7 +694,7 @@ CreateSplitShardsForShardGroup(List *shardGroupSplitIntervalListList,
 	 * Iterate over all the shards in the shard group.
 	 */
 	List *shardIntervalList = NIL;
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		WorkerNode *workerPlacementNode = NULL;
@@ -778,7 +778,7 @@ CreateAuxiliaryStructuresForShardGroup(List *shardGroupSplitIntervalListList,
 	/*
 	 * Iterate over all the shards in the shard group.
 	 */
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		WorkerNode *workerPlacementNode = NULL;
@@ -1029,7 +1029,7 @@ CreateSplitIntervalsForShardGroup(List *sourceColocatedShardIntervalList,
 	List *shardGroupSplitIntervalListList = NIL;
 
 	ShardInterval *shardToSplitInterval = NULL;
-	foreach_ptr(shardToSplitInterval, sourceColocatedShardIntervalList)
+	foreach_declared_ptr(shardToSplitInterval, sourceColocatedShardIntervalList)
 	{
 		List *shardSplitIntervalList = NIL;
 		CreateSplitIntervalsForShard(shardToSplitInterval, splitPointsForShard,
@@ -1121,7 +1121,7 @@ UpdateDistributionColumnsForShardGroup(List *colocatedShardList,
 									   uint32 colocationId)
 {
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, colocatedShardList)
+	foreach_declared_ptr(shardInterval, colocatedShardList)
 	{
 		Oid relationId = shardInterval->relationId;
 		Var *distributionColumn = GetDistributionColumnFromMap(distributionColumnMap,
@@ -1162,7 +1162,7 @@ InsertSplitChildrenShardMetadata(List *shardGroupSplitIntervalListList,
 	/*
 	 * Iterate over all the shards in the shard group.
 	 */
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		/*
 		 * Iterate on split shards list for a given shard and insert metadata.
@@ -1195,7 +1195,7 @@ InsertSplitChildrenShardMetadata(List *shardGroupSplitIntervalListList,
 	/* send commands to synced nodes one by one */
 	List *splitOffShardMetadataCommandList = ShardListInsertCommand(syncedShardList);
 	char *command = NULL;
-	foreach_ptr(command, splitOffShardMetadataCommandList)
+	foreach_declared_ptr(command, splitOffShardMetadataCommandList)
 	{
 		SendCommandToWorkersWithMetadata(command);
 	}
@@ -1216,7 +1216,7 @@ CreatePartitioningHierarchyForBlockingSplit(List *shardGroupSplitIntervalListLis
 	/*
 	 * Iterate over all the shards in the shard group.
 	 */
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		WorkerNode *workerPlacementNode = NULL;
@@ -1255,7 +1255,7 @@ CreateForeignKeyConstraints(List *shardGroupSplitIntervalListList,
 	/*
 	 * Iterate over all the shards in the shard group.
 	 */
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		WorkerNode *workerPlacementNode = NULL;
@@ -1281,7 +1281,7 @@ CreateForeignKeyConstraints(List *shardGroupSplitIntervalListList,
 												referenceTableForeignConstraintList);
 
 			char *constraintCommand = NULL;
-			foreach_ptr(constraintCommand, constraintCommandList)
+			foreach_declared_ptr(constraintCommand, constraintCommandList)
 			{
 				SendCommandToWorker(
 					workerPlacementNode->workerName,
@@ -1685,7 +1685,7 @@ CreateDummyShardsForShardGroup(HTAB *mapOfPlacementToDummyShardList,
 		}
 
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, sourceColocatedShardIntervalList)
+		foreach_declared_ptr(shardInterval, sourceColocatedShardIntervalList)
 		{
 			/* Populate list of commands necessary to create shard interval on destination */
 			List *splitShardCreationCommandList = GetPreLoadTableCreationCommands(
@@ -1739,7 +1739,7 @@ CreateDummyShardsForShardGroup(HTAB *mapOfPlacementToDummyShardList,
 	 * If the target shard was created on source node as placement, skip it (See Note 2 from function description).
 	 */
 	List *shardIntervalList = NULL;
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		workerPlacementNode = NULL;
@@ -1818,7 +1818,7 @@ CreateWorkerForPlacementSet(List *workersForPlacementList)
 											  hashFlags);
 
 	WorkerNode *workerForPlacement = NULL;
-	foreach_ptr(workerForPlacement, workersForPlacementList)
+	foreach_declared_ptr(workerForPlacement, workersForPlacementList)
 	{
 		void *hashKey = (void *) workerForPlacement;
 		hash_search(workerForPlacementSet, hashKey, HASH_ENTER, NULL);

--- a/src/backend/distributed/operations/shard_transfer.c
+++ b/src/backend/distributed/operations/shard_transfer.c
@@ -492,7 +492,7 @@ TransferShards(int64 shardId, char *sourceNodeName,
 	DropOrphanedResourcesInSeparateTransaction();
 
 	ShardInterval *colocatedShard = NULL;
-	foreach_ptr(colocatedShard, colocatedShardList)
+	foreach_declared_ptr(colocatedShard, colocatedShardList)
 	{
 		/*
 		 * This is to prevent any race condition possibility among the shard moves.
@@ -519,7 +519,7 @@ TransferShards(int64 shardId, char *sourceNodeName,
 	 * metadata workers.
 	 */
 	colocatedShard = NULL;
-	foreach_ptr(colocatedShard, colocatedShardList)
+	foreach_declared_ptr(colocatedShard, colocatedShardList)
 	{
 		uint64 colocatedShardId = colocatedShard->shardId;
 		uint32 groupId = GroupForNode(targetNodeName, targetNodePort);
@@ -612,7 +612,7 @@ InsertCleanupRecordsForShardPlacementsOnNode(List *shardIntervalList,
 											 int32 groupId)
 {
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		/* get shard name */
 		char *qualifiedShardName = ConstructQualifiedShardName(shardInterval);
@@ -649,7 +649,7 @@ IsShardListOnNode(List *colocatedShardList, char *targetNodeName, uint32 targetN
 	 * We exhaustively search all co-located shards
 	 */
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, colocatedShardList)
+	foreach_declared_ptr(shardInterval, colocatedShardList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		List *placementList = ActiveShardPlacementListOnGroup(shardId,
@@ -672,7 +672,7 @@ static void
 LockColocatedRelationsForMove(List *colocatedTableList)
 {
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		LockRelationOid(colocatedTableId, ShareUpdateExclusiveLock);
 	}
@@ -688,7 +688,7 @@ ErrorIfForeignTableForShardTransfer(List *colocatedTableList,
 									ShardTransferType transferType)
 {
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		if (IsForeignTable(colocatedTableId))
 		{
@@ -714,7 +714,7 @@ EnsureAllShardsCanBeCopied(List *colocatedShardList,
 						   char *targetNodeName, uint32 targetNodePort)
 {
 	ShardInterval *colocatedShard = NULL;
-	foreach_ptr(colocatedShard, colocatedShardList)
+	foreach_declared_ptr(colocatedShard, colocatedShardList)
 	{
 		uint64 colocatedShardId = colocatedShard->shardId;
 
@@ -1109,7 +1109,7 @@ void
 BlockWritesToShardList(List *shardList)
 {
 	ShardInterval *shard = NULL;
-	foreach_ptr(shard, shardList)
+	foreach_declared_ptr(shard, shardList)
 	{
 		/*
 		 * We need to lock the referenced reference table metadata to avoid
@@ -1280,7 +1280,7 @@ static void
 EnsureTableListOwner(List *tableIdList)
 {
 	Oid tableId = InvalidOid;
-	foreach_oid(tableId, tableIdList)
+	foreach_declared_oid(tableId, tableIdList)
 	{
 		EnsureTableOwner(tableId);
 	}
@@ -1295,7 +1295,7 @@ static void
 ErrorIfReplicatingDistributedTableWithFKeys(List *tableIdList)
 {
 	Oid tableId = InvalidOid;
-	foreach_oid(tableId, tableIdList)
+	foreach_declared_oid(tableId, tableIdList)
 	{
 		List *foreignConstraintCommandList =
 			GetReferencingForeignConstaintCommands(tableId);
@@ -1366,7 +1366,7 @@ CopyShardTablesViaLogicalReplication(List *shardIntervalList, char *sourceNodeNa
 	 * target node. We do not create the indexes yet.
 	 */
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		Oid relationId = shardInterval->relationId;
 		uint64 shardId = shardInterval->shardId;
@@ -1433,7 +1433,7 @@ CopyShardTablesViaBlockWrites(List *shardIntervalList, char *sourceNodeName,
 
 	/* iterate through the colocated shards and copy each */
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		/*
 		 * For each shard we first create the shard table in a separate
@@ -1475,7 +1475,7 @@ CopyShardTablesViaBlockWrites(List *shardIntervalList, char *sourceNodeName,
 		sourceNodePort,
 		PLACEMENT_UPDATE_STATUS_CREATING_CONSTRAINTS);
 
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		List *ddlCommandList =
 			PostLoadShardCreationCommandList(shardInterval, sourceNodeName,
@@ -1492,7 +1492,7 @@ CopyShardTablesViaBlockWrites(List *shardIntervalList, char *sourceNodeName,
 	 * Create DDL commands to Attach child tables to their parents in a partitioning hierarchy.
 	 */
 	List *shardIntervalWithDDCommandsList = NIL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		if (PartitionTable(shardInterval->relationId))
 		{
@@ -1517,7 +1517,7 @@ CopyShardTablesViaBlockWrites(List *shardIntervalList, char *sourceNodeName,
 	 * Iterate through the colocated shards and create DDL commamnds
 	 * to create the foreign constraints.
 	 */
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		List *shardForeignConstraintCommandList = NIL;
 		List *referenceTableForeignConstraintList = NIL;
@@ -1536,7 +1536,7 @@ CopyShardTablesViaBlockWrites(List *shardIntervalList, char *sourceNodeName,
 
 	/* Now execute the Partitioning & Foreign constraints creation commads. */
 	ShardCommandList *shardCommandList = NULL;
-	foreach_ptr(shardCommandList, shardIntervalWithDDCommandsList)
+	foreach_declared_ptr(shardCommandList, shardIntervalWithDDCommandsList)
 	{
 		char *tableOwner = TableOwner(shardCommandList->shardInterval->relationId);
 		SendCommandListToWorkerOutsideTransaction(targetNodeName, targetNodePort,
@@ -1566,7 +1566,7 @@ CopyShardsToNode(WorkerNode *sourceNode, WorkerNode *targetNode, List *shardInte
 	int taskId = 0;
 	List *copyTaskList = NIL;
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		/*
 		 * Skip copying data for partitioned tables, because they contain no
@@ -1699,7 +1699,7 @@ SearchShardPlacementInList(List *shardPlacementList, const char *nodeName,
 						   uint32 nodePort)
 {
 	ShardPlacement *shardPlacement = NULL;
-	foreach_ptr(shardPlacement, shardPlacementList)
+	foreach_declared_ptr(shardPlacement, shardPlacementList)
 	{
 		if (strncmp(nodeName, shardPlacement->nodeName, MAX_NODE_LENGTH) == 0 &&
 			nodePort == shardPlacement->nodePort)
@@ -1820,7 +1820,7 @@ CopyShardForeignConstraintCommandListGrouped(ShardInterval *shardInterval,
 	*referenceTableForeignConstraintList = NIL;
 
 	const char *command = NULL;
-	foreach_ptr(command, commandList)
+	foreach_declared_ptr(command, commandList)
 	{
 		char *escapedCommand = quote_literal_cstr(command);
 
@@ -1989,7 +1989,7 @@ DropShardPlacementsFromMetadata(List *shardList,
 								char *nodeName, int32 nodePort)
 {
 	ShardInterval *shardInverval = NULL;
-	foreach_ptr(shardInverval, shardList)
+	foreach_declared_ptr(shardInverval, shardList)
 	{
 		uint64 shardId = shardInverval->shardId;
 		List *shardPlacementList = ShardPlacementList(shardId);
@@ -2053,7 +2053,7 @@ WorkerApplyShardDDLCommandList(List *ddlCommandList, int64 shardId)
 	List *applyDDLCommandList = NIL;
 
 	TableDDLCommand *ddlCommand = NULL;
-	foreach_ptr(ddlCommand, ddlCommandList)
+	foreach_declared_ptr(ddlCommand, ddlCommandList)
 	{
 		Assert(CitusIsA(ddlCommand, TableDDLCommand));
 		char *applyDDLCommand = GetShardedTableDDLCommand(ddlCommand, shardId, NULL);
@@ -2087,7 +2087,7 @@ UpdatePlacementUpdateStatusForShardIntervalList(List *shardIntervalList,
 	}
 
 	ProgressMonitorData *monitor = NULL;
-	foreach_ptr(monitor, rebalanceMonitorList)
+	foreach_declared_ptr(monitor, rebalanceMonitorList)
 	{
 		PlacementUpdateEventProgress *steps = ProgressMonitorSteps(monitor);
 
@@ -2098,7 +2098,7 @@ UpdatePlacementUpdateStatusForShardIntervalList(List *shardIntervalList,
 			bool foundInList = false;
 
 			ShardInterval *candidateShard = NULL;
-			foreach_ptr(candidateShard, shardIntervalList)
+			foreach_declared_ptr(candidateShard, shardIntervalList)
 			{
 				if (candidateShard->shardId == currentShardId)
 				{

--- a/src/backend/distributed/operations/stage_protocol.c
+++ b/src/backend/distributed/operations/stage_protocol.c
@@ -431,7 +431,7 @@ CreateShardsOnWorkers(Oid distributedRelationId, List *shardPlacements,
 	int poolSize = 1;
 
 	ShardPlacement *shardPlacement = NULL;
-	foreach_ptr(shardPlacement, shardPlacements)
+	foreach_declared_ptr(shardPlacement, shardPlacements)
 	{
 		uint64 shardId = shardPlacement->shardId;
 		ShardInterval *shardInterval = LoadShardInterval(shardId);
@@ -516,7 +516,7 @@ RelationShardListForShardCreate(ShardInterval *shardInterval)
 
 	/* all foregin key constraint relations */
 	Oid fkeyRelationid = InvalidOid;
-	foreach_oid(fkeyRelationid, allForeignKeyRelations)
+	foreach_declared_oid(fkeyRelationid, allForeignKeyRelations)
 	{
 		uint64 fkeyShardId = INVALID_SHARD_ID;
 
@@ -590,7 +590,7 @@ WorkerCreateShardCommandList(Oid relationId, uint64 shardId,
 	char *schemaName = get_namespace_name(schemaId);
 
 	TableDDLCommand *ddlCommand = NULL;
-	foreach_ptr(ddlCommand, ddlCommandList)
+	foreach_declared_ptr(ddlCommand, ddlCommandList)
 	{
 		Assert(CitusIsA(ddlCommand, TableDDLCommand));
 		char *applyDDLCommand = GetShardedTableDDLCommand(ddlCommand, shardId,
@@ -645,7 +645,7 @@ UpdateShardStatistics(int64 shardId)
 
 	/* get shard's statistics from a shard placement */
 	ShardPlacement *placement = NULL;
-	foreach_ptr(placement, shardPlacementList)
+	foreach_declared_ptr(placement, shardPlacementList)
 	{
 		statsOK = WorkerShardStats(placement, relationId, shardQualifiedName,
 								   &shardSize);
@@ -713,7 +713,7 @@ ReceiveAndUpdateShardsSizes(List *connectionList)
 																	  "oid visited hash set");
 
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		if (PQstatus(connection->pgConn) != CONNECTION_OK)
 		{
@@ -809,7 +809,7 @@ UpdateShardSize(uint64 shardId, ShardInterval *shardInterval, Oid relationId,
 	ShardPlacement *placement = NULL;
 
 	/* update metadata for each shard placement */
-	foreach_ptr(placement, shardPlacementList)
+	foreach_declared_ptr(placement, shardPlacementList)
 	{
 		uint64 placementId = placement->placementId;
 		int32 groupId = placement->groupId;

--- a/src/backend/distributed/operations/worker_node_manager.c
+++ b/src/backend/distributed/operations/worker_node_manager.c
@@ -421,7 +421,7 @@ GetFirstPrimaryWorkerNode(void)
 	List *workerNodeList = ActivePrimaryNonCoordinatorNodeList(RowShareLock);
 	WorkerNode *firstWorkerNode = NULL;
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if (firstWorkerNode == NULL ||
 			CompareWorkerNodes(&workerNode, &firstWorkerNode) < 0)

--- a/src/backend/distributed/operations/worker_split_copy_udf.c
+++ b/src/backend/distributed/operations/worker_split_copy_udf.c
@@ -146,7 +146,7 @@ TraceWorkerSplitCopyUdf(char *sourceShardToCopySchemaName,
 	int index = 1;
 	int splitWayCount = list_length(splitCopyInfoList);
 	SplitCopyInfo *splitCopyInfo = NULL;
-	foreach_ptr(splitCopyInfo, splitCopyInfoList)
+	foreach_declared_ptr(splitCopyInfo, splitCopyInfoList)
 	{
 		char *shardNameCopy = pstrdup(sourceShardToCopyPrefix);
 		AppendShardIdToName(&shardNameCopy, splitCopyInfo->destinationShardId);
@@ -236,7 +236,7 @@ BuildMinMaxRangeArrays(List *splitCopyInfoList, ArrayType **minValueArray,
 
 	SplitCopyInfo *splitCopyInfo = NULL;
 	int index = 0;
-	foreach_ptr(splitCopyInfo, splitCopyInfoList)
+	foreach_declared_ptr(splitCopyInfo, splitCopyInfoList)
 	{
 		minValues[index] = splitCopyInfo->destinationShardMinHashValue;
 		maxValues[index] = splitCopyInfo->destinationShardMaxHashValue;
@@ -269,7 +269,7 @@ CreateShardCopyDestReceivers(EState *estate, ShardInterval *shardIntervalToSplit
 	SplitCopyInfo *splitCopyInfo = NULL;
 	int index = 0;
 	char *sourceShardNamePrefix = get_rel_name(shardIntervalToSplitCopy->relationId);
-	foreach_ptr(splitCopyInfo, splitCopyInfoList)
+	foreach_declared_ptr(splitCopyInfo, splitCopyInfoList)
 	{
 		Oid destinationShardSchemaOid = get_rel_namespace(
 			shardIntervalToSplitCopy->relationId);

--- a/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
+++ b/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
@@ -298,7 +298,7 @@ PopulateShardSplitInfoInSM(ShardSplitInfoSMHeader *shardSplitInfoSMHeader,
 
 		List *shardSplitInfoList = entry->shardSplitInfoList;
 		ShardSplitInfo *splitShardInfo = NULL;
-		foreach_ptr(splitShardInfo, shardSplitInfoList)
+		foreach_declared_ptr(splitShardInfo, shardSplitInfoList)
 		{
 			shardSplitInfoSMHeader->splitInfoArray[splitInfoIndex] = *splitShardInfo;
 			strcpy_s(shardSplitInfoSMHeader->splitInfoArray[splitInfoIndex].slotName,

--- a/src/backend/distributed/planner/combine_query_planner.c
+++ b/src/backend/distributed/planner/combine_query_planner.c
@@ -217,7 +217,7 @@ CitusCustomScanPathPlan(PlannerInfo *root,
 	{
 		TargetEntry *targetEntry = NULL;
 
-		foreach_ptr(targetEntry, citusPath->remoteScan->custom_scan_tlist)
+		foreach_declared_ptr(targetEntry, citusPath->remoteScan->custom_scan_tlist)
 		{
 			/* we created this list, so we know it only contains Var */
 			Assert(IsA(targetEntry->expr, Var));
@@ -231,7 +231,7 @@ CitusCustomScanPathPlan(PlannerInfo *root,
 	/* clauses might have been added by the planner, need to add them to our scan */
 	RestrictInfo *restrictInfo = NULL;
 	List **quals = &citusPath->remoteScan->scan.plan.qual;
-	foreach_ptr(restrictInfo, clauses)
+	foreach_declared_ptr(restrictInfo, clauses)
 	{
 		*quals = lappend(*quals, restrictInfo->clause);
 	}
@@ -273,7 +273,7 @@ BuildSelectStatementViaStdPlanner(Query *combineQuery, List *remoteScanTargetLis
 		/* extract column names from the remoteScanTargetList */
 		List *columnNameList = NIL;
 		TargetEntry *targetEntry = NULL;
-		foreach_ptr(targetEntry, remoteScanTargetList)
+		foreach_declared_ptr(targetEntry, remoteScanTargetList)
 		{
 			columnNameList = lappend(columnNameList, makeString(targetEntry->resname));
 		}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -67,7 +67,7 @@ RebuildQueryStrings(Job *workerJob)
 		AddInsertAliasIfNeeded(originalQuery);
 	}
 
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		Query *query = originalQuery;
 
@@ -298,7 +298,7 @@ FindRelationShard(Oid inputRelationId, List *relationShardList)
 	 * some, otherwise this query wouldn't be eligible as a router query.
 	 * FIXME: We should probably use a hashtable here, to do efficient lookup.
 	 */
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		if (inputRelationId == relationShard->relationId)
 		{

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -1545,7 +1545,7 @@ FinalizeRouterPlan(PlannedStmt *localPlan, CustomScan *customScan)
 
 	/* extract the column names from the final targetlist*/
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, customScan->scan.plan.targetlist)
+	foreach_declared_ptr(targetEntry, customScan->scan.plan.targetlist)
 	{
 		String *columnName = makeString(targetEntry->resname);
 		columnNameList = lappend(columnNameList, columnName);
@@ -1586,7 +1586,7 @@ makeCustomScanTargetlistFromExistingTargetList(List *existingTargetlist)
 
 	/* build a targetlist to read from the custom scan output */
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, existingTargetlist)
+	foreach_declared_ptr(targetEntry, existingTargetlist)
 	{
 		Assert(IsA(targetEntry, TargetEntry));
 
@@ -1636,7 +1636,7 @@ makeTargetListFromCustomScanList(List *custom_scan_tlist)
 	List *targetList = NIL;
 	TargetEntry *targetEntry = NULL;
 	int resno = 1;
-	foreach_ptr(targetEntry, custom_scan_tlist)
+	foreach_declared_ptr(targetEntry, custom_scan_tlist)
 	{
 		/*
 		 * INDEX_VAR is used to reference back to the TargetEntry in custom_scan_tlist by
@@ -2105,7 +2105,7 @@ TranslatedVars(PlannerInfo *root, int relationIndex)
 		{
 			/* postgres deletes translated_vars, hence we deep copy them here */
 			Node *targetNode = NULL;
-			foreach_ptr(targetNode, targetAppendRelInfo->translated_vars)
+			foreach_declared_ptr(targetNode, targetAppendRelInfo->translated_vars)
 			{
 				translatedVars =
 					lappend(translatedVars, copyObject(targetNode));
@@ -2126,7 +2126,7 @@ FindTargetAppendRelInfo(PlannerInfo *root, int relationRteIndex)
 	AppendRelInfo *appendRelInfo = NULL;
 
 	/* iterate on the queries that are part of UNION ALL subselects */
-	foreach_ptr(appendRelInfo, root->append_rel_list)
+	foreach_declared_ptr(appendRelInfo, root->append_rel_list)
 	{
 		/*
 		 * We're only interested in the child rel that is equal to the
@@ -2449,7 +2449,7 @@ TranslatedVarsForRteIdentity(int rteIdentity)
 		currentPlannerRestrictionContext->relationRestrictionContext->
 		relationRestrictionList;
 	RelationRestriction *relationRestriction = NULL;
-	foreach_ptr(relationRestriction, relationRestrictionList)
+	foreach_declared_ptr(relationRestriction, relationRestrictionList)
 	{
 		if (GetRTEIdentity(relationRestriction->rte) == rteIdentity)
 		{
@@ -2619,7 +2619,7 @@ GetRTEListProperties(List *rangeTableList)
 	RTEListProperties *rteListProperties = palloc0(sizeof(RTEListProperties));
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		if (rangeTableEntry->rtekind != RTE_RELATION)
 		{
@@ -2712,7 +2712,7 @@ WarnIfListHasForeignDistributedTable(List *rangeTableList)
 	static bool DistributedForeignTableWarningPrompted = false;
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		if (DistributedForeignTableWarningPrompted)
 		{

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -566,7 +566,7 @@ CreateCombineQueryForRouterPlan(DistributedPlan *distPlan)
 	List *funcCollations = NIL;
 
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, dependentTargetList)
+	foreach_declared_ptr(targetEntry, dependentTargetList)
 	{
 		Node *expr = (Node *) targetEntry->expr;
 
@@ -640,7 +640,7 @@ CreateTargetListForCombineQuery(List *targetList)
 
 	/* iterate over original target entries */
 	TargetEntry *originalTargetEntry = NULL;
-	foreach_ptr(originalTargetEntry, targetList)
+	foreach_declared_ptr(originalTargetEntry, targetList)
 	{
 		TargetEntry *newTargetEntry = flatCopyTargetEntry(originalTargetEntry);
 
@@ -1571,7 +1571,7 @@ WrapSubquery(Query *subquery)
 
 	/* create a target list that matches the SELECT */
 	TargetEntry *selectTargetEntry = NULL;
-	foreach_ptr(selectTargetEntry, subquery->targetList)
+	foreach_declared_ptr(selectTargetEntry, subquery->targetList)
 	{
 		/* exactly 1 entry in FROM */
 		int indexInRangeTable = 1;
@@ -1723,7 +1723,7 @@ AddInsertSelectCasts(List *insertTargetList, List *selectTargetList,
 	selectTargetList = list_concat(projectedEntries, nonProjectedEntries);
 	int entryResNo = 1;
 	TargetEntry *selectTargetEntry = NULL;
-	foreach_ptr(selectTargetEntry, selectTargetList)
+	foreach_declared_ptr(selectTargetEntry, selectTargetList)
 	{
 		selectTargetEntry->resno = entryResNo++;
 	}

--- a/src/backend/distributed/planner/intermediate_result_pruning.c
+++ b/src/backend/distributed/planner/intermediate_result_pruning.c
@@ -277,7 +277,7 @@ AppendAllWorkerNodes(IntermediateResultsHashEntry *entry)
 	List *workerNodeList = ActiveReadableNodeList();
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		entry->nodeIdList =
 			list_append_unique_int(entry->nodeIdList, workerNode->nodeId);
@@ -421,7 +421,7 @@ LogIntermediateResultMulticastSummary(IntermediateResultsHashEntry *entry,
 		}
 
 		WorkerNode *workerNode = NULL;
-		foreach_ptr(workerNode, workerNodeList)
+		foreach_declared_ptr(workerNode, workerNodeList)
 		{
 			elog(logLevel, "Subplan %s will be sent to %s:%d", resultId,
 				 workerNode->workerName, workerNode->workerPort);

--- a/src/backend/distributed/planner/local_distributed_join_planner.c
+++ b/src/backend/distributed/planner/local_distributed_join_planner.c
@@ -328,7 +328,7 @@ static void
 ConvertRTEsToSubquery(List *rangeTableEntryDetailsList, RecursivePlanningContext *context)
 {
 	RangeTableEntryDetails *rangeTableEntryDetails = NULL;
-	foreach_ptr(rangeTableEntryDetails, rangeTableEntryDetailsList)
+	foreach_declared_ptr(rangeTableEntryDetails, rangeTableEntryDetailsList)
 	{
 		RangeTblEntry *rangeTableEntry = rangeTableEntryDetails->rangeTableEntry;
 		List *requiredAttributeNumbers = rangeTableEntryDetails->requiredAttributeNumbers;
@@ -351,7 +351,7 @@ static bool
 AllRangeTableEntriesHaveUniqueIndex(List *rangeTableEntryDetailsList)
 {
 	RangeTableEntryDetails *rangeTableEntryDetails = NULL;
-	foreach_ptr(rangeTableEntryDetails, rangeTableEntryDetailsList)
+	foreach_declared_ptr(rangeTableEntryDetails, rangeTableEntryDetailsList)
 	{
 		if (!rangeTableEntryDetails->hasConstantFilterOnUniqueColumn)
 		{
@@ -420,7 +420,7 @@ HasConstantFilterOnUniqueColumn(RangeTblEntry *rangeTableEntry,
 																   AppendUniqueIndexColumnsToList,
 																   INCLUDE_INDEX_ALL_STATEMENTS);
 	IndexColumns *indexColumns = NULL;
-	foreach_ptr(indexColumns, uniqueIndexColumnsList)
+	foreach_declared_ptr(indexColumns, uniqueIndexColumnsList)
 	{
 		List *uniqueIndexColumnNos = indexColumns->indexColumnNos;
 		if (FirstIsSuperSetOfSecond(rteEqualityColumnsNos,
@@ -441,7 +441,7 @@ static bool
 FirstIsSuperSetOfSecond(List *firstIntList, List *secondIntList)
 {
 	int curInt = 0;
-	foreach_int(curInt, secondIntList)
+	foreach_declared_int(curInt, secondIntList)
 	{
 		if (!list_member_int(firstIntList, curInt))
 		{
@@ -526,7 +526,7 @@ RequiredAttrNumbersForRelationInternal(Query *queryToProcess, int rteIndex)
 	List *requiredAttrNumbers = NIL;
 
 	Var *var = NULL;
-	foreach_ptr(var, allVarsInQuery)
+	foreach_declared_ptr(var, allVarsInQuery)
 	{
 		if (var->varno == rteIndex)
 		{
@@ -554,7 +554,7 @@ CreateConversionCandidates(PlannerRestrictionContext *plannerRestrictionContext,
 
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		/* we're only interested in tables */
 		if (!IsRecursivelyPlannableRelation(rangeTableEntry))

--- a/src/backend/distributed/planner/local_plan_cache.c
+++ b/src/backend/distributed/planner/local_plan_cache.c
@@ -244,7 +244,7 @@ GetCachedLocalPlan(Task *task, DistributedPlan *distributedPlan)
 
 	int32 localGroupId = GetLocalGroupId();
 
-	foreach_ptr(localPlannedStatement, cachedPlanList)
+	foreach_declared_ptr(localPlannedStatement, cachedPlanList)
 	{
 		if (localPlannedStatement->shardId == task->anchorShardId &&
 			localPlannedStatement->localGroupId == localGroupId)

--- a/src/backend/distributed/planner/merge_planner.c
+++ b/src/backend/distributed/planner/merge_planner.c
@@ -375,7 +375,7 @@ static void
 ErrorIfMergeHasUnsupportedTables(Oid targetRelationId, List *rangeTableList)
 {
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		Oid relationId = rangeTableEntry->relid;
 
@@ -734,7 +734,7 @@ ErrorIfRepartitionMergeNotSupported(Oid targetRelationId, Query *mergeQuery,
 	}
 
 	MergeAction *action = NULL;
-	foreach_ptr(action, mergeQuery->mergeActionList)
+	foreach_declared_ptr(action, mergeQuery->mergeActionList)
 	{
 		if (FindNodeMatchingCheckFunction((Node *) action, IsNodeSubquery))
 		{
@@ -763,7 +763,7 @@ ConvertCteRTEIntoSubquery(Query *mergeQuery, RangeTblEntry *sourceRte)
 	 * Presently, CTEs are only permitted within the USING clause, and thus,
 	 * we search for the corresponding one
 	 */
-	foreach_ptr(candidateCte, mergeQuery->cteList)
+	foreach_declared_ptr(candidateCte, mergeQuery->cteList)
 	{
 		if (strcmp(candidateCte->ctename, sourceRte->ctename) == 0)
 		{
@@ -1018,7 +1018,7 @@ DeferErrorIfRoutableMergeNotSupported(Query *query, List *rangeTableList,
 	List *localTablesList = NIL;
 	RangeTblEntry *rangeTableEntry = NULL;
 
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		Oid relationId = rangeTableEntry->relid;
 
@@ -1224,7 +1224,7 @@ ErrorIfMergeQueryQualAndTargetListNotSupported(Oid targetRelationId, Query *orig
 	 * within itself. Check each INSERT/UPDATE/DELETE individually.
 	 */
 	MergeAction *action = NULL;
-	foreach_ptr(action, originalQuery->mergeActionList)
+	foreach_declared_ptr(action, originalQuery->mergeActionList)
 	{
 		Assert(originalQuery->returningList == NULL);
 		deferredError = MergeQualAndTargetListFunctionsSupported(targetRelationId,
@@ -1472,7 +1472,7 @@ FetchAndValidateInsertVarIfExists(Oid targetRelationId, Query *query)
 	bool foundDistributionColumn = false;
 	MergeAction *action = NULL;
 	uint32 targetRangeTableIndex = query->resultRelation;
-	foreach_ptr(action, query->mergeActionList)
+	foreach_declared_ptr(action, query->mergeActionList)
 	{
 		/* Skip MATCHED clause as INSERTS are not allowed in it */
 		if (action->matched)
@@ -1502,7 +1502,7 @@ FetchAndValidateInsertVarIfExists(Oid targetRelationId, Query *query)
 			PartitionColumn(targetRelationId, targetRangeTableIndex);
 
 		TargetEntry *targetEntry = NULL;
-		foreach_ptr(targetEntry, action->targetList)
+		foreach_declared_ptr(targetEntry, action->targetList)
 		{
 			AttrNumber originalAttrNo = targetEntry->resno;
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -495,7 +495,7 @@ ExplainJob(CitusScanState *scanState, Job *job, ExplainState *es,
 	{
 		Task *task = NULL;
 		uint64 totalReceivedTupleDataForAllTasks = 0;
-		foreach_ptr(task, taskList)
+		foreach_declared_ptr(task, taskList)
 		{
 			totalReceivedTupleDataForAllTasks += TaskReceivedTupleData(task);
 		}
@@ -673,7 +673,7 @@ ExplainTaskList(CitusScanState *scanState, List *taskList, ExplainState *es,
 	}
 
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		RemoteExplainPlan *remoteExplain = RemoteExplain(task, es, params);
 		remoteExplainList = lappend(remoteExplainList, remoteExplain);
@@ -1400,7 +1400,7 @@ void
 ResetExplainAnalyzeData(List *taskList)
 {
 	Task *task = NULL;
-	foreach_ptr(task, taskList)
+	foreach_declared_ptr(task, taskList)
 	{
 		if (task->fetchedExplainAnalyzePlan != NULL)
 		{
@@ -1463,7 +1463,7 @@ ExplainAnalyzeTaskList(List *originalTaskList,
 	List *explainAnalyzeTaskList = NIL;
 	Task *originalTask = NULL;
 
-	foreach_ptr(originalTask, originalTaskList)
+	foreach_declared_ptr(originalTask, originalTaskList)
 	{
 		if (originalTask->queryCount != 1)
 		{

--- a/src/backend/distributed/planner/multi_join_order.c
+++ b/src/backend/distributed/planner/multi_join_order.c
@@ -224,10 +224,10 @@ JoinOnColumns(List *currentPartitionColumnList, Var *candidateColumn,
 	}
 
 	Var *currentColumn = NULL;
-	foreach_ptr(currentColumn, currentPartitionColumnList)
+	foreach_declared_ptr(currentColumn, currentPartitionColumnList)
 	{
 		Node *joinClause = NULL;
-		foreach_ptr(joinClause, joinClauseList)
+		foreach_declared_ptr(joinClause, joinClauseList)
 		{
 			if (!NodeIsEqualsOpExpr(joinClause))
 			{
@@ -1094,10 +1094,10 @@ SinglePartitionJoinClause(List *partitionColumnList, List *applicableJoinClauses
 	}
 
 	Var *partitionColumn = NULL;
-	foreach_ptr(partitionColumn, partitionColumnList)
+	foreach_declared_ptr(partitionColumn, partitionColumnList)
 	{
 		Node *applicableJoinClause = NULL;
-		foreach_ptr(applicableJoinClause, applicableJoinClauses)
+		foreach_declared_ptr(applicableJoinClause, applicableJoinClauses)
 		{
 			if (!NodeIsEqualsOpExpr(applicableJoinClause))
 			{
@@ -1177,7 +1177,7 @@ OpExpr *
 DualPartitionJoinClause(List *applicableJoinClauses)
 {
 	Node *applicableJoinClause = NULL;
-	foreach_ptr(applicableJoinClause, applicableJoinClauses)
+	foreach_declared_ptr(applicableJoinClause, applicableJoinClauses)
 	{
 		if (!NodeIsEqualsOpExpr(applicableJoinClause))
 		{
@@ -1262,7 +1262,7 @@ IsApplicableJoinClause(List *leftTableIdList, uint32 rightTableId, Node *joinCla
 	List *varList = pull_var_clause_default(joinClause);
 	Var *var = NULL;
 	bool joinContainsRightTable = false;
-	foreach_ptr(var, varList)
+	foreach_declared_ptr(var, varList)
 	{
 		uint32 columnTableId = var->varno;
 		if (rightTableId == columnTableId)
@@ -1301,7 +1301,7 @@ ApplicableJoinClauses(List *leftTableIdList, uint32 rightTableId, List *joinClau
 	joinClauseList = JoinClauseList(joinClauseList);
 
 	Node *joinClause = NULL;
-	foreach_ptr(joinClause, joinClauseList)
+	foreach_declared_ptr(joinClause, joinClauseList)
 	{
 		if (IsApplicableJoinClause(leftTableIdList, rightTableId, joinClause))
 		{

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -414,7 +414,7 @@ MultiLogicalPlanOptimize(MultiTreeRoot *multiLogicalPlan)
 	/* pull up collect nodes and merge duplicate collects */
 	List *collectNodeList = FindNodesOfType(logicalPlanNode, T_MultiCollect);
 	MultiCollect *collectNode = NULL;
-	foreach_ptr(collectNode, collectNodeList)
+	foreach_declared_ptr(collectNode, collectNodeList)
 	{
 		PullUpCollectLoop(collectNode);
 	}
@@ -436,7 +436,7 @@ MultiLogicalPlanOptimize(MultiTreeRoot *multiLogicalPlan)
 
 	List *tableNodeList = FindNodesOfType(logicalPlanNode, T_MultiTable);
 	MultiTable *tableNode = NULL;
-	foreach_ptr(tableNode, tableNodeList)
+	foreach_declared_ptr(tableNode, tableNodeList)
 	{
 		if (tableNode->relationId == SUBQUERY_RELATION_ID)
 		{
@@ -542,7 +542,7 @@ OrSelectClauseList(List *selectClauseList)
 	List *orSelectClauseList = NIL;
 
 	Node *selectClause = NULL;
-	foreach_ptr(selectClause, selectClauseList)
+	foreach_declared_ptr(selectClause, selectClauseList)
 	{
 		bool orClause = is_orclause(selectClause);
 		if (orClause)
@@ -968,7 +968,7 @@ SelectClauseTableIdList(List *selectClauseList)
 	List *tableIdList = NIL;
 
 	Node *selectClause = NULL;
-	foreach_ptr(selectClause, selectClauseList)
+	foreach_declared_ptr(selectClause, selectClauseList)
 	{
 		List *selectColumnList = pull_var_clause_default(selectClause);
 
@@ -1077,7 +1077,7 @@ TableIdListColumns(List *tableIdList, List *columnList)
 	List *tableColumnList = NIL;
 
 	Var *column = NULL;
-	foreach_ptr(column, columnList)
+	foreach_declared_ptr(column, columnList)
 	{
 		int columnTableId = (int) column->varno;
 
@@ -1103,7 +1103,7 @@ TableIdListSelectClauses(List *tableIdList, List *selectClauseList)
 	List *tableSelectClauseList = NIL;
 
 	Node *selectClause = NULL;
-	foreach_ptr(selectClause, selectClauseList)
+	foreach_declared_ptr(selectClause, selectClauseList)
 	{
 		List *selectColumnList = pull_var_clause_default(selectClause);
 		if (list_length(selectColumnList) == 0)
@@ -1425,7 +1425,7 @@ MasterExtendedOpNode(MultiExtendedOp *originalOpNode,
 
 	/* iterate over original target entries */
 	TargetEntry *originalTargetEntry = NULL;
-	foreach_ptr(originalTargetEntry, targetEntryList)
+	foreach_declared_ptr(originalTargetEntry, targetEntryList)
 	{
 		TargetEntry *newTargetEntry = flatCopyTargetEntry(originalTargetEntry);
 		Expr *originalExpression = originalTargetEntry->expr;
@@ -1598,7 +1598,7 @@ MasterAggregateExpression(Aggref *originalAggregate,
 		Aggref *aggregate = (Aggref *) copyObject(originalAggregate);
 
 		TargetEntry *targetEntry;
-		foreach_ptr(targetEntry, aggregate->args)
+		foreach_declared_ptr(targetEntry, aggregate->args)
 		{
 			targetEntry->expr = (Expr *)
 								makeVar(masterTableId, walkerContext->columnId,
@@ -1611,7 +1611,7 @@ MasterAggregateExpression(Aggref *originalAggregate,
 
 		aggregate->aggdirectargs = NIL;
 		Expr *directarg;
-		foreach_ptr(directarg, originalAggregate->aggdirectargs)
+		foreach_declared_ptr(directarg, originalAggregate->aggdirectargs)
 		{
 			/*
 			 * Need to replace nodes that contain any Vars with Vars referring
@@ -1662,7 +1662,7 @@ MasterAggregateExpression(Aggref *originalAggregate,
 
 		/* determine unique vars that were placed in target list by worker */
 		Var *column = NULL;
-		foreach_ptr(column, varList)
+		foreach_declared_ptr(column, varList)
 		{
 			uniqueVarList = list_append_unique(uniqueVarList, copyObject(column));
 		}
@@ -1672,12 +1672,12 @@ MasterAggregateExpression(Aggref *originalAggregate,
 		 * worker query target entry column index.
 		 */
 		Var *columnToUpdate = NULL;
-		foreach_ptr(columnToUpdate, varList)
+		foreach_declared_ptr(columnToUpdate, varList)
 		{
 			int columnIndex = 0;
 
 			Var *currentVar = NULL;
-			foreach_ptr(currentVar, uniqueVarList)
+			foreach_declared_ptr(currentVar, uniqueVarList)
 			{
 				if (equal(columnToUpdate, currentVar))
 				{
@@ -2526,7 +2526,7 @@ ProcessTargetListForWorkerQuery(List *targetEntryList,
 
 	/* iterate over original target entries */
 	TargetEntry *originalTargetEntry = NULL;
-	foreach_ptr(originalTargetEntry, targetEntryList)
+	foreach_declared_ptr(originalTargetEntry, targetEntryList)
 	{
 		Expr *originalExpression = originalTargetEntry->expr;
 		List *newExpressionList = NIL;
@@ -2733,7 +2733,7 @@ ProcessWindowFunctionPullUpForWorkerQuery(List *windowClause,
 		List *columnList = pull_var_clause_default((Node *) windowClause);
 
 		Expr *newExpression = NULL;
-		foreach_ptr(newExpression, columnList)
+		foreach_declared_ptr(newExpression, columnList)
 		{
 			TargetEntry *newTargetEntry = makeNode(TargetEntry);
 
@@ -2823,7 +2823,7 @@ bool
 TargetListHasAggregates(List *targetEntryList)
 {
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, targetEntryList)
+	foreach_declared_ptr(targetEntry, targetEntryList)
 	{
 		Expr *targetExpr = targetEntry->expr;
 		bool hasAggregates = contain_aggs_of_level((Node *) targetExpr, 0);
@@ -2867,7 +2867,7 @@ ExpandWorkerTargetEntry(List *expressionList, TargetEntry *originalTargetEntry,
 {
 	/* now create target entries for each new expression */
 	Expr *newExpression = NULL;
-	foreach_ptr(newExpression, expressionList)
+	foreach_declared_ptr(newExpression, expressionList)
 	{
 		/* generate and add the new target entry to the target list */
 		TargetEntry *newTargetEntry =
@@ -2904,7 +2904,7 @@ GetNextSortGroupRef(List *targetEntryList)
 
 	/* find max of sort group ref index */
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, targetEntryList)
+	foreach_declared_ptr(targetEntry, targetEntryList)
 	{
 		if (targetEntry->ressortgroupref > nextSortGroupRefIndex)
 		{
@@ -3060,13 +3060,13 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 	if (walkerContext->extendedOpNodeProperties->pullUpIntermediateRows)
 	{
 		TargetEntry *targetEntry;
-		foreach_ptr(targetEntry, originalAggregate->args)
+		foreach_declared_ptr(targetEntry, originalAggregate->args)
 		{
 			workerAggregateList = lappend(workerAggregateList, targetEntry->expr);
 		}
 
 		Expr *directarg;
-		foreach_ptr(directarg, originalAggregate->aggdirectargs)
+		foreach_declared_ptr(directarg, originalAggregate->aggdirectargs)
 		{
 			/*
 			 * The worker aggregation should execute any node that contains any
@@ -3099,7 +3099,7 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 		List *columnList = pull_var_clause_default((Node *) aggregate);
 
 		Var *column = NULL;
-		foreach_ptr(column, columnList)
+		foreach_declared_ptr(column, columnList)
 		{
 			workerAggregateList = list_append_unique(workerAggregateList, column);
 		}
@@ -3326,7 +3326,7 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 				rowExpr->colnames = NIL;
 
 				TargetEntry *arg = NULL;
-				foreach_ptr(arg, originalAggregate->args)
+				foreach_declared_ptr(arg, originalAggregate->args)
 				{
 					rowExpr->args = lappend(rowExpr->args, copyObject(arg->expr));
 				}
@@ -3830,7 +3830,7 @@ HasNonDistributableAggregates(MultiNode *logicalPlanNode)
 								 pull_var_clause(havingQual, PVC_INCLUDE_AGGREGATES));
 
 	Node *expression = NULL;
-	foreach_ptr(expression, expressionList)
+	foreach_declared_ptr(expression, expressionList)
 	{
 		/* only consider aggregate expressions */
 		if (!IsA(expression, Aggref))
@@ -3936,7 +3936,7 @@ DeferErrorIfHasNonDistributableAggregates(MultiNode *logicalPlanNode)
 								 pull_var_clause(havingQual, PVC_INCLUDE_AGGREGATES));
 
 	Node *expression = NULL;
-	foreach_ptr(expression, expressionList)
+	foreach_declared_ptr(expression, expressionList)
 	{
 		/* only consider aggregate expressions */
 		if (!IsA(expression, Aggref))
@@ -4079,7 +4079,7 @@ DeferErrorIfUnsupportedAggregateDistinct(Aggref *aggregateExpression,
 		List *columnList = pull_var_clause_default(aggregateArgument);
 
 		Var *column = NULL;
-		foreach_ptr(column, columnList)
+		foreach_declared_ptr(column, columnList)
 		{
 			if (column->varattno <= 0)
 			{
@@ -4095,7 +4095,7 @@ DeferErrorIfUnsupportedAggregateDistinct(Aggref *aggregateExpression,
 		List *multiTableNodeList = FindNodesOfType(logicalPlanNode, T_MultiTable);
 
 		MultiTable *multiTable = NULL;
-		foreach_ptr(multiTable, multiTableNodeList)
+		foreach_declared_ptr(multiTable, multiTableNodeList)
 		{
 			if (multiTable->relationId == SUBQUERY_RELATION_ID ||
 				multiTable->relationId == SUBQUERY_PUSHDOWN_RELATION_ID)
@@ -4251,7 +4251,7 @@ TablePartitioningSupportsDistinct(List *tableNodeList, MultiExtendedOp *opNode,
 	bool distinctSupported = true;
 
 	MultiTable *tableNode = NULL;
-	foreach_ptr(tableNode, tableNodeList)
+	foreach_declared_ptr(tableNode, tableNodeList)
 	{
 		Oid relationId = tableNode->relationId;
 		bool tableDistinctSupported = false;
@@ -4327,7 +4327,7 @@ GroupedByColumn(List *groupClauseList, List *targetList, Var *column)
 	}
 
 	SortGroupClause *groupClause = NULL;
-	foreach_ptr(groupClause, groupClauseList)
+	foreach_declared_ptr(groupClause, groupClauseList)
 	{
 		TargetEntry *groupTargetEntry = get_sortgroupclause_tle(groupClause, targetList);
 
@@ -4359,7 +4359,7 @@ SubqueryMultiTableList(MultiNode *multiNode)
 	List *multiTableNodeList = FindNodesOfType(multiNode, T_MultiTable);
 
 	MultiTable *multiTable = NULL;
-	foreach_ptr(multiTable, multiTableNodeList)
+	foreach_declared_ptr(multiTable, multiTableNodeList)
 	{
 		Query *subquery = multiTable->subquery;
 
@@ -4383,7 +4383,7 @@ GroupTargetEntryList(List *groupClauseList, List *targetEntryList)
 	List *groupTargetEntryList = NIL;
 
 	SortGroupClause *groupClause = NULL;
-	foreach_ptr(groupClause, groupClauseList)
+	foreach_declared_ptr(groupClause, groupClauseList)
 	{
 		TargetEntry *groupTargetEntry =
 			get_sortgroupclause_tle(groupClause, targetEntryList);
@@ -4585,7 +4585,7 @@ FindReferencedTableColumn(Expr *columnExpression, List *parentQueryList, Query *
 		}
 
 		CommonTableExpr *candidateCte = NULL;
-		foreach_ptr(candidateCte, cteList)
+		foreach_declared_ptr(candidateCte, cteList)
 		{
 			if (strcmp(candidateCte->ctename, rangeTableEntry->ctename) == 0)
 			{
@@ -4878,7 +4878,7 @@ HasOrderByAggregate(List *sortClauseList, List *targetList)
 	bool hasOrderByAggregate = false;
 
 	SortGroupClause *sortClause = NULL;
-	foreach_ptr(sortClause, sortClauseList)
+	foreach_declared_ptr(sortClause, sortClauseList)
 	{
 		Node *sortExpression = get_sortgroupclause_expr(sortClause, targetList);
 
@@ -4904,7 +4904,7 @@ HasOrderByNonCommutativeAggregate(List *sortClauseList, List *targetList)
 	bool hasOrderByNonCommutativeAggregate = false;
 
 	SortGroupClause *sortClause = NULL;
-	foreach_ptr(sortClause, sortClauseList)
+	foreach_declared_ptr(sortClause, sortClauseList)
 	{
 		Node *sortExpression = get_sortgroupclause_expr(sortClause, targetList);
 
@@ -4944,7 +4944,7 @@ HasOrderByComplexExpression(List *sortClauseList, List *targetList)
 	bool hasOrderByComplexExpression = false;
 
 	SortGroupClause *sortClause = NULL;
-	foreach_ptr(sortClause, sortClauseList)
+	foreach_declared_ptr(sortClause, sortClauseList)
 	{
 		Node *sortExpression = get_sortgroupclause_expr(sortClause, targetList);
 
@@ -4986,7 +4986,7 @@ HasOrderByHllType(List *sortClauseList, List *targetList)
 	Oid hllTypeId = TypeOid(hllSchemaOid, HLL_TYPE_NAME);
 
 	SortGroupClause *sortClause = NULL;
-	foreach_ptr(sortClause, sortClauseList)
+	foreach_declared_ptr(sortClause, sortClauseList)
 	{
 		Node *sortExpression = get_sortgroupclause_expr(sortClause, targetList);
 
@@ -5070,12 +5070,12 @@ IsGroupBySubsetOfDistinct(List *groupClauses, List *distinctClauses)
 	}
 
 	SortGroupClause *groupClause = NULL;
-	foreach_ptr(groupClause, groupClauses)
+	foreach_declared_ptr(groupClause, groupClauses)
 	{
 		bool isFound = false;
 
 		SortGroupClause *distinctClause = NULL;
-		foreach_ptr(distinctClause, distinctClauses)
+		foreach_declared_ptr(distinctClause, distinctClauses)
 		{
 			if (groupClause->tleSortGroupRef == distinctClause->tleSortGroupRef)
 			{

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -1414,7 +1414,7 @@ IsJoinClause(Node *clause)
 	}
 	Var *initialVar = castNode(Var, linitial(varList));
 
-	foreach_ptr(var, varList)
+	foreach_declared_ptr(var, varList)
 	{
 		if (var->varno != initialVar->varno)
 		{

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -895,7 +895,7 @@ WrapUngroupedVarsInAnyValueAggregate(Node *expression, List *groupClauseList,
 		 * subexpression equality check.
 		 */
 		TargetEntry *targetEntry = NULL;
-		foreach_ptr(targetEntry, context.groupByTargetEntryList)
+		foreach_declared_ptr(targetEntry, context.groupByTargetEntryList)
 		{
 			if (!IsA(targetEntry->expr, Var))
 			{
@@ -953,7 +953,7 @@ AddAnyValueAggregates(Node *node, AddAnyValueAggregatesContext *context)
 		 * Check whether this Var appears in the GROUP BY.
 		 */
 		TargetEntry *groupByTargetEntry = NULL;
-		foreach_ptr(groupByTargetEntry, context->groupByTargetEntryList)
+		foreach_declared_ptr(groupByTargetEntry, context->groupByTargetEntryList)
 		{
 			if (!IsA(groupByTargetEntry->expr, Var))
 			{
@@ -996,7 +996,7 @@ AddAnyValueAggregates(Node *node, AddAnyValueAggregatesContext *context)
 		 * Otherwise, continue to descend into subexpressions.
 		 */
 		TargetEntry *groupByTargetEntry = NULL;
-		foreach_ptr(groupByTargetEntry, context->groupByTargetEntryList)
+		foreach_declared_ptr(groupByTargetEntry, context->groupByTargetEntryList)
 		{
 			if (equal(node, groupByTargetEntry->expr))
 			{
@@ -1192,7 +1192,7 @@ QueryJoinTree(MultiNode *multiNode, List *dependentJobList, List **rangeTableLis
 			List *funcCollations = NIL;
 
 			TargetEntry *targetEntry = NULL;
-			foreach_ptr(targetEntry, dependentTargetList)
+			foreach_declared_ptr(targetEntry, dependentTargetList)
 			{
 				Node *expr = (Node *) targetEntry->expr;
 
@@ -2237,7 +2237,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		}
 
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, prunedShardList)
+		foreach_declared_ptr(shardInterval, prunedShardList)
 		{
 			int shardIndex = shardInterval->shardIndex;
 
@@ -2305,7 +2305,7 @@ static bool
 IsInnerTableOfOuterJoin(RelationRestriction *relationRestriction)
 {
 	RestrictInfo *joinInfo = NULL;
-	foreach_ptr(joinInfo, relationRestriction->relOptInfo->joininfo)
+	foreach_declared_ptr(joinInfo, relationRestriction->relOptInfo->joininfo)
 	{
 		if (joinInfo->outer_relids == NULL)
 		{
@@ -3473,7 +3473,7 @@ FetchEqualityAttrNumsForList(List *nodeList)
 	List *attributeNums = NIL;
 	Node *node = NULL;
 	bool hasAtLeastOneEquality = false;
-	foreach_ptr(node, nodeList)
+	foreach_declared_ptr(node, nodeList)
 	{
 		List *fetchedEqualityAttrNums =
 			FetchEqualityAttrNumsForRTE(node);
@@ -3531,7 +3531,7 @@ FetchEqualityAttrNumsForRTEBoolExpr(BoolExpr *boolExpr)
 	List *attributeNums = NIL;
 	bool hasEquality = true;
 	Node *arg = NULL;
-	foreach_ptr(arg, boolExpr->args)
+	foreach_declared_ptr(arg, boolExpr->args)
 	{
 		List *attributeNumsInSubExpression = FetchEqualityAttrNumsForRTE(arg);
 		if (boolExpr->boolop == AND_EXPR)
@@ -3622,7 +3622,7 @@ JoinSequenceArray(List *rangeTableFragmentsList, Query *jobQuery, List *dependen
 		 * tables and this new one.
 		 */
 		Node *nextJoinClause = NULL;
-		foreach_ptr(nextJoinClause, nextJoinClauseList)
+		foreach_declared_ptr(nextJoinClause, nextJoinClauseList)
 		{
 			if (!NodeIsEqualsOpExpr(nextJoinClause))
 			{
@@ -4183,7 +4183,7 @@ FetchTaskResultNameList(List *mapOutputFetchTaskList)
 	List *resultNameList = NIL;
 	Task *mapOutputFetchTask = NULL;
 
-	foreach_ptr(mapOutputFetchTask, mapOutputFetchTaskList)
+	foreach_declared_ptr(mapOutputFetchTask, mapOutputFetchTaskList)
 	{
 		Task *mapTask = linitial(mapOutputFetchTask->dependentTaskList);
 		int partitionId = mapOutputFetchTask->partitionId;
@@ -4344,7 +4344,7 @@ PartitionColumnIndex(Var *targetVar, List *targetList)
 {
 	TargetEntry *targetEntry = NULL;
 	int resNo = 1;
-	foreach_ptr(targetEntry, targetList)
+	foreach_declared_ptr(targetEntry, targetList)
 	{
 		if (IsA(targetEntry->expr, Var))
 		{
@@ -4571,7 +4571,7 @@ RowModifyLevelForQuery(Query *query)
 		{
 			/* skip checking for INSERT as those CTEs are recursively planned */
 			CommonTableExpr *cte = NULL;
-			foreach_ptr(cte, query->cteList)
+			foreach_declared_ptr(cte, query->cteList)
 			{
 				Query *cteQuery = (Query *) cte->ctequery;
 

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -851,7 +851,7 @@ ModifiesLocalTableWithRemoteCitusLocalTable(List *rangeTableList)
 	bool containsRemoteCitusLocalTable = false;
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		if (!IsRecursivelyPlannableRelation(rangeTableEntry))
 		{
@@ -982,7 +982,7 @@ ModifyQuerySupported(Query *queryTree, Query *originalQuery, bool multiShardQuer
 		ContainsLocalTableDistributedTableJoin(queryTree->rtable);
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		if (rangeTableEntry->rtekind == RTE_RELATION)
 		{
@@ -1744,7 +1744,7 @@ RouterInsertTaskList(Query *query, bool parametersInQueryResolved,
 	}
 
 	ModifyRoute *modifyRoute = NULL;
-	foreach_ptr(modifyRoute, modifyRouteList)
+	foreach_declared_ptr(modifyRoute, modifyRouteList)
 	{
 		Task *modifyTask = CreateTask(MODIFY_TASK);
 		modifyTask->anchorShardId = modifyRoute->shardId;
@@ -2137,7 +2137,7 @@ SingleShardTaskList(Query *query, uint64 jobId, List *relationShardList,
 		/* assume ErrorIfQueryHasUnroutableModifyingCTE checked query already */
 
 		CommonTableExpr *cte = NULL;
-		foreach_ptr(cte, query->cteList)
+		foreach_declared_ptr(cte, query->cteList)
 		{
 			Query *cteQuery = (Query *) cte->ctequery;
 
@@ -2482,7 +2482,7 @@ AllShardsColocated(List *relationShardList)
 	int colocationId = -1;
 	CitusTableType tableType = ANY_CITUS_TABLE_TYPE;
 
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		Oid relationId = relationShard->relationId;
 		uint64 shardId = relationShard->shardId;
@@ -2607,7 +2607,7 @@ CreateTaskPlacementListForShardIntervals(List *shardIntervalListList, bool shard
 			 * If there is a local table, we only allow the local placement to
 			 * be used. If there is none, we disallow the query.
 			 */
-			foreach_ptr(taskPlacement, shardPlacementList)
+			foreach_declared_ptr(taskPlacement, shardPlacementList)
 			{
 				if (taskPlacement->groupId == GetLocalGroupId())
 				{
@@ -3024,7 +3024,7 @@ PlacementsForWorkersContainingAllShards(List *shardIntervalListList)
 	List *currentPlacementList = NIL;
 	List *shardIntervalList = NIL;
 
-	foreach_ptr(shardIntervalList, shardIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardIntervalListList)
 	{
 		if (shardIntervalList == NIL)
 		{
@@ -3923,7 +3923,7 @@ ErrorIfQueryHasUnroutableModifyingCTE(Query *queryTree)
 	char replicationModel = 0;
 
 	CommonTableExpr *cte = NULL;
-	foreach_ptr(cte, queryTree->cteList)
+	foreach_declared_ptr(cte, queryTree->cteList)
 	{
 		Query *cteQuery = (Query *) cte->ctequery;
 

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -1187,7 +1187,7 @@ DeferErrorIfUnsupportedTableCombination(Query *queryTree)
 	ExtractRangeTableIndexWalker((Node *) queryTree->jointree,
 								 &joinTreeTableIndexList);
 
-	foreach_int(joinTreeTableIndex, joinTreeTableIndexList)
+	foreach_declared_int(joinTreeTableIndex, joinTreeTableIndexList)
 	{
 		/*
 		 * Join tree's range table index starts from 1 in the query tree. But,
@@ -2010,7 +2010,7 @@ CreateSubqueryTargetListAndAdjustVars(List *columnList)
 	Var *column = NULL;
 	List *subqueryTargetEntryList = NIL;
 
-	foreach_ptr(column, columnList)
+	foreach_declared_ptr(column, columnList)
 	{
 		/*
 		 * To avoid adding the same column multiple times, we first check whether there
@@ -2064,7 +2064,7 @@ static AttrNumber
 FindResnoForVarInTargetList(List *targetList, int varno, int varattno)
 {
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, targetList)
+	foreach_declared_ptr(targetEntry, targetList)
 	{
 		if (!IsA(targetEntry->expr, Var))
 		{
@@ -2127,7 +2127,7 @@ PartitionColumnForPushedDownSubquery(Query *query)
 	List *targetEntryList = query->targetList;
 
 	TargetEntry *targetEntry = NULL;
-	foreach_ptr(targetEntry, targetEntryList)
+	foreach_declared_ptr(targetEntry, targetEntryList)
 	{
 		if (targetEntry->resjunk)
 		{

--- a/src/backend/distributed/planner/recursive_planning.c
+++ b/src/backend/distributed/planner/recursive_planning.c
@@ -1736,7 +1736,7 @@ NodeContainsSubqueryReferencingOuterQuery(Node *node)
 	ExtractSublinkWalker(node, &sublinks);
 
 	SubLink *sublink;
-	foreach_ptr(sublink, sublinks)
+	foreach_declared_ptr(sublink, sublinks)
 	{
 		if (ContainsReferencesToOuterQuery(castNode(Query, sublink->subselect)))
 		{
@@ -1894,7 +1894,7 @@ GenerateRequiredColNamesFromTargetList(List *targetList)
 {
 	TargetEntry *entry = NULL;
 	List *innerSubqueryColNames = NIL;
-	foreach_ptr(entry, targetList)
+	foreach_declared_ptr(entry, targetList)
 	{
 		if (IsA(entry->expr, Var))
 		{
@@ -1921,7 +1921,7 @@ UpdateVarNosInNode(Node *node, Index newVarNo)
 	List *varList = pull_var_clause(node, PVC_RECURSE_AGGREGATES |
 									PVC_RECURSE_PLACEHOLDERS);
 	Var *var = NULL;
-	foreach_ptr(var, varList)
+	foreach_declared_ptr(var, varList)
 	{
 		var->varno = newVarNo;
 	}
@@ -1958,7 +1958,7 @@ ContainsLocalTableDistributedTableJoin(List *rangeTableList)
 	bool containsDistributedTable = false;
 
 	RangeTblEntry *rangeTableEntry = NULL;
-	foreach_ptr(rangeTableEntry, rangeTableList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableList)
 	{
 		if (FindNodeMatchingCheckFunctionInRangeTableList(list_make1(rangeTableEntry),
 														  IsDistributedOrReferenceTableRTE))

--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -1516,7 +1516,7 @@ ParentCountPriorToAppendRel(List *appendRelList, AppendRelInfo *targetAppendRelI
 	int targetParentIndex = targetAppendRelInfo->parent_relid;
 	Bitmapset *parent_ids = NULL;
 	AppendRelInfo *appendRelInfo = NULL;
-	foreach_ptr(appendRelInfo, appendRelList)
+	foreach_declared_ptr(appendRelInfo, appendRelList)
 	{
 		int curParentIndex = appendRelInfo->parent_relid;
 		if (curParentIndex <= targetParentIndex)
@@ -1962,7 +1962,7 @@ AllDistributedRelationsInRestrictionContextColocated(
 	List *relationIdList = NIL;
 
 	/* check whether all relations exists in the main restriction list */
-	foreach_ptr(relationRestriction, restrictionContext->relationRestrictionList)
+	foreach_declared_ptr(relationRestriction, restrictionContext->relationRestrictionList)
 	{
 		relationIdList = lappend_oid(relationIdList, relationRestriction->relationId);
 	}
@@ -1981,7 +1981,7 @@ AllDistributedRelationsInRTEListColocated(List *rangeTableEntryList)
 	RangeTblEntry *rangeTableEntry = NULL;
 	List *relationIdList = NIL;
 
-	foreach_ptr(rangeTableEntry, rangeTableEntryList)
+	foreach_declared_ptr(rangeTableEntry, rangeTableEntryList)
 	{
 		relationIdList = lappend_oid(relationIdList, rangeTableEntry->relid);
 	}
@@ -2000,7 +2000,7 @@ AllDistributedRelationsInListColocated(List *relationList)
 	int initialColocationId = INVALID_COLOCATION_ID;
 	Oid relationId = InvalidOid;
 
-	foreach_oid(relationId, relationList)
+	foreach_declared_oid(relationId, relationList)
 	{
 		if (!IsCitusTable(relationId))
 		{
@@ -2155,7 +2155,7 @@ GetRestrictInfoListForRelation(RangeTblEntry *rangeTblEntry,
 
 	List *restrictExprList = NIL;
 	RestrictInfo *restrictInfo = NULL;
-	foreach_ptr(restrictInfo, baseRestrictInfo)
+	foreach_declared_ptr(restrictInfo, baseRestrictInfo)
 	{
 		Expr *restrictionClause = restrictInfo->clause;
 
@@ -2199,7 +2199,7 @@ GetRestrictInfoListForRelation(RangeTblEntry *rangeTblEntry,
 		Expr *copyOfRestrictClause = (Expr *) copyObject((Node *) restrictionClause);
 		List *varClauses = pull_var_clause_default((Node *) copyOfRestrictClause);
 		Var *column = NULL;
-		foreach_ptr(column, varClauses)
+		foreach_declared_ptr(column, varClauses)
 		{
 			column->varno = SINGLE_RTE_INDEX;
 			column->varnosyn = SINGLE_RTE_INDEX;

--- a/src/backend/distributed/planner/shard_pruning.c
+++ b/src/backend/distributed/planner/shard_pruning.c
@@ -1390,7 +1390,7 @@ DeepCopyShardIntervalList(List *originalShardIntervalList)
 	List *copiedShardIntervalList = NIL;
 
 	ShardInterval *originalShardInterval = NULL;
-	foreach_ptr(originalShardInterval, originalShardIntervalList)
+	foreach_declared_ptr(originalShardInterval, originalShardIntervalList)
 	{
 		ShardInterval *copiedShardInterval = CopyShardInterval(originalShardInterval);
 

--- a/src/backend/distributed/progress/multi_progress.c
+++ b/src/backend/distributed/progress/multi_progress.c
@@ -286,7 +286,7 @@ void
 DetachFromDSMSegments(List *dsmSegmentList)
 {
 	dsm_segment *dsmSegment = NULL;
-	foreach_ptr(dsmSegment, dsmSegmentList)
+	foreach_declared_ptr(dsmSegment, dsmSegmentList)
 	{
 		dsm_detach(dsmSegment);
 	}

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -150,7 +150,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 			AppendShardIdToName(relationName, shardId);
 
 			AlterTableCmd *command = NULL;
-			foreach_ptr(command, commandList)
+			foreach_declared_ptr(command, commandList)
 			{
 				if (command->subtype == AT_AddConstraint)
 				{
@@ -162,7 +162,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 				{
 					ColumnDef *columnDefinition = (ColumnDef *) command->def;
 					Constraint *constraint = NULL;
-					foreach_ptr(constraint, columnDefinition->constraints)
+					foreach_declared_ptr(constraint, columnDefinition->constraints)
 					{
 						RelayEventExtendConstraintAndIndexNames(alterTableStmt,
 																constraint, shardId);
@@ -385,7 +385,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 			{
 				List *shardStatisticsList = NIL;
 				List *objectNameList = NULL;
-				foreach_ptr(objectNameList, dropStmt->objects)
+				foreach_declared_ptr(objectNameList, dropStmt->objects)
 				{
 					RangeVar *stat = makeRangeVarFromNameList(objectNameList);
 
@@ -415,7 +415,7 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 				grantStmt->objtype == OBJECT_TABLE)
 			{
 				RangeVar *relation = NULL;
-				foreach_ptr(relation, grantStmt->objects)
+				foreach_declared_ptr(relation, grantStmt->objects)
 				{
 					char **relationName = &(relation->relname);
 					char **relationSchemaName = &(relation->schemaname);
@@ -673,7 +673,7 @@ RelayEventExtendNamesForInterShardCommands(Node *parseTree, uint64 leftShardId,
 			List *commandList = alterTableStmt->cmds;
 
 			AlterTableCmd *command = NULL;
-			foreach_ptr(command, commandList)
+			foreach_declared_ptr(command, commandList)
 			{
 				char **referencedTableName = NULL;
 				char **relationSchemaName = NULL;
@@ -693,7 +693,7 @@ RelayEventExtendNamesForInterShardCommands(Node *parseTree, uint64 leftShardId,
 					List *columnConstraints = columnDefinition->constraints;
 
 					Constraint *constraint = NULL;
-					foreach_ptr(constraint, columnConstraints)
+					foreach_declared_ptr(constraint, columnConstraints)
 					{
 						if (constraint->contype == CONSTR_FOREIGN)
 						{

--- a/src/backend/distributed/replication/multi_logical_replication.c
+++ b/src/backend/distributed/replication/multi_logical_replication.c
@@ -282,7 +282,7 @@ CreateGroupedLogicalRepTargetsHash(List *logicalRepTargetList)
 {
 	HTAB *logicalRepTargetsHash = CreateSimpleHash(uint32, GroupedLogicalRepTargets);
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		bool found = false;
 		GroupedLogicalRepTargets *groupedLogicalRepTargets =
@@ -413,7 +413,7 @@ CreateShardMovePublicationInfoHash(WorkerNode *targetNode, List *shardIntervals)
 {
 	HTAB *publicationInfoHash = CreateSimpleHash(NodeAndOwner, PublicationInfo);
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervals)
+	foreach_declared_ptr(shardInterval, shardIntervals)
 	{
 		NodeAndOwner key;
 		key.nodeId = targetNode->nodeId;
@@ -474,7 +474,7 @@ CreateShardMoveLogicalRepTargetList(HTAB *publicationInfoHash, List *shardList)
 	}
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		NodeAndOwner key;
 		key.nodeId = nodeId;
@@ -552,7 +552,7 @@ void
 CreateReplicaIdentities(List *logicalRepTargetList)
 {
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		MultiConnection *superuserConnection = target->superuserConnection;
 		CreateReplicaIdentitiesOnNode(
@@ -576,7 +576,7 @@ CreateReplicaIdentitiesOnNode(List *shardList, char *nodeName, int32 nodePort)
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
 	ShardInterval *shardInterval;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		uint64 shardId = shardInterval->shardId;
 		Oid relationId = shardInterval->relationId;
@@ -725,10 +725,10 @@ ExecuteCreateIndexCommands(List *logicalRepTargetList)
 {
 	List *taskList = NIL;
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			Oid relationId = shardInterval->relationId;
 
@@ -787,10 +787,10 @@ ExecuteCreateConstraintsBackedByIndexCommands(List *logicalRepTargetList)
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			Oid relationId = shardInterval->relationId;
 
@@ -873,10 +873,10 @@ ExecuteClusterOnCommands(List *logicalRepTargetList)
 {
 	List *taskList = NIL;
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			Oid relationId = shardInterval->relationId;
 
@@ -925,10 +925,10 @@ ExecuteCreateIndexStatisticsCommands(List *logicalRepTargetList)
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			Oid relationId = shardInterval->relationId;
 
@@ -983,10 +983,10 @@ ExecuteRemainingPostLoadTableCommands(List *logicalRepTargetList)
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			Oid relationId = shardInterval->relationId;
 
@@ -1042,10 +1042,10 @@ CreatePartitioningHierarchy(List *logicalRepTargetList)
 	MemoryContext oldContext = MemoryContextSwitchTo(localContext);
 
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			if (PartitionTable(shardInterval->relationId))
 			{
@@ -1100,14 +1100,14 @@ CreateUncheckedForeignKeyConstraints(List *logicalRepTargetList)
 	 * Iterate over all the shards in the shard group.
 	 */
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ShardInterval *shardInterval = NULL;
 
 		/*
 		 * Iterate on split shards list for a given shard and create constraints.
 		 */
-		foreach_ptr(shardInterval, target->newShards)
+		foreach_declared_ptr(shardInterval, target->newShards)
 		{
 			List *commandList = CopyShardForeignConstraintCommandList(
 				shardInterval);
@@ -1320,7 +1320,7 @@ CreatePublications(MultiConnection *connection,
 						 quote_identifier(entry->name));
 
 		ShardInterval *shard = NULL;
-		foreach_ptr(shard, entry->shardIntervals)
+		foreach_declared_ptr(shard, entry->shardIntervals)
 		{
 			char *shardName = ConstructQualifiedShardName(shard);
 
@@ -1429,7 +1429,7 @@ CreateReplicationSlots(MultiConnection *sourceConnection,
 	ReplicationSlotInfo *firstReplicationSlot = NULL;
 	char *snapshot = NULL;
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ReplicationSlotInfo *replicationSlot = target->replicationSlot;
 
@@ -1481,7 +1481,7 @@ CreateSubscriptions(MultiConnection *sourceConnection,
 					List *logicalRepTargetList)
 {
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		int ownerId = target->tableOwnerId;
 
@@ -1603,7 +1603,7 @@ void
 EnableSubscriptions(List *logicalRepTargetList)
 {
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		ExecuteCriticalRemoteCommand(target->superuserConnection, psprintf(
 										 "ALTER SUBSCRIPTION %s ENABLE",
@@ -1737,7 +1737,7 @@ CreateGroupedLogicalRepTargetsConnections(HTAB *groupedLogicalRepTargetsHash,
 		groupedLogicalRepTargets->superuserConnection = superuserConnection;
 
 		LogicalRepTarget *target = NULL;
-		foreach_ptr(target, groupedLogicalRepTargets->logicalRepTargetList)
+		foreach_declared_ptr(target, groupedLogicalRepTargets->logicalRepTargetList)
 		{
 			target->superuserConnection = superuserConnection;
 		}
@@ -1774,7 +1774,7 @@ SubscriptionNamesValueList(List *logicalRepTargetList)
 	bool first = true;
 
 	LogicalRepTarget *target = NULL;
-	foreach_ptr(target, logicalRepTargetList)
+	foreach_declared_ptr(target, logicalRepTargetList)
 	{
 		if (!first)
 		{

--- a/src/backend/distributed/shardsplit/shardsplit_decoder.c
+++ b/src/backend/distributed/shardsplit/shardsplit_decoder.c
@@ -291,7 +291,7 @@ FindTargetRelationOid(Relation sourceShardRelation,
 												 shardSplitInfo->distributedTableOid);
 
 	shardSplitInfo = NULL;
-	foreach_ptr(shardSplitInfo, entry->shardSplitInfoList)
+	foreach_declared_ptr(shardSplitInfo, entry->shardSplitInfoList)
 	{
 		if (shardSplitInfo->shardMinValue <= hashValue &&
 			shardSplitInfo->shardMaxValue >= hashValue)

--- a/src/backend/distributed/shardsplit/shardsplit_logical_replication.c
+++ b/src/backend/distributed/shardsplit/shardsplit_logical_replication.c
@@ -154,7 +154,7 @@ AddPublishableShardEntryInMap(uint32 targetNodeId, ShardInterval *shardInterval,
 
 	/* Check if parent is already added */
 	ShardInterval *existingShardInterval = NULL;
-	foreach_ptr(existingShardInterval, publicationInfo->shardIntervals)
+	foreach_declared_ptr(existingShardInterval, publicationInfo->shardIntervals)
 	{
 		if (existingShardInterval->shardId == shardInterval->shardId)
 		{
@@ -204,7 +204,7 @@ PopulateShardSplitSubscriptionsMetadataList(HTAB *shardSplitInfoHashMap,
 	}
 
 	List *shardIntervalList = NIL;
-	foreach_ptr(shardIntervalList, shardGroupSplitIntervalListList)
+	foreach_declared_ptr(shardIntervalList, shardGroupSplitIntervalListList)
 	{
 		ShardInterval *shardInterval = NULL;
 		WorkerNode *workerPlacementNode = NULL;
@@ -256,7 +256,7 @@ CreateLogicalRepTarget(Oid tableOwnerId, uint32 nodeId,
 	 * table owner and node.
 	 */
 	ReplicationSlotInfo *replicationSlot = NULL;
-	foreach_ptr(replicationSlot, replicationSlotInfoList)
+	foreach_declared_ptr(replicationSlot, replicationSlotInfoList)
 	{
 		if (nodeId == replicationSlot->targetNodeId &&
 			tableOwnerId == replicationSlot->tableOwnerId)

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2805,7 +2805,7 @@ ShowShardsForAppNamePrefixesCheckHook(char **newval, void **extra, GucSource sou
 	}
 
 	char *appNamePrefix = NULL;
-	foreach_ptr(appNamePrefix, prefixList)
+	foreach_declared_ptr(appNamePrefix, prefixList)
 	{
 		int prefixLength = strlen(appNamePrefix);
 		if (prefixLength >= NAMEDATALEN)

--- a/src/backend/distributed/test/colocation_utils.c
+++ b/src/backend/distributed/test/colocation_utils.c
@@ -93,7 +93,7 @@ get_colocated_table_array(PG_FUNCTION_ARGS)
 	int colocatedTableIndex = 0;
 
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		Datum colocatedTableDatum = ObjectIdGetDatum(colocatedTableId);
 

--- a/src/backend/distributed/test/create_shards.c
+++ b/src/backend/distributed/test/create_shards.c
@@ -46,7 +46,7 @@ sort_names(PG_FUNCTION_ARGS)
 	StringInfo sortedNames = makeStringInfo();
 
 	const char *name = NULL;
-	foreach_ptr(name, nameList)
+	foreach_declared_ptr(name, nameList)
 	{
 		appendStringInfo(sortedNames, "%s\n", name);
 	}

--- a/src/backend/distributed/test/deparse_shard_query.c
+++ b/src/backend/distributed/test/deparse_shard_query.c
@@ -49,14 +49,14 @@ deparse_shard_query_test(PG_FUNCTION_ARGS)
 	List *parseTreeList = pg_parse_query(queryStringChar);
 
 	Node *parsetree = NULL;
-	foreach_ptr(parsetree, parseTreeList)
+	foreach_declared_ptr(parsetree, parseTreeList)
 	{
 		List *queryTreeList = pg_analyze_and_rewrite_fixedparams((RawStmt *) parsetree,
 																 queryStringChar,
 																 NULL, 0, NULL);
 
 		Query *query = NULL;
-		foreach_ptr(query, queryTreeList)
+		foreach_declared_ptr(query, queryTreeList)
 		{
 			StringInfo buffer = makeStringInfo();
 

--- a/src/backend/distributed/test/dependency.c
+++ b/src/backend/distributed/test/dependency.c
@@ -50,7 +50,7 @@ citus_get_all_dependencies_for_object(PG_FUNCTION_ARGS)
 
 	List *dependencies = GetAllSupportedDependenciesForObject(&address);
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		Datum values[3];
 		bool isNulls[3];
@@ -95,7 +95,7 @@ citus_get_dependencies_for_object(PG_FUNCTION_ARGS)
 
 	List *dependencies = GetDependenciesForObject(&address);
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencies)
+	foreach_declared_ptr(dependency, dependencies)
 	{
 		Datum values[3];
 		bool isNulls[3];

--- a/src/backend/distributed/test/distributed_intermediate_results.c
+++ b/src/backend/distributed/test/distributed_intermediate_results.c
@@ -90,7 +90,7 @@ partition_task_list_results(PG_FUNCTION_ARGS)
 	Tuplestorestate *tupleStore = SetupTuplestore(fcinfo, &tupleDescriptor);
 
 	DistributedResultFragment *fragment = NULL;
-	foreach_ptr(fragment, fragmentList)
+	foreach_declared_ptr(fragment, fragmentList)
 	{
 		bool columnNulls[5] = { 0 };
 		Datum columnValues[5] = {
@@ -169,7 +169,7 @@ redistribute_task_list_results(PG_FUNCTION_ARGS)
 
 		const char *resultId = NULL;
 		int resultIdIndex = 0;
-		foreach_ptr(resultId, sortedResultIds)
+		foreach_declared_ptr(resultId, sortedResultIds)
 		{
 			resultIdValues[resultIdIndex++] = CStringGetTextDatum(resultId);
 		}

--- a/src/backend/distributed/test/distribution_metadata.c
+++ b/src/backend/distributed/test/distribution_metadata.c
@@ -74,7 +74,7 @@ load_shard_id_array(PG_FUNCTION_ARGS)
 	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		Datum shardIdDatum = Int64GetDatum(shardInterval->shardId);
 
@@ -144,7 +144,7 @@ load_shard_placement_array(PG_FUNCTION_ARGS)
 	Datum *placementDatumArray = palloc0(placementCount * sizeof(Datum));
 
 	ShardPlacement *placement = NULL;
-	foreach_ptr(placement, placementList)
+	foreach_declared_ptr(placement, placementList)
 	{
 		appendStringInfo(placementInfo, "%s:%d", placement->nodeName,
 						 placement->nodePort);
@@ -263,14 +263,14 @@ relation_count_in_query(PG_FUNCTION_ARGS)
 	List *parseTreeList = pg_parse_query(queryStringChar);
 
 	Node *parsetree = NULL;
-	foreach_ptr(parsetree, parseTreeList)
+	foreach_declared_ptr(parsetree, parseTreeList)
 	{
 		List *queryTreeList = pg_analyze_and_rewrite_fixedparams((RawStmt *) parsetree,
 																 queryStringChar,
 																 NULL, 0, NULL);
 
 		Query *query = NULL;
-		foreach_ptr(query, queryTreeList)
+		foreach_declared_ptr(query, queryTreeList)
 		{
 			List *rangeTableList = NIL;
 

--- a/src/backend/distributed/test/foreign_key_relationship_query.c
+++ b/src/backend/distributed/test/foreign_key_relationship_query.c
@@ -205,7 +205,7 @@ get_foreign_key_connected_relations(PG_FUNCTION_ARGS)
 
 	Oid connectedRelationId;
 	List *fkeyConnectedRelationIdList = GetForeignKeyConnectedRelationIdList(relationId);
-	foreach_oid(connectedRelationId, fkeyConnectedRelationIdList)
+	foreach_declared_oid(connectedRelationId, fkeyConnectedRelationIdList)
 	{
 		Datum values[GET_FKEY_CONNECTED_RELATIONS_COLUMNS];
 		bool nulls[GET_FKEY_CONNECTED_RELATIONS_COLUMNS];

--- a/src/backend/distributed/test/metadata_sync.c
+++ b/src/backend/distributed/test/metadata_sync.c
@@ -73,7 +73,7 @@ activate_node_snapshot(PG_FUNCTION_ARGS)
 												   sizeof(Datum));
 
 	const char *activateNodeSnapshotCommand = NULL;
-	foreach_ptr(activateNodeSnapshotCommand, activateNodeCommandList)
+	foreach_declared_ptr(activateNodeSnapshotCommand, activateNodeCommandList)
 	{
 		Datum activateNodeSnapshotCommandDatum = CStringGetTextDatum(
 			activateNodeSnapshotCommand);
@@ -105,7 +105,7 @@ wait_until_metadata_sync(PG_FUNCTION_ARGS)
 	bool waitNotifications = false;
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerList)
+	foreach_declared_ptr(workerNode, workerList)
 	{
 		/* if already has metadata, no need to do it again */
 		if (workerNode->hasMetadata && !workerNode->metadataSynced)

--- a/src/backend/distributed/test/partitioning_utils.c
+++ b/src/backend/distributed/test/partitioning_utils.c
@@ -85,7 +85,7 @@ print_partitions(PG_FUNCTION_ARGS)
 	partitionList = SortList(partitionList, CompareOids);
 
 	Oid partitionOid = InvalidOid;
-	foreach_oid(partitionOid, partitionList)
+	foreach_declared_oid(partitionOid, partitionList)
 	{
 		/* at least one table is already added, add comma */
 		if (resultRelationNames->len > 0)

--- a/src/backend/distributed/test/progress_utils.c
+++ b/src/backend/distributed/test/progress_utils.c
@@ -95,7 +95,7 @@ show_progress(PG_FUNCTION_ARGS)
 	Tuplestorestate *tupstore = SetupTuplestore(fcinfo, &tupdesc);
 
 	ProgressMonitorData *monitor = NULL;
-	foreach_ptr(monitor, monitorList)
+	foreach_declared_ptr(monitor, monitorList)
 	{
 		uint64 *steps = ProgressMonitorSteps(monitor);
 

--- a/src/backend/distributed/test/prune_shard_list.c
+++ b/src/backend/distributed/test/prune_shard_list.c
@@ -224,7 +224,7 @@ PrunedShardIdsForTable(Oid distributedTableId, List *whereClauseList)
 	Datum *shardIdDatumArray = palloc0(shardIdCount * sizeof(Datum));
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardList)
+	foreach_declared_ptr(shardInterval, shardList)
 	{
 		Datum shardIdDatum = Int64GetDatum(shardInterval->shardId);
 

--- a/src/backend/distributed/test/shard_rebalancer.c
+++ b/src/backend/distributed/test/shard_rebalancer.c
@@ -128,13 +128,13 @@ shard_placement_rebalance_array(PG_FUNCTION_ARGS)
 	pfree(shardPlacementJsonArray);
 
 	/* map workerTestInfoList to a list of its WorkerNodes */
-	foreach_ptr(workerTestInfo, context.workerTestInfoList)
+	foreach_declared_ptr(workerTestInfo, context.workerTestInfoList)
 	{
 		workerNodeList = lappend(workerNodeList, workerTestInfo->node);
 	}
 
 	/* map shardPlacementTestInfoList to a list of list of its ShardPlacements */
-	foreach_ptr(shardPlacementTestInfo, context.shardPlacementTestInfoList)
+	foreach_declared_ptr(shardPlacementTestInfo, context.shardPlacementTestInfoList)
 	{
 		if (shardPlacementTestInfo->nextColocationGroup)
 		{
@@ -197,7 +197,7 @@ ShardAllowedOnNode(uint64 shardId, WorkerNode *workerNode, void *voidContext)
 	RebalancePlacementContext *context = voidContext;
 	WorkerTestInfo *workerTestInfo = NULL;
 	uint64 *disallowedShardIdPtr = NULL;
-	foreach_ptr(workerTestInfo, context->workerTestInfoList)
+	foreach_declared_ptr(workerTestInfo, context->workerTestInfoList)
 	{
 		if (workerTestInfo->node == workerNode)
 		{
@@ -206,7 +206,7 @@ ShardAllowedOnNode(uint64 shardId, WorkerNode *workerNode, void *voidContext)
 	}
 	Assert(workerTestInfo != NULL);
 
-	foreach_ptr(disallowedShardIdPtr, workerTestInfo->disallowedShardIds)
+	foreach_declared_ptr(disallowedShardIdPtr, workerTestInfo->disallowedShardIds)
 	{
 		if (shardId == *disallowedShardIdPtr)
 		{
@@ -226,7 +226,7 @@ NodeCapacity(WorkerNode *workerNode, void *voidContext)
 {
 	RebalancePlacementContext *context = voidContext;
 	WorkerTestInfo *workerTestInfo = NULL;
-	foreach_ptr(workerTestInfo, context->workerTestInfoList)
+	foreach_declared_ptr(workerTestInfo, context->workerTestInfoList)
 	{
 		if (workerTestInfo->node == workerNode)
 		{
@@ -251,7 +251,7 @@ GetShardCost(uint64 shardId, void *voidContext)
 	shardCost.shardId = shardId;
 
 	ShardPlacementTestInfo *shardPlacementTestInfo = NULL;
-	foreach_ptr(shardPlacementTestInfo, context->shardPlacementTestInfoList)
+	foreach_declared_ptr(shardPlacementTestInfo, context->shardPlacementTestInfoList)
 	{
 		if (shardPlacementTestInfo->placement->shardId == shardId)
 		{
@@ -300,12 +300,12 @@ shard_placement_replication_array(PG_FUNCTION_ARGS)
 	pfree(workerNodeJsonArray);
 	pfree(shardPlacementJsonArray);
 
-	foreach_ptr(workerTestInfo, workerTestInfoList)
+	foreach_declared_ptr(workerTestInfo, workerTestInfoList)
 	{
 		workerNodeList = lappend(workerNodeList, workerTestInfo->node);
 	}
 
-	foreach_ptr(shardPlacementTestInfo, shardPlacementTestInfoList)
+	foreach_declared_ptr(shardPlacementTestInfo, shardPlacementTestInfoList)
 	{
 		shardPlacementList = lappend(shardPlacementList,
 									 shardPlacementTestInfo->placement);

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -267,7 +267,7 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 
 	/* open connections in parallel */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -289,7 +289,7 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 
 	/* send commands in parallel */
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		int querySent = SendRemoteCommand(connection, queryToSend->data);
 		if (querySent == 0)
@@ -299,7 +299,7 @@ get_global_active_transactions(PG_FUNCTION_ARGS)
 	}
 
 	/* receive query results */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		bool raiseInterrupts = true;
 		Datum values[ACTIVE_TRANSACTION_COLUMN_COUNT];

--- a/src/backend/distributed/transaction/distributed_deadlock_detection.c
+++ b/src/backend/distributed/transaction/distributed_deadlock_detection.c
@@ -177,7 +177,7 @@ CheckForDistributedDeadlocks(void)
 			 * this node.
 			 */
 			TransactionNode *currentNode = NULL;
-			foreach_ptr(currentNode, deadlockPath)
+			foreach_declared_ptr(currentNode, deadlockPath)
 			{
 				bool transactionAssociatedWithProc =
 					AssociateDistributedTransactionWithBackendProc(currentNode);
@@ -305,7 +305,7 @@ PrependOutgoingNodesToQueue(TransactionNode *transactionNode, int currentStackDe
 
 	/* prepend to the list to continue depth-first search */
 	TransactionNode *waitForTransaction = NULL;
-	foreach_ptr(waitForTransaction, transactionNode->waitsFor)
+	foreach_declared_ptr(waitForTransaction, transactionNode->waitsFor)
 	{
 		QueuedTransactionNode *queuedNode = palloc0(sizeof(QueuedTransactionNode));
 
@@ -672,7 +672,7 @@ WaitsForToString(List *waitsFor)
 	StringInfo transactionIdStr = makeStringInfo();
 
 	TransactionNode *waitingNode = NULL;
-	foreach_ptr(waitingNode, waitsFor)
+	foreach_declared_ptr(waitingNode, waitsFor)
 	{
 		if (transactionIdStr->len != 0)
 		{

--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -149,7 +149,7 @@ BuildGlobalWaitGraph(bool onlyDistributedTx)
 
 	/* open connections in parallel */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -172,7 +172,7 @@ BuildGlobalWaitGraph(bool onlyDistributedTx)
 
 	/* send commands in parallel */
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		StringInfo queryString = makeStringInfo();
 
@@ -203,7 +203,7 @@ BuildGlobalWaitGraph(bool onlyDistributedTx)
 	}
 
 	/* receive dump_local_wait_edges results */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		bool raiseInterrupts = true;
 

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -367,7 +367,7 @@ RecordRelationParallelSelectAccessForTask(Task *task)
 	List *relationShardList = task->relationShardList;
 
 	RelationShard *relationShard = NULL;
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		Oid currentRelationId = relationShard->relationId;
 
@@ -412,7 +412,7 @@ RecordRelationParallelModifyAccessForTask(Task *task)
 	{
 		relationShardList = task->relationShardList;
 		RelationShard *relationShard = NULL;
-		foreach_ptr(relationShard, relationShardList)
+		foreach_declared_ptr(relationShard, relationShardList)
 		{
 			Oid currentRelationId = relationShard->relationId;
 
@@ -446,7 +446,7 @@ RecordRelationParallelDDLAccessForTask(Task *task)
 	Oid lastRelationId = InvalidOid;
 
 	RelationShard *relationShard = NULL;
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		Oid currentRelationId = relationShard->relationId;
 
@@ -534,7 +534,7 @@ RecordParallelRelationAccess(Oid relationId, ShardPlacementAccessType placementA
 		List *partitionList = PartitionList(relationId);
 
 		Oid partitionOid = InvalidOid;
-		foreach_oid(partitionOid, partitionList)
+		foreach_declared_oid(partitionOid, partitionList)
 		{
 			/* recursively record all relation accesses of its partitions */
 			RecordParallelRelationAccess(partitionOid, placementAccess);
@@ -926,7 +926,7 @@ HoldsConflictingLockWithReferencedRelations(Oid relationId, ShardPlacementAccess
 	CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
 
 	Oid referencedRelation = InvalidOid;
-	foreach_oid(referencedRelation, cacheEntry->referencedRelationsViaForeignKey)
+	foreach_declared_oid(referencedRelation, cacheEntry->referencedRelationsViaForeignKey)
 	{
 		/*
 		 * We're only interested in foreign keys to reference tables and citus
@@ -997,7 +997,7 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	Assert(!IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE));
 
 	Oid referencingRelation = InvalidOid;
-	foreach_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)
+	foreach_declared_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)
 	{
 		/*
 		 * We're only interested in foreign keys to reference tables from

--- a/src/backend/distributed/transaction/relation_access_tracking.c
+++ b/src/backend/distributed/transaction/relation_access_tracking.c
@@ -997,7 +997,8 @@ HoldsConflictingLockWithReferencingRelations(Oid relationId, ShardPlacementAcces
 	Assert(!IsCitusTableTypeCacheEntry(cacheEntry, DISTRIBUTED_TABLE));
 
 	Oid referencingRelation = InvalidOid;
-	foreach_declared_oid(referencingRelation, cacheEntry->referencingRelationsViaForeignKey)
+	foreach_declared_oid(referencingRelation,
+						 cacheEntry->referencingRelationsViaForeignKey)
 	{
 		/*
 		 * We're only interested in foreign keys to reference tables from

--- a/src/backend/distributed/transaction/remote_transaction.c
+++ b/src/backend/distributed/transaction/remote_transaction.c
@@ -100,7 +100,7 @@ StartRemoteTransactionBegin(struct MultiConnection *connection)
 	transaction->lastQueuedSubXact = TopSubTransactionId;
 
 	SubXactContext *subXactState = NULL;
-	foreach_ptr(subXactState, activeSubXacts)
+	foreach_declared_ptr(subXactState, activeSubXacts)
 	{
 		/* append SET LOCAL state from when SAVEPOINT was encountered... */
 		if (subXactState->setLocalCmds != NULL)
@@ -311,13 +311,13 @@ RemoteTransactionListBegin(List *connectionList)
 	MultiConnection *connection = NULL;
 
 	/* send BEGIN to all nodes */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		StartRemoteTransactionBegin(connection);
 	}
 
 	/* wait for BEGIN to finish on all nodes */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		FinishRemoteTransactionBegin(connection);
 	}
@@ -724,7 +724,7 @@ RemoteTransactionsBeginIfNecessary(List *connectionList)
 	}
 
 	/* issue BEGIN to all connections needing it */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 
@@ -748,7 +748,7 @@ RemoteTransactionsBeginIfNecessary(List *connectionList)
 	WaitForAllConnections(connectionList, raiseInterrupts);
 
 	/* get result of all the BEGINs */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		RemoteTransaction *transaction = &connection->remoteTransaction;
 

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -1118,7 +1118,7 @@ TrackPropagatedTableAndSequences(Oid relationId)
 	/* track its sequences */
 	List *ownedSeqIdList = getOwnedSequences(relationId);
 	Oid ownedSeqId = InvalidOid;
-	foreach_oid(ownedSeqId, ownedSeqIdList)
+	foreach_declared_oid(ownedSeqId, ownedSeqIdList)
 	{
 		ObjectAddress *seqAddress = palloc0(sizeof(ObjectAddress));
 		ObjectAddressSet(*seqAddress, RelationRelationId, ownedSeqId);
@@ -1147,7 +1147,7 @@ HasAnyDependencyInPropagatedObjects(const ObjectAddress *objectAddress)
 {
 	List *dependencyList = GetAllSupportedDependenciesForObject(objectAddress);
 	ObjectAddress *dependency = NULL;
-	foreach_ptr(dependency, dependencyList)
+	foreach_declared_ptr(dependency, dependencyList)
 	{
 		/* first search in root transaction */
 		if (DependencyInPropagatedObjectsHash(PropagatedObjectsInTx, dependency))
@@ -1161,7 +1161,7 @@ HasAnyDependencyInPropagatedObjects(const ObjectAddress *objectAddress)
 			continue;
 		}
 		SubXactContext *state = NULL;
-		foreach_ptr(state, activeSubXactContexts)
+		foreach_declared_ptr(state, activeSubXactContexts)
 		{
 			if (DependencyInPropagatedObjectsHash(state->propagatedObjects, dependency))
 			{

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -124,7 +124,7 @@ RecoverTwoPhaseCommits(void)
 
 	List *workerList = ActivePrimaryNodeList(NoLock);
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerList)
+	foreach_declared_ptr(workerNode, workerList)
 	{
 		recoveredTransactionCount += RecoverWorkerTransactions(workerNode);
 	}

--- a/src/backend/distributed/transaction/worker_transaction.c
+++ b/src/backend/distributed/transaction/worker_transaction.c
@@ -72,7 +72,7 @@ SendCommandToWorkersAsUser(TargetWorkerSet targetWorkerSet, const char *nodeUser
 
 	/* run commands serially */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -145,7 +145,7 @@ void
 SendCommandListToWorkersWithMetadata(List *commands)
 {
 	char *command = NULL;
-	foreach_ptr(command, commands)
+	foreach_declared_ptr(command, commands)
 	{
 		SendCommandToWorkersWithMetadata(command);
 	}
@@ -171,7 +171,7 @@ TargetWorkerSetNodeList(TargetWorkerSet targetWorkerSet, LOCKMODE lockMode)
 	List *result = NIL;
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if ((targetWorkerSet == NON_COORDINATOR_METADATA_NODES || targetWorkerSet ==
 			 METADATA_NODES) &&
@@ -205,7 +205,7 @@ SendBareCommandListToMetadataWorkers(List *commandList)
 
 	/* run commands serially */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -218,7 +218,7 @@ SendBareCommandListToMetadataWorkers(List *commandList)
 
 		/* iterate over the commands and execute them in the same connection */
 		const char *commandString = NULL;
-		foreach_ptr(commandString, commandList)
+		foreach_declared_ptr(commandString, commandList)
 		{
 			ExecuteCriticalRemoteCommand(workerConnection, commandString);
 		}
@@ -271,7 +271,7 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 
 	/* open connections in parallel */
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -299,7 +299,7 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 
 	/* send commands in parallel */
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		int querySent = SendRemoteCommandParams(connection, command, parameterCount,
 												parameterTypes, parameterValues, false);
@@ -310,7 +310,7 @@ SendCommandToWorkersParamsInternal(TargetWorkerSet targetWorkerSet, const char *
 	}
 
 	/* get results */
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		PGresult *result = GetRemoteCommandResult(connection, true);
 		if (!IsResponseOK(result))
@@ -381,7 +381,7 @@ SendCommandListToWorkerOutsideTransactionWithConnection(MultiConnection *workerC
 
 	/* iterate over the commands and execute them in the same connection */
 	const char *commandString = NULL;
-	foreach_ptr(commandString, commandList)
+	foreach_declared_ptr(commandString, commandList)
 	{
 		ExecuteCriticalRemoteCommand(workerConnection, commandString);
 	}
@@ -422,7 +422,7 @@ SendCommandListToWorkerListWithBareConnections(List *workerConnectionList,
 
 	/* send commands in parallel */
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, workerConnectionList)
+	foreach_declared_ptr(connection, workerConnectionList)
 	{
 		int querySent = SendRemoteCommand(connection, stringToSend);
 		if (querySent == 0)
@@ -432,7 +432,7 @@ SendCommandListToWorkerListWithBareConnections(List *workerConnectionList,
 	}
 
 	bool failOnError = true;
-	foreach_ptr(connection, workerConnectionList)
+	foreach_declared_ptr(connection, workerConnectionList)
 	{
 		ClearResults(connection, failOnError);
 	}
@@ -462,7 +462,7 @@ SendMetadataCommandListToWorkerListInCoordinatedTransaction(List *workerNodeList
 	List *connectionList = NIL;
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		int nodePort = workerNode->workerPort;
@@ -499,7 +499,7 @@ SendMetadataCommandListToWorkerListInCoordinatedTransaction(List *workerNodeList
 	/* send commands in parallel */
 	bool failOnError = true;
 	MultiConnection *connection = NULL;
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		int querySent = SendRemoteCommand(connection, stringToSend);
 		if (querySent == 0)
@@ -508,7 +508,7 @@ SendMetadataCommandListToWorkerListInCoordinatedTransaction(List *workerNodeList
 		}
 	}
 
-	foreach_ptr(connection, connectionList)
+	foreach_declared_ptr(connection, connectionList)
 	{
 		ClearResults(connection, failOnError);
 	}
@@ -537,7 +537,7 @@ SendOptionalCommandListToWorkerOutsideTransactionWithConnection(
 	/* iterate over the commands and execute them in the same connection */
 	bool failed = false;
 	const char *commandString = NULL;
-	foreach_ptr(commandString, commandList)
+	foreach_declared_ptr(commandString, commandList)
 	{
 		if (ExecuteOptionalRemoteCommand(workerConnection, commandString, NULL) != 0)
 		{
@@ -613,7 +613,7 @@ SendOptionalMetadataCommandListToWorkerInCoordinatedTransaction(const char *node
 
 	/* iterate over the commands and execute them in the same connection */
 	const char *commandString = NULL;
-	foreach_ptr(commandString, commandList)
+	foreach_declared_ptr(commandString, commandList)
 	{
 		if (ExecuteOptionalRemoteCommand(workerConnection, commandString, NULL) !=
 			RESPONSE_OKAY)
@@ -648,7 +648,7 @@ static void
 ErrorIfAnyMetadataNodeOutOfSync(List *metadataNodeList)
 {
 	WorkerNode *metadataNode = NULL;
-	foreach_ptr(metadataNode, metadataNodeList)
+	foreach_declared_ptr(metadataNode, metadataNodeList)
 	{
 		Assert(metadataNode->hasMetadata);
 

--- a/src/backend/distributed/utils/background_jobs.c
+++ b/src/backend/distributed/utils/background_jobs.c
@@ -158,7 +158,7 @@ citus_job_cancel(PG_FUNCTION_ARGS)
 
 	/* send cancellation to any running backends */
 	int pid = 0;
-	foreach_int(pid, pids)
+	foreach_declared_int(pid, pids)
 	{
 		Datum pidDatum = Int32GetDatum(pid);
 		Datum signalSuccessDatum = DirectFunctionCall1(pg_cancel_backend, pidDatum);
@@ -891,7 +891,7 @@ IncrementParallelTaskCountForNodesInvolved(BackgroundTask *task)
 		int node;
 
 		/* first check whether we have reached the limit for any of the nodes */
-		foreach_int(node, task->nodesInvolved)
+		foreach_declared_int(node, task->nodesInvolved)
 		{
 			bool found;
 			ParallelTasksPerNodeEntry *hashEntry = hash_search(
@@ -908,7 +908,7 @@ IncrementParallelTaskCountForNodesInvolved(BackgroundTask *task)
 		}
 
 		/* then, increment the parallel task count per each node */
-		foreach_int(node, task->nodesInvolved)
+		foreach_declared_int(node, task->nodesInvolved)
 		{
 			ParallelTasksPerNodeEntry *hashEntry = hash_search(
 				ParallelTasksPerNode, &(node), HASH_FIND, NULL);
@@ -934,7 +934,7 @@ DecrementParallelTaskCountForNodesInvolved(BackgroundTask *task)
 	if (task->nodesInvolved)
 	{
 		int node;
-		foreach_int(node, task->nodesInvolved)
+		foreach_declared_int(node, task->nodesInvolved)
 		{
 			ParallelTasksPerNodeEntry *hashEntry = hash_search(ParallelTasksPerNode,
 															   &(node),
@@ -1278,7 +1278,7 @@ CitusBackgroundTaskQueueMonitorMain(Datum arg)
 
 		/* iterate over all handle entries and monitor each task's output */
 		BackgroundExecutorHashEntry *handleEntry = NULL;
-		foreach_ptr(handleEntry, runningTaskEntries)
+		foreach_declared_ptr(handleEntry, runningTaskEntries)
 		{
 			/* create task execution context and assign it to queueMonitorExecutionContext */
 			TaskExecutionContext taskExecutionContext = {
@@ -1916,7 +1916,7 @@ ExecuteSqlString(const char *sql)
 	 * analysis on the next one, since there may be interdependencies.
 	 */
 	RawStmt *parsetree = NULL;
-	foreach_ptr(parsetree, raw_parsetree_list)
+	foreach_declared_ptr(parsetree, raw_parsetree_list)
 	{
 		/*
 		 * We don't allow transaction-control commands like COMMIT and ABORT

--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -78,7 +78,7 @@ CitusSetTag(Node *node, int tag)
 	do { \
 		char *curString = NULL; \
 		List *newList = NIL; \
-		foreach_ptr(curString, from->fldname) { \
+		foreach_declared_ptr(curString, from->fldname) { \
 			char *newString = curString ? pstrdup(curString) : (char *) NULL; \
 			newList = lappend(newList, newString); \
 		} \

--- a/src/backend/distributed/utils/citus_depended_object.c
+++ b/src/backend/distributed/utils/citus_depended_object.c
@@ -138,7 +138,7 @@ HideCitusDependentObjectsOnQueriesOfPgMetaTables(Node *node, void *context)
 		int varno = 0;
 		RangeTblEntry *rangeTableEntry = NULL;
 
-		foreach_ptr(rangeTableEntry, query->rtable)
+		foreach_declared_ptr(rangeTableEntry, query->rtable)
 		{
 			varno++;
 
@@ -376,7 +376,7 @@ DistOpsValidityState(Node *node, const DistributeObjectOps *ops)
 		bool isPostprocess = false;
 		List *objectAddresses = ops->address(node, missingOk, isPostprocess);
 		ObjectAddress *objectAddress = NULL;
-		foreach_ptr(objectAddress, objectAddresses)
+		foreach_declared_ptr(objectAddress, objectAddresses)
 		{
 			if (OidIsValid(objectAddress->objectId))
 			{
@@ -478,7 +478,7 @@ AnyObjectViolatesOwnership(DropStmt *dropStmt)
 	PG_TRY();
 	{
 		Node *object = NULL;
-		foreach_ptr(object, dropStmt->objects)
+		foreach_declared_ptr(object, dropStmt->objects)
 		{
 			Relation rel = NULL;
 			objectAddress = get_object_address(objectType, object,

--- a/src/backend/distributed/utils/colocation_utils.c
+++ b/src/backend/distributed/utils/colocation_utils.c
@@ -204,7 +204,7 @@ get_colocated_shard_array(PG_FUNCTION_ARGS)
 	int colocatedShardIndex = 0;
 
 	ShardInterval *colocatedShardInterval = NULL;
-	foreach_ptr(colocatedShardInterval, colocatedShardList)
+	foreach_declared_ptr(colocatedShardInterval, colocatedShardList)
 	{
 		uint64 colocatedShardId = colocatedShardInterval->shardId;
 
@@ -1065,7 +1065,7 @@ ColocatedShardIntervalList(ShardInterval *shardInterval)
 	Assert(shardIntervalIndex >= 0);
 
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		CitusTableCacheEntry *colocatedTableCacheEntry =
 			GetCitusTableCacheEntry(colocatedTableId);
@@ -1131,7 +1131,7 @@ ColocatedNonPartitionShardIntervalList(ShardInterval *shardInterval)
 	Assert(shardIntervalIndex >= 0);
 
 	Oid colocatedTableId = InvalidOid;
-	foreach_oid(colocatedTableId, colocatedTableList)
+	foreach_declared_oid(colocatedTableId, colocatedTableList)
 	{
 		if (PartitionTable(colocatedTableId))
 		{

--- a/src/backend/distributed/utils/distribution_column_map.c
+++ b/src/backend/distributed/utils/distribution_column_map.c
@@ -81,7 +81,7 @@ AddDistributionColumnForRelation(DistributionColumnMap *distributionColumnMap,
 		List *partitionList = PartitionList(relationId);
 		Oid partitionRelationId = InvalidOid;
 
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			AddDistributionColumnForRelation(distributionColumnMap, partitionRelationId,
 											 distributionColumnName);

--- a/src/backend/distributed/utils/foreign_key_relationship.c
+++ b/src/backend/distributed/utils/foreign_key_relationship.c
@@ -190,7 +190,7 @@ GetRelationshipNodesForFKeyConnectedRelations(
 	{
 		List *allNeighboursList = GetAllNeighboursList(currentNode);
 		ForeignConstraintRelationshipNode *neighbourNode = NULL;
-		foreach_ptr(neighbourNode, allNeighboursList)
+		foreach_declared_ptr(neighbourNode, allNeighboursList)
 		{
 			Oid neighbourRelationId = neighbourNode->relationId;
 			if (OidVisited(oidVisitedMap, neighbourRelationId))
@@ -437,7 +437,7 @@ GetConnectedListHelper(ForeignConstraintRelationshipNode *node, bool isReferenci
 
 		List *neighbourList = GetNeighbourList(currentNode, isReferencing);
 		ForeignConstraintRelationshipNode *neighbourNode = NULL;
-		foreach_ptr(neighbourNode, neighbourList)
+		foreach_declared_ptr(neighbourNode, neighbourList)
 		{
 			Oid neighbourRelationId = neighbourNode->relationId;
 			if (!OidVisited(oidVisitedMap, neighbourRelationId))
@@ -508,7 +508,7 @@ GetRelationIdsFromRelationshipNodeList(List *fKeyRelationshipNodeList)
 	List *relationIdList = NIL;
 
 	ForeignConstraintRelationshipNode *fKeyRelationshipNode = NULL;
-	foreach_ptr(fKeyRelationshipNode, fKeyRelationshipNodeList)
+	foreach_declared_ptr(fKeyRelationshipNode, fKeyRelationshipNodeList)
 	{
 		Oid relationId = fKeyRelationshipNode->relationId;
 		relationIdList = lappend_oid(relationIdList, relationId);
@@ -561,7 +561,7 @@ PopulateAdjacencyLists(void)
 	frelEdgeList = SortList(frelEdgeList, CompareForeignConstraintRelationshipEdges);
 
 	ForeignConstraintRelationshipEdge *currentFConstraintRelationshipEdge = NULL;
-	foreach_ptr(currentFConstraintRelationshipEdge, frelEdgeList)
+	foreach_declared_ptr(currentFConstraintRelationshipEdge, frelEdgeList)
 	{
 		/* we just saw this edge, no need to add it twice */
 		if (currentFConstraintRelationshipEdge->referencingRelationOID ==

--- a/src/backend/distributed/utils/listutils.c
+++ b/src/backend/distributed/utils/listutils.c
@@ -43,7 +43,7 @@ SortList(List *pointerList, int (*comparisonFunction)(const void *, const void *
 	void **array = (void **) palloc0(arraySize * sizeof(void *));
 
 	void *pointer = NULL;
-	foreach_ptr(pointer, pointerList)
+	foreach_declared_ptr(pointer, pointerList)
 	{
 		array[arrayIndex] = pointer;
 
@@ -82,7 +82,7 @@ PointerArrayFromList(List *pointerList)
 	int pointerIndex = 0;
 
 	void *pointer = NULL;
-	foreach_ptr(pointer, pointerList)
+	foreach_declared_ptr(pointer, pointerList)
 	{
 		pointerArray[pointerIndex] = pointer;
 		pointerIndex += 1;
@@ -130,7 +130,7 @@ ListToHashSet(List *itemList, Size keySize, bool isStringList)
 	HTAB *itemSet = hash_create("ListToHashSet", capacity, &info, flags);
 
 	void *item = NULL;
-	foreach_ptr(item, itemList)
+	foreach_declared_ptr(item, itemList)
 	{
 		bool foundInSet = false;
 
@@ -188,7 +188,7 @@ StringJoinParams(List *stringList, char delimiter, char *prefix, char *postfix)
 
 	const char *command = NULL;
 	int curIndex = 0;
-	foreach_ptr(command, stringList)
+	foreach_declared_ptr(command, stringList)
 	{
 		if (curIndex > 0)
 		{
@@ -219,7 +219,7 @@ ListTake(List *pointerList, int size)
 	int listIndex = 0;
 
 	void *pointer = NULL;
-	foreach_ptr(pointer, pointerList)
+	foreach_declared_ptr(pointer, pointerList)
 	{
 		result = lappend(result, pointer);
 		listIndex++;
@@ -279,7 +279,7 @@ list_filter_oid(List *list, bool (*keepElement)(Oid element))
 {
 	List *result = NIL;
 	Oid element = InvalidOid;
-	foreach_oid(element, list)
+	foreach_declared_oid(element, list)
 	{
 		if (keepElement(element))
 		{

--- a/src/backend/distributed/utils/multi_partitioning_utils.c
+++ b/src/backend/distributed/utils/multi_partitioning_utils.c
@@ -259,7 +259,7 @@ worker_fix_partition_shard_index_names(PG_FUNCTION_ARGS)
 	List *partitionShardIndexIds = find_inheritance_children(parentShardIndexId,
 															 ShareRowExclusiveLock);
 	Oid partitionShardIndexId = InvalidOid;
-	foreach_oid(partitionShardIndexId, partitionShardIndexIds)
+	foreach_declared_oid(partitionShardIndexId, partitionShardIndexIds)
 	{
 		if (IndexGetRelation(partitionShardIndexId, false) == partitionShardId)
 		{
@@ -372,7 +372,7 @@ CreateFixPartitionConstraintsTaskList(Oid relationId)
 	LockShardListMetadata(shardIntervalList, ShareLock);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		uint64 shardId = shardInterval->shardId;
 
@@ -458,7 +458,7 @@ WorkerFixPartitionConstraintCommandList(Oid relationId, uint64 shardId,
 	char *quotedShardName = quote_qualified_identifier(schemaName, shardRelationName);
 
 	char *constraintName = NULL;
-	foreach_ptr(constraintName, checkConstraintList)
+	foreach_declared_ptr(constraintName, checkConstraintList)
 	{
 		StringInfo shardQueryString = makeStringInfo();
 		appendStringInfo(shardQueryString,
@@ -543,7 +543,7 @@ CreateFixPartitionShardIndexNames(Oid parentRelationId, Oid partitionRelationId,
 	else
 	{
 		Oid partitionId = InvalidOid;
-		foreach_oid(partitionId, partitionList)
+		foreach_declared_oid(partitionId, partitionList)
 		{
 			List *partitionShardIntervalList = LoadShardIntervalList(partitionId);
 			LockShardListMetadata(partitionShardIntervalList, ShareLock);
@@ -563,7 +563,7 @@ CreateFixPartitionShardIndexNames(Oid parentRelationId, Oid partitionRelationId,
 	int taskId = 1;
 
 	ShardInterval *parentShardInterval = NULL;
-	foreach_ptr(parentShardInterval, parentShardIntervalList)
+	foreach_declared_ptr(parentShardInterval, parentShardIntervalList)
 	{
 		uint64 parentShardId = parentShardInterval->shardId;
 
@@ -615,7 +615,7 @@ WorkerFixPartitionShardIndexNamesCommandList(uint64 parentShardId,
 {
 	List *commandList = NIL;
 	Oid parentIndexId = InvalidOid;
-	foreach_oid(parentIndexId, parentIndexIdList)
+	foreach_declared_oid(parentIndexId, parentIndexIdList)
 	{
 		if (!has_subclass(parentIndexId))
 		{
@@ -666,7 +666,7 @@ WorkerFixPartitionShardIndexNamesCommandListForParentShardIndex(
 
 	bool addAllPartitions = (partitionRelationId == InvalidOid);
 	Oid partitionIndexId = InvalidOid;
-	foreach_oid(partitionIndexId, partitionIndexIds)
+	foreach_declared_oid(partitionIndexId, partitionIndexIds)
 	{
 		Oid partitionId = IndexGetRelation(partitionIndexId, false);
 		if (addAllPartitions || partitionId == partitionRelationId)
@@ -701,7 +701,7 @@ WorkerFixPartitionShardIndexNamesCommandListForPartitionIndex(Oid partitionIndex
 	List *partitionShardIntervalList = LoadShardIntervalList(partitionId);
 
 	ShardInterval *partitionShardInterval = NULL;
-	foreach_ptr(partitionShardInterval, partitionShardIntervalList)
+	foreach_declared_ptr(partitionShardInterval, partitionShardIntervalList)
 	{
 		/*
 		 * Prepare commands for each shard of current partition
@@ -1044,7 +1044,7 @@ PartitionWithLongestNameRelationId(Oid parentRelationId)
 	List *partitionList = PartitionList(parentRelationId);
 
 	Oid partitionRelationId = InvalidOid;
-	foreach_oid(partitionRelationId, partitionList)
+	foreach_declared_oid(partitionRelationId, partitionList)
 	{
 		char *partitionName = get_rel_name(partitionRelationId);
 		int partitionNameLength = strnlen(partitionName, NAMEDATALEN);
@@ -1130,7 +1130,7 @@ GenerateDetachPartitionCommandRelationIdList(List *relationIds)
 {
 	List *detachPartitionCommands = NIL;
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIds)
+	foreach_declared_oid(relationId, relationIds)
 	{
 		Assert(PartitionTable(relationId));
 		char *detachCommand = GenerateDetachPartitionCommand(relationId);
@@ -1246,7 +1246,7 @@ GenerateAttachPartitionCommandRelationIdList(List *relationIds)
 {
 	List *attachPartitionCommands = NIL;
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationIds)
+	foreach_declared_oid(relationId, relationIds)
 	{
 		char *attachCommand = GenerateAlterTableAttachPartitionCommand(relationId);
 		attachPartitionCommands = lappend(attachPartitionCommands, attachCommand);
@@ -1318,7 +1318,7 @@ ListShardsUnderParentRelation(Oid relationId)
 		List *partitionList = PartitionList(relationId);
 		Oid partitionRelationId = InvalidOid;
 
-		foreach_oid(partitionRelationId, partitionList)
+		foreach_declared_oid(partitionRelationId, partitionList)
 		{
 			List *childShardList = ListShardsUnderParentRelation(partitionRelationId);
 			shardList = list_concat(shardList, childShardList);

--- a/src/backend/distributed/utils/reference_table_utils.c
+++ b/src/backend/distributed/utils/reference_table_utils.c
@@ -228,7 +228,7 @@ EnsureReferenceTablesExistOnAllNodesExtended(char transferMode)
 	}
 
 	WorkerNode *newWorkerNode = NULL;
-	foreach_ptr(newWorkerNode, newWorkersList)
+	foreach_declared_ptr(newWorkerNode, newWorkersList)
 	{
 		ereport(NOTICE, (errmsg("replicating reference table '%s' to %s:%d ...",
 								referenceTableName, newWorkerNode->workerName,
@@ -360,7 +360,7 @@ AnyRelationsModifiedInTransaction(List *relationIdList)
 {
 	Oid relationId = InvalidOid;
 
-	foreach_oid(relationId, relationIdList)
+	foreach_declared_oid(relationId, relationIdList)
 	{
 		if (GetRelationDDLAccessMode(relationId) != RELATION_NOT_ACCESSED ||
 			GetRelationDMLAccessMode(relationId) != RELATION_NOT_ACCESSED)
@@ -389,7 +389,7 @@ WorkersWithoutReferenceTablePlacement(uint64 shardId, LOCKMODE lockMode)
 	workerNodeList = SortList(workerNodeList, CompareWorkerNodes);
 
 	WorkerNode *workerNode = NULL;
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
@@ -538,7 +538,7 @@ ReplicatedPlacementsForNodeGroup(int32 groupId)
 
 	List *replicatedPlacementsForNodeGroup = NIL;
 	Oid replicatedTableId = InvalidOid;
-	foreach_oid(replicatedTableId, replicatedTableList)
+	foreach_declared_oid(replicatedTableId, replicatedTableList)
 	{
 		List *placements =
 			GroupShardPlacementsForTableOnGroup(replicatedTableId, groupId);
@@ -591,7 +591,7 @@ DeleteAllReplicatedTablePlacementsFromNodeGroup(int32 groupId, bool localOnly)
 	}
 
 	GroupShardPlacement *placement = NULL;
-	foreach_ptr(placement, replicatedPlacementListForGroup)
+	foreach_declared_ptr(placement, replicatedPlacementListForGroup)
 	{
 		LockShardDistributionMetadata(placement->shardId, ExclusiveLock);
 
@@ -627,7 +627,7 @@ DeleteAllReplicatedTablePlacementsFromNodeGroupViaMetadataContext(
 
 	MemoryContext oldContext = MemoryContextSwitchTo(context->context);
 	GroupShardPlacement *placement = NULL;
-	foreach_ptr(placement, replicatedPlacementListForGroup)
+	foreach_declared_ptr(placement, replicatedPlacementListForGroup)
 	{
 		LockShardDistributionMetadata(placement->shardId, ExclusiveLock);
 
@@ -663,7 +663,7 @@ ReplicatedMetadataSyncedDistributedTableList(void)
 	List *replicatedHashDistributedTableList = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, distributedRelationList)
+	foreach_declared_oid(relationId, distributedRelationList)
 	{
 		if (ShouldSyncTableMetadata(relationId) && !SingleReplicatedTable(relationId))
 		{
@@ -707,7 +707,7 @@ ErrorIfNotAllNodesHaveReferenceTableReplicas(List *workerNodeList)
 {
 	WorkerNode *workerNode = NULL;
 
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		if (!NodeHasAllReferenceTableReplicas(workerNode))
 		{
@@ -763,7 +763,7 @@ NodeHasAllReferenceTableReplicas(WorkerNode *workerNode)
 	List *shardPlacementList = ActiveShardPlacementList(shardInterval->shardId);
 
 	ShardPlacement *placement = NULL;
-	foreach_ptr(placement, shardPlacementList)
+	foreach_declared_ptr(placement, shardPlacementList)
 	{
 		if (placement->groupId == workerNode->groupId)
 		{

--- a/src/backend/distributed/utils/resource_lock.c
+++ b/src/backend/distributed/utils/resource_lock.c
@@ -299,7 +299,7 @@ LockShardListResourcesOnFirstWorker(LOCKMODE lockmode, List *shardIntervalList)
 	appendStringInfo(lockCommand, "SELECT lock_shard_resources(%d, ARRAY[", lockmode);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		int64 shardId = shardInterval->shardId;
 
@@ -388,7 +388,7 @@ LockShardListMetadataOnWorkers(LOCKMODE lockmode, List *shardIntervalList)
 	appendStringInfo(lockCommand, "SELECT lock_shard_metadata(%d, ARRAY[", lockmode);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		int64 shardId = shardInterval->shardId;
 
@@ -529,7 +529,7 @@ LockReferencedReferenceShardDistributionMetadata(uint64 shardId, LOCKMODE lockMo
 	}
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		LockShardDistributionMetadata(shardInterval->shardId, lockMode);
 	}
@@ -573,7 +573,7 @@ LockReferencedReferenceShardResources(uint64 shardId, LOCKMODE lockMode)
 	}
 
 	ShardInterval *referencedShardInterval = NULL;
-	foreach_ptr(referencedShardInterval, referencedShardIntervalList)
+	foreach_declared_ptr(referencedShardInterval, referencedShardIntervalList)
 	{
 		LockShardResource(referencedShardInterval->shardId, lockMode);
 	}
@@ -590,7 +590,7 @@ GetSortedReferenceShardIntervals(List *relationList)
 	List *shardIntervalList = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationList)
+	foreach_declared_oid(relationId, relationList)
 	{
 		if (!IsCitusTableType(relationId, REFERENCE_TABLE))
 		{
@@ -652,7 +652,7 @@ LockShardListMetadata(List *shardIntervalList, LOCKMODE lockMode)
 	shardIntervalList = SortList(shardIntervalList, CompareShardIntervalsById);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		int64 shardId = shardInterval->shardId;
 
@@ -673,7 +673,7 @@ LockShardsInPlacementListMetadata(List *shardPlacementList, LOCKMODE lockMode)
 		SortList(shardPlacementList, CompareShardPlacementsByShardId);
 
 	GroupShardPlacement *placement = NULL;
-	foreach_ptr(placement, shardPlacementList)
+	foreach_declared_ptr(placement, shardPlacementList)
 	{
 		int64 shardId = placement->shardId;
 
@@ -760,7 +760,7 @@ AnyTableReplicated(List *shardIntervalList, List **replicatedShardIntervalList)
 	List *localList = NIL;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		int64 shardId = shardInterval->shardId;
 
@@ -797,7 +797,7 @@ LockShardListResources(List *shardIntervalList, LOCKMODE lockMode)
 	shardIntervalList = SortList(shardIntervalList, CompareShardIntervalsById);
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		int64 shardId = shardInterval->shardId;
 
@@ -820,7 +820,7 @@ LockRelationShardResources(List *relationShardList, LOCKMODE lockMode)
 
 	List *shardIntervalList = NIL;
 	RelationShard *relationShard = NULL;
-	foreach_ptr(relationShard, relationShardList)
+	foreach_declared_ptr(relationShard, relationShardList)
 	{
 		uint64 shardId = relationShard->shardId;
 
@@ -846,7 +846,7 @@ LockParentShardResourceIfPartition(List *shardIntervalList, LOCKMODE lockMode)
 	List *parentShardIntervalList = NIL;
 
 	ShardInterval *shardInterval = NULL;
-	foreach_ptr(shardInterval, shardIntervalList)
+	foreach_declared_ptr(shardInterval, shardIntervalList)
 	{
 		Oid relationId = shardInterval->relationId;
 
@@ -1092,7 +1092,7 @@ static bool
 LockRelationRecordListMember(List *lockRelationRecordList, Oid relationId)
 {
 	LockRelationRecord *record = NULL;
-	foreach_ptr(record, lockRelationRecordList)
+	foreach_declared_ptr(record, lockRelationRecordList)
 	{
 		if (record->relationId == relationId)
 		{
@@ -1131,7 +1131,7 @@ ConcatLockRelationRecordList(List *lockRelationRecordList, List *relationOidList
 	List *constructedList = NIL;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, relationOidList)
+	foreach_declared_oid(relationId, relationOidList)
 	{
 		if (!LockRelationRecordListMember(lockRelationRecordList, relationId))
 		{
@@ -1178,7 +1178,7 @@ AcquireDistributedLockOnRelations_Internal(List *lockRelationRecordList,
 
 	int lockedRelations = 0;
 	LockRelationRecord *lockRelationRecord;
-	foreach_ptr(lockRelationRecord, lockRelationRecordList)
+	foreach_declared_ptr(lockRelationRecord, lockRelationRecordList)
 	{
 		Oid relationId = lockRelationRecord->relationId;
 		bool lockDescendants = lockRelationRecord->inh;
@@ -1251,7 +1251,7 @@ AcquireDistributedLockOnRelations_Internal(List *lockRelationRecordList,
 
 	WorkerNode *workerNode = NULL;
 	const char *currentUser = CurrentUserName();
-	foreach_ptr(workerNode, workerNodeList)
+	foreach_declared_ptr(workerNode, workerNodeList)
 	{
 		/* if local node is one of the targets, acquire the lock locally */
 		if (workerNode->groupId == localGroupId)
@@ -1294,7 +1294,7 @@ AcquireDistributedLockOnRelations(List *relationList, LOCKMODE lockMode, uint32 
 	bool nowait = (configs & DIST_LOCK_NOWAIT) > 0;
 
 	RangeVar *rangeVar = NULL;
-	foreach_ptr(rangeVar, relationList)
+	foreach_declared_ptr(rangeVar, relationList)
 	{
 		Oid relationId = RangeVarGetRelid(rangeVar, NoLock, false);
 

--- a/src/backend/distributed/utils/shardinterval_utils.c
+++ b/src/backend/distributed/utils/shardinterval_utils.c
@@ -472,7 +472,7 @@ SingleReplicatedTable(Oid relationId)
 
 	List *shardIntervalList = LoadShardList(relationId);
 	uint64 *shardIdPointer = NULL;
-	foreach_ptr(shardIdPointer, shardIntervalList)
+	foreach_declared_ptr(shardIdPointer, shardIntervalList)
 	{
 		uint64 shardId = *shardIdPointer;
 		shardPlacementList = ShardPlacementListSortedByWorker(shardId);

--- a/src/backend/distributed/utils/statistics_collection.c
+++ b/src/backend/distributed/utils/statistics_collection.c
@@ -184,7 +184,7 @@ DistributedTablesSize(List *distTableOids)
 	uint64 totalSize = 0;
 
 	Oid relationId = InvalidOid;
-	foreach_oid(relationId, distTableOids)
+	foreach_declared_oid(relationId, distTableOids)
 	{
 		/*
 		 * Relations can get dropped after getting the Oid list and before we

--- a/src/backend/distributed/worker/worker_create_or_replace.c
+++ b/src/backend/distributed/worker/worker_create_or_replace.c
@@ -85,7 +85,7 @@ WrapCreateOrReplaceList(List *sqls)
 	appendStringInfoString(&textArrayLitteral, "ARRAY[");
 	const char *sql = NULL;
 	bool first = true;
-	foreach_ptr(sql, sqls)
+	foreach_declared_ptr(sql, sqls)
 	{
 		if (!first)
 		{
@@ -251,7 +251,7 @@ WorkerCreateOrReplaceObject(List *sqlStatements)
 
 	/* apply all statement locally */
 	char *sqlStatement = NULL;
-	foreach_ptr(sqlStatement, sqlStatements)
+	foreach_declared_ptr(sqlStatement, sqlStatements)
 	{
 		parseTree = ParseTreeNode(sqlStatement);
 		ProcessUtilityParseTree(parseTree, sqlStatement, PROCESS_UTILITY_QUERY, NULL,

--- a/src/backend/distributed/worker/worker_data_fetch_protocol.c
+++ b/src/backend/distributed/worker/worker_data_fetch_protocol.c
@@ -377,7 +377,7 @@ check_log_statement(List *statementList)
 
 	/* else we have to inspect the statement(s) to see whether to log */
 	Node *statement = NULL;
-	foreach_ptr(statement, statementList)
+	foreach_declared_ptr(statement, statementList)
 	{
 		if (GetCommandLogLevel(statement) <= log_statement)
 		{
@@ -480,7 +480,7 @@ void
 SetDefElemArg(AlterSeqStmt *statement, const char *name, Node *arg)
 {
 	DefElem *defElem = NULL;
-	foreach_ptr(defElem, statement->options)
+	foreach_declared_ptr(defElem, statement->options)
 	{
 		if (strcmp(defElem->defname, name) == 0)
 		{

--- a/src/backend/distributed/worker/worker_drop_protocol.c
+++ b/src/backend/distributed/worker/worker_drop_protocol.c
@@ -93,7 +93,7 @@ worker_drop_distributed_table(PG_FUNCTION_ARGS)
 		 */
 		List *partitionList = PartitionList(relationId);
 		Oid partitionOid = InvalidOid;
-		foreach_oid(partitionOid, partitionList)
+		foreach_declared_oid(partitionOid, partitionList)
 		{
 			WorkerDropDistributedTable(partitionOid);
 		}
@@ -128,7 +128,7 @@ WorkerDropDistributedTable(Oid relationId)
 	List *ownedSequences = getOwnedSequences(relationId);
 
 	Oid ownedSequenceOid = InvalidOid;
-	foreach_oid(ownedSequenceOid, ownedSequences)
+	foreach_declared_oid(ownedSequenceOid, ownedSequences)
 	{
 		ObjectAddress ownedSequenceAddress = { 0 };
 		ObjectAddressSet(ownedSequenceAddress, RelationRelationId, ownedSequenceOid);
@@ -144,13 +144,13 @@ WorkerDropDistributedTable(Oid relationId)
 	 */
 	List *shardList = LoadShardList(relationId);
 	uint64 *shardIdPointer = NULL;
-	foreach_ptr(shardIdPointer, shardList)
+	foreach_declared_ptr(shardIdPointer, shardList)
 	{
 		uint64 shardId = *shardIdPointer;
 
 		List *shardPlacementList = ShardPlacementList(shardId);
 		ShardPlacement *placement = NULL;
-		foreach_ptr(placement, shardPlacementList)
+		foreach_declared_ptr(placement, shardPlacementList)
 		{
 			/* delete the row from pg_dist_placement */
 			DeleteShardPlacementRow(placement->placementId);
@@ -240,7 +240,7 @@ worker_drop_shell_table(PG_FUNCTION_ARGS)
 	List *ownedSequences = getOwnedSequences(relationId);
 
 	Oid ownedSequenceOid = InvalidOid;
-	foreach_oid(ownedSequenceOid, ownedSequences)
+	foreach_declared_oid(ownedSequenceOid, ownedSequences)
 	{
 		ObjectAddress ownedSequenceAddress = { 0 };
 		ObjectAddressSet(ownedSequenceAddress, RelationRelationId, ownedSequenceOid);
@@ -288,7 +288,7 @@ worker_drop_sequence_dependency(PG_FUNCTION_ARGS)
 	List *ownedSequences = getOwnedSequences(relationId);
 
 	Oid ownedSequenceOid = InvalidOid;
-	foreach_oid(ownedSequenceOid, ownedSequences)
+	foreach_declared_oid(ownedSequenceOid, ownedSequences)
 	{
 		/* the caller doesn't want to drop the sequence, so break the dependency */
 		deleteDependencyRecordsForSpecific(RelationRelationId, ownedSequenceOid,

--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -382,7 +382,7 @@ ShouldHideShardsInternal(void)
 	}
 
 	char *appNamePrefix = NULL;
-	foreach_ptr(appNamePrefix, prefixList)
+	foreach_declared_ptr(appNamePrefix, prefixList)
 	{
 		/* never hide shards when one of the prefixes is * */
 		if (strcmp(appNamePrefix, "*") == 0)
@@ -446,7 +446,7 @@ FilterShardsFromPgclass(Node *node, void *context)
 		int varno = 0;
 		RangeTblEntry *rangeTableEntry = NULL;
 
-		foreach_ptr(rangeTableEntry, query->rtable)
+		foreach_declared_ptr(rangeTableEntry, query->rtable)
 		{
 			varno++;
 

--- a/src/include/distributed/listutils.h
+++ b/src/include/distributed/listutils.h
@@ -36,7 +36,7 @@ typedef struct ListCellAndListWrapper
 } ListCellAndListWrapper;
 
 /*
- * foreach_ptr -
+ * foreach_declared_ptr -
  *	  a convenience macro which loops through a pointer list without needing a
  *	  ListCell, just a declared pointer variable to store the pointer of the
  *	  cell in.
@@ -50,7 +50,7 @@ typedef struct ListCellAndListWrapper
  *	  - || true is used to always enter the loop when cell is not null even if
  *	    var is NULL.
  */
-#define foreach_ptr(var, l) \
+#define foreach_declared_ptr(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst(var ## CellDoNotUse)) || true); \
@@ -58,12 +58,12 @@ typedef struct ListCellAndListWrapper
 
 
 /*
- * foreach_int -
+ * foreach_declared_int -
  *	  a convenience macro which loops through an int list without needing a
  *	  ListCell, just a declared int variable to store the int of the cell in.
- *	  For explanation of how it works see foreach_ptr.
+ *	  For explanation of how it works see foreach_declared_ptr.
  */
-#define foreach_int(var, l) \
+#define foreach_declared_int(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_int(var ## CellDoNotUse)) || true); \
@@ -71,12 +71,12 @@ typedef struct ListCellAndListWrapper
 
 
 /*
- * foreach_oid -
+ * foreach_declared_oid -
  *	  a convenience macro which loops through an oid list without needing a
  *	  ListCell, just a declared Oid variable to store the oid of the cell in.
- *	  For explanation of how it works see foreach_ptr.
+ *	  For explanation of how it works see foreach_declared_ptr.
  */
-#define foreach_oid(var, l) \
+#define foreach_declared_oid(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_oid(var ## CellDoNotUse)) || true); \


### PR DESCRIPTION
This is prep work for successful compilation with PG17

PG17added foreach_ptr, foreach_int and foreach_oid macros
Relevant PG commit
14dd0f27d7cd56ffae9ecdbe324965073d01a9ff
https://github.com/postgres/postgres/commit/14dd0f27d7cd56ffae9ecdbe324965073d01a9ff

We already have these macros, but they are different with the
PG17 ones because our macros take a DECLARED variable, whereas
the PG16 macros declare a locally-scoped loop variable themselves.

Hence I am renaming our macros to foreach_declared_

I am separating this into its own PR since it touches many files. The main compilation PR is https://github.com/citusdata/citus/pull/7699