### PR TITLE
Fix Isolation Test Failure in isolation_multiuser_locking in PG17

### DIFF
--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -355,4 +355,3 @@ step s1-commit:
 step s2-truncate: <... completed>
 step s2-commit:
  COMMIT;
-

--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -355,3 +355,4 @@ step s1-commit:
 step s2-truncate: <... completed>
 step s2-commit:
  COMMIT;
+ 

--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -355,4 +355,4 @@ step s1-commit:
 step s2-truncate: <... completed>
 step s2-commit:
  COMMIT;
- 
+

--- a/src/test/regress/expected/isolation_multiuser_locking.out
+++ b/src/test/regress/expected/isolation_multiuser_locking.out
@@ -7,31 +7,31 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s2-reindex:
-	REINDEX TABLE test_table;
+ REINDEX TABLE test_table;
 
-ERROR:  must be owner of table test_table
+ERROR:  permission denied for table test_table
 step s1-insert:
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-reindex s1-insert s2-insert s2-commit s1-commit
@@ -41,39 +41,38 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s2-reindex:
-	REINDEX TABLE test_table;
+ REINDEX TABLE test_table;
 
-ERROR:  must be owner of table test_table
 step s1-insert:
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
+ <waiting ...>
+step s2-insert: 
+ UPDATE test_table SET column2 = 2;
 
-step s2-insert:
-	UPDATE test_table SET column2 = 2;
-
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
+step s1-insert: <... completed>
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-reindex s2-insert s1-insert s1-commit s2-commit
@@ -83,38 +82,38 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s1-reindex:
-	REINDEX TABLE test_table;
+ REINDEX TABLE test_table;
 
 step s2-insert:
-	UPDATE test_table SET column2 = 2;
+ UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-index s1-insert s2-commit s1-commit s2-drop-index
@@ -124,34 +123,34 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s2-index:
-	CREATE INDEX test_index ON test_table(column1);
+ CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-drop-index:
-	DROP INDEX IF EXISTS test_index;
+ DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-insert s1-index s2-insert s2-commit s1-commit s1-drop-index
@@ -161,41 +160,41 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s2-insert:
-	UPDATE test_table SET column2 = 2;
+ UPDATE test_table SET column2 = 2;
 
 step s1-index:
-	CREATE INDEX test_index ON test_table(column1);
+ CREATE INDEX test_index ON test_table(column1);
  <waiting ...>
 step s2-insert: 
-	UPDATE test_table SET column2 = 2;
+ UPDATE test_table SET column2 = 2;
 
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-index: <... completed>
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-drop-index:
-	DROP INDEX IF EXISTS test_index;
+ DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-index s2-index s1-insert s1-commit s2-commit s1-drop-index s2-drop-index
@@ -205,44 +204,44 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s1-index:
-	CREATE INDEX test_index ON test_table(column1);
+ CREATE INDEX test_index ON test_table(column1);
 
 step s2-index:
-	CREATE INDEX test_index ON test_table(column1);
+ CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-drop-index:
-	DROP INDEX IF EXISTS test_index;
+ DROP INDEX IF EXISTS test_index;
 
 step s2-drop-index:
-	DROP INDEX IF EXISTS test_index;
+ DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-truncate s1-insert s2-commit s1-commit
@@ -252,31 +251,31 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s2-truncate:
-	TRUNCATE test_table;
+ TRUNCATE test_table;
 
 ERROR:  permission denied for table test_table
 step s1-insert:
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-insert s1-insert s1-commit s2-commit
@@ -286,38 +285,38 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s1-truncate:
-	TRUNCATE test_table;
+ TRUNCATE test_table;
 
 step s2-insert:
-	UPDATE test_table SET column2 = 2;
+ UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
-	UPDATE test_table SET column2 = 1;
+ UPDATE test_table SET column2 = 1;
 
 step s1-commit:
-	COMMIT;
+ COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
-	COMMIT;
+ COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit
@@ -327,33 +326,33 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
-	SET citus.max_cached_conns_per_worker to 0;
+ SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
-	SET ROLE test_user_1;
-	GRANT ALL ON test_table TO test_user_2;
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
-	BEGIN;
-	SET ROLE test_user_1;
+ BEGIN;
+ SET ROLE test_user_1;
 
 step s2-begin:
-	BEGIN;
-	SET ROLE test_user_2;
+ BEGIN;
+ SET ROLE test_user_2;
 
 step s1-truncate:
-	TRUNCATE test_table;
+ TRUNCATE test_table;
 
 step s2-truncate:
-	TRUNCATE test_table;
+ TRUNCATE test_table;
  <waiting ...>
 step s1-commit: 
-	COMMIT;
+ COMMIT;
 
 step s2-truncate: <... completed>
 step s2-commit:
-	COMMIT;
+ COMMIT;
 

--- a/src/test/regress/expected/isolation_multiuser_locking_0.out
+++ b/src/test/regress/expected/isolation_multiuser_locking_0.out
@@ -1,0 +1,358 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-reindex s1-insert s2-commit s1-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s2-reindex:
+ REINDEX TABLE test_table;
+
+ERROR:  permission denied for table test_table
+step s1-insert:
+ UPDATE test_table SET column2 = 1;
+
+step s2-commit:
+ COMMIT;
+
+step s1-commit:
+ COMMIT;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-reindex s1-insert s2-insert s2-commit s1-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s2-reindex:
+ REINDEX TABLE test_table;
+
+step s1-insert:
+ UPDATE test_table SET column2 = 1;
+ <waiting ...>
+step s2-insert: 
+ UPDATE test_table SET column2 = 2;
+
+step s2-commit:
+ COMMIT;
+
+step s1-insert: <... completed>
+step s1-commit:
+ COMMIT;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-reindex s2-insert s1-insert s1-commit s2-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s1-reindex:
+ REINDEX TABLE test_table;
+
+step s2-insert:
+ UPDATE test_table SET column2 = 2;
+ <waiting ...>
+step s1-insert: 
+ UPDATE test_table SET column2 = 1;
+
+step s1-commit:
+ COMMIT;
+
+step s2-insert: <... completed>
+step s2-commit:
+ COMMIT;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-index s1-insert s2-commit s1-commit s2-drop-index
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s2-index:
+ CREATE INDEX test_index ON test_table(column1);
+
+ERROR:  must be owner of table test_table
+step s1-insert:
+ UPDATE test_table SET column2 = 1;
+
+step s2-commit:
+ COMMIT;
+
+step s1-commit:
+ COMMIT;
+
+step s2-drop-index:
+ DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-insert s1-index s2-insert s2-commit s1-commit s1-drop-index
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s2-insert:
+ UPDATE test_table SET column2 = 2;
+
+step s1-index:
+ CREATE INDEX test_index ON test_table(column1);
+ <waiting ...>
+step s2-insert: 
+ UPDATE test_table SET column2 = 2;
+
+step s2-commit:
+ COMMIT;
+
+step s1-index: <... completed>
+step s1-commit:
+ COMMIT;
+
+step s1-drop-index:
+ DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-index s2-index s1-insert s1-commit s2-commit s1-drop-index s2-drop-index
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s1-index:
+ CREATE INDEX test_index ON test_table(column1);
+
+step s2-index:
+ CREATE INDEX test_index ON test_table(column1);
+
+ERROR:  must be owner of table test_table
+step s1-insert:
+ UPDATE test_table SET column2 = 1;
+
+step s1-commit:
+ COMMIT;
+
+step s2-commit:
+ COMMIT;
+
+step s1-drop-index:
+ DROP INDEX IF EXISTS test_index;
+
+step s2-drop-index:
+ DROP INDEX IF EXISTS test_index;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-truncate s1-insert s2-commit s1-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s2-truncate:
+ TRUNCATE test_table;
+
+ERROR:  permission denied for table test_table
+step s1-insert:
+ UPDATE test_table SET column2 = 1;
+
+step s2-commit:
+ COMMIT;
+
+step s1-commit:
+ COMMIT;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-insert s1-insert s1-commit s2-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s1-truncate:
+ TRUNCATE test_table;
+
+step s2-insert:
+ UPDATE test_table SET column2 = 2;
+ <waiting ...>
+step s1-insert: 
+ UPDATE test_table SET column2 = 1;
+
+step s1-commit:
+ COMMIT;
+
+step s2-insert: <... completed>
+step s2-commit:
+ COMMIT;
+
+
+starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit
+create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+step s1-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s2-no-connection-cache:
+ SET citus.max_cached_conns_per_worker to 0;
+
+step s1-grant:
+ SET ROLE test_user_1;
+ GRANT ALL ON test_table TO test_user_2;
+
+step s1-begin:
+ BEGIN;
+ SET ROLE test_user_1;
+
+step s2-begin:
+ BEGIN;
+ SET ROLE test_user_2;
+
+step s1-truncate:
+ TRUNCATE test_table;
+
+step s2-truncate:
+ TRUNCATE test_table;
+ <waiting ...>
+step s1-commit: 
+ COMMIT;
+
+step s2-truncate: <... completed>
+step s2-commit:
+ COMMIT;
+

--- a/src/test/regress/expected/isolation_multiuser_locking_0.out
+++ b/src/test/regress/expected/isolation_multiuser_locking_0.out
@@ -356,4 +356,3 @@ step s1-commit:
 step s2-truncate: <... completed>
 step s2-commit:
 	COMMIT;
-

--- a/src/test/regress/expected/isolation_multiuser_locking_0.out
+++ b/src/test/regress/expected/isolation_multiuser_locking_0.out
@@ -7,31 +7,31 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
-ERROR:  permission denied for table test_table
+ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-reindex s1-insert s2-insert s2-commit s1-commit
@@ -41,38 +41,39 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
+ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
- <waiting ...>
-step s2-insert: 
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 1;
 
+step s2-insert:
+	UPDATE test_table SET column2 = 2;
+
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step s2-commit:
- COMMIT;
+	COMMIT;
 
-step s1-insert: <... completed>
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-reindex s2-insert s1-insert s1-commit s2-commit
@@ -82,38 +83,38 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-reindex:
- REINDEX TABLE test_table;
+	REINDEX TABLE test_table;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-index s1-insert s2-commit s1-commit s2-drop-index
@@ -123,34 +124,34 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s2-insert s1-index s2-insert s2-commit s1-commit s1-drop-index
@@ -160,41 +161,41 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
 
 step s1-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
  <waiting ...>
 step s2-insert: 
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-index: <... completed>
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s1-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-index s2-index s1-insert s1-commit s2-commit s1-drop-index s2-drop-index
@@ -204,44 +205,44 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 step s2-index:
- CREATE INDEX test_index ON test_table(column1);
+	CREATE INDEX test_index ON test_table(column1);
 
 ERROR:  must be owner of table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 step s2-drop-index:
- DROP INDEX IF EXISTS test_index;
+	DROP INDEX IF EXISTS test_index;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-begin s2-begin s2-truncate s1-insert s2-commit s1-commit
@@ -251,31 +252,31 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s2-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 ERROR:  permission denied for table test_table
 step s1-insert:
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-insert s1-insert s1-commit s2-commit
@@ -285,38 +286,38 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 step s2-insert:
- UPDATE test_table SET column2 = 2;
+	UPDATE test_table SET column2 = 2;
  <waiting ...>
 step s1-insert: 
- UPDATE test_table SET column2 = 1;
+	UPDATE test_table SET column2 = 1;
 
 step s1-commit:
- COMMIT;
+	COMMIT;
 
 step s2-insert: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 
 
 starting permutation: s1-no-connection-cache s2-no-connection-cache s1-grant s1-begin s2-begin s1-truncate s2-truncate s1-commit s2-commit
@@ -326,33 +327,33 @@ create_distributed_table
 (1 row)
 
 step s1-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s2-no-connection-cache:
- SET citus.max_cached_conns_per_worker to 0;
+	SET citus.max_cached_conns_per_worker to 0;
 
 step s1-grant:
- SET ROLE test_user_1;
- GRANT ALL ON test_table TO test_user_2;
+	SET ROLE test_user_1;
+	GRANT ALL ON test_table TO test_user_2;
 
 step s1-begin:
- BEGIN;
- SET ROLE test_user_1;
+	BEGIN;
+	SET ROLE test_user_1;
 
 step s2-begin:
- BEGIN;
- SET ROLE test_user_2;
+	BEGIN;
+	SET ROLE test_user_2;
 
 step s1-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
 
 step s2-truncate:
- TRUNCATE test_table;
+	TRUNCATE test_table;
  <waiting ...>
 step s1-commit: 
- COMMIT;
+	COMMIT;
 
 step s2-truncate: <... completed>
 step s2-commit:
- COMMIT;
+	COMMIT;
 

--- a/src/test/regress/expected/isolation_multiuser_locking_0.out
+++ b/src/test/regress/expected/isolation_multiuser_locking_0.out
@@ -356,3 +356,4 @@ step s1-commit:
 step s2-truncate: <... completed>
 step s2-commit:
 	COMMIT;
+	

--- a/src/test/regress/spec/isolation_multiuser_locking.spec
+++ b/src/test/regress/spec/isolation_multiuser_locking.spec
@@ -1,3 +1,7 @@
+// Two alternative test outputs:
+// isolation_multiuser_locking.out for PG16 and before
+// isolation_multiuser_locking_0.out for PG17
+
 setup
 {
 	SET citus.max_cached_conns_per_worker to 0;

--- a/src/test/regress/spec/isolation_multiuser_locking.spec
+++ b/src/test/regress/spec/isolation_multiuser_locking.spec
@@ -1,6 +1,6 @@
 // Two alternative test outputs:
-// isolation_multiuser_locking.out for PG16 and before
-// isolation_multiuser_locking_0.out for PG17
+// isolation_multiuser_locking_0.out for PG16 and before
+// isolation_multiuser_locking.out for PG17
 
 setup
 {

--- a/src/test/regress/spec/isolation_multiuser_locking.spec
+++ b/src/test/regress/spec/isolation_multiuser_locking.spec
@@ -1,6 +1,14 @@
 // Two alternative test outputs:
 // isolation_multiuser_locking_0.out for PG16 and before
 // isolation_multiuser_locking.out for PG17
+//
+// REINDEX TABLE now requires table ownership (PostgreSQL commit ecb0fd337).
+// UPDATE statements include <waiting ...> to reflect new lock waiting behavior.
+// Previous behavior: Transactions failed with "current transaction is aborted".
+// New behavior: Transactions wait for locks, ensuring proper isolation.
+// <... completed> tracks transaction states for clarity with locking changes.
+// Reference: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=ecb0fd337
+
 
 setup
 {


### PR DESCRIPTION
This PR enhances `isolation_multiuser_locking.spec` test compatibility across multiple PostgreSQL versions by handling differences in error messages and behavior. Key updates include:

- **Error Message Handling:** Adjustments to manage version-specific error messages, ensuring consistent test results.
  
- Modified to address variations in locking behavior across PostgreSQL versions, ensuring test stability in multiuser scenarios.

- **REINDEX Behavior Adjustment**: This PR accounts for a behavioral change introduced in PostgreSQL by commit ecb0fd337, which alters how REINDEX interacts with system catalogs. 

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=ecb0fd337

