### PR TITLE
PG17 compatibility: Fix Test Failure in multi_alter_table_add_const

### DIFF
--- a/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
+++ b/src/test/regress/expected/multi_alter_table_add_constraints_without_name.out
@@ -1119,9 +1119,6 @@ SELECT con.conname
 
 \c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table DROP CONSTRAINT citus_local_partitioned_table_partition_col_key;
--- Check "ADD EXCLUDE" errors out for partitioned table since the postgres does not allow it
-ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD EXCLUDE(partition_col WITH =);
-ERROR:  exclusion constraints are not supported on partitioned tables
 -- Check "ADD CHECK"
 SET client_min_messages TO DEBUG1;
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD CHECK (dist_col > 0);

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -955,6 +955,165 @@ DROP TABLE pt_3;
 DROP TABLE pt_4;
 DROP TABLE alt_test;
 -- End of partition with identity columns testing
+-- Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
+-- Step 1: Create a distributed partitioned table
+\c - - :master_host :master_port
+CREATE TABLE distributed_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the distributed partitioned table
+CREATE TABLE distributed_partitioned_table_p1 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE distributed_partitioned_table_p2 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (100) TO (200);
+-- Distribute the table
+SELECT create_distributed_table('distributed_partitioned_table', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Additional test for long names and sequential execution mode
+-- Create schema if it doesn't already exist
+CREATE SCHEMA IF NOT EXISTS AT_AddConstNoName;
+CREATE TABLE AT_AddConstNoName.dist_partitioned_table (
+    dist_col int,
+    another_col int,
+    partition_col timestamp
+) PARTITION BY RANGE (partition_col);
+CREATE TABLE AT_AddConstNoName.p1 PARTITION OF AT_AddConstNoName.dist_partitioned_table
+FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc PARTITION OF AT_AddConstNoName.dist_partitioned_table
+FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('AT_AddConstNoName.dist_partitioned_table', 'partition_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Step 1.1: Insert and query data from long name partition
+INSERT INTO AT_AddConstNoName.dist_partitioned_table (dist_col, another_col, partition_col)
+VALUES (1, 10, '2020-06-01'), (2, 20, '2020-09-01');
+SELECT * FROM AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc;
+ dist_col | another_col |      partition_col
+---------------------------------------------------------------------
+        1 |          10 | Mon Jun 01 00:00:00 2020
+        2 |          20 | Tue Sep 01 00:00:00 2020
+(2 rows)
+
+-- Step 1.2: Verify sequential execution mode
+EXPLAIN SELECT * FROM AT_AddConstNoName.dist_partitioned_table WHERE partition_col = '2020-06-01';
+                                                                     QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
+   Task Count: 1
+   Tasks Shown: All
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Seq Scan on longlonglonglonglonglonglonglonglonglonglonglon_537570f5_361817 dist_partitioned_table  (cost=0.00..33.12 rows=9 width=16)
+               Filter: (partition_col = '2020-06-01 00:00:00'::timestamp without time zone)
+(7 rows)
+
+-- Step 1.3: Add exclusion constraints on parent table
+ALTER TABLE AT_AddConstNoName.dist_partitioned_table
+ADD CONSTRAINT long_name_exclude EXCLUDE USING btree (dist_col WITH =, partition_col WITH =);
+-- Verify the constraint was added
+SELECT conname FROM pg_constraint WHERE conrelid = 'AT_AddConstNoName.dist_partitioned_table'::regclass AND conname = 'long_name_exclude';
+      conname
+---------------------------------------------------------------------
+ long_name_exclude
+(1 row)
+
+-- Step 2: Create a partitioned Citus local table
+CREATE TABLE local_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the local partitioned table
+CREATE TABLE local_partitioned_table_p1 PARTITION OF local_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE local_partitioned_table_p2 PARTITION OF local_partitioned_table
+FOR VALUES FROM (100) TO (200);
+SELECT citus_add_local_table_to_metadata('local_partitioned_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Verify the Citus tables
+SELECT table_name, citus_table_type FROM citus_tables
+WHERE table_name::regclass::text like '%_partitioned_table' ORDER BY 1;
+                table_name                | citus_table_type
+---------------------------------------------------------------------
+ distributed_partitioned_table            | distributed
+ at_addconstnoname.dist_partitioned_table | distributed
+ local_partitioned_table                  | local
+(3 rows)
+
+-- Step 3: Add an exclusion constraint with a name to the distributed partitioned table
+ALTER TABLE distributed_partitioned_table ADD CONSTRAINT dist_exclude_named EXCLUDE USING btree (id WITH =, partition_col WITH =);
+-- Step 4: Verify propagation of exclusion constraint to worker nodes
+\c - - :public_worker_1_host :worker_1_port
+SELECT conname FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND conname = 'dist_exclude_named';
+      conname
+---------------------------------------------------------------------
+ dist_exclude_named
+(1 row)
+
+-- Step 5: Add an exclusion constraint with a name to the Citus local partitioned table
+\c - - :master_host :master_port
+ALTER TABLE local_partitioned_table ADD CONSTRAINT local_exclude_named EXCLUDE USING btree (partition_col WITH =);
+-- Step 6: Verify the exclusion constraint on the local partitioned table
+SELECT conname, contype FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+       conname       | contype
+---------------------------------------------------------------------
+ local_exclude_named | x
+(1 row)
+
+-- Step 7: Add exclusion constraints without names to both tables
+ALTER TABLE distributed_partitioned_table ADD EXCLUDE USING btree (id WITH =, partition_col WITH =);
+ALTER TABLE local_partitioned_table ADD EXCLUDE USING btree (partition_col WITH =);
+-- Step 8: Verify the unnamed exclusion constraints were added
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'local_partitioned_table'::regclass AND contype = 'x';
+                  conname                   | contype
+---------------------------------------------------------------------
+ local_exclude_named                        | x
+ local_partitioned_table_partition_col_excl | x
+(2 rows)
+
+\c - - :public_worker_1_host :worker_1_port
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND contype = 'x';
+                       conname                       | contype
+---------------------------------------------------------------------
+ dist_exclude_named                                  | x
+ distributed_partitioned_table_id_partition_col_excl | x
+(2 rows)
+
+-- Step 9: Drop the exclusion constraints from both tables
+\c - - :master_host :master_port
+ALTER TABLE distributed_partitioned_table DROP CONSTRAINT dist_exclude_named;
+ALTER TABLE local_partitioned_table DROP CONSTRAINT local_exclude_named;
+-- Step 10: Verify the constraints were dropped
+SELECT * FROM pg_constraint WHERE conname = 'dist_exclude_named' AND contype = 'x';
+ oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+ oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
+---------------------------------------------------------------------
+(0 rows)
+
+-- Step 11: Clean up - Drop the tables
+DROP TABLE distributed_partitioned_table, local_partitioned_table;
+DROP TABLE AT_AddConstNoName.p1,
+          AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc,
+          AT_AddConstNoName.dist_partitioned_table;
+DROP SCHEMA AT_AddConstNoName CASCADE;
+-- End of Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
 -- Correlated sublinks are now supported as of PostgreSQL 17, resolving issue #4470.
 -- Enable DEBUG-level logging to capture detailed execution plans
 -- Create the tables

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -955,165 +955,6 @@ DROP TABLE pt_3;
 DROP TABLE pt_4;
 DROP TABLE alt_test;
 -- End of partition with identity columns testing
--- Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
--- Step 1: Create a distributed partitioned table
-\c - - :master_host :master_port
-CREATE TABLE distributed_partitioned_table (
-    id serial NOT NULL,
-    partition_col int NOT NULL,
-    PRIMARY KEY (id, partition_col)
-) PARTITION BY RANGE (partition_col);
--- Add partitions to the distributed partitioned table
-CREATE TABLE distributed_partitioned_table_p1 PARTITION OF distributed_partitioned_table
-FOR VALUES FROM (1) TO (100);
-CREATE TABLE distributed_partitioned_table_p2 PARTITION OF distributed_partitioned_table
-FOR VALUES FROM (100) TO (200);
--- Distribute the table
-SELECT create_distributed_table('distributed_partitioned_table', 'id');
- create_distributed_table
----------------------------------------------------------------------
-
-(1 row)
-
--- Additional test for long names and sequential execution mode
--- Create schema if it doesn't already exist
-CREATE SCHEMA IF NOT EXISTS AT_AddConstNoName;
-CREATE TABLE AT_AddConstNoName.dist_partitioned_table (
-    dist_col int,
-    another_col int,
-    partition_col timestamp
-) PARTITION BY RANGE (partition_col);
-CREATE TABLE AT_AddConstNoName.p1 PARTITION OF AT_AddConstNoName.dist_partitioned_table
-FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
-CREATE TABLE AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc PARTITION OF AT_AddConstNoName.dist_partitioned_table
-FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
-SELECT create_distributed_table('AT_AddConstNoName.dist_partitioned_table', 'partition_col');
- create_distributed_table
----------------------------------------------------------------------
-
-(1 row)
-
--- Step 1.1: Insert and query data from long name partition
-INSERT INTO AT_AddConstNoName.dist_partitioned_table (dist_col, another_col, partition_col)
-VALUES (1, 10, '2020-06-01'), (2, 20, '2020-09-01');
-SELECT * FROM AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc;
- dist_col | another_col |      partition_col
----------------------------------------------------------------------
-        1 |          10 | Mon Jun 01 00:00:00 2020
-        2 |          20 | Tue Sep 01 00:00:00 2020
-(2 rows)
-
--- Step 1.2: Verify sequential execution mode
-EXPLAIN SELECT * FROM AT_AddConstNoName.dist_partitioned_table WHERE partition_col = '2020-06-01';
-                                                                     QUERY PLAN
----------------------------------------------------------------------
- Custom Scan (Citus Adaptive)  (cost=0.00..0.00 rows=0 width=0)
-   Task Count: 1
-   Tasks Shown: All
-   ->  Task
-         Node: host=localhost port=xxxxx dbname=regression
-         ->  Seq Scan on longlonglonglonglonglonglonglonglonglonglonglon_537570f5_361817 dist_partitioned_table  (cost=0.00..33.12 rows=9 width=16)
-               Filter: (partition_col = '2020-06-01 00:00:00'::timestamp without time zone)
-(7 rows)
-
--- Step 1.3: Add exclusion constraints on parent table
-ALTER TABLE AT_AddConstNoName.dist_partitioned_table
-ADD CONSTRAINT long_name_exclude EXCLUDE USING btree (dist_col WITH =, partition_col WITH =);
--- Verify the constraint was added
-SELECT conname FROM pg_constraint WHERE conrelid = 'AT_AddConstNoName.dist_partitioned_table'::regclass AND conname = 'long_name_exclude';
-      conname
----------------------------------------------------------------------
- long_name_exclude
-(1 row)
-
--- Step 2: Create a partitioned Citus local table
-CREATE TABLE local_partitioned_table (
-    id serial NOT NULL,
-    partition_col int NOT NULL,
-    PRIMARY KEY (id, partition_col)
-) PARTITION BY RANGE (partition_col);
--- Add partitions to the local partitioned table
-CREATE TABLE local_partitioned_table_p1 PARTITION OF local_partitioned_table
-FOR VALUES FROM (1) TO (100);
-CREATE TABLE local_partitioned_table_p2 PARTITION OF local_partitioned_table
-FOR VALUES FROM (100) TO (200);
-SELECT citus_add_local_table_to_metadata('local_partitioned_table');
- citus_add_local_table_to_metadata
----------------------------------------------------------------------
-
-(1 row)
-
--- Verify the Citus tables
-SELECT table_name, citus_table_type FROM citus_tables
-WHERE table_name::regclass::text like '%_partitioned_table' ORDER BY 1;
-                table_name                | citus_table_type
----------------------------------------------------------------------
- distributed_partitioned_table            | distributed
- at_addconstnoname.dist_partitioned_table | distributed
- local_partitioned_table                  | local
-(3 rows)
-
--- Step 3: Add an exclusion constraint with a name to the distributed partitioned table
-ALTER TABLE distributed_partitioned_table ADD CONSTRAINT dist_exclude_named EXCLUDE USING btree (id WITH =, partition_col WITH =);
--- Step 4: Verify propagation of exclusion constraint to worker nodes
-\c - - :public_worker_1_host :worker_1_port
-SELECT conname FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND conname = 'dist_exclude_named';
-      conname
----------------------------------------------------------------------
- dist_exclude_named
-(1 row)
-
--- Step 5: Add an exclusion constraint with a name to the Citus local partitioned table
-\c - - :master_host :master_port
-ALTER TABLE local_partitioned_table ADD CONSTRAINT local_exclude_named EXCLUDE USING btree (partition_col WITH =);
--- Step 6: Verify the exclusion constraint on the local partitioned table
-SELECT conname, contype FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
-       conname       | contype
----------------------------------------------------------------------
- local_exclude_named | x
-(1 row)
-
--- Step 7: Add exclusion constraints without names to both tables
-ALTER TABLE distributed_partitioned_table ADD EXCLUDE USING btree (id WITH =, partition_col WITH =);
-ALTER TABLE local_partitioned_table ADD EXCLUDE USING btree (partition_col WITH =);
--- Step 8: Verify the unnamed exclusion constraints were added
-SELECT conname, contype FROM pg_constraint WHERE conrelid = 'local_partitioned_table'::regclass AND contype = 'x';
-                  conname                   | contype
----------------------------------------------------------------------
- local_exclude_named                        | x
- local_partitioned_table_partition_col_excl | x
-(2 rows)
-
-\c - - :public_worker_1_host :worker_1_port
-SELECT conname, contype FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND contype = 'x';
-                       conname                       | contype
----------------------------------------------------------------------
- dist_exclude_named                                  | x
- distributed_partitioned_table_id_partition_col_excl | x
-(2 rows)
-
--- Step 9: Drop the exclusion constraints from both tables
-\c - - :master_host :master_port
-ALTER TABLE distributed_partitioned_table DROP CONSTRAINT dist_exclude_named;
-ALTER TABLE local_partitioned_table DROP CONSTRAINT local_exclude_named;
--- Step 10: Verify the constraints were dropped
-SELECT * FROM pg_constraint WHERE conname = 'dist_exclude_named' AND contype = 'x';
- oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
----------------------------------------------------------------------
-(0 rows)
-
-SELECT * FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
- oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
----------------------------------------------------------------------
-(0 rows)
-
--- Step 11: Clean up - Drop the tables
-DROP TABLE distributed_partitioned_table, local_partitioned_table;
-DROP TABLE AT_AddConstNoName.p1,
-          AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc,
-          AT_AddConstNoName.dist_partitioned_table;
-DROP SCHEMA AT_AddConstNoName CASCADE;
--- End of Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
 -- Correlated sublinks are now supported as of PostgreSQL 17, resolving issue #4470.
 -- Enable DEBUG-level logging to capture detailed execution plans
 -- Create the tables
@@ -1172,6 +1013,110 @@ RESET citus.local_table_join_policy;
 RESET client_min_messages;
 DROP TABLE reference_table;
 -- End for Correlated sublinks are now supported as of PostgreSQL 17, resolving issue #4470.
+-- Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
+-- Step 1: Create a distributed partitioned table
+\c - - :master_host :master_port
+SET search_path TO pg17;
+CREATE TABLE distributed_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the distributed partitioned table
+CREATE TABLE distributed_partitioned_table_p1 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE distributed_partitioned_table_p2 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (100) TO (200);
+-- Distribute the table
+SELECT create_distributed_table('distributed_partitioned_table', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Step 2: Create a partitioned Citus local table
+CREATE TABLE local_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the local partitioned table
+CREATE TABLE local_partitioned_table_p1 PARTITION OF local_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE local_partitioned_table_p2 PARTITION OF local_partitioned_table
+FOR VALUES FROM (100) TO (200);
+SELECT citus_add_local_table_to_metadata('local_partitioned_table');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Verify the Citus tables
+SELECT table_name, citus_table_type FROM pg_catalog.citus_tables
+WHERE table_name::regclass::text LIKE '%_partitioned_table' ORDER BY 1;
+ERROR:  relation "pg_catalog.citus_tables" does not exist
+-- Step 3: Add an exclusion constraint with a name to the distributed partitioned table
+ALTER TABLE distributed_partitioned_table ADD CONSTRAINT dist_exclude_named EXCLUDE USING btree (id WITH =, partition_col WITH =);
+-- Step 4: Verify propagation of exclusion constraint to worker nodes
+\c - - :public_worker_1_host :worker_1_port
+SET search_path TO pg17;
+SELECT conname FROM pg_constraint WHERE conrelid = 'pg17.distributed_partitioned_table'::regclass AND conname = 'dist_exclude_named';
+      conname
+---------------------------------------------------------------------
+ dist_exclude_named
+(1 row)
+
+-- Step 5: Add an exclusion constraint with a name to the Citus local partitioned table
+\c - - :master_host :master_port
+SET search_path TO pg17;
+ALTER TABLE local_partitioned_table ADD CONSTRAINT local_exclude_named EXCLUDE USING btree (partition_col WITH =);
+-- Step 6: Verify the exclusion constraint on the local partitioned table
+SELECT conname, contype FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+       conname       | contype
+---------------------------------------------------------------------
+ local_exclude_named | x
+(1 row)
+
+-- Step 7: Add exclusion constraints without names to both tables
+ALTER TABLE distributed_partitioned_table ADD EXCLUDE USING btree (id WITH =, partition_col WITH =);
+ALTER TABLE local_partitioned_table ADD EXCLUDE USING btree (partition_col WITH =);
+-- Step 8: Verify the unnamed exclusion constraints were added
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'local_partitioned_table'::regclass AND contype = 'x';
+                  conname                   | contype
+---------------------------------------------------------------------
+ local_exclude_named                        | x
+ local_partitioned_table_partition_col_excl | x
+(2 rows)
+
+\c - - :public_worker_1_host :worker_1_port
+SET search_path TO pg17;
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'pg17.distributed_partitioned_table'::regclass AND contype = 'x';
+                       conname                       | contype
+---------------------------------------------------------------------
+ dist_exclude_named                                  | x
+ distributed_partitioned_table_id_partition_col_excl | x
+(2 rows)
+
+-- Step 9: Drop the exclusion constraints from both tables
+\c - - :master_host :master_port
+SET search_path TO pg17;
+ALTER TABLE distributed_partitioned_table DROP CONSTRAINT dist_exclude_named;
+ALTER TABLE local_partitioned_table DROP CONSTRAINT local_exclude_named;
+-- Step 10: Verify the constraints were dropped
+SELECT * FROM pg_constraint WHERE conname = 'dist_exclude_named' AND contype = 'x';
+ oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+ oid | conname | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | confdelsetcols | conexclop | conbin
+---------------------------------------------------------------------
+(0 rows)
+
+-- Step 11: Clean up - Drop the tables
+DROP TABLE distributed_partitioned_table CASCADE;
+DROP TABLE local_partitioned_table CASCADE;
+-- End of Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
 DROP SCHEMA pg17 CASCADE;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function fake_am_handler(internal)

--- a/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
+++ b/src/test/regress/sql/multi_alter_table_add_constraints_without_name.sql
@@ -785,9 +785,6 @@ SELECT con.conname
 \c - - :master_host :master_port
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table DROP CONSTRAINT citus_local_partitioned_table_partition_col_key;
 
--- Check "ADD EXCLUDE" errors out for partitioned table since the postgres does not allow it
-ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD EXCLUDE(partition_col WITH =);
-
 -- Check "ADD CHECK"
 SET client_min_messages TO DEBUG1;
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD CHECK (dist_col > 0);

--- a/src/test/regress/sql/pg17.sql
+++ b/src/test/regress/sql/pg17.sql
@@ -464,6 +464,109 @@ DROP TABLE alt_test;
 
 -- End of partition with identity columns testing
 
+-- Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
+-- Step 1: Create a distributed partitioned table
+\c - - :master_host :master_port
+CREATE TABLE distributed_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the distributed partitioned table
+CREATE TABLE distributed_partitioned_table_p1 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE distributed_partitioned_table_p2 PARTITION OF distributed_partitioned_table
+FOR VALUES FROM (100) TO (200);
+-- Distribute the table
+SELECT create_distributed_table('distributed_partitioned_table', 'id');
+
+-- Additional test for long names and sequential execution mode
+-- Create schema if it doesn't already exist
+CREATE SCHEMA IF NOT EXISTS AT_AddConstNoName;
+
+CREATE TABLE AT_AddConstNoName.dist_partitioned_table (
+    dist_col int,
+    another_col int,
+    partition_col timestamp
+) PARTITION BY RANGE (partition_col);
+CREATE TABLE AT_AddConstNoName.p1 PARTITION OF AT_AddConstNoName.dist_partitioned_table
+FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc PARTITION OF AT_AddConstNoName.dist_partitioned_table
+FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('AT_AddConstNoName.dist_partitioned_table', 'partition_col');
+
+-- Step 1.1: Insert and query data from long name partition
+INSERT INTO AT_AddConstNoName.dist_partitioned_table (dist_col, another_col, partition_col)
+VALUES (1, 10, '2020-06-01'), (2, 20, '2020-09-01');
+SELECT * FROM AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc;
+
+-- Step 1.2: Verify sequential execution mode
+EXPLAIN SELECT * FROM AT_AddConstNoName.dist_partitioned_table WHERE partition_col = '2020-06-01';
+
+-- Step 1.3: Add exclusion constraints on parent table
+ALTER TABLE AT_AddConstNoName.dist_partitioned_table
+ADD CONSTRAINT long_name_exclude EXCLUDE USING btree (dist_col WITH =, partition_col WITH =);
+
+-- Verify the constraint was added
+SELECT conname FROM pg_constraint WHERE conrelid = 'AT_AddConstNoName.dist_partitioned_table'::regclass AND conname = 'long_name_exclude';
+
+-- Step 2: Create a partitioned Citus local table
+CREATE TABLE local_partitioned_table (
+    id serial NOT NULL,
+    partition_col int NOT NULL,
+    PRIMARY KEY (id, partition_col)
+) PARTITION BY RANGE (partition_col);
+-- Add partitions to the local partitioned table
+CREATE TABLE local_partitioned_table_p1 PARTITION OF local_partitioned_table
+FOR VALUES FROM (1) TO (100);
+CREATE TABLE local_partitioned_table_p2 PARTITION OF local_partitioned_table
+FOR VALUES FROM (100) TO (200);
+SELECT citus_add_local_table_to_metadata('local_partitioned_table');
+
+-- Verify the Citus tables
+SELECT table_name, citus_table_type FROM citus_tables
+WHERE table_name::regclass::text like '%_partitioned_table' ORDER BY 1;
+
+-- Step 3: Add an exclusion constraint with a name to the distributed partitioned table
+ALTER TABLE distributed_partitioned_table ADD CONSTRAINT dist_exclude_named EXCLUDE USING btree (id WITH =, partition_col WITH =);
+
+-- Step 4: Verify propagation of exclusion constraint to worker nodes
+\c - - :public_worker_1_host :worker_1_port
+SELECT conname FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND conname = 'dist_exclude_named';
+
+-- Step 5: Add an exclusion constraint with a name to the Citus local partitioned table
+\c - - :master_host :master_port
+ALTER TABLE local_partitioned_table ADD CONSTRAINT local_exclude_named EXCLUDE USING btree (partition_col WITH =);
+
+-- Step 6: Verify the exclusion constraint on the local partitioned table
+SELECT conname, contype FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+
+-- Step 7: Add exclusion constraints without names to both tables
+ALTER TABLE distributed_partitioned_table ADD EXCLUDE USING btree (id WITH =, partition_col WITH =);
+ALTER TABLE local_partitioned_table ADD EXCLUDE USING btree (partition_col WITH =);
+
+-- Step 8: Verify the unnamed exclusion constraints were added
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'local_partitioned_table'::regclass AND contype = 'x';
+\c - - :public_worker_1_host :worker_1_port
+SELECT conname, contype FROM pg_constraint WHERE conrelid = 'distributed_partitioned_table'::regclass AND contype = 'x';
+
+-- Step 9: Drop the exclusion constraints from both tables
+\c - - :master_host :master_port
+ALTER TABLE distributed_partitioned_table DROP CONSTRAINT dist_exclude_named;
+ALTER TABLE local_partitioned_table DROP CONSTRAINT local_exclude_named;
+
+-- Step 10: Verify the constraints were dropped
+SELECT * FROM pg_constraint WHERE conname = 'dist_exclude_named' AND contype = 'x';
+SELECT * FROM pg_constraint WHERE conname = 'local_exclude_named' AND contype = 'x';
+
+-- Step 11: Clean up - Drop the tables
+DROP TABLE distributed_partitioned_table, local_partitioned_table;
+DROP TABLE AT_AddConstNoName.p1,
+          AT_AddConstNoName.longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc,
+          AT_AddConstNoName.dist_partitioned_table;
+DROP SCHEMA AT_AddConstNoName CASCADE;
+-- End of Test for exclusion constraints on partitioned and distributed partitioned tables in Citus environment
+
 -- Correlated sublinks are now supported as of PostgreSQL 17, resolving issue #4470.
 -- Enable DEBUG-level logging to capture detailed execution plans
 


### PR DESCRIPTION
In earlier versions of PostgreSQL, exclusion constraints were not allowed on partitioned tables. This is why the error in your regression test (ERROR: exclusion constraints are not supported on partitioned tables) was raised in PostgreSQL 16. In PostgreSQL 17, exclusion constraints are now allowed on partitioned tables, which is why the error no longer appears when you attempt to add an exclusion constraint.

The constraint exclusion mechanism, described in the documentation, relies on CHECK constraints to decide which partitions or child tables need to be queried.

[CHECK constraints](https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-CONSTRAINT-EXCLUSION)

```diff
 -- Check "ADD EXCLUDE" errors out for partitioned table since the postgres does not allow it
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD EXCLUDE(partition_col WITH =);
-ERROR:  exclusion constraints are not supported on partitioned tables
 -- Check "ADD CHECK"
 SET client_min_messages TO DEBUG1;
 ALTER TABLE AT_AddConstNoName.citus_local_partitioned_table ADD CHECK (dist_col > 0);
 DEBUG:  the constraint name on the shards of the partition is too long, switching to sequential and local execution mode to prevent self deadlocks: longlonglonglonglonglonglonglonglonglonglonglo_537570f5_5_check
 DEBUG:  verifying table "longlonglonglonglonglonglonglonglonglonglonglonglonglonglongabc"
 DEBUG:  verifying table "p1"
 RESET client_min_messages;
 SELECT con.conname
     FROM pg_catalog.pg_constraint con
       INNER JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
       INNER JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
           WHERE rel.relname = 'citus_local_partitioned_table';
                      conname                      
 --------------------------------------------------
+ citus_local_partitioned_table_partition_col_excl
  citus_local_partitioned_table_check
-(1 row)
+(2 rows)
```