### PR TITLE
PG17 compatibility: Check whether table AM is default

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2256,7 +2256,9 @@ ColumnarProcessAlterTable(AlterTableStmt *alterTableStmt, List **columnarOptions
 									"Specify SET ACCESS METHOD before storage parameters, or use separate ALTER TABLE commands.")));
 			}
 
-			destIsColumnar = (strcmp(alterTableCmd->name, COLUMNAR_AM_NAME) == 0);
+			destIsColumnar = (strcmp(alterTableCmd->name ? alterTableCmd->name :
+									 default_table_access_method,
+									 COLUMNAR_AM_NAME) == 0);
 
 			if (srcIsColumnar && !destIsColumnar)
 			{


### PR DESCRIPTION
PG 17 added support for DEFAULT in ALTER TABLE .. SET ACCESS METHOD

Relevant PG commit:
d61a6cad6418f643a5773352038d0dfe5d3535b8
https://github.com/postgres/postgres/commit/d61a6cad6418f643a5773352038d0dfe5d3535b8

In that case, name in `AlterTableCmd->name` would be null.
Add a null check here to avoid crash.

Note to reviewer: I have opened the pull request against `naisila/pg17_columnar_issue` as the fix from that PR is necessary to see what this PR is fixing. Naturally, this fix will be merged after https://github.com/citusdata/citus/pull/7738 has been merged