### PR TITLE
PG17 compatibility: add COLLPROVIDER_BUILTIN option and fix tests

### DIFF
--- a/src/backend/distributed/commands/collation.c
+++ b/src/backend/distributed/commands/collation.c
@@ -132,6 +132,7 @@ CreateCollationDDLInternal(Oid collationId, Oid *collowner, char **quotedCollati
 	char *schemaName = get_namespace_name(collnamespace);
 	*quotedCollationName = quote_qualified_identifier(schemaName, collname);
 	const char *providerString =
+		collprovider == COLLPROVIDER_BUILTIN ? "builtin" :
 		collprovider == COLLPROVIDER_DEFAULT ? "default" :
 		collprovider == COLLPROVIDER_ICU ? "icu" :
 		collprovider == COLLPROVIDER_LIBC ? "libc" : NULL;

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -144,6 +144,8 @@ getStxstattarget_compat(HeapTuple tup)
 #define getProcNo_compat(a) (a->pgprocno)
 #define getLxid_compat(a) (a->lxid)
 
+#define COLLPROVIDER_BUILTIN 'b'
+
 #endif
 
 #if PG_VERSION_NUM >= PG_VERSION_16

--- a/src/test/regress/expected/multi_mx_create_table.out
+++ b/src/test/regress/expected/multi_mx_create_table.out
@@ -56,7 +56,14 @@ SET search_path TO public;
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
 \gset
-\if :server_version_ge_16
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
+\if :server_version_ge_17
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN datlocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset
+\elif :server_version_ge_16
 -- In PG16, read-only server settings lc_collate and lc_ctype are removed
 -- Relevant PG commit: b0f6c437160db640d4ea3e49398ebc3ba39d1982
 SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN daticulocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset

--- a/src/test/regress/expected/multi_schema_support.out
+++ b/src/test/regress/expected/multi_schema_support.out
@@ -350,7 +350,14 @@ SET search_path TO public;
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
 \gset
-\if :server_version_ge_16
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
+\if :server_version_ge_17
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN datlocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset
+\elif :server_version_ge_16
 -- In PG16, read-only server settings lc_collate and lc_ctype are removed
 -- Relevant PG commit: b0f6c437160db640d4ea3e49398ebc3ba39d1982
 SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN daticulocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset

--- a/src/test/regress/expected/pg15.out
+++ b/src/test/regress/expected/pg15.out
@@ -51,9 +51,32 @@ SELECT result FROM run_command_on_all_nodes('
 
 (3 rows)
 
-SELECT result FROM run_command_on_all_nodes('
-    SELECT colliculocale FROM pg_collation WHERE collname = ''german_phonebook_test'';
-');
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
+\if :server_version_ge_17
+SELECT '$$' ||
+       'SELECT colllocale FROM pg_collation WHERE collname = ''german_phonebook_test'';'
+       || '$$'
+    AS worker_query_1 \gset
+SELECT '$$' ||
+       'SELECT colllocale FROM pg_collation WHERE collname = ''default_provider'';'
+       || '$$'
+    AS worker_query_2 \gset
+\else
+SELECT '$$' ||
+       'SELECT colliculocale FROM pg_collation WHERE collname = ''german_phonebook_test'';'
+       || '$$'
+    AS worker_query_1 \gset
+SELECT '$$' ||
+       'SELECT colliculocale FROM pg_collation WHERE collname = ''default_provider'';'
+       || '$$'
+    AS worker_query_2 \gset
+\endif
+SELECT result FROM run_command_on_all_nodes(:worker_query_1);
      result
 ---------------------------------------------------------------------
  de-u-co-phonebk
@@ -83,9 +106,7 @@ SELECT result FROM run_command_on_all_nodes('
  POSIX
 (3 rows)
 
-SELECT result FROM run_command_on_all_nodes('
-    SELECT colliculocale FROM pg_collation WHERE collname = ''default_provider'';
-');
+SELECT result FROM run_command_on_all_nodes(:worker_query_2);
  result
 ---------------------------------------------------------------------
 

--- a/src/test/regress/expected/pg16.out
+++ b/src/test/regress/expected/pg16.out
@@ -330,14 +330,14 @@ SELECT create_distributed_table('test_collation_rules', 'a');
 (1 row)
 
 INSERT INTO test_collation_rules VALUES ('Abernathy'), ('apple'), ('bird'), ('Boston'), ('Graham'), ('green');
-SELECT collname, collprovider, colliculocale, collicurules
+SELECT collname, collprovider, collicurules
 FROM pg_collation
 WHERE collname like '%_rule%'
 ORDER BY 1;
-   collname   | collprovider | colliculocale | collicurules
+   collname   | collprovider | collicurules
 ---------------------------------------------------------------------
- default_rule | i            | und           |
- special_rule | i            | und           | &a < g
+ default_rule | i            |
+ special_rule | i            | &a < g
 (2 rows)
 
 SELECT * FROM test_collation_rules ORDER BY a COLLATE default_rule;
@@ -364,14 +364,14 @@ SELECT * FROM test_collation_rules ORDER BY a COLLATE special_rule;
 
 \c - - - :worker_1_port
 SET search_path TO pg16;
-SELECT collname, collprovider, colliculocale, collicurules
+SELECT collname, collprovider, collicurules
 FROM pg_collation
 WHERE collname like '%_rule%'
 ORDER BY 1;
-   collname   | collprovider | colliculocale | collicurules
+   collname   | collprovider | collicurules
 ---------------------------------------------------------------------
- default_rule | i            | und           |
- special_rule | i            | und           | &a < g
+ default_rule | i            |
+ special_rule | i            | &a < g
 (2 rows)
 
 SELECT * FROM test_collation_rules ORDER BY a COLLATE default_rule;

--- a/src/test/regress/sql/multi_mx_create_table.sql
+++ b/src/test/regress/sql/multi_mx_create_table.sql
@@ -55,8 +55,15 @@ SET search_path TO public;
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
 \gset
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
 
-\if :server_version_ge_16
+\if :server_version_ge_17
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN datlocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset
+\elif :server_version_ge_16
 -- In PG16, read-only server settings lc_collate and lc_ctype are removed
 -- Relevant PG commit: b0f6c437160db640d4ea3e49398ebc3ba39d1982
 SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN daticulocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset

--- a/src/test/regress/sql/multi_schema_support.sql
+++ b/src/test/regress/sql/multi_schema_support.sql
@@ -297,8 +297,15 @@ SET search_path TO public;
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
 \gset
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
 
-\if :server_version_ge_16
+\if :server_version_ge_17
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN datlocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset
+\elif :server_version_ge_16
 -- In PG16, read-only server settings lc_collate and lc_ctype are removed
 -- Relevant PG commit: b0f6c437160db640d4ea3e49398ebc3ba39d1982
 SELECT quote_ident((SELECT CASE WHEN datlocprovider='i' THEN daticulocale ELSE datcollate END FROM pg_database WHERE datname = current_database())) as current_locale \gset

--- a/src/test/regress/sql/pg15.sql
+++ b/src/test/regress/sql/pg15.sql
@@ -41,9 +41,36 @@ SELECT result FROM run_command_on_all_nodes('
 SELECT result FROM run_command_on_all_nodes('
     SELECT collctype FROM pg_collation WHERE collname = ''german_phonebook_test'';
 ');
-SELECT result FROM run_command_on_all_nodes('
-    SELECT colliculocale FROM pg_collation WHERE collname = ''german_phonebook_test'';
-');
+
+-- PG17 renamed colliculocale to colllocale
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
+
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 17 AS server_version_ge_17
+\gset
+
+\if :server_version_ge_17
+SELECT '$$' ||
+       'SELECT colllocale FROM pg_collation WHERE collname = ''german_phonebook_test'';'
+       || '$$'
+    AS worker_query_1 \gset
+SELECT '$$' ||
+       'SELECT colllocale FROM pg_collation WHERE collname = ''default_provider'';'
+       || '$$'
+    AS worker_query_2 \gset
+\else
+SELECT '$$' ||
+       'SELECT colliculocale FROM pg_collation WHERE collname = ''german_phonebook_test'';'
+       || '$$'
+    AS worker_query_1 \gset
+SELECT '$$' ||
+       'SELECT colliculocale FROM pg_collation WHERE collname = ''default_provider'';'
+       || '$$'
+    AS worker_query_2 \gset
+\endif
+
+SELECT result FROM run_command_on_all_nodes(:worker_query_1);
 
 -- with non-icu provider, colliculocale will be null, collcollate and collctype will be set
 CREATE COLLATION default_provider (provider = libc, lc_collate = "POSIX", lc_ctype = "POSIX");
@@ -54,9 +81,7 @@ SELECT result FROM run_command_on_all_nodes('
 SELECT result FROM run_command_on_all_nodes('
     SELECT collctype FROM pg_collation WHERE collname = ''default_provider'';
 ');
-SELECT result FROM run_command_on_all_nodes('
-    SELECT colliculocale FROM pg_collation WHERE collname = ''default_provider'';
-');
+SELECT result FROM run_command_on_all_nodes(:worker_query_2);
 
 --
 -- In PG15, Renaming triggers on partitioned tables had two problems

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -159,7 +159,7 @@ CREATE TABLE test_collation_rules (a text);
 SELECT create_distributed_table('test_collation_rules', 'a');
 INSERT INTO test_collation_rules VALUES ('Abernathy'), ('apple'), ('bird'), ('Boston'), ('Graham'), ('green');
 
-SELECT collname, collprovider, colliculocale, collicurules
+SELECT collname, collprovider, collicurules
 FROM pg_collation
 WHERE collname like '%_rule%'
 ORDER BY 1;
@@ -170,7 +170,7 @@ SELECT * FROM test_collation_rules ORDER BY a COLLATE special_rule;
 \c - - - :worker_1_port
 SET search_path TO pg16;
 
-SELECT collname, collprovider, colliculocale, collicurules
+SELECT collname, collprovider, collicurules
 FROM pg_collation
 WHERE collname like '%_rule%'
 ORDER BY 1;


### PR DESCRIPTION
In PG17 adds builtin C.UTF-8 locale option, we add it in the code to avoid "unknown collation provider" in vanilla tests.

Relevant PG commit:
https://github.com/postgres/postgres/commit/f69319f2f1fb16eda4b535bcccec90dff3a6795e
f69319f2f1fb16eda4b535bcccec90dff3a6795e

Also in PG17, colliculocale, daticulocale renamed to colllocale, datlocale
Here we fix the following tests to avoid alternative output
pg15 pg16 multi_mx_create_table multi_schema_support

Relevant PG commit:
https://github.com/postgres/postgres/commit/f696c0cd5f299f1b51e214efc55a22a782cc175d
f696c0cd5f299f1b51e214efc55a22a782cc175d

Note to reviewer: First three commits are for PG17 testing purposes. Only the last 2 commits will be merged. Also, I wasn't sure whether I should add tests here.