### PR TITLE
PG17 compatibility: Normalize COPY error messages

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -309,3 +309,13 @@ s/permission denied to terminate process/must be a superuser to terminate superu
 s/permission denied to cancel query/must be a superuser to cancel superuser query/g
 
 #endif /* PG_VERSION_NUM < PG_VERSION_16 */
+
+# pg17 changes
+# can be removed when dropping PG15&16 support
+#if PG_VERSION_NUM < PG_VERSION_17
+# (This is not preprocessor directive, but a reminder for the developer that will drop PG15&16 support )
+
+s/COPY DEFAULT only available using COPY FROM/COPY DEFAULT cannot be used with COPY TO/
+s/COPY delimiter must not appear in the DEFAULT specification/COPY delimiter character must not appear in the DEFAULT specification/
+
+#endif /* PG_VERSION_NUM < PG_VERSION_17 */

--- a/src/test/regress/expected/pg16.out
+++ b/src/test/regress/expected/pg16.out
@@ -517,7 +517,7 @@ COPY copy_default FROM stdin WITH (default E'\r');
 ERROR:  COPY default representation cannot use newline or carriage return
 -- DELIMITER cannot appear in DEFAULT spec
 COPY copy_default FROM stdin WITH (delimiter ';', default 'test;test');
-ERROR:  COPY delimiter must not appear in the DEFAULT specification
+ERROR:  COPY delimiter character must not appear in the DEFAULT specification
 -- CSV quote cannot appear in DEFAULT spec
 COPY copy_default FROM stdin WITH (format csv, quote '"', default 'test"test');
 ERROR:  CSV quote character must not appear in the DEFAULT specification
@@ -603,7 +603,7 @@ SET citus.shard_count TO 1;
 SET citus.shard_replication_factor TO 1;
 -- DEFAULT cannot be used in COPY TO
 COPY (select 1 as test) TO stdout WITH (default '\D');
-ERROR:  COPY DEFAULT only available using COPY FROM
+ERROR:  COPY DEFAULT cannot be used with COPY TO
 -- Tests for SQL/JSON: JSON_ARRAYAGG and JSON_OBJECTAGG aggregates
 -- Relevant PG commit:
 -- https://github.com/postgres/postgres/commit/7081ac4


### PR DESCRIPTION
A recent Postgres commit (*) that refactored error messages is the cause of the diffs in pg16 regress test when running Citus on Postgres 17. The fix changes the pg16 goldfile and includes a normalization rule for the error messages so pg16 will pass when running with version 16 of Postgres.
    
(*) https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=498ee9ee2f