### PR TITLE
PG17 compatibility: Adjust print_extension_changes function for extra type outputs in PG17

### DIFF
--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -38,6 +38,24 @@ $definition$ create_function_test_maintenance_worker
 CREATE TABLE multi_extension.prev_objects(description text);
 CREATE TABLE multi_extension.extension_diff(previous_object text COLLATE "C",
                             current_object text COLLATE "C");
+-- In PG17, Auto-generated array types, multirange types, and relation rowtypes
+-- are treated as dependent objects, hence changing the output of the
+-- print_extension_changes function.
+-- Relevant PG commit: e5bc9454e527b1cba97553531d8d4992892fdeef
+-- Here we create a table with only the basic extension types
+-- in order to avoid printing extra ones for now
+-- This can be removed when we drop PG16 support.
+CREATE TABLE multi_extension.extension_basic_types (description text);
+INSERT INTO multi_extension.extension_basic_types VALUES ('type citus.distribution_type'),
+                                                         ('type citus.shard_transfer_mode'),
+                                                         ('type citus_copy_format'),
+                                                         ('type noderole'),
+                                                         ('type citus_job_status'),
+                                                         ('type citus_task_status'),
+                                                         ('type replication_slot_info'),
+                                                         ('type split_copy_info'),
+                                                         ('type split_shard_info'),
+                                                         ('type cluster_clock');
 CREATE FUNCTION multi_extension.print_extension_changes()
 RETURNS TABLE(previous_object text, current_object text)
 AS $func$
@@ -53,7 +71,10 @@ BEGIN
 	WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
 		AND refobjid = e.oid
 		AND deptype = 'e'
-		AND e.extname='citus';
+		AND e.extname='citus'
+        AND (pg_catalog.pg_describe_object(classid, objid, 0) NOT LIKE 'type%'
+             OR
+             pg_catalog.pg_describe_object(classid, objid, 0) IN (SELECT * FROM extension_basic_types));
 
 	INSERT INTO extension_diff
 	SELECT p.description previous_object, c.description current_object
@@ -88,7 +109,8 @@ FROM pg_depend AS pgd,
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal')
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal') AND
+      pgio.type      != 'type'
 ORDER BY 1, 2;
  type |       identity
 ---------------------------------------------------------------------
@@ -1424,7 +1446,8 @@ FROM pg_depend AS pgd,
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal')
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal') AND
+      pgio.type      != 'type'
 ORDER BY 1, 2;
  type |       identity
 ---------------------------------------------------------------------
@@ -1914,6 +1937,7 @@ RESET citus.enable_schema_based_sharding;
 DROP EXTENSION citus;
 CREATE EXTENSION citus;
 DROP TABLE version_mismatch_table;
+DROP TABLE  multi_extension.extension_basic_types;
 DROP SCHEMA multi_extension;
 ERROR:  cannot drop schema multi_extension because other objects depend on it
 DETAIL:  function multi_extension.print_extension_changes() depends on schema multi_extension

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -1,3 +1,21 @@
+-- In PG17, Auto-generated array types, multirange types, and relation rowtypes
+-- are treated as dependent objects, hence changing the output of the
+-- print_extension_changes function.
+-- Relevant PG commit: e5bc9454e527b1cba97553531d8d4992892fdeef
+-- Here we create a table with only the basic extension types
+-- in order to avoid printing extra ones for now
+-- This can be removed when we drop PG16 support.
+CREATE TABLE extension_basic_types (description text);
+INSERT INTO extension_basic_types VALUES ('type citus.distribution_type'),
+                                         ('type citus.shard_transfer_mode'),
+                                         ('type citus_copy_format'),
+                                         ('type noderole'),
+                                         ('type citus_job_status'),
+                                         ('type citus_task_status'),
+                                         ('type replication_slot_info'),
+                                         ('type split_copy_info'),
+                                         ('type split_shard_info'),
+                                         ('type cluster_clock');
 -- list all postgres objects belonging to the citus extension
 SELECT pg_catalog.pg_describe_object(classid, objid, 0) AS description
 FROM pg_catalog.pg_depend, pg_catalog.pg_extension e
@@ -5,6 +23,9 @@ WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
   AND refobjid = e.oid
   AND deptype = 'e'
   AND e.extname='citus'
+  AND (pg_catalog.pg_describe_object(classid, objid, 0) NOT LIKE 'type%'
+       OR
+       pg_catalog.pg_describe_object(classid, objid, 0) IN (SELECT * FROM extension_basic_types))
   AND pg_catalog.pg_describe_object(classid, objid, 0) != 'function any_value(anyelement)'
   AND pg_catalog.pg_describe_object(classid, objid, 0) != 'function any_value_agg(anyelement,anyelement)'
 ORDER BY 1;
@@ -345,3 +366,4 @@ ORDER BY 1;
  view time_partitions
 (333 rows)
 
+DROP TABLE extension_basic_types;

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -42,6 +42,26 @@ CREATE TABLE multi_extension.prev_objects(description text);
 CREATE TABLE multi_extension.extension_diff(previous_object text COLLATE "C",
                             current_object text COLLATE "C");
 
+-- In PG17, Auto-generated array types, multirange types, and relation rowtypes
+-- are treated as dependent objects, hence changing the output of the
+-- print_extension_changes function.
+-- Relevant PG commit: e5bc9454e527b1cba97553531d8d4992892fdeef
+-- Here we create a table with only the basic extension types
+-- in order to avoid printing extra ones for now
+-- This can be removed when we drop PG16 support.
+
+CREATE TABLE multi_extension.extension_basic_types (description text);
+INSERT INTO multi_extension.extension_basic_types VALUES ('type citus.distribution_type'),
+                                                         ('type citus.shard_transfer_mode'),
+                                                         ('type citus_copy_format'),
+                                                         ('type noderole'),
+                                                         ('type citus_job_status'),
+                                                         ('type citus_task_status'),
+                                                         ('type replication_slot_info'),
+                                                         ('type split_copy_info'),
+                                                         ('type split_shard_info'),
+                                                         ('type cluster_clock');
+
 CREATE FUNCTION multi_extension.print_extension_changes()
 RETURNS TABLE(previous_object text, current_object text)
 AS $func$
@@ -57,7 +77,10 @@ BEGIN
 	WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
 		AND refobjid = e.oid
 		AND deptype = 'e'
-		AND e.extname='citus';
+		AND e.extname='citus'
+        AND (pg_catalog.pg_describe_object(classid, objid, 0) NOT LIKE 'type%'
+             OR
+             pg_catalog.pg_describe_object(classid, objid, 0) IN (SELECT * FROM extension_basic_types));
 
 	INSERT INTO extension_diff
 	SELECT p.description previous_object, c.description current_object
@@ -90,7 +113,8 @@ FROM pg_depend AS pgd,
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal')
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal') AND
+      pgio.type      != 'type'
 ORDER BY 1, 2;
 
 
@@ -647,7 +671,8 @@ FROM pg_depend AS pgd,
 WHERE pgd.refclassid = 'pg_extension'::regclass AND
 	  pgd.refobjid   = pge.oid AND
 	  pge.extname    = 'citus' AND
-	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal')
+	  pgio.schema    NOT IN ('pg_catalog', 'citus', 'citus_internal', 'test', 'columnar', 'columnar_internal') AND
+      pgio.type      != 'type'
 ORDER BY 1, 2;
 
 -- see incompatible version errors out
@@ -1015,4 +1040,5 @@ DROP EXTENSION citus;
 CREATE EXTENSION citus;
 
 DROP TABLE version_mismatch_table;
+DROP TABLE  multi_extension.extension_basic_types;
 DROP SCHEMA multi_extension;

--- a/src/test/regress/sql/upgrade_list_citus_objects.sql
+++ b/src/test/regress/sql/upgrade_list_citus_objects.sql
@@ -1,3 +1,22 @@
+-- In PG17, Auto-generated array types, multirange types, and relation rowtypes
+-- are treated as dependent objects, hence changing the output of the
+-- print_extension_changes function.
+-- Relevant PG commit: e5bc9454e527b1cba97553531d8d4992892fdeef
+-- Here we create a table with only the basic extension types
+-- in order to avoid printing extra ones for now
+-- This can be removed when we drop PG16 support.
+CREATE TABLE extension_basic_types (description text);
+INSERT INTO extension_basic_types VALUES ('type citus.distribution_type'),
+                                         ('type citus.shard_transfer_mode'),
+                                         ('type citus_copy_format'),
+                                         ('type noderole'),
+                                         ('type citus_job_status'),
+                                         ('type citus_task_status'),
+                                         ('type replication_slot_info'),
+                                         ('type split_copy_info'),
+                                         ('type split_shard_info'),
+                                         ('type cluster_clock');
+
 -- list all postgres objects belonging to the citus extension
 SELECT pg_catalog.pg_describe_object(classid, objid, 0) AS description
 FROM pg_catalog.pg_depend, pg_catalog.pg_extension e
@@ -5,6 +24,11 @@ WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
   AND refobjid = e.oid
   AND deptype = 'e'
   AND e.extname='citus'
+  AND (pg_catalog.pg_describe_object(classid, objid, 0) NOT LIKE 'type%'
+       OR
+       pg_catalog.pg_describe_object(classid, objid, 0) IN (SELECT * FROM extension_basic_types))
   AND pg_catalog.pg_describe_object(classid, objid, 0) != 'function any_value(anyelement)'
   AND pg_catalog.pg_describe_object(classid, objid, 0) != 'function any_value_agg(anyelement,anyelement)'
 ORDER BY 1;
+
+DROP TABLE extension_basic_types;


### PR DESCRIPTION
In PG17, Auto-generated array types, multirange types, and relation rowtypes
are treated as dependent objects, hence changing the output of the
print_extension_changes function.

Relevant PG commit:
e5bc9454e527b1cba97553531d8d4992892fdeef
https://github.com/postgres/postgres/commit/e5bc9454e527b1cba97553531d8d4992892fdeef

Here we create a table with only the basic extension types
in order to avoid printing extra ones for now.
This can be removed when we drop PG16 support.

https://github.com/citusdata/citus/actions/runs/11960253650/attempts/1#summary-33343972656
```diff
                  | table pg_dist_local_group 
                  | table pg_dist_node 
                  | table pg_dist_node_metadata 
                  | table pg_dist_partition 
                  | table pg_dist_placement 
                  | table pg_dist_poolinfo 
                  | table pg_dist_rebalance_strategy 
                  | table pg_dist_shard 
                  | table pg_dist_transaction 
                  | type citus.distribution_type 
+                 | type citus.distribution_type[] 
+                 | type citus.pg_dist_object 
+                 | type citus.pg_dist_object[] 
                  | type citus.shard_transfer_mode 
+                 | type citus.shard_transfer_mode[] 
                  | type citus_copy_format 
+                 | type citus_copy_format[] 
+                 | type citus_dist_stat_activity 
+                 | type citus_dist_stat_activity[] 
+                 | type citus_lock_waits 
+                 | type citus_lock_waits[] 
+                 | type citus_shard_indexes_on_worker 
+                 | type citus_shard_indexes_on_worker[] 
+                 | type citus_shards_on_worker 
+                 | type citus_shards_on_worker[] 
+                 | type citus_stat_statements 
+                 | type citus_stat_statements[] 
+                 | type citus_worker_stat_activity 
+                 | type citus_worker_stat_activity[] 
                  | type noderole 
+                 | type noderole[] 
+                 | type pg_dist_authinfo 
+                 | type pg_dist_authinfo[] 
+                 | type pg_dist_colocation 
+                 | type pg_dist_colocation[] 
+                 | type pg_dist_local_group 
+                 | type pg_dist_local_group[] 
+                 | type pg_dist_node 
+                 | type pg_dist_node[] 
+                 | type pg_dist_node_metadata 
+                 | type pg_dist_node_metadata[] 
+                 | type pg_dist_partition 
+                 | type pg_dist_partition[] 
+                 | type pg_dist_placement 
+                 | type pg_dist_placement[] 
+                 | type pg_dist_poolinfo 
+                 | type pg_dist_poolinfo[] 
+                 | type pg_dist_rebalance_strategy 
+                 | type pg_dist_rebalance_strategy[] 
+                 | type pg_dist_shard 
+                 | type pg_dist_shard[] 
+                 | type pg_dist_shard_placement 
+                 | type pg_dist_shard_placement[] 
+                 | type pg_dist_transaction 
+                 | type pg_dist_transaction[] 
                  | view citus_dist_stat_activity 
                  | view citus_lock_waits 
                  | view citus_shard_indexes_on_worker 
                  | view citus_shards_on_worker 
                  | view citus_stat_statements 
                  | view citus_worker_stat_activity 
                  | view pg_dist_shard_placement 
-(186 rows)
+(228 rows)
```