### PR TITLE
PG17 regress test sanity: fix diffs in union_pushdown.

### DIFF
--- a/src/test/regress/expected/union_pushdown.out
+++ b/src/test/regress/expected/union_pushdown.out
@@ -1409,7 +1409,7 @@ $$);
 
 -- we hit https://github.com/citusdata/citus/blob/f00c63c33daf3d16f06462626ca14732b141ae7a/src/backend/distributed/planner/relation_restriction_equivalence.c#L235-L242
 SELECT public.explain_has_distributed_subplan($$
-EXPLAIN SELECT * FROM users_table_part u1 WHERE (value_1, user_id) IN
+EXPLAIN SELECT * FROM users_table_part u1 WHERE (value_1 + random(), user_id) IN
 (
 SELECT u1.user_id, user_id FROM users_table_part
 UNION

--- a/src/test/regress/sql/union_pushdown.sql
+++ b/src/test/regress/sql/union_pushdown.sql
@@ -1068,7 +1068,7 @@ $$);
 
 -- we hit https://github.com/citusdata/citus/blob/f00c63c33daf3d16f06462626ca14732b141ae7a/src/backend/distributed/planner/relation_restriction_equivalence.c#L235-L242
 SELECT public.explain_has_distributed_subplan($$
-EXPLAIN SELECT * FROM users_table_part u1 WHERE (value_1, user_id) IN
+EXPLAIN SELECT * FROM users_table_part u1 WHERE (value_1 + random(), user_id) IN
 (
 SELECT u1.user_id, user_id FROM users_table_part
 UNION


### PR DESCRIPTION
Preserve the test error message by adjusting the query so that PG17 cannot pull it up to a join. Another instance of a subquery that can be pulled up to a join with PG17 (#7745)

This should have been fixed in, but slipped by, #7745