### PR TITLE
PG17 regress sanity: fix error unrecognized alter database option tablespace seen in database vanilla test

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -511,6 +511,9 @@ if($vanillatest)
 
     # we disable some restrictions for local objects like local views to not break postgres vanilla test behaviour.
     push(@pgOptions, "citus.enforce_object_restrictions_for_local_objects=false");
+
+    # we disable metadata synchronization to enable postgres vanilla DDL tests to pass.
+    push(@pgOptions, "citus.enable_metadata_sync=false");
 }
 
 if ($useMitmproxy)


### PR DESCRIPTION
Disable DDL propagation for the vanilla test suite. This enables the vanilla `database ` test to pass, where previously it was correctly returning `ERROR:  unrecognized ALTER DATABASE option: tablespace` because release-13.0 does not propagate this ALTER DATABASE variant. 

We (Citus team) discussed cherry picking [#7253](https://github.com/citusdata/citus/pull/7253) from main to release-13.0 because it does propagate ALTER DATABASE tablespace option (as well as a couple of others) but decided fixing the regress test was not the proper context for that. The fix disables `citus.enable_metadata_sync` when running vanilla, we discussed disabling `citus.enable_create_database_propagation` but this is not in release-13.0. 