### PR TITLE
PG17 compatibility: fix some tests outputs

### DIFF
--- a/src/test/regress/expected/issue_5248.out
+++ b/src/test/regress/expected/issue_5248.out
@@ -201,7 +201,6 @@ FROM     (
                                                    sample_6.info        AS c1,
                                                    subq_0.c2            AS c2,
                                                    subq_0.c3            AS c3,
-                                                   ref_3.domain_default AS c4,
                                                    sample_6.user_id     AS c5,
                                                    ref_3.collation_name AS c6
                                             FROM   orders        AS sample_6 TABLESAMPLE system (3.8)

--- a/src/test/regress/expected/issue_5248_0.out
+++ b/src/test/regress/expected/issue_5248_0.out
@@ -201,7 +201,6 @@ FROM     (
                                                    sample_6.info        AS c1,
                                                    subq_0.c2            AS c2,
                                                    subq_0.c3            AS c3,
-                                                   ref_3.domain_default AS c4,
                                                    sample_6.user_id     AS c5,
                                                    ref_3.collation_name AS c6
                                             FROM   orders        AS sample_6 TABLESAMPLE system (3.8)

--- a/src/test/regress/expected/stat_statements.out
+++ b/src/test/regress/expected/stat_statements.out
@@ -179,10 +179,10 @@ ORDER BY 1, 2, 3, 4;
 SET citus.stat_statements_track TO 'all';
 -- reset pg_stat_statements and verify it also cleans citus_stat_statements output
 -- verify that entries are actually removed from citus_stat_statements
-SELECT pg_stat_statements_reset();
- pg_stat_statements_reset
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
+ t
 ---------------------------------------------------------------------
-
+ t
 (1 row)
 
 SELECT * FROM citus_stat_statements;
@@ -251,10 +251,10 @@ ORDER BY 1, 2, 3, 4;
  SELECT l_orderkey FROM lineitem_hash_part WHERE l_orderkey > ? | adaptive |               |     1
 (6 rows)
 
-SELECT pg_stat_statements_reset();
- pg_stat_statements_reset
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
+ t
 ---------------------------------------------------------------------
-
+ t
 (1 row)
 
 SELECT count(*) FROM lineitem_hash_part;

--- a/src/test/regress/sql/issue_5248.sql
+++ b/src/test/regress/sql/issue_5248.sql
@@ -184,7 +184,6 @@ FROM     (
                                                    sample_6.info        AS c1,
                                                    subq_0.c2            AS c2,
                                                    subq_0.c3            AS c3,
-                                                   ref_3.domain_default AS c4,
                                                    sample_6.user_id     AS c5,
                                                    ref_3.collation_name AS c6
                                             FROM   orders        AS sample_6 TABLESAMPLE system (3.8)

--- a/src/test/regress/sql/stat_statements.sql
+++ b/src/test/regress/sql/stat_statements.sql
@@ -91,7 +91,7 @@ SET citus.stat_statements_track TO 'all';
 
 -- reset pg_stat_statements and verify it also cleans citus_stat_statements output
 -- verify that entries are actually removed from citus_stat_statements
-SELECT pg_stat_statements_reset();
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
 SELECT * FROM citus_stat_statements;
 
 -- run some queries
@@ -109,7 +109,7 @@ SELECT normalize_query_string(query), executor, partition_key, calls
 FROM citus_stat_statements
 ORDER BY 1, 2, 3, 4;
 
-SELECT pg_stat_statements_reset();
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
 
 SELECT count(*) FROM lineitem_hash_part;
 SELECT count(*) FROM lineitem_hash_part WHERE l_orderkey = 4;


### PR DESCRIPTION
There are two commits in this PR:

1)
[Remove domain_default column since it has been removed from PG17](https://github.com/citusdata/citus/pull/7765/commits/9e45ec9f57eb93846d6304a496050ff5eeeb80eb)
Relevant PG commit:
https://github.com/postgres/postgres/commit/78806a95095c4fb9230a441925244690d9c07d23
78806a95095c4fb9230a441925244690d9c07d23


2)
[pg_stat_statements reset output diff fix](https://github.com/citusdata/citus/pull/7765/commits/d3bb1e1c7432b6e05d3492ecb086832a7d1df1ac)
Relevant PG commits:
pg_stat_statements reset output changed in PG17, fix idea from
https://github.com/postgres/postgres/commit/6ab1dbd26bbf307055d805feaaca16dc3e750d36
6ab1dbd26bbf307055d805feaaca16dc3e750d36
