### PR TITLE
PG17 compatibility (#7653): Fix test diffs in columnar schedule

### DIFF
--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -977,6 +977,7 @@ DETAIL:  unparameterized; 1 clauses pushed down
 (1 row)
 
 SET hash_mem_multiplier = 1.0;
+SELECT public.explain_with_pg16_subplan_format($Q$
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where
 (
@@ -989,13 +990,18 @@ SELECT sum(a) FROM pushdown_test where
 )
 or
 (a > 200000-2010);
+$Q$) as "QUERY PLAN";
 NOTICE:  columnar planner: adding CustomScan path for pushdown_test
 DETAIL:  unparameterized; 0 clauses pushed down
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: cannot push down clause: must match 'Var <op> Expr' or 'Expr <op> Var'
 HINT:  Var must only reference this rel, and Expr must not reference this rel
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: cannot push down clause: must not contain a subplan
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: adding CustomScan path for pushdown_test
 DETAIL:  unparameterized; 1 clauses pushed down
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
                                                                   QUERY PLAN
 ---------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
@@ -1092,14 +1098,14 @@ BEGIN;
 END;
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');
-                                QUERY PLAN
+                               QUERY PLAN
 ---------------------------------------------------------------------
  Custom Scan (ColumnarScan) on pushdown_test (actual rows=3 loops=1)
-    Filter: (country = ANY ('{USA,BR,ZW}'::text[]))
-    Rows Removed by Filter: 1
-    Columnar Projected Columns: id, country
-    Columnar Chunk Group Filters: (country = ANY ('{USA,BR,ZW}'::text[]))
-    Columnar Chunk Groups Removed by Filter: 2
+   Filter: (country = ANY ('{USA,BR,ZW}'::text[]))
+   Rows Removed by Filter: 1
+   Columnar Projected Columns: id, country
+   Columnar Chunk Group Filters: (country = ANY ('{USA,BR,ZW}'::text[]))
+   Columnar Chunk Groups Removed by Filter: 2
 (6 rows)
 
 SELECT id FROM pushdown_test WHERE country IN ('USA', 'BR', 'ZW');

--- a/src/test/regress/expected/columnar_chunk_filtering_0.out
+++ b/src/test/regress/expected/columnar_chunk_filtering_0.out
@@ -977,6 +977,7 @@ DETAIL:  unparameterized; 1 clauses pushed down
 (1 row)
 
 SET hash_mem_multiplier = 1.0;
+SELECT public.explain_with_pg16_subplan_format($Q$
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where
 (
@@ -989,13 +990,18 @@ SELECT sum(a) FROM pushdown_test where
 )
 or
 (a > 200000-2010);
+$Q$) as "QUERY PLAN";
 NOTICE:  columnar planner: adding CustomScan path for pushdown_test
 DETAIL:  unparameterized; 0 clauses pushed down
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: cannot push down clause: must match 'Var <op> Expr' or 'Expr <op> Var'
 HINT:  Var must only reference this rel, and Expr must not reference this rel
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: cannot push down clause: must not contain a subplan
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
 NOTICE:  columnar planner: adding CustomScan path for pushdown_test
 DETAIL:  unparameterized; 1 clauses pushed down
+CONTEXT:  PL/pgSQL function explain_with_pg16_subplan_format(text) line XX at FOR over EXECUTE statement
                                                                   QUERY PLAN
 ---------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)

--- a/src/test/regress/expected/columnar_paths_0.out
+++ b/src/test/regress/expected/columnar_paths_0.out
@@ -301,16 +301,20 @@ SELECT * FROM w AS w1 JOIN w AS w2 ON w1.a = w2.d
 WHERE w2.a = 123;
                       QUERY PLAN
 ---------------------------------------------------------------------
- Hash Join
-   Hash Cond: (w1.a = w2.d)
+ Merge Join
+   Merge Cond: (w2.d = w1.a)
    CTE w
      ->  Custom Scan (ColumnarScan) on full_correlated
            Columnar Projected Columns: a, b, c, d
-   ->  CTE Scan on w w1
-   ->  Hash
+   ->  Sort
+         Sort Key: w2.d
          ->  CTE Scan on w w2
                Filter: (a = 123)
-(9 rows)
+   ->  Materialize
+         ->  Sort
+               Sort Key: w1.a
+               ->  CTE Scan on w w1
+(13 rows)
 
 -- use index
 EXPLAIN (COSTS OFF) WITH w AS NOT MATERIALIZED (SELECT * FROM full_correlated)

--- a/src/test/regress/expected/multi_test_helpers.out
+++ b/src/test/regress/expected/multi_test_helpers.out
@@ -585,3 +585,23 @@ BEGIN
     RETURN NEXT;
   END LOOP;
 END; $$ language plpgsql;
+-- This function formats EXPLAIN output to conform to how pg <= 16 EXPLAIN
+-- shows ANY <subquery> in an expression the pg version >= 17. When 17 is
+-- the minimum supported pgversion this function can be retired. The commit
+-- that changed how ANY <subquery> exrpressions appear in EXPLAIN is:
+-- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=fd0398fcb
+CREATE OR REPLACE FUNCTION explain_with_pg16_subplan_format(explain_command text, out query_plan text)
+RETURNS SETOF TEXT AS $$
+DECLARE
+  pgversion int = 0;
+BEGIN
+  pgversion = substring(version(), '\d+')::int ;
+  FOR query_plan IN execute explain_command LOOP
+    IF pgversion >= 17 THEN
+      IF query_plan ~ 'SubPlan \d+\).col' THEN
+    	  query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (\d+)\).col1\)\)', '(SubPlan \1)', 'g');
+      END IF;
+    END IF;
+    RETURN NEXT;
+  END LOOP;
+END; $$ language plpgsql;

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -415,6 +415,7 @@ SELECT sum(a) FROM pushdown_test where (a > random() and a <= 2000) or (a > 2000
 SELECT sum(a) FROM pushdown_test where (a > random() and a <= 2000) or (a > 200000-1010);
 
 SET hash_mem_multiplier = 1.0;
+SELECT public.explain_with_pg16_subplan_format($Q$
 EXPLAIN (analyze on, costs off, timing off, summary off)
 SELECT sum(a) FROM pushdown_test where
 (
@@ -427,6 +428,7 @@ SELECT sum(a) FROM pushdown_test where
 )
 or
 (a > 200000-2010);
+$Q$) as "QUERY PLAN";
 RESET hash_mem_multiplier;
 SELECT sum(a) FROM pushdown_test where
 (

--- a/src/test/regress/sql/columnar_paths.sql
+++ b/src/test/regress/sql/columnar_paths.sql
@@ -1,6 +1,12 @@
 CREATE SCHEMA columnar_paths;
 SET search_path TO columnar_paths;
 
+-- columnar_paths has an alternative test output file because PG17 improved
+-- the optimizer's ability to use statistics to estimate the size of a CTE
+-- scan. 
+-- The relevant PG commit is:
+-- https://github.com/postgres/postgres/commit/f7816aec23eed1dc1da5f9a53cb6507d30b7f0a2
+
 CREATE TABLE full_correlated (a int, b text, c int, d int) USING columnar;
 INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000000) i;
 CREATE INDEX full_correlated_btree ON full_correlated (a);

--- a/src/test/regress/sql/multi_test_helpers.sql
+++ b/src/test/regress/sql/multi_test_helpers.sql
@@ -611,3 +611,24 @@ BEGIN
     RETURN NEXT;
   END LOOP;
 END; $$ language plpgsql;
+
+-- This function formats EXPLAIN output to conform to how pg <= 16 EXPLAIN 
+-- shows ANY <subquery> in an expression the pg version >= 17. When 17 is
+-- the minimum supported pgversion this function can be retired. The commit  
+-- that changed how ANY <subquery> exrpressions appear in EXPLAIN is:
+-- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=fd0398fcb
+CREATE OR REPLACE FUNCTION explain_with_pg16_subplan_format(explain_command text, out query_plan text)
+RETURNS SETOF TEXT AS $$
+DECLARE
+  pgversion int = 0;
+BEGIN
+  pgversion = substring(version(), '\d+')::int ;
+  FOR query_plan IN execute explain_command LOOP
+    IF pgversion >= 17 THEN
+      IF query_plan ~ 'SubPlan \d+\).col' THEN
+    	  query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (\d+)\).col1\)\)', '(SubPlan \1)', 'g');
+      END IF;
+    END IF;
+    RETURN NEXT;
+  END LOOP;
+END; $$ language plpgsql;


### PR DESCRIPTION
This PR fixes diffs in `columnnar_chunk_filtering` and `columnar_paths` tests. 

In `columnnar_chunk_filtering` an expression `(NOT (SubPlan 1))` changed to `(NOT (ANY (a = (SubPlan 1).col1)))`. This is due to [aPG17 commit](https://github.com/postgres/postgres/commit/fd0398fc) that improved how scalar subqueries (InitPlans) and ANY subqueries (SubPlans) are EXPLAINed in expressions. The fix uses a helper function which converts the PG17 format to the pre-PG17 format. It is done this way because pre-PG17 EXPLAIN does not provide enough context to convert to the PG17 format. The helper function can (and should) be retired when 17 becomes the minimum supported PG.

In `columnar_paths`, a merge join changed to a hash join. This is due to [this PG17 commit](https://github.com/postgres/postgres/commit/f7816aec23eed1dc1da5f9a53cb6507d30b7f0a2), which improved the PG optimizer's ability to estimate the size of a CTE scan. The impacted query involves a CTE scan with a point predicate `(a=123)` and before the change the CTE size was estimated to be 5000, but with the change it is correctly (given the data in the table) estimated to be 1, making hash join a more attractive join method. The fix is to have an alternative goldfile for pre-PG17. I tried, but was unable, to force a specific kind of join method using the GUCs (`enable_nestloop`, `enable_hashjoin`, `enable_mergejoin`), but it was not possible to obtain a consistent plan across all supported PG versions (in some cases the join inputs switched sides).