### PR TITLE
PG17 compatibility: account for MAINTAIN privilege in regress tests

### DIFF
--- a/src/backend/distributed/deparser/citus_ruleutils.c
+++ b/src/backend/distributed/deparser/citus_ruleutils.c
@@ -1359,6 +1359,10 @@ convert_aclright_to_string(int aclright)
 			return "TEMPORARY";
 		case ACL_CONNECT:
 			return "CONNECT";
+#if PG_VERSION_NUM >= PG_VERSION_17
+		case ACL_MAINTAIN:
+			return "MAINTAIN";
+#endif
 		default:
 			elog(ERROR, "unrecognized aclright: %d", aclright);
 			return NULL;

--- a/src/test/regress/expected/multi_multiuser_master_protocol_0.out
+++ b/src/test/regress/expected/multi_multiuser_master_protocol_0.out
@@ -24,8 +24,6 @@ SELECT * FROM master_get_table_ddl_events('lineitem') order by 1;
  GRANT DELETE ON public.lineitem TO postgres
  GRANT INSERT ON public.lineitem TO full_access
  GRANT INSERT ON public.lineitem TO postgres
- GRANT MAINTAIN ON public.lineitem TO full_access
- GRANT MAINTAIN ON public.lineitem TO postgres
  GRANT REFERENCES ON public.lineitem TO full_access
  GRANT REFERENCES ON public.lineitem TO postgres
  GRANT SELECT ON public.lineitem TO full_access
@@ -38,7 +36,7 @@ SELECT * FROM master_get_table_ddl_events('lineitem') order by 1;
  GRANT UPDATE ON public.lineitem TO full_access
  GRANT UPDATE ON public.lineitem TO postgres
  REVOKE ALL ON public.lineitem FROM PUBLIC
-(22 rows)
+(20 rows)
 
 SELECT * FROM master_get_new_shardid();
  master_get_new_shardid
@@ -82,9 +80,8 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO postgres
  GRANT REFERENCES ON public.checkperm TO postgres
  GRANT TRIGGER ON public.checkperm TO postgres
- GRANT MAINTAIN ON public.checkperm TO postgres
  ALTER TABLE public.checkperm OWNER TO postgres
-(11 rows)
+(10 rows)
 
 GRANT SELECT ON checkperm TO read_access;
 GRANT ALL ON checkperm TO full_access;
@@ -100,7 +97,6 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO postgres
  GRANT REFERENCES ON public.checkperm TO postgres
  GRANT TRIGGER ON public.checkperm TO postgres
- GRANT MAINTAIN ON public.checkperm TO postgres
  GRANT SELECT ON public.checkperm TO read_access
  GRANT INSERT ON public.checkperm TO full_access
  GRANT SELECT ON public.checkperm TO full_access
@@ -109,9 +105,8 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO full_access
  GRANT REFERENCES ON public.checkperm TO full_access
  GRANT TRIGGER ON public.checkperm TO full_access
- GRANT MAINTAIN ON public.checkperm TO full_access
  ALTER TABLE public.checkperm OWNER TO postgres
-(20 rows)
+(18 rows)
 
 REVOKE ALL ON checkperm FROM read_access;
 GRANT SELECT ON checkperm TO PUBLIC;
@@ -127,7 +122,6 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO postgres
  GRANT REFERENCES ON public.checkperm TO postgres
  GRANT TRIGGER ON public.checkperm TO postgres
- GRANT MAINTAIN ON public.checkperm TO postgres
  GRANT INSERT ON public.checkperm TO full_access
  GRANT SELECT ON public.checkperm TO full_access
  GRANT UPDATE ON public.checkperm TO full_access
@@ -135,10 +129,9 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO full_access
  GRANT REFERENCES ON public.checkperm TO full_access
  GRANT TRIGGER ON public.checkperm TO full_access
- GRANT MAINTAIN ON public.checkperm TO full_access
  GRANT SELECT ON public.checkperm TO PUBLIC
  ALTER TABLE public.checkperm OWNER TO postgres
-(20 rows)
+(18 rows)
 
 GRANT ALL ON checkperm TO full_access WITH GRANT OPTION;
 SELECT * FROM master_get_table_ddl_events('checkperm');
@@ -153,7 +146,6 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO postgres
  GRANT REFERENCES ON public.checkperm TO postgres
  GRANT TRIGGER ON public.checkperm TO postgres
- GRANT MAINTAIN ON public.checkperm TO postgres
  GRANT INSERT ON public.checkperm TO full_access WITH GRANT OPTION
  GRANT SELECT ON public.checkperm TO full_access WITH GRANT OPTION
  GRANT UPDATE ON public.checkperm TO full_access WITH GRANT OPTION
@@ -161,10 +153,9 @@ SELECT * FROM master_get_table_ddl_events('checkperm');
  GRANT TRUNCATE ON public.checkperm TO full_access WITH GRANT OPTION
  GRANT REFERENCES ON public.checkperm TO full_access WITH GRANT OPTION
  GRANT TRIGGER ON public.checkperm TO full_access WITH GRANT OPTION
- GRANT MAINTAIN ON public.checkperm TO full_access WITH GRANT OPTION
  GRANT SELECT ON public.checkperm TO PUBLIC
  ALTER TABLE public.checkperm OWNER TO postgres
-(20 rows)
+(18 rows)
 
 -- create table as superuser/postgres
 CREATE TABLE trivial_postgres (id int);
@@ -186,10 +177,10 @@ SELECT create_distributed_table('trivial_full_access', 'id', 'append');
 
 RESET ROLE;
 SELECT relname, rolname, relacl FROM pg_class JOIN pg_roles ON (pg_roles.oid = pg_class.relowner) WHERE relname LIKE 'trivial%' ORDER BY relname;
-       relname       |   rolname   |                           relacl
+       relname       |   rolname   |                          relacl
 ---------------------------------------------------------------------
  trivial_full_access | full_access |
- trivial_postgres    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
+ trivial_postgres    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
 (2 rows)
 
 SET citus.shard_replication_factor = 2; -- on all workers...
@@ -236,26 +227,26 @@ SELECT master_create_empty_shard('trivial_full_access');
 RESET ROLE;
 \c - - - :worker_1_port
 SELECT relname, rolname, relacl FROM pg_class JOIN pg_roles ON (pg_roles.oid = pg_class.relowner) WHERE relname LIKE 'trivial%' ORDER BY relname;
-          relname           |   rolname   |                           relacl
+          relname           |   rolname   |                          relacl
 ---------------------------------------------------------------------
  trivial_full_access_109081 | full_access |
  trivial_full_access_109083 | full_access |
  trivial_full_access_109085 | full_access |
- trivial_postgres_109080    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
- trivial_postgres_109082    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
- trivial_postgres_109084    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
+ trivial_postgres_109080    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
+ trivial_postgres_109082    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
+ trivial_postgres_109084    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
 (6 rows)
 
 \c - - - :worker_2_port
 SELECT relname, rolname, relacl FROM pg_class JOIN pg_roles ON (pg_roles.oid = pg_class.relowner) WHERE relname LIKE 'trivial%' ORDER BY relname;
-          relname           |   rolname   |                           relacl
+          relname           |   rolname   |                          relacl
 ---------------------------------------------------------------------
  trivial_full_access_109081 | full_access |
  trivial_full_access_109083 | full_access |
  trivial_full_access_109085 | full_access |
- trivial_postgres_109080    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
- trivial_postgres_109082    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
- trivial_postgres_109084    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
+ trivial_postgres_109080    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
+ trivial_postgres_109082    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
+ trivial_postgres_109084    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
 (6 rows)
 
 \c - - - :master_port

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -338,9 +338,6 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 
 RESET client_min_messages;
 RESET search_path;
-RESET citus.next_shard_id;
-RESET citus.shard_count;
-RESET citus.shard_replication_factor;
 DROP SCHEMA pg17_corr_subq_folding CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table pg17_corr_subq_folding.test
@@ -353,19 +350,19 @@ drop cascades to table pg17_corr_subq_folding.events
 -- PG17-specific tests go here.
 --
 CREATE SCHEMA pg17;
-SET search_path TO pg17;
+SET search_path to pg17;
 -- Test specifying access method on partitioned tables. PG17 feature, added by:
 -- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=374c7a229
 -- The following tests were failing tests in tableam but will pass on PG >= 17.
 -- There is some set-up duplication of tableam, and this test can be returned
 -- to tableam when 17 is the minimum supported PG version.
 SELECT public.run_command_on_coordinator_and_workers($Q$
-	SET citus.enable_ddl_propagation TO off;
-	CREATE FUNCTION fake_am_handler(internal)
-	RETURNS table_am_handler
-	AS 'citus'
-	LANGUAGE C;
-	CREATE ACCESS METHOD fake_am TYPE TABLE HANDLER fake_am_handler;
+        SET citus.enable_ddl_propagation TO off;
+        CREATE FUNCTION fake_am_handler(internal)
+        RETURNS table_am_handler
+        AS 'citus'
+        LANGUAGE C;
+        CREATE ACCESS METHOD fake_am TYPE TABLE HANDLER fake_am_handler;
 $Q$);
  run_command_on_coordinator_and_workers
 ---------------------------------------------------------------------
@@ -379,9 +376,9 @@ CREATE TABLE test_partitioned(id int, p int, val int)
 PARTITION BY RANGE (p) USING fake_am;
 -- Test that children inherit access method from parent
 CREATE TABLE test_partitioned_p1 PARTITION OF test_partitioned
-	FOR VALUES FROM (1) TO (10);
+        FOR VALUES FROM (1) TO (10);
 CREATE TABLE test_partitioned_p2 PARTITION OF test_partitioned
-	FOR VALUES FROM (11) TO (20);
+        FOR VALUES FROM (11) TO (20);
 INSERT INTO test_partitioned VALUES (1, 5, -1), (2, 15, -2);
 WARNING:  fake_tuple_insert
 WARNING:  fake_tuple_insert
@@ -416,10 +413,93 @@ ORDER BY c.relname;
  test_partitioned_p2 | fake_am
 (2 rows)
 
+-- Clean up
 DROP TABLE test_partitioned;
 ALTER EXTENSION citus DROP ACCESS METHOD fake_am;
+SELECT public.run_command_on_coordinator_and_workers($Q$
+        RESET citus.enable_ddl_propagation;
+$Q$);
+ run_command_on_coordinator_and_workers
+---------------------------------------------------------------------
+
+(1 row)
+
 -- End of testing specifying access method on partitioned tables.
+-- MAINTAIN privilege tests
+CREATE ROLE regress_maintain;
+CREATE ROLE regress_no_maintain;
+ALTER ROLE regress_maintain WITH login;
+GRANT USAGE ON SCHEMA pg17 TO regress_maintain;
+ALTER ROLE regress_no_maintain WITH login;
+GRANT USAGE ON SCHEMA pg17 TO regress_no_maintain;
+SET citus.shard_count TO 1; -- For consistent remote command logging
+CREATE TABLE dist_test(a int, b int);
+SELECT create_distributed_table('dist_test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist_test SELECT i % 10, i FROM generate_series(1, 100) t(i);
+SET citus.log_remote_commands TO on;
+SET citus.grep_remote_commands = '%maintain%';
+GRANT MAINTAIN ON dist_test TO regress_maintain;
+NOTICE:  issuing GRANT maintain ON dist_test TO regress_maintain
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing GRANT maintain ON dist_test TO regress_maintain
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT worker_apply_shard_ddl_command (20240023, 'pg17', 'GRANT maintain ON dist_test TO regress_maintain')
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+RESET citus.grep_remote_commands;
+SET ROLE regress_no_maintain;
+-- Current role does not have MAINTAIN privileges on dist_test
+ANALYZE dist_test;
+WARNING:  permission denied to analyze "dist_test", skipping it
+NOTICE:  issuing ANALYZE pg17.dist_test_20240023
+DETAIL:  on server regress_no_maintain@localhost:xxxxx connectionId: xxxxxxx
+VACUUM dist_test;
+WARNING:  permission denied to vacuum "dist_test", skipping it
+NOTICE:  issuing VACUUM pg17.dist_test_20240023
+DETAIL:  on server regress_no_maintain@localhost:xxxxx connectionId: xxxxxxx
+SET ROLE regress_maintain;
+-- Current role has MAINTAIN privileges on dist_test
+ANALYZE dist_test;
+NOTICE:  issuing ANALYZE pg17.dist_test_20240023
+DETAIL:  on server regress_maintain@localhost:xxxxx connectionId: xxxxxxx
+VACUUM dist_test;
+NOTICE:  issuing VACUUM pg17.dist_test_20240023
+DETAIL:  on server regress_maintain@localhost:xxxxx connectionId: xxxxxxx
+-- Take away regress_maintain's MAINTAIN privileges on dist_test
+RESET ROLE;
+SET citus.grep_remote_commands = '%maintain%';
+REVOKE MAINTAIN ON dist_test FROM regress_maintain;
+NOTICE:  issuing REVOKE maintain ON dist_test FROM regress_maintain
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing REVOKE maintain ON dist_test FROM regress_maintain
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing SELECT worker_apply_shard_ddl_command (20240023, 'pg17', 'REVOKE maintain ON dist_test FROM regress_maintain')
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+RESET citus.grep_remote_commands;
+SET ROLE regress_maintain;
+-- Current role does not have MAINTAIN privileges on dist_test
+ANALYZE dist_test;
+WARNING:  permission denied to analyze "dist_test", skipping it
+NOTICE:  issuing ANALYZE pg17.dist_test_20240023
+DETAIL:  on server regress_maintain@localhost:xxxxx connectionId: xxxxxxx
+VACUUM dist_test;
+WARNING:  permission denied to vacuum "dist_test", skipping it
+NOTICE:  issuing VACUUM pg17.dist_test_20240023
+DETAIL:  on server regress_maintain@localhost:xxxxx connectionId: xxxxxxx
+RESET ROLE;
+-- End of MAINTAIN privilege tests
+RESET citus.log_remote_commands;
+RESET citus.next_shard_id;
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;
 DROP SCHEMA pg17 CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function fake_am_handler(internal)
 drop cascades to access method fake_am
+drop cascades to table dist_test
+DROP ROLE regress_maintain;
+DROP ROLE regress_no_maintain;

--- a/src/test/regress/expected/pg17_0.out
+++ b/src/test/regress/expected/pg17_0.out
@@ -282,9 +282,6 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 
 RESET client_min_messages;
 RESET search_path;
-RESET citus.next_shard_id;
-RESET citus.shard_count;
-RESET citus.shard_replication_factor;
 DROP SCHEMA pg17_corr_subq_folding CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table pg17_corr_subq_folding.test

--- a/src/test/regress/sql/multi_multiuser_master_protocol.sql
+++ b/src/test/regress/sql/multi_multiuser_master_protocol.sql
@@ -2,6 +2,12 @@
 -- MULTI_MULTIUSER_MASTER_PROTOCOL
 --
 
+-- Test multi_multiuser_master_protocol has an alternative output file because
+-- PG17's support for the MAINTAIN privilege:
+-- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=ecb0fd337
+-- means that calls of master_get_table_ddl_events() can show MAINTAIN and the
+-- pg_class.relacl column may have 'm' for MAINTAIN
+
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 109079;
 
 -- Tests that check the metadata returned by the master node. At the


### PR DESCRIPTION
This PR addresses regress tests impacted by the introduction of [the MAINTAIN privilege in PG17](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=ecb0fd337). The impacted tests include `generated_identity`, `create_single_shard_table`, `grant_on_sequence_propagation`, `grant_on_foreign_server_propagation`, `single_node_enterprise`, `multi_multiuser_master_protocol`, `multi_alter_table_row_level_security`, `shard_move_constraints` which show the following error:
```
SELECT start_metadata_sync_to_node('localhost', :worker_2_port);
- start_metadata_sync_to_node
----------------------------------------------------------------------
-
-(1 row)
-
+ERROR:  unrecognized aclright: 16384
```

and `multi_multiuser_master_protocol`, where the `pg_class.relacl` column has 'm' for MAINTAIN if applicable:
```
        relname       |   rolname   |                           relacl                           
 ---------------------+-------------+------------------------------------------------------------
  trivial_full_access | full_access | 
- trivial_postgres    | postgres    | {postgres=arwdDxt/postgres,full_access=arwdDxt/postgres}
+ trivial_postgres    | postgres    | {postgres=arwdDxtm/postgres,full_access=arwdDxtm/postgres}
```

The PR updates function `convert_aclright_to_string()` in citus_ruleutils.c to include a case for `ACL_MAINTAIN`. Per the comment on `convert_aclright_to_string()` in citus_ruleutils.c, it is a copy of `convert_aclright_to_string()` in Postgres (where it is in `src/backend/utils/adt/acl.c`), so requires updating to be consistent with Postgres. With this change Citus can recognize the MAINTAIN privilege, and will not emit the `unrecognized aclright` error. The PR also adds an alternative goldfile for `multi_multiuser_master_protocol`.

Note that `convert_aclright_to_string()` in Postgres includes access types SET and ALTER SYSTEM on system parameters (aka GUCs), added by [this PG16 commit](https://github.com/postgres/postgres/commit/a0ffa885e). If Citus were to have a requirement to support granting SET and ALTER SYSTEM we would need to update `convert_aclright_to_string()` in citus_ruleutils.c with SET and ALTER SYSTEM.

