### PR TITLE
Fix bug: alter database shouldn't propagate for undistributed database

### DIFF
--- a/src/test/regress/expected/alter_database_propagation.out
+++ b/src/test/regress/expected/alter_database_propagation.out
@@ -33,4 +33,11 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 -- this statement will get error since we don't have a multiple database support for now
 alter database regression rename to regression2;
 ERROR:  current database cannot be renamed
+-- this database is not distributed so we will not see any remote commands
+CREATE DATABASE db_to_test;
+NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
+DETAIL:  Citus does not propagate CREATE DATABASE command to workers
+HINT:  You can manually create a database and its extensions on workers.
+alter database db_to_test with CONNECTION LIMIT 100;
+DROP DATABASE db_to_test;
 set citus.log_remote_commands = false;

--- a/src/test/regress/sql/alter_database_propagation.sql
+++ b/src/test/regress/sql/alter_database_propagation.sql
@@ -15,4 +15,9 @@ alter database regression with IS_TEMPLATE false;
 -- this statement will get error since we don't have a multiple database support for now
 alter database regression rename to regression2;
 
+-- this database is not distributed so we will not see any remote commands
+CREATE DATABASE db_to_test;
+alter database db_to_test with CONNECTION LIMIT 100;
+DROP DATABASE db_to_test;
+
 set citus.log_remote_commands = false;


### PR DESCRIPTION
Before this fix, the following would happen for a database that is not distributed:

```sql
CREATE DATABASE db_to_test;
NOTICE:  Citus partially supports CREATE DATABASE for distributed databases
DETAIL:  Citus does not propagate CREATE DATABASE command to workers
HINT:  You can manually create a database and its extensions on workers.

ALTER DATABASE db_to_test with CONNECTION LIMIT 100;
NOTICE:  issuing ALTER DATABASE db_to_test WITH  CONNECTION LIMIT 100;
DETAIL:  on server postgres@localhost:57638 connectionId: 2
NOTICE:  issuing ALTER DATABASE db_to_test WITH  CONNECTION LIMIT 100;
DETAIL:  on server postgres@localhost:57637 connectionId: 1
ERROR:  database "db_to_test" does not exist
```

With this fix, we also take care of https://github.com/citusdata/citus/issues/7763

Fixes #7763 
