### PR TITLE
PG17 compatibility: ensure get_progress() output is consistent

### DIFF
--- a/src/test/regress/expected/isolation_progress_monitoring.out
+++ b/src/test/regress/expected/isolation_progress_monitoring.out
@@ -70,21 +70,21 @@ step s3-start-operation:
  SELECT sample_operation(3778, 30, 9);
  <waiting ...>
 step show-progress: 
- SELECT show_progress(1337);
- SELECT show_progress(3778);
+ SELECT step, progress FROM show_progress(1337) ORDER BY 1, 2;
+ SELECT step, progress FROM show_progress(3778) ORDER BY 1, 2;
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,0)
-(1,0)
-(0,0)
-(1,0)
+   0|       0
+   0|       0
+   1|       0
+   1|       0
 (4 rows)
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,0)
-(1,0)
+   0|       0
+   1|       0
 (2 rows)
 
 step release-locks-1:
@@ -109,21 +109,21 @@ t
 (1 row)
 
 step show-progress:
- SELECT show_progress(1337);
- SELECT show_progress(3778);
+ SELECT step, progress FROM show_progress(1337) ORDER BY 1, 2;
+ SELECT step, progress FROM show_progress(3778) ORDER BY 1, 2;
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,-1)
-(1,0)
-(0,2)
-(1,0)
+   0|      -1
+   0|       2
+   1|       0
+   1|       0
 (4 rows)
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,9)
-(1,0)
+   0|       9
+   1|       0
 (2 rows)
 
 step release-locks-2:
@@ -148,21 +148,21 @@ t
 (1 row)
 
 step show-progress:
- SELECT show_progress(1337);
- SELECT show_progress(3778);
+ SELECT step, progress FROM show_progress(1337) ORDER BY 1, 2;
+ SELECT step, progress FROM show_progress(3778) ORDER BY 1, 2;
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,-1)
-(1,-1)
-(0,2)
-(1,2)
+   0|      -1
+   0|       2
+   1|      -1
+   1|       2
 (4 rows)
 
-show_progress
+step|progress
 ---------------------------------------------------------------------
-(0,9)
-(1,9)
+   0|       9
+   1|       9
 (2 rows)
 
 step release-locks-3:

--- a/src/test/regress/spec/isolation_progress_monitoring.spec
+++ b/src/test/regress/spec/isolation_progress_monitoring.spec
@@ -126,8 +126,8 @@ session "monitor"
 
 step "show-progress"
 {
-	SELECT show_progress(1337);
-	SELECT show_progress(3778);
+	SELECT step, progress FROM show_progress(1337) ORDER BY 1, 2;
+	SELECT step, progress FROM show_progress(3778) ORDER BY 1, 2;
 }
 
 permutation "take-locks" "s1-start-operation" "s2-start-operation" "s3-start-operation" "show-progress" "release-locks-1" "show-progress" "release-locks-2" "show-progress" "release-locks-3"


### PR DESCRIPTION
in regress test isolation_progress_monitoring, with an ORDER BY. The implementation of get_progress() uses a tuplestore to hold the step and progress values, and tuplestore does not provide any guarantee on the ordering of the tuples so ORDER BY ensures stable test output. Also make the output more user friendly by including the column names. Fixing occasional failures seen in isolation_progress_monitoring.

![Screenshot (86)](https://github.com/user-attachments/assets/a019639f-559f-408d-b8a8-8b7a44d8095d)

