### PR TITLE
Raise an ERROR instead of causing a crash when backend data is not init

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -855,6 +855,16 @@ GetCurrentDistributedTransactionId(void)
 void
 AssignDistributedTransactionId(void)
 {
+	/*
+	 * MyBackendData should always be available. However, we observed some
+	 * crashes where certain hooks were not executed.
+	 * Bug 3697586: Server crashes when assigning distributed transaction
+	 */
+	if (!MyBackendData)
+	{
+		ereport(ERROR, (errmsg("backend is not ready for distributed transactions")));
+	}
+
 	pg_atomic_uint64 *transactionNumberSequence =
 		&backendManagementShmemData->nextTransactionNumber;
 


### PR DESCRIPTION
DESCRIPTION: Avoids a crash that could happen if another extension breaks auth-hook chain.

[Bug 3697586](https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/3697586): Server crashes when assigning distributed transaction
 
There is a bug in the Azure extension's auth hook not calling the Citus auth hook (which we already fixed), which caused the uninitialized `MyBackendData`. However, we should add this check in AssignDistributedTransactionId as an extra protection to prevent crashing with a segmentation fault (SEGV).

We already have such checks in `assign_distributed_transaction_id`

<img width="644" alt="image" src="https://github.com/user-attachments/assets/2f4b5966-8c08-4d6f-b182-ebebb18c94c2" />
