### PR TITLE
Add tests for inserting with AT LOCAL operator

### DIFF
--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -1417,6 +1417,42 @@ DROP TABLE test_local_table_expr CASCADE;
 DROP TABLE test_distributed_table_expr CASCADE;
 DROP TABLE test_partitioned_expr CASCADE;
 -- End of Test for ALTER TABLE ... ALTER COLUMN ... SET EXPRESSION
+RESET citus.grep_remote_commands;
+RESET citus.log_remote_commands;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 27122024;
+-- PG17 has added support for AT LOCAL operator
+-- it converts the given time type to
+-- time stamp with the session's TimeZone value as time zone.
+-- Here we add tests that validate that we can use AT LOCAL at INSERT commands
+-- Relevant PG commit:
+-- https://github.com/postgres/postgres/commit/97957fdba
+CREATE TABLE test_at_local (id int, time_example timestamp with time zone);
+SELECT create_distributed_table('test_at_local', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+BEGIN;
+SET LOCAL TimeZone TO 'Europe/Tirane';
+SELECT timestamp '2001-02-16 20:38:40' AT LOCAL;
+           timezone
+---------------------------------------------------------------------
+ Fri Feb 16 20:38:40 2001 CET
+(1 row)
+
+-- verify that we evaluate AT LOCAL at the coordinator and then perform the insert remotely
+SET citus.log_remote_commands TO on;
+INSERT INTO test_at_local VALUES (1, timestamp '2001-02-16 20:38:40' AT LOCAL);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing INSERT INTO pg17.test_at_local_27122024 (id, time_example) VALUES (1, 'Fri Feb 16 20:38:40 2001 CET'::timestamp with time zone)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+ROLLBACK;
+NOTICE:  issuing ROLLBACK
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+-- End of Testing AT LOCAL option
 \set VERBOSITY terse
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg17 CASCADE;


### PR DESCRIPTION
PG17 has added support for AT LOCAL operator
it converts the given time type to
time stamp with the session's TimeZone value as time zone. Here we add tests that validate that we can use AT LOCAL at INSERT commands

Relevant PG commit:
https://github.com/postgres/postgres/commit/97957fdba

With the tests, we verify that we evaluate AT LOCAL at the coordinator and then perform the insert remotely.