### PR TITLE
Allow configuring sslnegotiation using citus.node_conn_info

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2905,6 +2905,9 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 		"sslcrl",
 		"sslkey",
 		"sslmode",
+#if PG_VERSION_NUM >= PG_VERSION_17
+		"sslnegotiation",
+#endif
 		"sslrootcert",
 		"tcp_user_timeout",
 	};


### PR DESCRIPTION
Relevant PG commit:
https://github.com/postgres/postgres/commit/d39a49c1e

PR similar to https://github.com/citusdata/citus/pull/5203
