### PR TITLE
Add tests with xmltext() and random(min, max)

### DIFF
--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -1519,6 +1519,93 @@ SELECT sample, sample::jsonpath FROM samples ORDER BY id;
 (13 rows)
 
 -- End of testing jsonpath methods
+-- xmltext() function added in PG17, test with columnar and distributed table
+-- Relevant PG17 commit: https://github.com/postgres/postgres/commit/526fe0d79
+CREATE TABLE test_xml (id int, a xml) USING columnar;
+-- expected to insert x&lt;P&gt;73&lt;/P&gt;0.42truej
+INSERT INTO test_xml VALUES (1, xmltext('x'|| '<P>73</P>'::xml || .42 || true || 'j'::char));
+SELECT * FROM test_xml ORDER BY 1;
+ id |                a
+---------------------------------------------------------------------
+  1 | x&lt;P&gt;73&lt;/P&gt;0.42truej
+(1 row)
+
+SELECT create_distributed_table('test_xml', 'id');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$pg17.test_xml$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- expected to insert foo &amp; &lt;&quot;bar&quot;&gt;
+INSERT INTO test_xml VALUES (2, xmltext('foo & <"bar">'));
+SELECT * FROM test_xml ORDER BY 1;
+ id |                 a
+---------------------------------------------------------------------
+  1 | x&lt;P&gt;73&lt;/P&gt;0.42truej
+  2 | foo &amp; &lt;&quot;bar&quot;&gt;
+(2 rows)
+
+-- end of xmltest() testing with Citus
+--
+-- random(min, max) to generate random numbers in a specified range
+-- adding here the same tests as the ones with random() in aggregate_support.sql
+-- Relevant PG commit: https://github.com/postgres/postgres/commit/e6341323a
+--
+CREATE TABLE dist_table (dist_col int, agg_col numeric);
+SELECT create_distributed_table('dist_table', 'dist_col');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE ref_table (int_col int);
+SELECT create_reference_table('ref_table');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Test the cases where the worker agg exec. returns no tuples.
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random(0, 1) FROM dist_table) a;
+ percentile_disc
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT PERCENTILE_DISC((2 > random(0, 1))::int::numeric / 10)
+       WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ percentile_disc
+---------------------------------------------------------------------
+
+(1 row)
+
+-- run the same queries after loading some data
+INSERT INTO dist_table VALUES (2, 11.2), (3, NULL), (6, 3.22), (3, 4.23), (5, 5.25),
+                              (4, 63.4), (75, NULL), (80, NULL), (96, NULL), (8, 1078), (0, 1.19);
+SELECT PERCENTILE_DISC(.25) WITHIN GROUP (ORDER BY agg_col)
+FROM (SELECT *, random(0, 1) FROM dist_table) a;
+ percentile_disc
+---------------------------------------------------------------------
+            3.22
+(1 row)
+
+SELECT PERCENTILE_DISC((2 > random_normal(0, 1))::int::numeric / 10)
+       WITHIN GROUP (ORDER BY agg_col)
+FROM dist_table
+LEFT JOIN ref_table ON TRUE;
+ percentile_disc
+---------------------------------------------------------------------
+            1.19
+(1 row)
+
+-- End of random(min, max) testing with Citus
 \set VERBOSITY terse
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg17 CASCADE;


### PR DESCRIPTION
xmltext() converts text into xml text nodes.
Test with columnar and citus tables.
Relevant PG17 commit:
https://github.com/postgres/postgres/commit/526fe0d79

random(min, max) generates random numbers in a specified range Add tests like the ones for random() in aggregate_support.sql References:
https://github.com/citusdata/citus/blob/main/src/test/regress/sql/aggregate_support.sql#L493-L532 
https://github.com/citusdata/citus/pull/7183
Relevant PG17 commit:
https://github.com/postgres/postgres/commit/e6341323a
