### PR TITLE
Bump pg versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ USER citus
 
 # build postgres versions separately for effective parrallelism and caching of already built versions when changing only certain versions
 FROM base AS pg14
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.14
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.15
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -80,7 +80,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg15
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.9
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.10
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -92,7 +92,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg16
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.5
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.6
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -211,7 +211,7 @@ COPY --chown=citus:citus .psqlrc .
 RUN sudo chown --from=root:root citus:citus -R ~
 
 # sets default pg version
-RUN pgenv switch 16.5
+RUN pgenv switch 16.6
 
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -13,15 +13,3 @@ runs:
       token: ${{ inputs.codecov_token }}
       verbose: true
       gcov: true
-  - name: Create codeclimate coverage
-    run: |-
-      lcov --directory . --capture --output-file lcov.info
-      lcov --remove lcov.info -o lcov.info '/usr/*'
-      sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
-      mkdir -p /tmp/codeclimate
-      cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/${{ inputs.flags }}.json lcov.info
-    shell: bash
-  - uses: actions/upload-artifact@v3.1.1
-    with:
-      path: "/tmp/codeclimate/*.json"
-      name: codeclimate

--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -13,3 +13,15 @@ runs:
       token: ${{ inputs.codecov_token }}
       verbose: true
       gcov: true
+  - name: Create codeclimate coverage
+    run: |-
+      lcov --directory . --capture --output-file lcov.info
+      lcov --remove lcov.info -o lcov.info '/usr/*'
+      sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
+      mkdir -p /tmp/codeclimate
+      cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/${{ inputs.flags }}.json lcov.info
+    shell: bash
+  - uses: actions/upload-artifact@v3.1.1
+    with:
+      path: "/tmp/codeclimate/*.json"
+      name: codeclimate

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -237,11 +237,11 @@ jobs:
       if: always()
       with:
         folder: ${{ fromJson(matrix.pg_version).major }}_${{ matrix.make }}
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    # - uses: "./.github/actions/upload_coverage"
+    #   if: always()
+    #   with:
+    #     flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
+    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-arbitrary-configs:
     name: PG${{ fromJson(matrix.pg_version).major }} - check-arbitrary-configs-${{ matrix.parallel }}
     runs-on: ["self-hosted", "1ES.Pool=1es-gha-citusdata-pool"]
@@ -284,11 +284,11 @@ jobs:
             check-arbitrary-configs parallel=4 CONFIGS=$TESTS
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.pg_major }}_upgrade
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    # - uses: "./.github/actions/upload_coverage"
+    #   if: always()
+    #   with:
+    #     flags: ${{ env.pg_major }}_upgrade
+    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade
     runs-on: ubuntu-20.04
@@ -335,11 +335,11 @@ jobs:
       if: failure()
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    # - uses: "./.github/actions/upload_coverage"
+    #   if: always()
+    #   with:
+    #     flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
+    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-upgrade:
     name: PG${{ fromJson(needs.params.outputs.pg14_version).major }} - check-citus-upgrade
     runs-on: ubuntu-20.04
@@ -380,11 +380,11 @@ jobs:
         done;
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.pg_major }}_upgrade
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    # - uses: "./.github/actions/upload_coverage"
+    #   if: always()
+    #   with:
+    #     flags: ${{ env.pg_major }}_upgrade
+    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
   upload-coverage:
     if: always()
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -237,11 +237,11 @@ jobs:
       if: always()
       with:
         folder: ${{ fromJson(matrix.pg_version).major }}_${{ matrix.make }}
-    # - uses: "./.github/actions/upload_coverage"
-    #   if: always()
-    #   with:
-    #     flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
-    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-arbitrary-configs:
     name: PG${{ fromJson(matrix.pg_version).major }} - check-arbitrary-configs-${{ matrix.parallel }}
     runs-on: ["self-hosted", "1ES.Pool=1es-gha-citusdata-pool"]
@@ -284,11 +284,11 @@ jobs:
             check-arbitrary-configs parallel=4 CONFIGS=$TESTS
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    # - uses: "./.github/actions/upload_coverage"
-    #   if: always()
-    #   with:
-    #     flags: ${{ env.pg_major }}_upgrade
-    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.pg_major }}_upgrade
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade
     runs-on: ubuntu-20.04
@@ -335,11 +335,11 @@ jobs:
       if: failure()
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    # - uses: "./.github/actions/upload_coverage"
-    #   if: always()
-    #   with:
-    #     flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
-    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-upgrade:
     name: PG${{ fromJson(needs.params.outputs.pg14_version).major }} - check-citus-upgrade
     runs-on: ubuntu-20.04
@@ -380,11 +380,11 @@ jobs:
         done;
     - uses: "./.github/actions/save_logs_and_results"
       if: always()
-    # - uses: "./.github/actions/upload_coverage"
-    #   if: always()
-    #   with:
-    #     flags: ${{ env.pg_major }}_upgrade
-    #     codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.pg_major }}_upgrade
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   upload-coverage:
     if: always()
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-20e585f"
+      image_suffix: "-dev-e142363"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-fda4e33"
+      image_suffix: "-dev-889e4c1"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-5779674"
+      image_suffix: "-v5779674"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-8b26747"
+      image_suffix: "-dev-278c385"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,9 @@ on:
         default: false
         type: boolean
   push:
+    branches:
+      - "main"
+      - "release-*"
   pull_request:
     types: [opened, reopened,synchronize]
   merge_group:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -385,6 +385,28 @@ jobs:
       with:
         flags: ${{ env.pg_major }}_upgrade
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
+  upload-coverage:
+    if: always()
+    env:
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+    runs-on: ubuntu-20.04
+    container:
+      image: ${{ needs.params.outputs.test_image_name }}:${{ fromJson(needs.params.outputs.pg16_version).full }}${{ needs.params.outputs.image_suffix }}
+    needs:
+      - params
+      - test-citus
+      - test-arbitrary-configs
+      - test-citus-upgrade
+      - test-pg-upgrade
+    steps:
+      - uses: actions/download-artifact@v3.0.1
+        with:
+          name: "codeclimate"
+          path: "codeclimate"
+      - name: Upload coverage results to Code Climate
+        run: |-
+          cc-test-reporter sum-coverage codeclimate/*.json -o total.json
+          cc-test-reporter upload-coverage -i total.json
   ch_benchmark:
     name: CH Benchmark
     if: startsWith(github.ref, 'refs/heads/ch_benchmark/')

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,11 +32,11 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-c31f6f8"
+      image_suffix: "-dev-2070de5"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'
-      upgrade_pg_versions: "14.15-15.10-16.6-17.2"
+      upgrade_pg_versions: "14.15-15.10-16.6"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-278c385"
+      image_suffix: "-dev-8c38fe2"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,12 +31,12 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
-      sql_snapshot_pg_version: "16.5"
-      image_suffix: "-v1d9d7d7"
-      pg14_version: '{ "major": "14", "full": "14.14" }'
-      pg15_version: '{ "major": "15", "full": "15.9" }'
-      pg16_version: '{ "major": "16", "full": "16.5" }'
-      upgrade_pg_versions: "14.14-15.9-16.5"
+      sql_snapshot_pg_version: "16.6"
+      image_suffix: "-dev-e142363"
+      pg14_version: '{ "major": "14", "full": "14.15" }'
+      pg15_version: '{ "major": "15", "full": "15.10" }'
+      pg16_version: '{ "major": "16", "full": "16.6" }'
+      upgrade_pg_versions: "14.15-15.10-16.6"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,8 +111,6 @@ jobs:
           - ${{ needs.params.outputs.image_suffix}}
         pg_version:
           - ${{ needs.params.outputs.pg14_version }}
-          - ${{ needs.params.outputs.pg15_version }}
-          - ${{ needs.params.outputs.pg16_version }}
     runs-on: ubuntu-20.04
     container:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-e142363"
+      image_suffix: "-dev-8b26747"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,11 +32,11 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-889e4c1"
+      image_suffix: "-dev-5779674"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'
-      upgrade_pg_versions: "14.15-15.10-16.6-17.2"
+      upgrade_pg_versions: "14.15-15.10-16.6"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -385,28 +385,6 @@ jobs:
       with:
         flags: ${{ env.pg_major }}_upgrade
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
-  upload-coverage:
-    if: always()
-    env:
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-    runs-on: ubuntu-20.04
-    container:
-      image: ${{ needs.params.outputs.test_image_name }}:${{ fromJson(needs.params.outputs.pg16_version).full }}${{ needs.params.outputs.image_suffix }}
-    needs:
-      - params
-      - test-citus
-      - test-arbitrary-configs
-      - test-citus-upgrade
-      - test-pg-upgrade
-    steps:
-      - uses: actions/download-artifact@v3.0.1
-        with:
-          name: "codeclimate"
-          path: "codeclimate"
-      - name: Upload coverage results to Code Climate
-        run: |-
-          cc-test-reporter sum-coverage codeclimate/*.json -o total.json
-          cc-test-reporter upload-coverage -i total.json
   ch_benchmark:
     name: CH Benchmark
     if: startsWith(github.ref, 'refs/heads/ch_benchmark/')

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,6 +111,8 @@ jobs:
           - ${{ needs.params.outputs.image_suffix}}
         pg_version:
           - ${{ needs.params.outputs.pg14_version }}
+          - ${{ needs.params.outputs.pg15_version }}
+          - ${{ needs.params.outputs.pg16_version }}
     runs-on: ubuntu-20.04
     container:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,9 +11,6 @@ on:
         default: false
         type: boolean
   push:
-    branches:
-      - "main"
-      - "release-*"
   pull_request:
     types: [opened, reopened,synchronize]
   merge_group:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-8c38fe2"
+      image_suffix: "-dev-c31f6f8"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-94f4e5a"
+      image_suffix: "-dev-20e585f"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-2070de5"
+      image_suffix: "-dev-fda4e33"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.6"
-      image_suffix: "-dev-e142363"
+      image_suffix: "-dev-94f4e5a"
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       pg14_version: '{ "major": "14", "full": "14.15" }'
       pg15_version: '{ "major": "15", "full": "15.10" }'
       pg16_version: '{ "major": "16", "full": "16.6" }'
-      upgrade_pg_versions: "14.15-15.10-16.6"
+      upgrade_pg_versions: "14.15-15.10-16.6-17.2"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters


### PR DESCRIPTION
Bump PG versions to the latest minors 14.15, 15.10, 16.6

There is a libpq symlink issue when the images are built remotely https://github.com/citusdata/citus/actions/runs/12583502447/job/35071296238
Hence, we use the commit sha of a local build of the images, pushed.
This is temporary, until we find the underlying cause of the symlink issue.