### PR TITLE
Remove Debian Buster support from packaging pipelines (#7828)

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -115,7 +115,6 @@ jobs:
         # for each deb based image and we use POSTGRES_VERSION to set
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
-          - debian-buster-all
           - debian-bookworm-all
           - debian-bullseye-all
           - ubuntu-focal-all


### PR DESCRIPTION
Remove Debian Buster support from packaging-test-pipelines

Co-authored-by: Gürkan İndibay <gindibay@microsoft.com>
(cherry picked from commit 70f84e4aeeb326b690c57380eafca7e904ebcc1d)