### PR TITLE
Bump to latest PG minors 17.2 16.6 15.10 14.15

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ USER citus
 
 # build postgres versions separately for effective parrallelism and caching of already built versions when changing only certain versions
 FROM base AS pg14
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.14
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 14.15
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -80,7 +80,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg15
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.9
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.10
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -92,7 +92,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg16
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.5
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.6
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -104,7 +104,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg17
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 17.1
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 17.2
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -223,7 +223,7 @@ COPY --chown=citus:citus .psqlrc .
 RUN sudo chown --from=root:root citus:citus -R ~
 
 # sets default pg version
-RUN pgenv switch 17.1
+RUN pgenv switch 17.2
 
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,13 +26,13 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
-      sql_snapshot_pg_version: "17.1"
-      image_suffix: "-v84c0cf8"
-      pg14_version: '{ "major": "14", "full": "14.14" }'
-      pg15_version: '{ "major": "15", "full": "15.9" }'
-      pg16_version: '{ "major": "16", "full": "16.5" }'
-      pg17_version: '{ "major": "17", "full": "17.1" }'
-      upgrade_pg_versions: "14.14-15.9-16.5-17.1"
+      sql_snapshot_pg_version: "17.2"
+      image_suffix: "-v889e4c1"
+      pg14_version: '{ "major": "14", "full": "14.15" }'
+      pg15_version: '{ "major": "15", "full": "15.10" }'
+      pg16_version: '{ "major": "16", "full": "16.6" }'
+      pg17_version: '{ "major": "17", "full": "17.2" }'
+      upgrade_pg_versions: "14.15-15.10-16.6-17.2"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters


### PR DESCRIPTION
Similar to https://github.com/citusdata/citus/commit/5ef2cd67edef2d05f69e3d0f8c9795b5d538e3fa, we use the commit sha of a local build of the images, pushed.