### PR TITLE
PG17 Compatibility - Fix crash when pg_class is used in MERGE

### DIFF
--- a/src/backend/distributed/worker/worker_shard_visibility.c
+++ b/src/backend/distributed/worker/worker_shard_visibility.c
@@ -471,47 +471,48 @@ FilterShardsFromPgclass(Node *node, void *context)
 			/* make sure the expression is in the right memory context */
 			MemoryContext originalContext = MemoryContextSwitchTo(queryContext);
 
-            /* add relation_is_a_known_shard(oid) IS NOT TRUE to the quals of the query */
-            Node *newQual = CreateRelationIsAKnownShardFilter(varno);
+			/* add relation_is_a_known_shard(oid) IS NOT TRUE to the quals of the query */
+			Node *newQual = CreateRelationIsAKnownShardFilter(varno);
 
 #if PG_VERSION_NUM >= PG_VERSION_17
-            /*
-             * In PG17, MERGE queries introduce a new struct `mergeJoinCondition`.
-             * We need to handle this condition safely.
-             */
-            if (query->mergeJoinCondition != NULL)
-            {
-                /* Add the filter to mergeJoinCondition */
-                query->mergeJoinCondition = (Node *) makeBoolExpr(
-                    AND_EXPR,
-                    list_make2(query->mergeJoinCondition, newQual),
-                    -1);
-            }
-            else
+
+			/*
+			 * In PG17, MERGE queries introduce a new struct `mergeJoinCondition`.
+			 * We need to handle this condition safely.
+			 */
+			if (query->mergeJoinCondition != NULL)
+			{
+				/* Add the filter to mergeJoinCondition */
+				query->mergeJoinCondition = (Node *) makeBoolExpr(
+					AND_EXPR,
+					list_make2(query->mergeJoinCondition, newQual),
+					-1);
+			}
+			else
 #endif
-            {
-                /* Handle older versions or queries without mergeJoinCondition */
-                Node *oldQuals = query->jointree->quals;
-                if (oldQuals)
-                {
-                    query->jointree->quals = (Node *) makeBoolExpr(
-                        AND_EXPR,
-                        list_make2(oldQuals, newQual),
-                        -1);
-                }
-                else
-                {
-                    query->jointree->quals = newQual;
-                }
-            }
+			{
+				/* Handle older versions or queries without mergeJoinCondition */
+				Node *oldQuals = query->jointree->quals;
+				if (oldQuals)
+				{
+					query->jointree->quals = (Node *) makeBoolExpr(
+						AND_EXPR,
+						list_make2(oldQuals, newQual),
+						-1);
+				}
+				else
+				{
+					query->jointree->quals = newQual;
+				}
+			}
 
-            MemoryContextSwitchTo(originalContext);
-        }
+			MemoryContextSwitchTo(originalContext);
+		}
 
-        return query_tree_walker((Query *) node, FilterShardsFromPgclass, context, 0);
-    }
+		return query_tree_walker((Query *) node, FilterShardsFromPgclass, context, 0);
+	}
 
-    return expression_tree_walker(node, FilterShardsFromPgclass, context);
+	return expression_tree_walker(node, FilterShardsFromPgclass, context);
 }
 
 

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -2690,6 +2690,32 @@ SELECT * FROM sensor_readings ORDER BY 1;
 (4 rows)
 
 -- End of MERGE ... WHEN NOT MATCHED BY SOURCE tests
+-- Issue #7846
+-- Create a non-distributed table with a random suffix
+CREATE TABLE non_dist_table_12345 (id INTEGER);
+-- Test crash scenario on a non-distributed table
+MERGE INTO non_dist_table_12345 AS target_0
+USING pg_catalog.pg_class AS ref_0
+ON target_0.id = ref_0.relpages
+WHEN NOT MATCHED THEN DO NOTHING;
+-- Create a distributed table with a random suffix
+CREATE TABLE dist_table_67890 (id INTEGER);
+SELECT create_distributed_table('dist_table_67890', 'id');
+ create_distributed_table 
+--------------------------
+ 
+(1 row)
+
+-- Test crash scenario on a distributed table
+MERGE INTO dist_table_67890 AS target_0
+USING pg_catalog.pg_class AS ref_0
+ON target_0.id = ref_0.relpages
+WHEN NOT MATCHED THEN DO NOTHING;
+ERROR:  MERGE INTO an distributed table from Postgres table is not yet supported
+-- Cleanup
+DROP TABLE IF EXISTS non_dist_table_12345;
+DROP TABLE IF EXISTS dist_table_67890 CASCADE;
+-- End of Issue #7846
 \set VERBOSITY terse
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg17 CASCADE;

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -2702,7 +2702,7 @@ USING pg_catalog.pg_class AS ref_0
 ON target_0.id = ref_0.relpages
 WHEN NOT MATCHED THEN DO NOTHING;
 -- Step 3: Switch back to the coordinator for distributed table operations
-\c - - - :master_port
+\c postgresql://postgres@localhost::master_port/regression?application_name=psql
 SET search_path TO pg17;
 -- Step 4: Create and test a distributed table
 CREATE TABLE dist_table_67890 (id INTEGER);

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -2701,9 +2701,9 @@ WHEN NOT MATCHED THEN DO NOTHING;
 -- Create a distributed table with a random suffix
 CREATE TABLE dist_table_67890 (id INTEGER);
 SELECT create_distributed_table('dist_table_67890', 'id');
- create_distributed_table 
---------------------------
- 
+ create_distributed_table
+---------------------------------------------------------------------
+
 (1 row)
 
 -- Test crash scenario on a distributed table

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -2690,15 +2690,21 @@ SELECT * FROM sensor_readings ORDER BY 1;
 (4 rows)
 
 -- End of MERGE ... WHEN NOT MATCHED BY SOURCE tests
--- Issue #7846
--- Create a non-distributed table with a random suffix
+-- Issue #7846: Test crash scenarios with MERGE on non-distributed and distributed tables
+-- Step 1: Connect to a worker node to verify shard visibility
+\c postgresql://postgres@localhost::worker_1_port/regression?application_name=psql
+SET search_path TO pg17;
+-- Step 2: Create and test a non-distributed table
 CREATE TABLE non_dist_table_12345 (id INTEGER);
--- Test crash scenario on a non-distributed table
+-- Test MERGE on the non-distributed table
 MERGE INTO non_dist_table_12345 AS target_0
 USING pg_catalog.pg_class AS ref_0
 ON target_0.id = ref_0.relpages
 WHEN NOT MATCHED THEN DO NOTHING;
--- Create a distributed table with a random suffix
+-- Step 3: Switch back to the coordinator for distributed table operations
+\c - - - :master_port
+SET search_path TO pg17;
+-- Step 4: Create and test a distributed table
 CREATE TABLE dist_table_67890 (id INTEGER);
 SELECT create_distributed_table('dist_table_67890', 'id');
  create_distributed_table
@@ -2706,15 +2712,16 @@ SELECT create_distributed_table('dist_table_67890', 'id');
 
 (1 row)
 
--- Test crash scenario on a distributed table
+-- Test MERGE on the distributed table
 MERGE INTO dist_table_67890 AS target_0
 USING pg_catalog.pg_class AS ref_0
 ON target_0.id = ref_0.relpages
 WHEN NOT MATCHED THEN DO NOTHING;
 ERROR:  MERGE INTO an distributed table from Postgres table is not yet supported
--- Cleanup
-DROP TABLE IF EXISTS non_dist_table_12345;
-DROP TABLE IF EXISTS dist_table_67890 CASCADE;
+-- Step 5: Cleanup
+DROP TABLE non_dist_table_12345;
+ERROR:  table "non_dist_table_12345" does not exist
+DROP TABLE dist_table_67890 CASCADE;
 -- End of Issue #7846
 \set VERBOSITY terse
 SET client_min_messages TO WARNING;

--- a/src/test/regress/sql/pg17.sql
+++ b/src/test/regress/sql/pg17.sql
@@ -1466,7 +1466,7 @@ ON target_0.id = ref_0.relpages
 WHEN NOT MATCHED THEN DO NOTHING;
 
 -- Step 3: Switch back to the coordinator for distributed table operations
-\c - - - :master_port
+\c postgresql://postgres@localhost::master_port/regression?application_name=psql
 SET search_path TO pg17;
 
 -- Step 4: Create and test a distributed table

--- a/src/test/regress/sql/pg17.sql
+++ b/src/test/regress/sql/pg17.sql
@@ -1451,6 +1451,31 @@ SELECT * FROM sensor_readings ORDER BY 1;
 
 -- End of MERGE ... WHEN NOT MATCHED BY SOURCE tests
 
+-- Issue #7846
+-- Create a non-distributed table with a random suffix
+CREATE TABLE non_dist_table_12345 (id INTEGER);
+
+-- Test crash scenario on a non-distributed table
+MERGE INTO non_dist_table_12345 AS target_0
+USING pg_catalog.pg_class AS ref_0
+ON target_0.id = ref_0.relpages
+WHEN NOT MATCHED THEN DO NOTHING;
+
+-- Create a distributed table with a random suffix
+CREATE TABLE dist_table_67890 (id INTEGER);
+SELECT create_distributed_table('dist_table_67890', 'id');
+
+-- Test crash scenario on a distributed table
+MERGE INTO dist_table_67890 AS target_0
+USING pg_catalog.pg_class AS ref_0
+ON target_0.id = ref_0.relpages
+WHEN NOT MATCHED THEN DO NOTHING;
+
+-- Cleanup
+DROP TABLE IF EXISTS non_dist_table_12345;
+DROP TABLE IF EXISTS dist_table_67890 CASCADE;
+-- End of Issue #7846
+
 \set VERBOSITY terse
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg17 CASCADE;


### PR DESCRIPTION
This pull request addresses Issue #7846, where specific MERGE queries on non-distributed and distributed tables can result in crashes in certain scenarios. The issue stems from the usage of `pg_class` catalog table, and the `FilterShardsFromPgclass` function in Citus. This function goes through the query's jointree to hide the shards. However, in PG17, MERGE's join quals are in a separate structure called `mergeJoinCondition`. Therefore FilterShardsFromPgclass was not filtering correctly in a `MERGE` command that involves `pg_class`. To fix the issue, we handle `mergeJoinCondition` separately in PG17.

Relevant PG commit:
https://github.com/postgres/postgres/commit/0294df2f1f842dfb0eed79007b21016f486a3c6c

**Non-Distributed Tables:**
A MERGE query involving a non-distributed table using `pg_catalog.pg_class` as the source may execute successfully but needs testing to ensure stability.

**Distributed Tables:**
Performing a MERGE on a distributed table using `pg_catalog.pg_class` as the source raises an error:
`ERROR: MERGE INTO a distributed table from Postgres table is not yet supported`
However, in some cases, this can lead to a server crash if the unsupported operation is not properly handled.

This is the test output from the same test conducted prior to the code changes being implemented.

```
-- Issue #7846: Test crash scenarios with MERGE on non-distributed and distributed tables
-- Step 1: Connect to a worker node to verify shard visibility
\c postgresql://postgres@localhost::worker_1_port/regression?application_name=psql
SET search_path TO pg17;
-- Step 2: Create and test a non-distributed table
CREATE TABLE non_dist_table_12345 (id INTEGER);
-- Test MERGE on the non-distributed table
MERGE INTO non_dist_table_12345 AS target_0
USING pg_catalog.pg_class AS ref_0
ON target_0.id = ref_0.relpages
WHEN NOT MATCHED THEN DO NOTHING;
SSL SYSCALL error: EOF detected
connection to server was lost
```

