### PR TITLE
Fix make install for OS/X: cherry picked from commit 0f28a69f12418d211ffba5f7ddd222fd0c47daeb

### DIFF
--- a/src/backend/distributed/cdc/Makefile.decoder
+++ b/src/backend/distributed/cdc/Makefile.decoder
@@ -14,11 +14,6 @@ override CPPFLAGS += -DDECODER=\"$(DECODER)\" -I$(citus_abs_top_srcdir)/include
 
 install: install-cdc
 
-clean: clean-cdc
-
 install-cdc:
 	mkdir -p '$(citus_decoders_dir)'
-	$(INSTALL_SHLIB) citus_$(DECODER).so '$(citus_decoders_dir)/$(DECODER).so'
-
-clean-cdc:
-	rm -f '$(DESTDIR)$(datadir)/$(datamoduledir)/citus_decoders/$(DECODER).so'
+	$(INSTALL_SHLIB) citus_$(DECODER)$(DLSUFFIX) '$(citus_decoders_dir)/$(DECODER)$(DLSUFFIX)'


### PR DESCRIPTION
Use the $(DLSUFFIX) instead of hard coded extensions for cdc (#7221)

cherry picked from commit 0f28a69f12418d211ffba5f7ddd222fd0c47daeb
