### PR TITLE
Add udf citus_node_list(active, role)

### DIFF
--- a/src/backend/distributed/sql/citus--13.0-1--13.1-1.sql
+++ b/src/backend/distributed/sql/citus--13.0-1--13.1-1.sql
@@ -48,3 +48,4 @@ DROP VIEW IF EXISTS pg_catalog.citus_lock_waits;
 #include "udfs/repl_origin_helper/13.1-1.sql"
 #include "udfs/citus_finish_pg_upgrade/13.1-1.sql"
 #include "udfs/citus_is_primary_node/13.1-1.sql"
+#include "udfs/citus_node_list/13.1-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--13.1-1--13.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.1-1--13.0-1.sql
@@ -41,3 +41,9 @@ DROP FUNCTION citus_internal.start_replication_origin_tracking();
 DROP FUNCTION citus_internal.stop_replication_origin_tracking();
 DROP FUNCTION citus_internal.is_replication_origin_tracking_active();
 #include "../udfs/citus_finish_pg_upgrade/12.1-1.sql"
+DROP FUNCTION pg_catalog.citus_node_list(
+    IN active BOOL,
+    IN role citus_noderole,
+    OUT node_name text,
+    OUT node_port bigint);
+DROP TYPE pg_catalog.citus_noderole;

--- a/src/backend/distributed/sql/udfs/citus_node_list/13.1-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_node_list/13.1-1.sql
@@ -1,0 +1,15 @@
+CREATE TYPE pg_catalog.citus_noderole AS ENUM (
+  'coordinator', -- node is coordinator
+  'worker'       -- node is worker
+);
+
+CREATE OR REPLACE FUNCTION pg_catalog.citus_node_list(
+  IN active BOOL DEFAULT null,
+  IN role citus_noderole DEFAULT null,
+  OUT node_name text,
+  OUT node_port bigint)
+    RETURNS SETOF record
+    LANGUAGE C VOLATILE ROWS 100
+    AS 'MODULE_PATHNAME', $$citus_node_list$$;
+COMMENT ON FUNCTION pg_catalog.citus_node_list(active BOOL, role citus_noderole)
+    IS 'fetch set of nodes which match the given criteria';

--- a/src/backend/distributed/sql/udfs/citus_node_list/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_node_list/latest.sql
@@ -1,0 +1,15 @@
+CREATE TYPE pg_catalog.citus_noderole AS ENUM (
+  'coordinator', -- node is coordinator
+  'worker'       -- node is worker
+);
+
+CREATE OR REPLACE FUNCTION pg_catalog.citus_node_list(
+  IN active BOOL DEFAULT null,
+  IN role citus_noderole DEFAULT null,
+  OUT node_name text,
+  OUT node_port bigint)
+    RETURNS SETOF record
+    LANGUAGE C VOLATILE ROWS 100
+    AS 'MODULE_PATHNAME', $$citus_node_list$$;
+COMMENT ON FUNCTION pg_catalog.citus_node_list(active BOOL, role citus_noderole)
+    IS 'fetch set of nodes which match the given criteria';

--- a/src/include/distributed/worker_manager.h
+++ b/src/include/distributed/worker_manager.h
@@ -112,4 +112,21 @@ extern int WorkerNodeCompare(const void *lhsKey, const void *rhsKey, Size keySiz
 extern int NodeNamePortCompare(const char *workerLhsName, const char *workerRhsName,
 							   int workerLhsPort, int workerRhsPort);
 
+typedef enum ActiveFilterEnum
+{
+	ACTIVE_FILTER_ALL = 0,
+	ACTIVE_FILTER_ACTIVE = 1,
+	ACTIVE_FILTER_INACTIVE = 2
+} ActiveFilterEnum;
+
+typedef enum CitusNodeRoleEnum
+{
+	CITUS_NODE_ROLE_ALL = 0,
+	CITUS_NODE_ROLE_COORDINATOR = 1,
+	CITUS_NODE_ROLE_WORKER = 2
+} CitusNodeRoleEnum;
+
+extern List * FilterNodeListFunc(LOCKMODE lockMode, ActiveFilterEnum active,
+								 CitusNodeRoleEnum role);
+
 #endif   /* WORKER_MANAGER_H */

--- a/src/test/regress/expected/multi_cluster_management.out
+++ b/src/test/regress/expected/multi_cluster_management.out
@@ -72,6 +72,22 @@ SELECT master_get_active_worker_nodes();
  (localhost,57637)
 (2 rows)
 
+SELECT * from citus_node_list();
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57636
+ localhost |     57638
+ localhost |     57637
+(3 rows)
+
+SELECT * from citus_node_list(active := NULL);
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57636
+ localhost |     57638
+ localhost |     57637
+(3 rows)
+
 -- try to add a node that is already in the cluster
 SELECT * FROM master_add_node('localhost', :worker_1_port);
  master_add_node
@@ -124,6 +140,53 @@ SELECT master_get_active_worker_nodes();
  master_get_active_worker_nodes
 ---------------------------------------------------------------------
  (localhost,57637)
+(1 row)
+
+SELECT * from citus_node_list(active := TRUE);
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57636
+ localhost |     57637
+(2 rows)
+
+SELECT * from citus_node_list(active := FALSE);
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57638
+(1 row)
+
+SELECT * from citus_node_list(role := 'worker');
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57638
+ localhost |     57637
+(2 rows)
+
+SELECT * from citus_node_list(role := 'coordinator');
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57636
+(1 row)
+
+SELECT * from citus_node_list(role := NULL);
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57636
+ localhost |     57638
+ localhost |     57637
+(3 rows)
+
+SELECT * from citus_node_list(role := 'foo');
+ERROR:  invalid input value for enum citus_noderole: "foo"
+SELECT * from citus_node_list(active := FALSE, role := 'coordinator');
+ node_name | node_port
+---------------------------------------------------------------------
+(0 rows)
+
+SELECT * from citus_node_list(active := FALSE, role := 'worker');
+ node_name | node_port
+---------------------------------------------------------------------
+ localhost |     57638
 (1 row)
 
 -- add some shard placements to the cluster

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1480,8 +1480,9 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                 | function citus_internal.update_placement_metadata(bigint,integer,integer) void
                                                                 | function citus_internal.update_relation_colocation(oid,integer) void
                                                                 | function citus_is_primary_node() boolean
+                                                                | function citus_node_list(boolean,citus_noderole) SETOF record
                                                                 | function citus_unmark_object_distributed(oid,oid,integer,boolean) void
-(27 rows)
+(28 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -148,6 +148,7 @@ ORDER BY 1;
  function citus_move_shard_placement(bigint,integer,integer,citus.shard_transfer_mode)
  function citus_move_shard_placement(bigint,text,integer,text,integer,citus.shard_transfer_mode)
  function citus_node_capacity_1(integer)
+ function citus_node_list(boolean,citus_noderole)
  function citus_nodeid_for_gpid(bigint)
  function citus_nodename_for_nodeid(integer)
  function citus_nodeport_for_nodeid(integer)
@@ -389,6 +390,6 @@ ORDER BY 1;
  view citus_stat_tenants_local
  view pg_dist_shard_placement
  view time_partitions
-(358 rows)
+(359 rows)
 
 DROP TABLE extension_basic_types;

--- a/src/test/regress/sql/multi_cluster_management.sql
+++ b/src/test/regress/sql/multi_cluster_management.sql
@@ -32,6 +32,10 @@ SELECT result FROM run_command_on_workers('SELECT citus_is_primary_node()');
 -- get the active nodes
 SELECT master_get_active_worker_nodes();
 
+SELECT * from citus_node_list();
+
+SELECT * from citus_node_list(active := NULL);
+
 -- try to add a node that is already in the cluster
 SELECT * FROM master_add_node('localhost', :worker_1_port);
 
@@ -50,6 +54,22 @@ SELECT 1 FROM master_add_node('localhost', :worker_2_port);
 SELECT citus_disable_node('localhost', :worker_2_port);
 SELECT public.wait_until_metadata_sync(20000);
 SELECT master_get_active_worker_nodes();
+
+SELECT * from citus_node_list(active := TRUE);
+
+SELECT * from citus_node_list(active := FALSE);
+
+SELECT * from citus_node_list(role := 'worker');
+
+SELECT * from citus_node_list(role := 'coordinator');
+
+SELECT * from citus_node_list(role := NULL);
+
+SELECT * from citus_node_list(role := 'foo');
+
+SELECT * from citus_node_list(active := FALSE, role := 'coordinator');
+
+SELECT * from citus_node_list(active := FALSE, role := 'worker');
 
 -- add some shard placements to the cluster
 SET citus.shard_count TO 16;


### PR DESCRIPTION
DESCRIPTION: Add new udf: citus_node_list with arguments:

```
  IN active BOOL DEFAULT null,
  IN role citus_noderole DEFAULT null,
  OUT node_name text,
  OUT node_port bigint
```

When the udf is called without any arguments, it will return all nodes.

Add corresponding drop statements for the downgrade script:
   `src/backend/distributed/sql/downgrades/citus--13.1-1--13.0-1.sql`

Reformat some of the function comments to fit in 80 character column limit.

Update test cases for the new udf.