### PR TITLE
AddressSanitizer: stack-use-after-scope on distributed_planner.c backport at release-12.1

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -2544,21 +2544,20 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 		/* check whether parameter is available (and valid) */
 		if (boundParams && paramId > 0 && paramId <= boundParams->numParams)
 		{
-			ParamExternData *externParam = NULL;
+			Oid paramType = InvalidOid;
 
 			/* give hook a chance in case parameter is dynamic */
 			if (boundParams->paramFetch != NULL)
 			{
 				ParamExternData externParamPlaceholder;
-				externParam = (*boundParams->paramFetch)(boundParams, paramId, false,
-														 &externParamPlaceholder);
+				paramType = (*boundParams->paramFetch)(boundParams, paramId, false,
+													   &externParamPlaceholder)->ptype;
 			}
 			else
 			{
-				externParam = &boundParams->params[paramId - 1];
+				paramType = boundParams->params[paramId - 1].ptype;
 			}
 
-			Oid paramType = externParam->ptype;
 			if (OidIsValid(paramType))
 			{
 				return false;


### PR DESCRIPTION
Backport of #7941 to release-12.1
Fixes #7960
