### PR TITLE
AddressSanitizer: stack-use-after-scope on distributed_planner.c backport at release-13.0

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -2548,21 +2548,20 @@ HasUnresolvedExternParamsWalker(Node *expression, ParamListInfo boundParams)
 		/* check whether parameter is available (and valid) */
 		if (boundParams && paramId > 0 && paramId <= boundParams->numParams)
 		{
-			ParamExternData *externParam = NULL;
+			Oid paramType = InvalidOid;
 
 			/* give hook a chance in case parameter is dynamic */
 			if (boundParams->paramFetch != NULL)
 			{
 				ParamExternData externParamPlaceholder;
-				externParam = (*boundParams->paramFetch)(boundParams, paramId, false,
-														 &externParamPlaceholder);
+				paramType = (*boundParams->paramFetch)(boundParams, paramId, false,
+													   &externParamPlaceholder)->ptype;
 			}
 			else
 			{
-				externParam = &boundParams->params[paramId - 1];
+				paramType = boundParams->params[paramId - 1].ptype;
 			}
 
-			Oid paramType = externParam->ptype;
 			if (OidIsValid(paramType))
 			{
 				return false;


### PR DESCRIPTION
Backport of https://github.com/citusdata/citus/issues/7941 to release-13.0
Fixes #7960
