### PR TITLE
Bump PG versions to 17.5, 16.9, 15.13 (#7986)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,7 +73,7 @@ USER citus
 
 # build postgres versions separately for effective parrallelism and caching of already built versions when changing only certain versions
 FROM base AS pg15
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.12
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 15.13
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -85,7 +85,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg16
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.8
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 16.9
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -97,7 +97,7 @@ RUN cp -r .pgenv/src .pgenv/pgsql-* .pgenv/config .pgenv-staging/
 RUN rm .pgenv-staging/config/default.conf
 
 FROM base AS pg17
-RUN MAKEFLAGS="-j $(nproc)" pgenv build 17.4
+RUN MAKEFLAGS="-j $(nproc)" pgenv build 17.5
 RUN rm .pgenv/src/*.tar*
 RUN make -C .pgenv/src/postgresql-*/ clean
 RUN make -C .pgenv/src/postgresql-*/src/include install
@@ -216,7 +216,7 @@ COPY --chown=citus:citus .psqlrc .
 RUN sudo chown --from=root:root citus:citus -R ~
 
 # sets default pg version
-RUN pgenv switch 17.4
+RUN pgenv switch 17.5
 
 # make connecting to the coordinator easy
 ENV PGPORT=9700

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,12 +31,12 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
-      sql_snapshot_pg_version: "17.4"
-      image_suffix: "-veab367a"
-      pg15_version: '{ "major": "15", "full": "15.12" }'
-      pg16_version: '{ "major": "16", "full": "16.8" }'
-      pg17_version: '{ "major": "17", "full": "17.4" }'
-      upgrade_pg_versions: "15.12-16.8-17.4"
+      sql_snapshot_pg_version: "17.5"
+      image_suffix: "-dev-d28f316"
+      pg15_version: '{ "major": "15", "full": "15.13" }'
+      pg16_version: '{ "major": "16", "full": "16.9" }'
+      pg17_version: '{ "major": "17", "full": "17.5" }'
+      upgrade_pg_versions: "15.13-16.9-17.5"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2245,6 +2245,18 @@ SelectsFromDistributedTable(List *rangeTableList, Query *query)
 			continue;
 		}
 
+#if PG_VERSION_NUM >= 150013 && PG_VERSION_NUM < PG_VERSION_16
+		if (rangeTableEntry->rtekind == RTE_SUBQUERY && rangeTableEntry->relkind == 0)
+		{
+			/*
+			 * In PG15.13 commit https://github.com/postgres/postgres/commit/317aba70e
+			 * relid is retained when converting views to subqueries,
+			 * so we need an extra check identifying those views
+			 */
+			continue;
+		}
+#endif
+
 		if (rangeTableEntry->relkind == RELKIND_VIEW ||
 			rangeTableEntry->relkind == RELKIND_MATVIEW)
 		{


### PR DESCRIPTION
Nontrivial bump because of the following PG15.3 commit 317aba70e
https://github.com/postgres/postgres/commit/317aba70e

Previously, when views were converted to RTE_SUBQUERY the relid would be cleared in PG15. In this patch of PG15, relid is retained. Therefore, we add a check with the "relkind and rtekind" to identify the converted views in 15.13

Sister PR https://github.com/citusdata/the-process/pull/164 Using dev image sha because I encountered the libpq symlink issue again with "-v219b87c"

DESCRIPTION: PR description that will go into the change log, up to 78 characters
