### PR TITLE
Remove columnar storage dependency from Citus core extension

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,8 +153,8 @@ jobs:
           - check-isolation
           - check-operations
           - check-follower-cluster
-          - check-columnar
-          - check-columnar-isolation
+          # - check-columnar
+          # - check-columnar-isolation
           - check-enterprise
           - check-enterprise-isolation
           - check-enterprise-isolation-logicalrep-1

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,15 @@ all: extension
 
 
 # build columnar only
+.PHONY: columnar
 columnar:
-	$(MAKE) -C src/backend/columnar all
+	@echo ">>> skipping columnar storage build <<<"
 # build extension
-extension: $(citus_top_builddir)/src/include/citus_version.h columnar
+extension: $(citus_top_builddir)/src/include/citus_version.h
 	$(MAKE) -C src/backend/distributed/ all
+.PHONY: install-columnar	
 install-columnar: columnar
-	$(MAKE) -C src/backend/columnar install
+	@echo ">>> skipping columnar storage install <<<"
 install-extension: extension install-columnar
 	$(MAKE) -C src/backend/distributed/ install
 install-headers: extension
@@ -33,7 +35,7 @@ install-headers: extension
 
 clean-extension:
 	$(MAKE) -C src/backend/distributed/ clean
-	$(MAKE) -C src/backend/columnar/ clean
+#	$(MAKE) -C src/backend/columnar/ clean
 clean-full:
 	$(MAKE) -C src/backend/distributed/ clean-full
 .PHONY: extension install-extension clean-extension clean-full
@@ -41,7 +43,7 @@ clean-full:
 install-downgrades:
 	$(MAKE) -C src/backend/distributed/ install-downgrades
 install-all: install-headers
-	$(MAKE) -C src/backend/columnar/ install-all
+#   $(MAKE) -C src/backend/columnar/ install-all
 	$(MAKE) -C src/backend/distributed/ install-all
 
 

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -212,7 +212,7 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 		 * Postgres forbids creating/altering other extensions from within an extension script, so we use a utility hook instead
 		 * This preprocess check whether citus_columnar should be installed first before citus
 		 */
-		PreprocessCreateExtensionStmtForCitusColumnar(parsetree);
+		// PreprocessCreateExtensionStmtForCitusColumnar(parsetree);
 	}
 
 	if (isCreateAlterExtensionUpdateCitusStmt || IsDropCitusExtensionStmt(parsetree))
@@ -797,7 +797,7 @@ citus_ProcessUtilityInternal(PlannedStmt *pstmt,
 			 * or drop citus_columnar fake version when downgrade citus to older version that do not support
 			 * citus_columnar
 			 */
-			PostprocessAlterExtensionCitusStmtForCitusColumnar(parsetree);
+			// PostprocessAlterExtensionCitusStmtForCitusColumnar(parsetree);
 		}
 
 		/*

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -784,7 +784,7 @@ citus_ProcessUtilityInternal(PlannedStmt *pstmt,
 			/*
 			 * Check whether need to install/drop citus_columnar when upgrade/downgrade citus
 			 */
-			PreprocessAlterExtensionCitusStmtForCitusColumnar(parsetree);
+			// PreprocessAlterExtensionCitusStmtForCitusColumnar(parsetree);
 		}
 
 		PrevProcessUtility(pstmt, queryString, false, context,

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -1233,10 +1233,10 @@ bool
 IsObjectAddressOwnedByCitus(const ObjectAddress *objectAddress)
 {
 	Oid citusId = get_extension_oid("citus", true);
-	Oid citusColumnarId = get_extension_oid("citus_columnar", true);
+	// Oid citusColumnarId = get_extension_oid("citus_columnar", true);
 
 	/* return false because we could not find any citus extension */
-	if (!OidIsValid(citusId) && !OidIsValid(citusColumnarId))
+	if (!OidIsValid(citusId))
 	{
 		return false;
 	}
@@ -1250,9 +1250,8 @@ IsObjectAddressOwnedByCitus(const ObjectAddress *objectAddress)
 	}
 
 	bool ownedByCitus = extObjectAddress.objectId == citusId;
-	bool ownedByCitusColumnar = extObjectAddress.objectId == citusColumnarId;
 
-	return ownedByCitus || ownedByCitusColumnar;
+	return ownedByCitus;
 }
 
 

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -45,7 +45,7 @@ vanilla_diffs_file = $(citus_abs_srcdir)/pg_vanilla_outputs/$(MAJORVERSION)/regr
 # intermediate, for muscle memory backward compatibility.
 check: check-full check-enterprise-full
 # check-full triggers all tests that ought to be run routinely
-check-full: check-multi check-multi-mx check-multi-1 check-operations check-follower-cluster check-isolation check-failure check-split check-vanilla check-columnar check-columnar-isolation check-pg-upgrade check-arbitrary-configs check-citus-upgrade check-citus-upgrade-mixed check-citus-upgrade-local check-citus-upgrade-mixed-local check-pytest check-query-generator
+check-full: check-multi check-multi-mx check-multi-1 check-operations check-follower-cluster check-isolation check-failure check-split check-vanilla check-pg-upgrade check-arbitrary-configs check-citus-upgrade check-citus-upgrade-mixed check-citus-upgrade-local check-citus-upgrade-mixed-local check-pytest check-query-generator
 # check-enterprise-full triggers all enterprise specific tests
 check-enterprise-full: check-enterprise check-enterprise-isolation check-enterprise-failure check-enterprise-isolation-logicalrep-1 check-enterprise-isolation-logicalrep-2 check-enterprise-isolation-logicalrep-3
 
@@ -180,10 +180,10 @@ check-multi-1-vg: all
 	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/multi_1_schedule $(EXTRA_TESTS)
 
-check-columnar-vg: all
-	$(pg_regress_multi_check) --load-extension=citus --valgrind \
-	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
-	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/columnar_schedule $(EXTRA_TESTS)
+# check-columnar-vg: all
+# 	$(pg_regress_multi_check) --load-extension=citus --valgrind \
+# 	--pg_ctl-timeout=360 --connection-timeout=500000 --valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
+# 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/columnar_schedule $(EXTRA_TESTS)
 
 check-isolation: all  $(isolation_test_files)
 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
@@ -227,13 +227,13 @@ check-operations: all
 	$(pg_regress_multi_check) --load-extension=citus  --worker-count=6 \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/operations_schedule $(EXTRA_TESTS)
 
-check-columnar: all
-	$(pg_regress_multi_check) --load-extension=citus_columnar --load-extension=citus \
-	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/columnar_schedule $(EXTRA_TESTS)
+# check-columnar: all
+# 	$(pg_regress_multi_check) --load-extension=citus_columnar --load-extension=citus \
+# 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/columnar_schedule $(EXTRA_TESTS)
 
-check-columnar-isolation: all  $(isolation_test_files)
-	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
-	-- $(MULTI_REGRESS_OPTS) --inputdir=$(citus_abs_srcdir)/build --schedule=$(citus_abs_srcdir)/columnar_isolation_schedule $(EXTRA_TESTS)
+# check-columnar-isolation: all  $(isolation_test_files)
+# 	$(pg_regress_multi_check) --load-extension=citus --isolationtester \
+# 	-- $(MULTI_REGRESS_OPTS) --inputdir=$(citus_abs_srcdir)/build --schedule=$(citus_abs_srcdir)/columnar_isolation_schedule $(EXTRA_TESTS)
 
 check-split: all
 	$(pg_regress_multi_check) --load-extension=citus \


### PR DESCRIPTION
- Makefile: Removed all columnar build targets (columnar, install-columnar) and dependencies
- Test Makefile: Removed check-columnar and check-columnar-isolation targets from test suite
- Simplified install-extension target to not depend on columnar components


