### PR TITLE
Fix PG15 compiler error introduced in commit 245a62df3e96f3e

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2138,7 +2138,6 @@ ConvertToQueryOnShard(Query *query, Oid citusTableOid, Oid shardId)
 	Assert(list_length(query->rtable) == 1);
 	RangeTblEntry *citusTableRte = (RangeTblEntry *) linitial(query->rtable);
 	Assert(citusTableRte->relid == citusTableOid);
-	Assert(list_length(query->rteperminfos) == 1);
 
 	const char *citusTableName = get_rel_name(citusTableOid);
 	Assert(citusTableName != NULL);


### PR DESCRIPTION
Commit 245a62df3e96f3e included an assertion on a struct field that is in PG16+, without PG_VERSION_NUM check. This commit removes the offending line of code. The same assertion is present later in the function with the PG_VERSION_NUM check, so the offending line of code is redundant.
