### PR TITLE
Move "DROP FUNCTION" for older version of UDF to correct file

### DIFF
--- a/src/backend/distributed/sql/downgrades/citus--13.2-1--13.1-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.2-1--13.1-1.sql
@@ -1,3 +1,5 @@
 -- citus--13.2-1--13.1-1
 -- downgrade version to 13.1-1
+
+DROP FUNCTION IF EXISTS pg_catalog.worker_last_saved_explain_analyze();
 #include "../udfs/worker_last_saved_explain_analyze/9.4-1.sql"

--- a/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/9.4-1.sql
+++ b/src/backend/distributed/sql/udfs/worker_last_saved_explain_analyze/9.4-1.sql
@@ -1,6 +1,4 @@
 
-DROP FUNCTION IF EXISTS pg_catalog.worker_last_saved_explain_analyze();
-
 CREATE OR REPLACE FUNCTION pg_catalog.worker_last_saved_explain_analyze()
     RETURNS TABLE(explain_analyze_output TEXT, execution_duration DOUBLE PRECISION)
     LANGUAGE C STRICT


### PR DESCRIPTION
We never update an older version of a SQL object for consistency across release tags, so this commit moves "DROP FUNCTION .." for the older version of "pg_catalog.worker_last_saved_explain_analyze();" to the appropriate migration script.

See https://github.com/citusdata/citus/pull/8017.