### PR TITLE
Fix PostgreSQL 18 compatibility in citus_split_shard_columnar_partitioned test

### DIFF
--- a/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
+++ b/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
@@ -155,6 +155,7 @@ SELECT pg_reload_conf();
  sensors_2020_01_01_8970002 | fkey_from_child_to_child_8970002                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
  sensors_2020_01_01_8970002 | fkey_from_child_to_dist_8970002                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
  sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002_1                     | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
  sensors_2020_01_01_8970002 | fkey_from_child_to_ref_8970002                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
  sensors_2020_01_01_8970002 | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
  sensors_2020_01_01_8970002 | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)


### PR DESCRIPTION
PostgreSQL 18 beta 2 creates an additional foreign key constraint 'fkey_from_child_to_parent_8970002_1' during shard splitting operations that wasn't present in earlier versions. This constraint represents correct behavior for partitioned table foreign key inheritance.

Updated the expected test output to include this additional constraint to maintain compatibility with PostgreSQL 18 beta 2.

Fixes test failure in citus_split_shard_columnar_partitioned regression test.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
