### PR TITLE
Fix memory corruptions around pg_dist_transaction accessors after a Citus downgrade is followed by an upgrade 

### DIFF
--- a/src/include/distributed/pg_dist_transaction.h
+++ b/src/include/distributed/pg_dist_transaction.h
@@ -40,5 +40,7 @@ typedef FormData_pg_dist_transaction *Form_pg_dist_transaction;
 #define Anum_pg_dist_transaction_gid 2
 #define Anum_pg_dist_transaction_outerxid 3
 
+extern int GetOuterXidAttrIndexInPgDistTransaction(TupleDesc tupleDesc);
+
 
 #endif   /* PG_DIST_TRANSACTION_H */


### PR DESCRIPTION
DESCRIPTION: Fixes potential memory corruptions that could happen when accessing pg_dist_transaction after a Citus downgrade is followed by a Citus upgrade.

In case of Citus downgrade and further upgrade an undefined behavior may be encountered. The reason is that Citus hardcoded the number of columns in the extension's tables, but in case of downgrade and following update some of these tables can have more columns, and some of them can be marked as dropped.

This PR fixes all such tables using the approach introduced in #7950, which solved the problem for the pg_dist_partition table.

See #7515 for a more thorough explanation.
