### PR TITLE
Remove incorrect assertion from Postgres ruleutils.

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_15.c
+++ b/src/backend/distributed/deparser/ruleutils_15.c
@@ -1568,7 +1568,6 @@ set_join_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 		if (colinfo->is_new_col[col_index])
 			i++;
 	}
-	Assert(i == colinfo->num_cols);
 	Assert(j == nnewcolumns);
 #endif
 

--- a/src/backend/distributed/deparser/ruleutils_16.c
+++ b/src/backend/distributed/deparser/ruleutils_16.c
@@ -1585,7 +1585,6 @@ set_join_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 		if (colinfo->is_new_col[col_index])
 			i++;
 	}
-	Assert(i == colinfo->num_cols);
 	Assert(j == nnewcolumns);
 #endif
 

--- a/src/backend/distributed/deparser/ruleutils_17.c
+++ b/src/backend/distributed/deparser/ruleutils_17.c
@@ -1599,7 +1599,6 @@ set_join_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 		if (colinfo->is_new_col[col_index])
 			i++;
 	}
-	Assert(i == colinfo->num_cols);
 	Assert(j == nnewcolumns);
 #endif
 

--- a/src/backend/distributed/deparser/ruleutils_18.c
+++ b/src/backend/distributed/deparser/ruleutils_18.c
@@ -1669,7 +1669,6 @@ set_join_column_names(deparse_namespace *dpns, RangeTblEntry *rte,
 		if (colinfo->is_new_col[col_index])
 			i++;
 	}
-	Assert(i == colinfo->num_cols);
 	Assert(j == nnewcolumns);
 #endif
 


### PR DESCRIPTION
DESCRIPTION: Remove an assertion from Postgres ruleutils that was rendered meaningless by a previous Citus commit.

Fixes #8123. This has been present since 00068e0, which changed the code preceding the assert as follows:
```
#ifdef USE_ASSERT_CHECKING
-	while (i < colinfo->num_cols && colinfo->colnames[i] == NULL)
-		i++;
+	for (int col_index = 0; col_index < colinfo->num_cols; col_index++)
+	{
+		/*
+		 * In the above processing-loops, "i" advances only if
+		 * the column is not new, check if this is a new column.
+		 */
+		if (colinfo->is_new_col[col_index])
+			i++;
+	}
	Assert(i == colinfo->num_cols);
	Assert(j == nnewcolumns);
#endif
```

This commit altered both the loop condition and the incrementing of `i`. After analysis, the assert no longer makes sense.