### PR TITLE
Fix incorrect usage of TupleDescSize() in #7950, #8120, #8124, #8121 and #8114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 * Fixes potential memory corruptions that could happen when accessing
   various catalog tables after a Citus downgrade is followed by a Citus
-  upgrade (#7950, #8120, #8124, #8121, #8114)
+  upgrade (#7950, #8120, #8124, #8121, #8114, #8146)
 
 * Fixes UPDATE statements with indirection and array/jsonb subscripting with
   more than one field (#7675)

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -2132,7 +2132,7 @@ GetHighestUsedRowNumber(uint64 storageId)
 static int
 GetFirstRowNumberAttrIndexInColumnarStripe(TupleDesc tupleDesc)
 {
-	return TupleDescSize(tupleDesc) == Natts_columnar_stripe
+	return tupleDesc->natts == Natts_columnar_stripe
 		   ? (Anum_columnar_stripe_first_row_number - 1)
 		   : tupleDesc->natts - 1;
 }

--- a/src/backend/distributed/metadata/distobject.c
+++ b/src/backend/distributed/metadata/distobject.c
@@ -801,7 +801,7 @@ DistributedSequenceList(void)
 int
 GetForceDelegationAttrIndexInPgDistObject(TupleDesc tupleDesc)
 {
-	return TupleDescSize(tupleDesc) == Natts_pg_dist_object
+	return tupleDesc->natts == Natts_pg_dist_object
 		   ? (Anum_pg_dist_object_force_delegation - 1)
 		   : tupleDesc->natts - 1;
 }

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -4486,7 +4486,7 @@ UnblockDependingBackgroundTasks(BackgroundTask *task)
 int
 GetAutoConvertedAttrIndexInPgDistPartition(TupleDesc tupleDesc)
 {
-	return TupleDescSize(tupleDesc) == Natts_pg_dist_partition
+	return tupleDesc->natts == Natts_pg_dist_partition
 		   ? (Anum_pg_dist_partition_autoconverted - 1)
 		   : tupleDesc->natts - 1;
 }
@@ -4506,7 +4506,7 @@ GetAutoConvertedAttrIndexInPgDistPartition(TupleDesc tupleDesc)
 int
 GetNodesInvolvedAttrIndexInPgDistBackgroundTask(TupleDesc tupleDesc)
 {
-	return TupleDescSize(tupleDesc) == Natts_pg_dist_background_task
+	return tupleDesc->natts == Natts_pg_dist_background_task
 		   ? (Anum_pg_dist_background_task_nodes_involved - 1)
 		   : tupleDesc->natts - 1;
 }

--- a/src/backend/distributed/transaction/transaction_recovery.c
+++ b/src/backend/distributed/transaction/transaction_recovery.c
@@ -685,7 +685,7 @@ DeleteWorkerTransactions(WorkerNode *workerNode)
 int
 GetOuterXidAttrIndexInPgDistTransaction(TupleDesc tupleDesc)
 {
-	return TupleDescSize(tupleDesc) == Natts_pg_dist_transaction
+	return tupleDesc->natts == Natts_pg_dist_transaction
 		   ? (Anum_pg_dist_transaction_outerxid - 1)
 		   : tupleDesc->natts - 1;
 }


### PR DESCRIPTION
In #7950, #8120, #8124, #8121 and #8114, TupleDescSize() was used to check whether the tuple length is `Natts_<catalog_table_name>`. However this was wrong because TupleDescSize() returns the size of the tupledesc, not the length of it (i.e., number of attributes).

Actually `TupleDescSize(tupleDesc) == Natts_<catalog_table_name>` was always returning false but this didn't cause any problems because using `tupleDesc->natts - 1` when `tupleDesc->natts == Natts_<catalog_table_name>` too had the same effect as using `Anum_<column_added_later> - 1` in that case.

So this also makes me thinking of always returning `tupleDesc->natts - 1` (or `tupleDesc->natts - 2` if it's the second to last attribute) but being more explicit seems more useful.

Even more, in the future we should probably switch to a different implementation if / when we think of adding more columns to those tables. We should probably scan non-dropped attributes of the relation, enumerate them and return the attribute number of the one that we're looking for, but seems this is not needed right now.

---

Not writing a DESCRIPTION because this is not fixing a bug that we had in older releases but a few potential issues that the listed bugfixes could have introduced in this release.