### PR TITLE
Make columnar_chunk_filtering pass consecutive runs

### DIFF
--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -10,6 +10,8 @@
 -- If chunks get filtered by columnar, less rows are passed to WHERE
 -- clause, so this function should return a lower number.
 --
+CREATE SCHEMA columnar_chunk_filtering;
+SET search_path TO columnar_chunk_filtering, public;
 CREATE OR REPLACE FUNCTION filtered_row_count (query text) RETURNS bigint AS
 $$
     DECLARE
@@ -1141,4 +1143,21 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
   8 | ZW
 (3 rows)
 
-DROP TABLE pushdown_test;
+DROP SCHEMA columnar_chunk_filtering CASCADE;
+NOTICE:  drop cascades to 16 other objects
+DETAIL:  drop cascades to function filtered_row_count(text)
+drop cascades to table test_chunk_filtering
+drop cascades to table collation_chunk_filtering_test
+drop cascades to table r1
+drop cascades to table r2
+drop cascades to table r3
+drop cascades to table r4
+drop cascades to table r5
+drop cascades to table r6
+drop cascades to table r7
+drop cascades to table coltest
+drop cascades to table coltest_part
+drop cascades to function vol()
+drop cascades to function stable_1(integer)
+drop cascades to table pushdown_test
+drop cascades to function volatilefunction()

--- a/src/test/regress/expected/columnar_chunk_filtering.out
+++ b/src/test/regress/expected/columnar_chunk_filtering.out
@@ -1143,21 +1143,6 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
   8 | ZW
 (3 rows)
 
+SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_chunk_filtering CASCADE;
-NOTICE:  drop cascades to 16 other objects
-DETAIL:  drop cascades to function filtered_row_count(text)
-drop cascades to table test_chunk_filtering
-drop cascades to table collation_chunk_filtering_test
-drop cascades to table r1
-drop cascades to table r2
-drop cascades to table r3
-drop cascades to table r4
-drop cascades to table r5
-drop cascades to table r6
-drop cascades to table r7
-drop cascades to table coltest
-drop cascades to table coltest_part
-drop cascades to function vol()
-drop cascades to function stable_1(integer)
-drop cascades to table pushdown_test
-drop cascades to function volatilefunction()
+RESET client_min_messages;

--- a/src/test/regress/expected/columnar_chunk_filtering_0.out
+++ b/src/test/regress/expected/columnar_chunk_filtering_0.out
@@ -10,6 +10,8 @@
 -- If chunks get filtered by columnar, less rows are passed to WHERE
 -- clause, so this function should return a lower number.
 --
+CREATE SCHEMA columnar_chunk_filtering;
+SET search_path TO columnar_chunk_filtering, public;
 CREATE OR REPLACE FUNCTION filtered_row_count (query text) RETURNS bigint AS
 $$
     DECLARE
@@ -1141,4 +1143,21 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
   8 | ZW
 (3 rows)
 
-DROP TABLE pushdown_test;
+DROP SCHEMA columnar_chunk_filtering CASCADE;
+NOTICE:  drop cascades to 16 other objects
+DETAIL:  drop cascades to function filtered_row_count(text)
+drop cascades to table test_chunk_filtering
+drop cascades to table collation_chunk_filtering_test
+drop cascades to table r1
+drop cascades to table r2
+drop cascades to table r3
+drop cascades to table r4
+drop cascades to table r5
+drop cascades to table r6
+drop cascades to table r7
+drop cascades to table coltest
+drop cascades to table coltest_part
+drop cascades to function vol()
+drop cascades to function stable_1(integer)
+drop cascades to table pushdown_test
+drop cascades to function volatilefunction()

--- a/src/test/regress/expected/columnar_chunk_filtering_0.out
+++ b/src/test/regress/expected/columnar_chunk_filtering_0.out
@@ -1143,21 +1143,6 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
   8 | ZW
 (3 rows)
 
+SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_chunk_filtering CASCADE;
-NOTICE:  drop cascades to 16 other objects
-DETAIL:  drop cascades to function filtered_row_count(text)
-drop cascades to table test_chunk_filtering
-drop cascades to table collation_chunk_filtering_test
-drop cascades to table r1
-drop cascades to table r2
-drop cascades to table r3
-drop cascades to table r4
-drop cascades to table r5
-drop cascades to table r6
-drop cascades to table r7
-drop cascades to table coltest
-drop cascades to table coltest_part
-drop cascades to function vol()
-drop cascades to function stable_1(integer)
-drop cascades to table pushdown_test
-drop cascades to function volatilefunction()
+RESET client_min_messages;

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -497,4 +497,6 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
 
 SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
 
+SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_chunk_filtering CASCADE;
+RESET client_min_messages;

--- a/src/test/regress/sql/columnar_chunk_filtering.sql
+++ b/src/test/regress/sql/columnar_chunk_filtering.sql
@@ -12,6 +12,10 @@
 -- If chunks get filtered by columnar, less rows are passed to WHERE
 -- clause, so this function should return a lower number.
 --
+
+CREATE SCHEMA columnar_chunk_filtering;
+SET search_path TO columnar_chunk_filtering, public;
+
 CREATE OR REPLACE FUNCTION filtered_row_count (query text) RETURNS bigint AS
 $$
     DECLARE
@@ -493,4 +497,4 @@ SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
 
 SELECT * FROM pushdown_test WHERE country IN ('USA', 'ZW', volatileFunction());
 
-DROP TABLE pushdown_test;
+DROP SCHEMA columnar_chunk_filtering CASCADE;


### PR DESCRIPTION
Test was not cleaning up after itself therefore failed consecutive runs

Test locally with: `make check-columnar-minimal EXTRA_TESTS='columnar_chunk_filtering columnar_chunk_filtering'`
