### PR TITLE
Also use pid in valgrind logfile name

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -259,7 +259,7 @@ exec $valgrindPath \\
     --leak-check=no \\
     --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END \\
     --max-stackframe=16000000 \\
-    --log-file=$valgrindLogFile \\
+    --log-file=$valgrindLogFile.%p \\
     --fullpath-after=/ \\
     $bindir/postgres.orig \\
     "\$@"


### PR DESCRIPTION
Also use pid in valgrind logfile name to avoid overwriting the valgrind logs due to the memory errors that can happen in different processes concurrently:

(from https://valgrind.org/docs/manual/manual-core.html)
```
--log-file=<filename>
Specifies that Valgrind should send all of its messages to the specified file. If the file name is empty, it causes an abort. There are three special format specifiers that can be used in the file name.

%p is replaced with the current process ID. This is very useful for program that invoke multiple processes. WARNING: If you use --trace-children=yes and your program invokes multiple processes OR your program forks without calling exec afterwards, and you don't use this specifier (or the %q specifier below), the Valgrind output from all those processes will go into one file, possibly jumbled up, and possibly incomplete.
```

With this change, we'll start having lots of valgrind output files generated under "src/test/regress" with the same prefix, citus_valgrind_test_log.txt, by default, during valgrind tests, so it'll look a bit ugly; but one can use `cat src/test/regress/citus_valgrind_test_log.txt.[0-9]*"` or such to combine them into a single valgrind log file later.