### PR TITLE
Fix invalid input syntax for type bigint

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_stats/13.2-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats/13.2-1.sql
@@ -22,7 +22,7 @@ most_common_vals_json AS (
 
 table_reltuples_json AS (
     SELECT distinct(shardid),
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples,
 	       (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table
     FROM most_common_vals_json),
 
@@ -32,8 +32,8 @@ table_reltuples AS (
 
 null_frac_json AS (
     SELECT (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table,
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples,
-           (json_array_elements(result::json)->>'null_frac')::float4 AS null_frac,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples,
+           CAST((json_array_elements(result::json)->>'null_frac') AS float4) AS null_frac,
            (json_array_elements(result::json)->>'attname')::text AS attname
     FROM most_common_vals_json
 ),
@@ -49,8 +49,8 @@ most_common_vals AS (
     SELECT (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table,
            (json_array_elements(result::json)->>'attname')::text AS attname,
            json_array_elements_text((json_array_elements(result::json)->>'most_common_vals')::json)::text AS common_val,
-           json_array_elements_text((json_array_elements(result::json)->>'most_common_freqs')::json)::float4 AS common_freq,
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples
+           CAST(json_array_elements_text((json_array_elements(result::json)->>'most_common_freqs')::json) AS float4) AS common_freq,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples
     FROM most_common_vals_json),
 
 common_val_occurrence AS (

--- a/src/backend/distributed/sql/udfs/citus_stats/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_stats/latest.sql
@@ -22,7 +22,7 @@ most_common_vals_json AS (
 
 table_reltuples_json AS (
     SELECT distinct(shardid),
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples,
 	       (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table
     FROM most_common_vals_json),
 
@@ -32,8 +32,8 @@ table_reltuples AS (
 
 null_frac_json AS (
     SELECT (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table,
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples,
-           (json_array_elements(result::json)->>'null_frac')::float4 AS null_frac,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples,
+           CAST((json_array_elements(result::json)->>'null_frac') AS float4) AS null_frac,
            (json_array_elements(result::json)->>'attname')::text AS attname
     FROM most_common_vals_json
 ),
@@ -49,8 +49,8 @@ most_common_vals AS (
     SELECT (json_array_elements(result::json)->>'citus_table')::regclass AS citus_table,
            (json_array_elements(result::json)->>'attname')::text AS attname,
            json_array_elements_text((json_array_elements(result::json)->>'most_common_vals')::json)::text AS common_val,
-           json_array_elements_text((json_array_elements(result::json)->>'most_common_freqs')::json)::float4 AS common_freq,
-           (json_array_elements(result::json)->>'reltuples')::bigint AS shard_reltuples
+           CAST(json_array_elements_text((json_array_elements(result::json)->>'most_common_freqs')::json) AS float4) AS common_freq,
+           CAST( CAST((json_array_elements(result::json)->>'reltuples') AS DOUBLE PRECISION) AS bigint) AS shard_reltuples
     FROM most_common_vals_json),
 
 common_val_occurrence AS (

--- a/src/test/regress/expected/citus_aggregated_stats.out
+++ b/src/test/regress/expected/citus_aggregated_stats.out
@@ -110,13 +110,38 @@ SELECT * FROM citus_stats
  citus_aggregated_stats | citus_local_current_check | rlsuser   |  0.142857 | {user1}          | {0.714286}
 (9 rows)
 
+-- create a dist table with million rows to simulate 3.729223e+06 in reltuples
+-- this tests casting numbers like 3.729223e+06 to bigint
+CREATE TABLE organizations (
+    org_id bigint,
+    id int
+);
+SELECT create_distributed_table('organizations', 'org_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO organizations(org_id, id)
+  SELECT i, 1
+  FROM generate_series(1,2000000) i;
+ANALYZE organizations;
+SELECT attname, null_frac, most_common_vals, most_common_freqs FROM citus_stats
+  WHERE tablename IN ('organizations')
+  ORDER BY 1;
+ attname | null_frac | most_common_vals | most_common_freqs
+---------------------------------------------------------------------
+ id      |         0 | {1}              | {1}
+(1 row)
+
 RESET SESSION AUTHORIZATION;
 DROP SCHEMA citus_aggregated_stats CASCADE;
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table current_check
 drop cascades to table dist_current_check
 drop cascades to table ref_current_check
 drop cascades to table citus_local_current_check_1870003
 drop cascades to table ref_current_check_1870002
 drop cascades to table citus_local_current_check
+drop cascades to table organizations
 DROP USER user1;

--- a/src/test/regress/sql/citus_aggregated_stats.sql
+++ b/src/test/regress/sql/citus_aggregated_stats.sql
@@ -82,6 +82,26 @@ SELECT * FROM citus_stats
   WHERE tablename IN ('current_check', 'dist_current_check', 'ref_current_check', 'citus_local_current_check')
   ORDER BY 1;
 
+-- create a dist table with million rows to simulate 3.729223e+06 in reltuples
+-- this tests casting numbers like 3.729223e+06 to bigint
+
+CREATE TABLE organizations (
+    org_id bigint,
+    id int
+);
+
+SELECT create_distributed_table('organizations', 'org_id');
+
+INSERT INTO organizations(org_id, id)
+  SELECT i, 1
+  FROM generate_series(1,2000000) i;
+
+ANALYZE organizations;
+
+SELECT attname, null_frac, most_common_vals, most_common_freqs FROM citus_stats
+  WHERE tablename IN ('organizations')
+  ORDER BY 1;
+
 RESET SESSION AUTHORIZATION;
 DROP SCHEMA citus_aggregated_stats CASCADE;
 DROP USER user1;


### PR DESCRIPTION
Fixes #8164 

Didn't add the test since I don't want to slow down testing by populating with millions of rows. Reviewer can test locally to verify. Or simply `SELECT CAST(CAST('3.729223e+06' AS DOUBLE PRECISION) AS BIGINT);`

Edit: added a test with 2 million rows, 2100 ms to execute in my local, acceptable.
