### PR TITLE
Remove Code Climate coverage upload steps from GitHub Actions workflow

### DIFF
--- a/.github/actions/upload_coverage/action.yml
+++ b/.github/actions/upload_coverage/action.yml
@@ -13,15 +13,3 @@ runs:
       token: ${{ inputs.codecov_token }}
       verbose: true
       gcov: true
-  - name: Create codeclimate coverage
-    run: |-
-      lcov --directory . --capture --output-file lcov.info
-      lcov --remove lcov.info -o lcov.info '/usr/*'
-      sed "s=^SF:$PWD/=SF:=g" -i lcov.info # relative pats are required by codeclimate
-      mkdir -p /tmp/codeclimate
-      cc-test-reporter format-coverage -t lcov -o /tmp/codeclimate/${{ inputs.flags }}.json lcov.info
-    shell: bash
-  - uses: actions/upload-artifact@v4.6.0
-    with:
-      path: "/tmp/codeclimate/*.json"
-      name: codeclimate-${{ inputs.flags }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,11 +242,6 @@ jobs:
       if: always()
       with:
         folder: ${{ fromJson(matrix.pg_version).major }}_${{ matrix.make }}
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-arbitrary-configs:
     name: PG${{ fromJson(matrix.pg_version).major }} - check-arbitrary-configs-${{ matrix.parallel }}
     runs-on: ["self-hosted", "1ES.Pool=1es-gha-citusdata-pool"]
@@ -291,11 +286,6 @@ jobs:
       if: always()
       with:
         folder: ${{ env.PG_MAJOR }}_arbitrary_configs_${{ matrix.parallel }}
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.PG_MAJOR }}_arbitrary_configs_${{ matrix.parallel }}
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade
     runs-on: ubuntu-latest
@@ -352,11 +342,6 @@ jobs:
       if: always()
       with:
         folder: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-upgrade:
     name: PG${{ fromJson(needs.params.outputs.pg15_version).major }} - check-citus-upgrade
     runs-on: ubuntu-latest
@@ -399,35 +384,6 @@ jobs:
       if: always()
       with:
         folder: ${{ env.PG_MAJOR }}_citus_upgrade
-    - uses: "./.github/actions/upload_coverage"
-      if: always()
-      with:
-        flags: ${{ env.PG_MAJOR }}_citus_upgrade
-        codecov_token: ${{ secrets.CODECOV_TOKEN }}
-  upload-coverage:
-    # secret below is not available for forks so disabling upload action for them
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
-    env:
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ needs.params.outputs.test_image_name }}:${{ fromJson(needs.params.outputs.pg17_version).full }}${{ needs.params.outputs.image_suffix }}
-    needs:
-      - params
-      - test-citus
-      - test-arbitrary-configs
-      - test-citus-upgrade
-      - test-pg-upgrade
-    steps:
-      - uses: actions/download-artifact@v4.1.8
-        with:
-          pattern: codeclimate*
-          path: codeclimate
-          merge-multiple: true
-      - name: Upload coverage results to Code Climate
-        run: |-
-          cc-test-reporter sum-coverage codeclimate/*.json -o total.json
-          cc-test-reporter upload-coverage -i total.json
   ch_benchmark:
     name: CH Benchmark
     if: startsWith(github.ref, 'refs/heads/ch_benchmark/')

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,6 +242,11 @@ jobs:
       if: always()
       with:
         folder: ${{ fromJson(matrix.pg_version).major }}_${{ matrix.make }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.PG_MAJOR }}_${{ matrix.suite }}_${{ matrix.make }}
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-arbitrary-configs:
     name: PG${{ fromJson(matrix.pg_version).major }} - check-arbitrary-configs-${{ matrix.parallel }}
     runs-on: ["self-hosted", "1ES.Pool=1es-gha-citusdata-pool"]
@@ -286,6 +291,11 @@ jobs:
       if: always()
       with:
         folder: ${{ env.PG_MAJOR }}_arbitrary_configs_${{ matrix.parallel }}
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.PG_MAJOR }}_arbitrary_configs_${{ matrix.parallel }}
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-pg-upgrade:
     name: PG${{ matrix.old_pg_major }}-PG${{ matrix.new_pg_major }} - check-pg-upgrade
     runs-on: ubuntu-latest
@@ -342,6 +352,11 @@ jobs:
       if: always()
       with:
         folder: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-upgrade:
     name: PG${{ fromJson(needs.params.outputs.pg15_version).major }} - check-citus-upgrade
     runs-on: ubuntu-latest
@@ -384,6 +399,11 @@ jobs:
       if: always()
       with:
         folder: ${{ env.PG_MAJOR }}_citus_upgrade
+    - uses: "./.github/actions/upload_coverage"
+      if: always()
+      with:
+        flags: ${{ env.PG_MAJOR }}_citus_upgrade
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
   ch_benchmark:
     name: CH Benchmark
     if: startsWith(github.ref, 'refs/heads/ch_benchmark/')


### PR DESCRIPTION
DESCRIPTION: Remove Code Climate coverage upload steps from GitHub Actions workflow

CI: remove Code Climate coverage reporting (cc-test-reporter) and related jobs; keep Codecov as source of truth

* **Why**
  Code Climate’s test-reporter has been archived; their download/API path is no longer served, which breaks our CC upload step (`cc-test-reporter …` ends up downloading HTML/404). 

* **What changed**

  * Drop the Code Climate formatting/artifact steps from the composite action `.github/actions/upload_coverage/action.yml`. 
  * Delete the `upload-coverage` job that aggregated and pushed to Code Climate (`cc-test-reporter sum-coverage` / `upload-coverage`).


* **Impact**

  * Codecov uploads remain; coverage stays visible via Codecov.
  * No test/build behavior change—only removes a failing reporter path.

