### PR TITLE
PG18 - normalize PG18 “RESTRICT” FK error wording to legacy form

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -359,3 +359,9 @@ s/(Actual[[:space:]]+Rows:[[:space:]]*)N\.N/\1N/gI
 s/^([ \t]*)List of tables$/\1List of relations/g
 s/^([ \t]*)List of indexes$/\1List of relations/g
 s/^([ \t]*)List of sequences$/\1List of relations/g
+
+# --- PG18 FK wording -> legacy generic form ---
+# e.g., "violates RESTRICT setting of foreign key constraint" -> "violates foreign key constraint"
+s/violates RESTRICT setting of foreign key constraint/violates foreign key constraint/g
+# DETAIL line changed "is referenced" -> old "is still referenced"
+s/\<is referenced from table\>/is still referenced from table/g


### PR DESCRIPTION
fixes #8186

https://github.com/postgres/postgres/commit/086c84b23d99c2ad268f97508cd840efc1fdfd79

PG18 emitting a more specific message for foreign-key violations when the action is `RESTRICT` (SQLSTATE 23001), e.g.
`violates RESTRICT setting of foreign key constraint ...` and `Key (...) is referenced from table ...`.
Older versions printed the generic FK text (SQLSTATE 23503), e.g.
`violates foreign key constraint ...` and `Key (...) is still referenced from table ...`.

This change was causing noisy diffs in our regression tests (e.g., `multi_foreign_key.out`).
To keep a single set of expected files across PG15–PG18, this PR adds two normalization rules to the test filter:

```sed
# PG18 FK wording -> legacy generic form
s/violates RESTRICT setting of foreign key constraint/violates foreign key constraint/g

# DETAIL line: "is referenced" -> "is still referenced"
s/\<is referenced from table\>/is still referenced from table/g
```

**Scope / impact**

* Test-only change; runtime behavior is unaffected.
* Keeps outputs stable across PG15–PG18 without version-splitting expected files.
* Rules are narrowly targeted to the FK wording introduced in PG18.

with pr: https://github.com/citusdata/citus/actions/runs/17698469722/job/50300960878#step:5:252
