### PR TITLE
Postgres 18: fix 'column does not exist' errors in grouping regress tests.

### DIFF
--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -2029,7 +2029,9 @@ SubqueryPushdownMultiNodeTree(Query *originalQuery)
 	pushedDownQuery->setOperations = copyObject(queryTree->setOperations);
 	pushedDownQuery->querySource = queryTree->querySource;
 	pushedDownQuery->hasSubLinks = queryTree->hasSubLinks;
-
+#if PG_VERSION_NUM >= PG_VERSION_18
+	pushedDownQuery->hasGroupRTE = queryTree->hasGroupRTE;
+#endif
 	MultiTable *subqueryNode = MultiSubqueryPushdownTable(pushedDownQuery);
 
 	SetChild((MultiUnaryNode *) subqueryCollectNode, (MultiNode *) subqueryNode);


### PR DESCRIPTION
DESCRIPTION: Fix 'column does not exist' errors in grouping regress tests.

Postgres 18's GROUP RTE was being ignored by query pushdown planning when constructing the query tree for the worker subquery. The solution is straightforward - ensure the worker subquery tree has the same groupRTE property as the original query. Postgres ruleutils then does the right thing when generating the pushed down query. Fixes category 1 in #7992.

Fixes #8070 
