### PR TITLE
Cleanup from dropping pg14 in merge isolation tests

### DIFF
--- a/src/test/regress/expected/isolation_merge_0.out
+++ b/src/test/regress/expected/isolation_merge_0.out
@@ -1,5 +1,0 @@
-Parsed test spec with 2 sessions
-
-starting permutation: s1-begin s1-upd-ins s2-result s1-commit s2-result
-setup failed: ERROR:  MERGE is not supported on PG versions below 15
-CONTEXT:  PL/pgSQL function inline_code_block line XX at RAISE

--- a/src/test/regress/expected/isolation_merge_replicated_0.out
+++ b/src/test/regress/expected/isolation_merge_replicated_0.out
@@ -1,5 +1,0 @@
-Parsed test spec with 2 sessions
-
-starting permutation: s1-begin s1-upd-ins s2-begin s2-update s1-commit s2-commit s1-result s2-result
-setup failed: ERROR:  MERGE is not supported on PG versions below 15
-CONTEXT:  PL/pgSQL function inline_code_block line XX at RAISE

--- a/src/test/regress/spec/isolation_merge.spec
+++ b/src/test/regress/spec/isolation_merge.spec
@@ -5,18 +5,6 @@
 // create distributed tables to test behavior of MERGE in concurrent operations
 setup
 {
-	DO
-	$do$
-	DECLARE ver int;
-	BEGIN
-	  SELECT substring(version(), '\d+')::int into ver;
-	  IF (ver < 15)
-	  THEN
-	    RAISE EXCEPTION 'MERGE is not supported on PG versions below 15';
-	  END IF;
-	  END
-	$do$;
-
 	SET citus.shard_replication_factor TO 1;
 	SELECT 1 FROM master_add_node('localhost', 57637);
 	SELECT 1 FROM master_add_node('localhost', 57638);

--- a/src/test/regress/spec/isolation_merge_replicated.spec
+++ b/src/test/regress/spec/isolation_merge_replicated.spec
@@ -5,18 +5,6 @@
 // create distributed tables to test behavior of MERGE in concurrent operations
 setup
 {
-	DO
-	$do$
-	DECLARE ver int;
-	BEGIN
-	  SELECT substring(version(), '\d+')::int into ver;
-	  IF (ver < 15)
-	  THEN
-	    RAISE EXCEPTION 'MERGE is not supported on PG versions below 15';
-	  END IF;
-	  END
-	$do$;
-
 	SET citus.shard_replication_factor TO 2;
 	SELECT 1 FROM master_add_node('localhost', 57637);
 	SELECT 1 FROM master_add_node('localhost', 57638);


### PR DESCRIPTION
These alternative test outputs are redundant since we have dropped PG14 support on main.