### PR TITLE
PG18 regress sanity: Fix crash in Range Table identity check.

### DIFF
--- a/src/backend/distributed/planner/relation_restriction_equivalence.c
+++ b/src/backend/distributed/planner/relation_restriction_equivalence.c
@@ -2431,7 +2431,7 @@ FilterJoinRestrictionContext(JoinRestrictionContext *joinRestrictionContext, Rel
 
 /*
  * RangeTableArrayContainsAnyRTEIdentities returns true if any of the range table entries
- * int rangeTableEntries array is an range table relation specified in queryRteIdentities.
+ * in rangeTableEntries array is a range table relation specified in queryRteIdentities.
  */
 static bool
 RangeTableArrayContainsAnyRTEIdentities(RangeTblEntry **rangeTableEntries, int
@@ -2443,6 +2443,18 @@ RangeTableArrayContainsAnyRTEIdentities(RangeTblEntry **rangeTableEntries, int
 		RangeTblEntry *rangeTableEntry = rangeTableEntries[rteIndex];
 		List *rangeTableRelationList = NULL;
 		ListCell *rteRelationCell = NULL;
+
+#if PG_VERSION_NUM >= PG_VERSION_18
+
+		/*
+		 * In PG18+, planner array simple_rte_array may contain NULL entries
+		 * for "dead relations". See PG commits 5f6f951 and e9a20e4 for details.
+		 */
+		if (rangeTableEntry == NULL)
+		{
+			continue;
+		}
+#endif
 
 		/*
 		 * Get list of all RTE_RELATIONs in the given range table entry


### PR DESCRIPTION
The range table entry array created by the Postgres planner for each SELECT in a query may have NULL entries as of PG18. Add a NULL check to skip over these when looking for matches in rte identities.

The crashes reported in #8197 are because of upstream commit [5f6f951](https://github.com/postgres/postgres/commit/5f6f951f88e53630b3ebe9bde762a9612ca6202f), which explicitly NULLs the index of range table entries that are not needed in the query. This commit was introduced in 18rc1. It is related to [e9a20e4](https://github.com/postgres/postgres/commit/e9a20e451f3aa0b64da807338012c65d8664d0ac), present since PG16, which removed "dead relations" from planner data structures. But that focused on `RelOptInfo` (path-tracking) instances, and did not consider `RangeTblEntry` instances, a loose end tied up by the recent 18rc1 commit. 