### PR TITLE
PG18 - fix naming diffs of child FK constraints

### DIFF
--- a/src/test/regress/expected/citus_non_blocking_split_columnar.out
+++ b/src/test/regress/expected/citus_non_blocking_split_columnar.out
@@ -160,7 +160,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -191,7 +191,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -250,7 +250,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
  relname | Constraint | Definition
 ---------------------------------------------------------------------
@@ -260,7 +260,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               0
@@ -389,7 +389,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -419,7 +419,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -478,36 +478,40 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |            Constraint             |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(16 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
 
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
-                              6
+                              2
 (1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
@@ -669,7 +673,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -699,7 +703,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -758,52 +762,60 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |            Constraint             |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999101            | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_8999101            | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999107       | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_news_8999107       | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999103        | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_old_8999103        | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(32 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999101            | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_8999101            | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(40 rows)
 
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
-                             12
+                              4
 (1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;

--- a/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
+++ b/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
@@ -152,7 +152,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -183,7 +183,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -242,7 +242,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
  relname | Constraint | Definition
 ---------------------------------------------------------------------
@@ -252,7 +252,7 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               0
@@ -381,7 +381,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -411,7 +411,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -470,36 +470,40 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |            Constraint             |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(16 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
 
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
-                              6
+                              2
 (1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
@@ -661,7 +665,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
           relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -691,7 +695,7 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               2
@@ -750,52 +754,60 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |            Constraint             |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999101            | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_8999101            | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999107       | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_news_8999107       | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999103        | fkey_from_parent_to_child_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_dist_8999101  | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_old_8999103        | fkey_from_parent_to_ref_8999101   | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(32 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999101            | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_8999101            | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(40 rows)
 
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
-                             12
+                              4
 (1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;

--- a/src/test/regress/expected/shard_move_constraints.out
+++ b/src/test/regress/expected/shard_move_constraints.out
@@ -137,7 +137,7 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 -- show the current state of the constraints
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -148,14 +148,14 @@ ORDER BY 1, 2;
 
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
 (1 row)
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -168,7 +168,7 @@ ORDER BY 1,2;
 (6 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
@@ -249,7 +249,7 @@ SELECT public.wait_for_resource_cleanup();
 \c - postgres - :worker_2_port
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -259,14 +259,14 @@ ORDER BY 1, 2;
 (3 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
 (1 row)
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -279,7 +279,7 @@ ORDER BY 1,2;
 (6 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1

--- a/src/test/regress/expected/shard_move_constraints_blocking.out
+++ b/src/test/regress/expected/shard_move_constraints_blocking.out
@@ -133,7 +133,7 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 -- show the current state of the constraints
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -145,14 +145,14 @@ ORDER BY 1, 2;
 
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
 (1 row)
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -167,7 +167,7 @@ ORDER BY 1,2;
 (8 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
@@ -248,7 +248,7 @@ SELECT public.wait_for_resource_cleanup();
 \c - postgres - :worker_2_port
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -259,14 +259,14 @@ ORDER BY 1, 2;
 (4 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1
 (1 row)
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
              Constraint             |                                                         Definition
 ---------------------------------------------------------------------
@@ -281,7 +281,7 @@ ORDER BY 1,2;
 (8 rows)
 
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
  generated_child_fk_constraints
 ---------------------------------------------------------------------
                               1

--- a/src/test/regress/sql/citus_non_blocking_split_columnar.sql
+++ b/src/test/regress/sql/citus_non_blocking_split_columnar.sql
@@ -138,14 +138,14 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -162,13 +162,13 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -222,13 +222,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -245,13 +245,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -305,13 +305,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -328,13 +328,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (

--- a/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
+++ b/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
@@ -134,14 +134,14 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -158,13 +158,13 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -218,13 +218,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -241,13 +241,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -301,13 +301,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -324,13 +324,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to_parent%_1'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
     SELECT count(*) AS generated_child_fk_constraints
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
-            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to_parent%_1');
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (

--- a/src/test/regress/sql/shard_move_constraints.sql
+++ b/src/test/regress/sql/shard_move_constraints.sql
@@ -128,17 +128,17 @@ SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 
 -- show the current state of the constraints
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
@@ -168,16 +168,16 @@ SELECT public.wait_for_resource_cleanup();
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;

--- a/src/test/regress/sql/shard_move_constraints_blocking.sql
+++ b/src/test/regress/sql/shard_move_constraints_blocking.sql
@@ -122,17 +122,17 @@ SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 
 -- show the current state of the constraints
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
 -- separating generated child FK constraints since PG18 changed their naming (3db61db4)
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
@@ -162,16 +162,16 @@ SELECT public.wait_for_resource_cleanup();
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1, 2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to_parent%_1'
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
 ORDER BY 1,2;
 SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
-AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to_parent%_1');
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;


### PR DESCRIPTION
PG18 changed the names generated for child foreign key constraints.
https://github.com/postgres/postgres/commit/3db61db48

The test failures in Citus regression suite are all changing the name of
a constraint from `'sensors%'` to `'%to_parent%_1'`: the naming is very
nice here because `to_parent` means that we have a foreign key to a
parent table.

To fix the diff, we exclude those constraints from the output.
To verify correctness, we still count the problematic constraints to
make sure they are there - we are simply removing them from the first
output (we add this count query right after the previous one)

Fixes #8126 
