### PR TITLE
PG18: use data-checksums by default in upgrades

### DIFF
--- a/src/test/regress/citus_tests/common.py
+++ b/src/test/regress/citus_tests/common.py
@@ -137,7 +137,7 @@ def initialize_db_for_cluster(pg_path, rel_data_path, settings, node_names):
             # --allow-group-access is used to ensure we set permissions on
             # private keys correctly
             "--allow-group-access",
-            "--no-data-checksums",
+            "--data-checksums",
             "--encoding",
             "UTF8",
             "--locale",
@@ -792,7 +792,7 @@ class Postgres(QueryRunner):
 
     def initdb(self):
         run(
-            f"initdb -A trust --nosync --username postgres --pgdata {self.pgdata} --allow-group-access --no-data-checksums --encoding UTF8 --locale POSIX",
+            f"initdb -A trust --nosync --username postgres --pgdata {self.pgdata} --allow-group-access --encoding UTF8 --locale POSIX",
             stdout=subprocess.DEVNULL,
         )
 


### PR DESCRIPTION
Checksums are now [on by default in PG18](https://github.com/postgres/postgres/commit/04bec894a04cb0d32533f1522ab81b7016141ff1). Upgrade to PG18 fails with the following error:
`old cluster does not use data checksums but the new one does`

To overcome this error, we add `data-checksums` option such that clusters with PG less than 18 also use data checksums.

Fixes #8229 

**_Note to reviewer:_** once the change is approved, I will change the base to main branch. The PG15-PG18 upgrade test added will not be merged to main for now - only added here to test sanity. Probably should be part of `m3hm3t/pg18_beta_confs` branch because we are not dropping pg15 support soon.