### PR TITLE
PG18 - fix naming diffs of child FK constraints

### DIFF
--- a/src/test/regress/expected/citus_non_blocking_split_columnar.out
+++ b/src/test/regress/expected/citus_non_blocking_split_columnar.out
@@ -160,32 +160,42 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8970002 | fkey_from_child_to_child_8970002                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_dist_8970002                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_ref_8970002                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8970002 | sensors_2020_01_01_8970002_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_8970000            | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8970000            | sensors_8970000_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_news_8970003       | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8970001        | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_old_8970001        | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_old_8970001        | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_old_8970001        | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_child_8970002   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_dist_8970002    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_ref_8970002     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8970000            | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_8970000            | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_8970000            | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_8970000            | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8970003       | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_news_8970003       | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_news_8970003       | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_news_8970003       | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8970001        | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_old_8970001        | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_old_8970001        | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_old_8970001        | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                       indexdef
@@ -240,10 +250,21 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
  relname | Constraint | Definition
 ---------------------------------------------------------------------
 (0 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              0
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
         tablename        |                                                                         indexdef
@@ -368,32 +389,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999004 | fkey_from_child_to_child_8999004                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_dist_8999004                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_parent_8999004                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_ref_8999004                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999004 | sensors_2020_01_01_8999004_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_8999000            | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999000            | sensors_8999000_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_news_8999006       | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999002        | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_old_8999002        | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_old_8999002        | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_old_8999002        | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_child_8999004   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_dist_8999004    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_parent_8999004  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_ref_8999004     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999000            | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_8999000            | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_8999000            | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_8999000            | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999006       | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_news_8999006       | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_news_8999006       | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_news_8999006       | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999002        | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_old_8999002        | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_old_8999002        | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_old_8999002        | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                       indexdef
@@ -448,32 +478,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | sensors_2020_01_01_8999005_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | sensors_8999001_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                       indexdef
@@ -634,32 +673,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999104 | fkey_from_child_to_child_8999104                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_dist_8999104                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_parent_8999104                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_ref_8999104                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999104 | sensors_2020_01_01_8999104_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_8999100            | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999100            | sensors_8999100_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_news_8999106       | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999102        | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_old_8999102        | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_old_8999102        | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_old_8999102        | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_child_8999104   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_dist_8999104    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_parent_8999104  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_ref_8999104     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999100            | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_8999100            | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_8999100            | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_8999100            | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999106       | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_news_8999106       | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_news_8999106       | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_news_8999106       | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999102        | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_old_8999102        | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_old_8999102        | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_old_8999102        | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                       indexdef
@@ -714,54 +762,61 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | sensors_2020_01_01_8999005_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | sensors_2020_01_01_8999105_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | sensors_8999001_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_8999101            | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999101            | sensors_8999101_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999107       | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_news_8999107       | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999103        | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_old_8999103        | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(44 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999101            | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_8999101            | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(40 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              4
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                       indexdef

--- a/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
+++ b/src/test/regress/expected/citus_split_shard_columnar_partitioned.out
@@ -152,32 +152,42 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8970002 | fkey_from_child_to_child_8970002                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_dist_8970002                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_child_to_ref_8970002                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_2020_01_01_8970002 | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8970002 | sensors_2020_01_01_8970002_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_8970000            | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_8970000            | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8970000            | sensors_8970000_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_news_8970003       | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_news_8970003       | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8970001        | fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
- sensors_old_8970001        | fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
- sensors_old_8970001        | fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
- sensors_old_8970001        | fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_child_8970002   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_dist_8970002    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_parent_8970002  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_child_to_ref_8970002     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_2020_01_01_8970002 | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8970000            | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_8970000            | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_8970000            | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_8970000            | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8970003       | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_news_8970003       | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_news_8970003       | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_news_8970003       | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8970001        | fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970010(eventdatetime, measureid)
+ sensors_old_8970001        | fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970008(measureid)
+ sensors_old_8970001        | fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970009(eventdatetime, measureid)
+ sensors_old_8970001        | fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                   indexdef
@@ -232,10 +242,21 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
  relname | Constraint | Definition
 ---------------------------------------------------------------------
 (0 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              0
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
         tablename        |                                                                     indexdef
@@ -360,32 +381,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999004 | fkey_from_child_to_child_8999004                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_dist_8999004                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_parent_8999004                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_child_to_ref_8999004                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_2020_01_01_8999004 | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999004 | sensors_2020_01_01_8999004_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_8999000            | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_8999000            | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999000            | sensors_8999000_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_news_8999006       | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_news_8999006       | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999002        | fkey_from_parent_to_child_8999000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
- sensors_old_8999002        | fkey_from_parent_to_dist_8999000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
- sensors_old_8999002        | fkey_from_parent_to_parent_8999000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
- sensors_old_8999002        | fkey_from_parent_to_ref_8999000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_child_8999004   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_dist_8999004    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_parent_8999004  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_child_to_ref_8999004     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_2020_01_01_8999004 | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999000            | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_8999000            | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_8999000            | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_8999000            | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999006       | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_news_8999006       | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_news_8999006       | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_news_8999006       | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999002        | fkey_from_parent_to_child_8999000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999020(eventdatetime, measureid)
+ sensors_old_8999002        | fkey_from_parent_to_dist_8999000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999016(measureid)
+ sensors_old_8999002        | fkey_from_parent_to_parent_8999000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999018(eventdatetime, measureid)
+ sensors_old_8999002        | fkey_from_parent_to_ref_8999000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                   indexdef
@@ -440,32 +470,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | sensors_2020_01_01_8999005_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | sensors_8999001_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                   indexdef
@@ -626,32 +665,41 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999104 | fkey_from_child_to_child_8999104                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_dist_8999104                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_parent_8999104                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_child_to_ref_8999104                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_2020_01_01_8999104 | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999104 | sensors_2020_01_01_8999104_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_8999100            | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_8999100            | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999100            | sensors_8999100_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_news_8999106       | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_news_8999106       | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999102        | fkey_from_parent_to_child_8999100                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
- sensors_old_8999102        | fkey_from_parent_to_dist_8999100                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
- sensors_old_8999102        | fkey_from_parent_to_parent_8999100                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
- sensors_old_8999102        | fkey_from_parent_to_ref_8999100                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(22 rows)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_child_8999104   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_dist_8999104    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_parent_8999104  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_child_to_ref_8999104     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_2020_01_01_8999104 | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999100            | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_8999100            | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_8999100            | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_8999100            | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999106       | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_news_8999106       | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_news_8999106       | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_news_8999106       | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999102        | fkey_from_parent_to_child_8999100  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999120(eventdatetime, measureid)
+ sensors_old_8999102        | fkey_from_parent_to_dist_8999100   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999116(measureid)
+ sensors_old_8999102        | fkey_from_parent_to_parent_8999100 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999118(eventdatetime, measureid)
+ sensors_old_8999102        | fkey_from_parent_to_ref_8999100    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(20 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              2
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                   indexdef
@@ -706,54 +754,61 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
-          relname           |                       Constraint                        |                                                         Definition
+          relname           |             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999005 | sensors_2020_01_01_8999005_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_2020_01_01_8999105 | sensors_2020_01_01_8999105_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_8999001            | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_8999001            | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999001            | sensors_8999001_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_8999101            | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_8999101            | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_8999101            | sensors_8999101_measureid_eventdatetime_fkey            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_news_8999007       | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_news_8999007       | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_news_8999107       | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_news_8999107       | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_news_8999107       | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999003        | fkey_from_parent_to_child_8999001                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_dist_8999001                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
- sensors_old_8999003        | fkey_from_parent_to_parent_8999001                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
- sensors_old_8999003        | fkey_from_parent_to_ref_8999001                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
- sensors_old_8999103        | fkey_from_parent_to_child_8999101                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_dist_8999101                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
- sensors_old_8999103        | fkey_from_parent_to_parent_8999101                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
- sensors_old_8999103        | fkey_from_parent_to_ref_8999101                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
-(44 rows)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_child_8999005   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_dist_8999005    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_parent_8999005  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_child_to_ref_8999005     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_2020_01_01_8999005 | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_child_8999105   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_dist_8999105    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_parent_8999105  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_child_to_ref_8999105     | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_2020_01_01_8999105 | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999001            | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_8999001            | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_8999001            | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_8999101            | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_8999101            | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_8999101            | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_news_8999007       | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_news_8999007       | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_news_8999107       | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_news_8999107       | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_child_8999001  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999021(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_dist_8999001   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999017(measureid)
+ sensors_old_8999003        | fkey_from_parent_to_parent_8999001 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999019(eventdatetime, measureid)
+ sensors_old_8999003        | fkey_from_parent_to_ref_8999001    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_child_8999101  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8999121(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_dist_8999101   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8999117(measureid)
+ sensors_old_8999103        | fkey_from_parent_to_parent_8999101 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8999119(eventdatetime, measureid)
+ sensors_old_8999103        | fkey_from_parent_to_ref_8999101    | FOREIGN KEY (measureid) REFERENCES reference_table_8970011(measureid)
+(40 rows)
+
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              4
+(1 row)
 
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
                    tablename                    |                                                                                                   indexdef

--- a/src/test/regress/expected/shard_move_constraints.out
+++ b/src/test/regress/expected/shard_move_constraints.out
@@ -136,26 +136,43 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 \c - postgres - :worker_1_port
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 -- show the current state of the constraints
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-                  Constraint                  |                                                         Definition
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- fkey_from_parent_to_child_8970000            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000             | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000           | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- sensors_8970000_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(4 rows)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+(3 rows)
 
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
-                       Constraint                        |                                                         Definition
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
 ---------------------------------------------------------------------
- fkey_from_child_to_child_8970008                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_child_to_dist_8970008                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_child_to_parent_8970008                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- sensors_2020_01_01_8970008_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(7 rows)
+                              1
+(1 row)
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+             Constraint             |                                                         Definition
+---------------------------------------------------------------------
+ fkey_from_child_to_child_8970008   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_child_to_dist_8970008    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_child_to_parent_8970008  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+(6 rows)
+
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              1
+(1 row)
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
     tablename    |                                                                                      indexdef
@@ -231,26 +248,42 @@ SELECT public.wait_for_resource_cleanup();
 
 \c - postgres - :worker_2_port
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-                  Constraint                  |                                                         Definition
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- fkey_from_parent_to_child_8970000            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000             | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000           | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- sensors_8970000_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(4 rows)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+(3 rows)
 
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
-                       Constraint                        |                                                         Definition
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
 ---------------------------------------------------------------------
- fkey_from_child_to_child_8970008                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_child_to_dist_8970008                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_child_to_parent_8970008                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- sensors_2020_01_01_8970008_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(7 rows)
+                              1
+(1 row)
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+             Constraint             |                                                         Definition
+---------------------------------------------------------------------
+ fkey_from_child_to_child_8970008   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_child_to_dist_8970008    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_child_to_parent_8970008  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+(6 rows)
+
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              1
+(1 row)
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
     tablename    |                                                                                      indexdef

--- a/src/test/regress/expected/shard_move_constraints_blocking.out
+++ b/src/test/regress/expected/shard_move_constraints_blocking.out
@@ -132,29 +132,46 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 \c - postgres - :worker_1_port
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 -- show the current state of the constraints
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-                  Constraint                  |                                                         Definition
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- fkey_from_parent_to_child_8970000            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000             | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000           | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_ref_8970000              | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- sensors_8970000_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(5 rows)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+(4 rows)
 
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
-                       Constraint                        |                                                         Definition
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
 ---------------------------------------------------------------------
- fkey_from_child_to_child_8970008                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_child_to_dist_8970008                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_child_to_parent_8970008                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_child_to_ref_8970008                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- sensors_2020_01_01_8970008_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(9 rows)
+                              1
+(1 row)
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+             Constraint             |                                                         Definition
+---------------------------------------------------------------------
+ fkey_from_child_to_child_8970008   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_child_to_dist_8970008    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_child_to_parent_8970008  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_child_to_ref_8970008     | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+(8 rows)
+
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              1
+(1 row)
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
     tablename    |                                                                                           indexdef
@@ -230,29 +247,45 @@ SELECT public.wait_for_resource_cleanup();
 
 \c - postgres - :worker_2_port
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-                  Constraint                  |                                                         Definition
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+             Constraint             |                                                         Definition
 ---------------------------------------------------------------------
- fkey_from_parent_to_child_8970000            | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000             | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000           | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_ref_8970000              | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- sensors_8970000_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(5 rows)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+(4 rows)
 
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
-                       Constraint                        |                                                         Definition
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
 ---------------------------------------------------------------------
- fkey_from_child_to_child_8970008                        | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_child_to_dist_8970008                         | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_child_to_parent_8970008                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_child_to_ref_8970008                          | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- fkey_from_parent_to_child_8970000                       | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
- fkey_from_parent_to_dist_8970000                        | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
- fkey_from_parent_to_parent_8970000                      | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
- fkey_from_parent_to_ref_8970000                         | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
- sensors_2020_01_01_8970008_measureid_eventdatetime_fkey | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
-(9 rows)
+                              1
+(1 row)
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+             Constraint             |                                                         Definition
+---------------------------------------------------------------------
+ fkey_from_child_to_child_8970008   | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_child_to_dist_8970008    | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_child_to_parent_8970008  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_child_to_ref_8970008     | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+ fkey_from_parent_to_child_8970000  | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_2020_01_01_8970024(eventdatetime, measureid)
+ fkey_from_parent_to_dist_8970000   | FOREIGN KEY (measureid) REFERENCES colocated_dist_table_8970016(measureid)
+ fkey_from_parent_to_parent_8970000 | FOREIGN KEY (eventdatetime, measureid) REFERENCES colocated_partitioned_table_8970020(eventdatetime, measureid)
+ fkey_from_parent_to_ref_8970000    | FOREIGN KEY (measureid) REFERENCES reference_table_8970028(measureid)
+(8 rows)
+
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+ generated_child_fk_constraints
+---------------------------------------------------------------------
+                              1
+(1 row)
 
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
     tablename    |                                                                                           indexdef

--- a/src/test/regress/sql/citus_non_blocking_split_columnar.sql
+++ b/src/test/regress/sql/citus_non_blocking_split_columnar.sql
@@ -138,7 +138,14 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -155,7 +162,13 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -209,7 +222,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -226,7 +245,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -280,7 +305,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -297,7 +328,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (

--- a/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
+++ b/src/test/regress/sql/citus_split_shard_columnar_partitioned.sql
@@ -134,7 +134,14 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -151,7 +158,13 @@ SELECT pg_reload_conf();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -205,7 +218,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -222,7 +241,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -276,7 +301,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (
@@ -293,7 +324,13 @@ SELECT public.wait_for_resource_cleanup();
             FROM pg_catalog.pg_class tbl
             JOIN public.table_fkeys fk on tbl.oid = fk.relid
             WHERE tbl.relname like '%_89%'
+            AND fk."Constraint" NOT LIKE 'sensors%' AND fk."Constraint" NOT LIKE '%to\_parent%\_1'
             ORDER BY 1, 2;
+    SELECT count(*) AS generated_child_fk_constraints
+            FROM pg_catalog.pg_class tbl
+            JOIN public.table_fkeys fk on tbl.oid = fk.relid
+            WHERE tbl.relname like '%_89%'
+            AND (fk."Constraint" LIKE 'sensors%' OR fk."Constraint" LIKE '%to\_parent%\_1');
     SELECT tablename, indexdef FROM pg_indexes WHERE tablename like '%_89%' ORDER BY 1,2;
     SELECT stxname FROM pg_statistic_ext
     WHERE stxnamespace IN (

--- a/src/test/regress/sql/shard_move_constraints.sql
+++ b/src/test/regress/sql/shard_move_constraints.sql
@@ -127,8 +127,19 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
 
 -- show the current state of the constraints
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='index_backed_rep_identity_8970029' ORDER BY 1,2;
@@ -155,8 +166,19 @@ SELECT public.wait_for_resource_cleanup();
 
 \c - postgres - :worker_2_port
 SET search_path TO "shard Move Fkeys Indexes", public, pg_catalog;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='index_backed_rep_identity_8970029' ORDER BY 1,2;

--- a/src/test/regress/sql/shard_move_constraints_blocking.sql
+++ b/src/test/regress/sql/shard_move_constraints_blocking.sql
@@ -121,8 +121,19 @@ INSERT INTO sensors SELECT i, '2020-01-05', '{}' FROM generate_series(0,1000)i;
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
 
 -- show the current state of the constraints
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+-- separating generated child FK constraints since PG18 changed their naming (3db61db4)
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='index_backed_rep_identity_8970029' ORDER BY 1,2;
@@ -149,8 +160,19 @@ SELECT public.wait_for_resource_cleanup();
 
 \c - postgres - :worker_2_port
 SET search_path TO "blocking shard Move Fkeys Indexes", public, pg_catalog;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass ORDER BY 1,2;
-SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass ORDER BY 1,2;
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1, 2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_8970000'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
+SELECT "Constraint", "Definition" FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND "Constraint" NOT LIKE 'sensors%' AND "Constraint" NOT LIKE '%to\_parent%\_1'
+ORDER BY 1,2;
+SELECT count(*) AS generated_child_fk_constraints FROM table_fkeys WHERE relid='sensors_2020_01_01_8970008'::regclass
+AND ("Constraint" LIKE 'sensors%' OR "Constraint" LIKE '%to\_parent%\_1');
+
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_8970000' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='sensors_2020_01_01_8970008' ORDER BY 1,2;
 SELECT tablename, indexdef FROM pg_indexes WHERE tablename ='index_backed_rep_identity_8970029' ORDER BY 1,2;


### PR DESCRIPTION
PG18 changed the names generated for child foreign key constraints. https://github.com/postgres/postgres/commit/3db61db48

The test failures in Citus regression suite are all changing the name of a constraint from `'sensors%'` to `'%to_parent%_1'`: the naming is very nice here because `to_parent` means that we have a foreign key to a parent table.

To fix the diff, we exclude those constraints from the output. To verify correctness, we still count the problematic constraints to make sure they are there - we are simply removing them from the first output (we add this count query right after the previous one)

Fixes #8126 
Same PR as #8226, except that this merges directly to main.
