### PR TITLE
pin PostgreSQL server development package version to 17

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,8 +60,7 @@ jobs:
           libzstd-dev \
           libzstd1 \
           lintian \
-          postgresql-server-dev-15 \
-          postgresql-server-dev-all \
+          postgresql-server-dev-17 \
           python3-pip \
           python3-setuptools \
           wget \


### PR DESCRIPTION
DESCRIPTION: pin PostgreSQL server development package version to 17 rather than full dev package which now pulls in 18 and Citus does not yet support pg18
