### PR TITLE
PG18: Normalize EXPLAIN ANALYZE output for drop “Index Searches” line

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -375,3 +375,6 @@ s/\<is referenced from table\>/is still referenced from table/g
 # pg18 extension_control_path GUC debugs
 # ignore any "find_in_path:" lines in test output
 /DEBUG:  find_in_path: trying .*/d
+
+# PG18: EXPLAIN ANALYZE prints "Index Searches: N" for index scans — remove it
+/^\s*Index Searches:\s*\d+\s*$/d


### PR DESCRIPTION
fixes #8265

https://github.com/postgres/postgres/commit/0fbceae841cb5a31b13d3f284ac8fdd19822eceb

PostgreSQL 18 started printing an extra line in `EXPLAIN (ANALYZE …)` for index scans:

```
Index Searches: N
```

**normalize.sed**: add a rule to remove the PG18-only line

 ```
 /^\s*Index Searches:\s*\d+\s*$/d
 ```



