### PR TITLE
PG18 - Normalize PG18 EXPLAIN: hide “Storage … Maximum Storage …” line

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -378,3 +378,7 @@ s/\<is referenced from table\>/is still referenced from table/g
 
 # PG18: EXPLAIN ANALYZE prints "Index Searches: N" for index scans — remove it
 /^\s*Index Searches:\s*\d+\s*$/d
+
+# EXPLAIN (PG18+): hide Materialize storage instrumentation
+# this rule can be removed when PG18 is the minimum supported version
+/^[ \t]*Storage:[ \t].*$/d


### PR DESCRIPTION
fixes #8267 

* Extend `src/test/regress/bin/normalize.sed` to drop the new PG18 EXPLAIN instrumentation line:

  ```
  Storage: <Memory|Disk|Memory and Disk>  Maximum Storage: <size>
  ```

  which appears under `Materialize`, some `CTE Scan`s, etc. when `ANALYZE` is on.

**Why**

* PG18 added storage usage reporting for materialization/tuplestore nodes. It’s useful for humans but creates noisy, non-semantic diffs in regression output. There’s no EXPLAIN flag to suppress it, so we normalize in tests instead. This PR wires that normalization into our sed pipeline. 

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1eff8279d

**How**

* Add a narrowly scoped sed rule that matches only lines starting with `Storage:` (keeping `Sort Method`, `Hash`, `Buffers`, etc. intact). Use ERE compatible with `sed -Ef` and Python `re` (no POSIX character classes), e.g.:

  ```
  /^[ \t]*Storage:[ \t].*$/d
  ```

