### PR TITLE
PG18 - Remove REINDEX SYSTEM test because of aio debug lines

### DIFF
--- a/src/test/regress/expected/pg16.out
+++ b/src/test/regress/expected/pg16.out
@@ -878,18 +878,10 @@ SET search_path TO pg16;
 -- We already don't propagate these commands automatically
 -- Testing here with run_command_on_workers
 -- Relevant PG commit: https://github.com/postgres/postgres/commit/2cbc3c1
+-- Testing only DATABASE here as SYSTEM produces aio output in PG18
 REINDEX DATABASE;
 SELECT result FROM run_command_on_workers
 ($$REINDEX DATABASE$$);
- result
----------------------------------------------------------------------
- REINDEX
- REINDEX
-(2 rows)
-
-REINDEX SYSTEM;
-SELECT result FROM run_command_on_workers
-($$REINDEX SYSTEM$$);
  result
 ---------------------------------------------------------------------
  REINDEX

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -521,14 +521,11 @@ SET search_path TO pg16;
 -- We already don't propagate these commands automatically
 -- Testing here with run_command_on_workers
 -- Relevant PG commit: https://github.com/postgres/postgres/commit/2cbc3c1
+-- Testing only DATABASE here as SYSTEM produces aio output in PG18
 
 REINDEX DATABASE;
 SELECT result FROM run_command_on_workers
 ($$REINDEX DATABASE$$);
-
-REINDEX SYSTEM;
-SELECT result FROM run_command_on_workers
-($$REINDEX SYSTEM$$);
 
 --
 -- random_normal() to provide normally-distributed random numbers


### PR DESCRIPTION
Fixes #8268 

PG18 added core async I/O infrastructure. Relevant PG commit: https://github.com/postgres/postgres/commit/da72269

In `pg16.sql test`, we tested `REINDEX SYSTEM` command, which would later cause io debug lines in a command of `multi_insert_select.sql` test, that runs _after_ `pg16.sql` test.

"This is expected because the I/O subsystem is repopulating its internal callback pool after heavy catalog I/O churn caused by REINDEX SYSTEM." - chatgpt (seems right 😄)

This PR removes `REINDEX SYSTEM` test as its not crucial anyway. `REINDEX DATABASE` is sufficient for the purpose presented in pg16.sql test.