### PR TITLE
(backport) Update GUC setting to not crash with ASAN (#8301)

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2405,8 +2405,8 @@ RegisterCitusConfigVariables(void)
 		NULL,
 		&SkipAdvisoryLockPermissionChecks,
 		false,
-		GUC_SUPERUSER_ONLY,
-		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+		PGC_SUSET,
+		GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(


### PR DESCRIPTION
The GUC configuration for SkipAdvisoryLockPermissionChecks had misconfigured the settings for GUC_SUPERUSER_ONLY for PGC_SUSET - when PostgreSQL running with ASAN, this fails when querying pg_settings due to exceeding the size of the array GucContext_Names. Fix up this GUC declaration to not crash with ASAN.

(cherry picked from commit 86010de73398646b4ae879261792199bea094f43)
