### PR TITLE
PG18: Print names in order in tables are not colocated error detail.

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2501,11 +2501,16 @@ ErrorIfUnsupportedShardDistribution(Query *query)
 													   currentRelationId);
 		if (!coPartitionedTables)
 		{
+			char *firstRelName = get_rel_name(firstTableRelationId);
+			char *currentRelName = get_rel_name(currentRelationId);
+			int compareResult = strcmp(firstRelName, currentRelName);
+
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							errmsg("cannot push down this subquery"),
 							errdetail("%s and %s are not colocated",
-									  get_rel_name(firstTableRelationId),
-									  get_rel_name(currentRelationId))));
+									  (compareResult > 0 ? currentRelName : firstRelName),
+									  (compareResult > 0 ? firstRelName :
+									   currentRelName))));
 		}
 	}
 }

--- a/src/test/regress/expected/multi_shard_update_delete.out
+++ b/src/test/regress/expected/multi_shard_update_delete.out
@@ -725,7 +725,7 @@ SET    value_2 = 5
 FROM   events_test_table_2
 WHERE  users_test_table.user_id = events_test_table_2.user_id;
 ERROR:  cannot push down this subquery
-DETAIL:  users_test_table and events_test_table_2 are not colocated
+DETAIL:  events_test_table_2 and users_test_table are not colocated
 -- Should error out due to multiple row return from subquery, but we can not get this information within
 -- subquery pushdown planner. This query will be sent to worker with recursive planner.
 \set VERBOSITY terse

--- a/src/test/regress/expected/query_single_shard_table.out
+++ b/src/test/regress/expected/query_single_shard_table.out
@@ -549,21 +549,21 @@ WHERE EXISTS (
 );
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 ERROR:  cannot push down this subquery
-DETAIL:  nullkey_c2_t2 and nullkey_c1_t1 are not colocated
+DETAIL:  nullkey_c1_t1 and nullkey_c2_t2 are not colocated
 SELECT COUNT(*) FROM nullkey_c1_t1 t1
 WHERE t1.b IN (
     SELECT b+1 FROM nullkey_c2_t2 t2 WHERE t2.b = t1.a
 );
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 ERROR:  cannot push down this subquery
-DETAIL:  nullkey_c2_t2 and nullkey_c1_t1 are not colocated
+DETAIL:  nullkey_c1_t1 and nullkey_c2_t2 are not colocated
 SELECT COUNT(*) FROM nullkey_c1_t1 t1
 WHERE t1.b NOT IN (
     SELECT a FROM nullkey_c2_t2 t2 WHERE t2.b > t1.a
 );
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 ERROR:  cannot push down this subquery
-DETAIL:  nullkey_c2_t2 and nullkey_c1_t1 are not colocated
+DETAIL:  nullkey_c1_t1 and nullkey_c2_t2 are not colocated
 -- join with a reference table
 SELECT COUNT(*) FROM nullkey_c1_t1, reference_table WHERE nullkey_c1_t1.a = reference_table.a;
 DEBUG:  Creating router plan
@@ -3009,14 +3009,14 @@ ORDER BY 1,2 LIMIT 1;
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 DEBUG:  push down of limit count: 1
 ERROR:  cannot push down this subquery
-DETAIL:  users_table and non_colocated_events_table are not colocated
+DETAIL:  non_colocated_events_table and users_table are not colocated
 SELECT event_type, (SELECT max(time) FROM users_table WHERE user_id = e.value_2)
 FROM non_colocated_events_table e
 ORDER BY 1,2 LIMIT 1;
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 DEBUG:  push down of limit count: 1
 ERROR:  cannot push down this subquery
-DETAIL:  users_table and non_colocated_events_table are not colocated
+DETAIL:  non_colocated_events_table and users_table are not colocated
 SELECT event_type, (SELECT max(time) FROM users_table)
 FROM non_colocated_events_table e
 ORDER BY 1,2 LIMIT 1;
@@ -3118,7 +3118,7 @@ ORDER BY 1 LIMIT 3;
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 DEBUG:  push down of limit count: 3
 ERROR:  cannot push down this subquery
-DETAIL:  users_table and non_colocated_events_table are not colocated
+DETAIL:  non_colocated_events_table and users_table are not colocated
 SELECT (SELECT (SELECT e.user_id + user_id) FROM users_reference_table WHERE user_id = e.user_id GROUP BY user_id)
 FROM non_colocated_events_table e
 GROUP BY 1
@@ -3169,7 +3169,7 @@ ORDER BY 1 LIMIT 3;
 DEBUG:  router planner does not support queries that reference non-colocated distributed tables
 DEBUG:  push down of limit count: 3
 ERROR:  cannot push down this subquery
-DETAIL:  users_table and non_colocated_events_table are not colocated
+DETAIL:  non_colocated_events_table and users_table are not colocated
 SELECT
 	user_id, count(*)
 FROM

--- a/src/test/regress/expected/recurring_join_pushdown.out
+++ b/src/test/regress/expected/recurring_join_pushdown.out
@@ -120,11 +120,11 @@ DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS c
 -- Test that the join is not pushed down when we have non-colocated tables in the RHS
 SELECT count(*) FROM r1 LEFT JOIN (SELECT d1.a, d3_not_colocated.b FROM d3_not_colocated FULL JOIN d1 ON d3_not_colocated.a = d1.a) AS t1 USING (a);
 ERROR:  cannot push down this subquery
-DETAIL:  d3_not_colocated and d1 are not colocated
+DETAIL:  d1 and d3_not_colocated are not colocated
 -- The same error with its RIGHT JOIN variant
 SELECT count(*) FROM r1 LEFT JOIN (SELECT d1.a, d3_not_colocated.b FROM d3_not_colocated JOIN d1 ON d3_not_colocated.a = d1.a) AS t1 USING (a);
 ERROR:  cannot push down this subquery
-DETAIL:  d3_not_colocated and d1 are not colocated
+DETAIL:  d1 and d3_not_colocated are not colocated
 -- Basic test cases with ON syntax
 -- Test that the join is pushed down to the worker nodes, using "on" syntax
 SET client_min_messages TO DEBUG3;


### PR DESCRIPTION
Fixes #8275 by printing the names in order so that in every message `DETAIL: x and y are not co-located` x precedes (or is lexicographically less than) y.