### PR TITLE
PG18: Fix missing Planning Fast Path Query DEBUG messages

### DIFF
--- a/src/backend/distributed/planner/fast_path_router_planner.c
+++ b/src/backend/distributed/planner/fast_path_router_planner.c
@@ -273,8 +273,16 @@ FastPathRouterQuery(Query *query, FastPathRestrictionContext *fastPathContext)
 		return true;
 	}
 
-	/* make sure that the only range table in FROM clause */
-	if (list_length(query->rtable) != 1)
+	int numFromRels = list_length(query->rtable);
+
+	/* make sure that there is only one range table in FROM clause */
+	if ((numFromRels != 1)
+#if PG_VERSION_NUM >= PG_VERSION_18
+
+	    /* with a PG18+ twist for GROUP rte - if present make sure there's two range tables */
+		&& (!query->hasGroupRTE || numFromRels != 2)
+#endif
+		)
 	{
 		return false;
 	}

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -2192,7 +2192,11 @@ CheckAndBuildDelayedFastPathPlan(DistributedPlanningContext *planContext,
 static bool
 ConvertToQueryOnShard(Query *query, Oid citusTableOid, Oid shardId)
 {
-	Assert(list_length(query->rtable) == 1);
+	Assert(list_length(query->rtable) == 1
+	#if PG_VERSION_NUM >= PG_VERSION_18
+		   || (list_length(query->rtable) == 2 && query->hasGroupRTE)
+	#endif
+		   );
 	RangeTblEntry *citusTableRte = (RangeTblEntry *) linitial(query->rtable);
 	Assert(citusTableRte->relid == citusTableOid);
 


### PR DESCRIPTION
With PG18's GROUP RTE, queries that should have been eligible for fast path planning were skipped because the fast path planner allows exactly one range table only. This fix extends that to account for a GROUP RTE.