### PR TITLE
PG18: Stabilize EXPLAIN output by disabling ANALYZE in index-scan test

### DIFF
--- a/src/test/regress/expected/upgrade_columnar_after.out
+++ b/src/test/regress/expected/upgrade_columnar_after.out
@@ -184,12 +184,12 @@ SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = 
 set columnar.enable_custom_scan to 'off';
 set enable_seqscan to off;
 set seq_page_cost TO 10000000;
-EXPLAIN (costs off, timing off, summary off, analyze on, BUFFERS OFF)
+EXPLAIN (costs off, timing off, summary off, analyze off, BUFFERS OFF)
 	SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = ARRAY[1];
-                                                 QUERY PLAN
+                                     QUERY PLAN
 ---------------------------------------------------------------------
- Aggregate (actual rows=1 loops=1)
-   ->  Index Scan using non_unique_index_on_columnar on less_common_data_types_table (actual rows=1 loops=1)
+ Aggregate
+   ->  Index Scan using non_unique_index_on_columnar on less_common_data_types_table
          Index Cond: ((dist_key = 1) AND (col1 = '{1}'::integer[]))
 (3 rows)
 

--- a/src/test/regress/expected/upgrade_columnar_before.out
+++ b/src/test/regress/expected/upgrade_columnar_before.out
@@ -337,12 +337,12 @@ SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = 
 set columnar.enable_custom_scan to 'off';
 set enable_seqscan to off;
 set seq_page_cost TO 10000000;
-EXPLAIN (costs off, timing off, summary off, analyze on, BUFFERS OFF)
+EXPLAIN (costs off, timing off, summary off, analyze off, BUFFERS OFF)
 	SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = ARRAY[1];
-                                                 QUERY PLAN
+                                     QUERY PLAN
 ---------------------------------------------------------------------
- Aggregate (actual rows=1 loops=1)
-   ->  Index Scan using non_unique_index_on_columnar on less_common_data_types_table (actual rows=1 loops=1)
+ Aggregate
+   ->  Index Scan using non_unique_index_on_columnar on less_common_data_types_table
          Index Cond: ((dist_key = 1) AND (col1 = '{1}'::integer[]))
 (3 rows)
 

--- a/src/test/regress/sql/upgrade_columnar_after.sql
+++ b/src/test/regress/sql/upgrade_columnar_after.sql
@@ -65,7 +65,7 @@ set columnar.enable_custom_scan to 'off';
 set enable_seqscan to off;
 set seq_page_cost TO 10000000;
 
-EXPLAIN (costs off, timing off, summary off, analyze on, BUFFERS OFF)
+EXPLAIN (costs off, timing off, summary off, analyze off, BUFFERS OFF)
 	SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = ARRAY[1];
 
 -- make sure that we re-enable columnar scan

--- a/src/test/regress/sql/upgrade_columnar_before.sql
+++ b/src/test/regress/sql/upgrade_columnar_before.sql
@@ -253,7 +253,7 @@ set columnar.enable_custom_scan to 'off';
 set enable_seqscan to off;
 set seq_page_cost TO 10000000;
 
-EXPLAIN (costs off, timing off, summary off, analyze on, BUFFERS OFF)
+EXPLAIN (costs off, timing off, summary off, analyze off, BUFFERS OFF)
 	SELECT count(*) FROM less_common_data_types_table WHERE dist_key = 1 AND col1 = ARRAY[1];
 
 -- make sure that we re-enable columnar scan


### PR DESCRIPTION
fixes #8318 

PostgreSQL 18 started printing an extra line in `EXPLAIN (ANALYZE …)` for index scans:

```
Index Searches: N
```

This makes our test output flap (extra line, footer row count changes) while the intent of the test is simply to **prove we plan an index scan**, not to assert runtime counters.

### What this PR does

  ```sql
  EXPLAIN (... analyze on, ...)
  ```

  to

  ```sql
  EXPLAIN (... analyze off, ...)
  ```

### Why this approach

* **Minimal change**: keeps the test’s purpose (“we exercise an index scan”) without introducing normalization rules
* **Version-stable**: avoids PG18’s new text while remaining valid on PG15–PG18.
* **No behavioral impact**: we still validate the plan node is an Index Scan; we just don’t request execution.

### Before → After (essence)

Before (PG18):

```
Aggregate
  ->  Index Scan ... (actual rows=1 loops=1)
        Index Cond: ...
        Index Searches: 1
```

After:

```
Aggregate
  ->  Index Scan ...
        Index Cond: ...
```

