### PR TITLE
PG18: fix query results diff in merge regress test.

### DIFF
--- a/src/backend/distributed/utils/citus_copyfuncs.c
+++ b/src/backend/distributed/utils/citus_copyfuncs.c
@@ -137,6 +137,8 @@ CopyNodeDistributedPlan(COPYFUNC_ARGS)
 	COPY_SCALAR_FIELD(fastPathRouterPlan);
 	COPY_SCALAR_FIELD(numberOfTimesExecuted);
 	COPY_NODE_FIELD(planningError);
+
+	COPY_SCALAR_FIELD(sourceResultRepartitionColumnIndex);
 }
 
 

--- a/src/backend/distributed/utils/citus_outfuncs.c
+++ b/src/backend/distributed/utils/citus_outfuncs.c
@@ -203,6 +203,7 @@ OutDistributedPlan(OUTFUNC_ARGS)
 	WRITE_UINT_FIELD(numberOfTimesExecuted);
 
 	WRITE_NODE_FIELD(planningError);
+	WRITE_INT_FIELD(sourceResultRepartitionColumnIndex);
 }
 
 


### PR DESCRIPTION
The `merge` regress test uses SQL functions which can be cached in PG18+ since commit [0dca5d68d](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=0dca5d68d7bebf2c1036fd84875533afef6df992). Distributed plan's copy function did not include the `sourceResultRepartitionColumnIndex` field, which is critical for MERGE queries, and for cached distributed plans this field was always 0 leading to the problem (#8285). Ensuring it is copied fixes it. This was an oversight in Citus, and not specific to PG18. 