### PR TITLE
PG18: Normalize verbose CREATE SUBSCRIPTION connect errors

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -379,3 +379,9 @@ s/\<is referenced from table\>/is still referenced from table/g
 # EXPLAIN (PG18+): hide Materialize storage instrumentation
 # this rule can be removed when PG18 is the minimum supported version
 /^[ \t]*Storage:[ \t].*$/d
+
+# PG18: drop 'subscription "<name>"' prefix
+# this rule can be removed when PG18 is the minimum supported version
+s/^[[:space:]]*ERROR:[[:space:]]+subscription "[^"]+" could not connect to the publisher:[[:space:]]*/ERROR:  could not connect to the publisher: /I
+# PG18: drop verbose 'connection to server … failed:' preamble
+s/^[[:space:]]*ERROR:[[:space:]]+could not connect to the publisher:[[:space:]]*connection to server .* failed:[[:space:]]*/ERROR:  could not connect to the publisher: /I


### PR DESCRIPTION
fixes #8317

https://github.com/postgres/postgres/commit/0d8bd0a72ea284ffb1d1154efbe799241cc5edc6

PG18 changed the wording of connection failures during `CREATE SUBSCRIPTION` to include a subscription prefix and a verbose “connection to server … failed:” preamble. This breaks one regression output (`multi_move_mx`). This PR adds normalization rules to map PG18 output back to the prior form so results are stable across PG15–PG18.

**What changes**
Add two rules in `src/test/regress/bin/normalize.sed`:

```sed
# PG18: drop 'subscription "<name>"' prefix
# remove when PG18 is the minimum supported version
s/^[[:space:]]*ERROR:[[:space:]]+subscription "[^"]+" could not connect to the publisher:[[:space:]]*/ERROR: could not connect to the publisher: /I

# PG18: drop verbose 'connection to server … failed:' preamble
s/^[[:space:]]*ERROR:[[:space:]]+could not connect to the publisher:[[:space:]]*connection to server .* failed:[[:space:]]*/ERROR: could not connect to the publisher: /I
```

**Before (PG18)**

```
ERROR:  subscription "subs_01" could not connect to the publisher:
        connection to server at "localhost" (::1), port 57637 failed:
        root certificate file "/non/existing/certificate.crt" does not exist
```

**After normalization**

```
ERROR:  could not connect to the publisher:
        root certificate file "/non/existing/certificate.crt" does not exist
```

**Why**
Maintain identical regression outputs across supported PG versions while Citus still supports PG<18.

