### PR TITLE
Keep temp reloid for columnar cases (Backport #8235 to release-13.2)

### DIFF
--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -1556,8 +1556,7 @@ ColumnarPerStripeScanCost(RelOptInfo *rel, Oid relationId, int numberOfColumnsRe
 		ereport(ERROR, (errmsg("could not open relation with OID %u", relationId)));
 	}
 
-	List *stripeList = StripesForRelfilelocator(RelationPhysicalIdentifier_compat(
-													relation));
+	List *stripeList = StripesForRelfilelocator(relation);
 	RelationClose(relation);
 
 	uint32 maxColumnCount = 0;
@@ -1614,8 +1613,7 @@ ColumnarTableStripeCount(Oid relationId)
 		ereport(ERROR, (errmsg("could not open relation with OID %u", relationId)));
 	}
 
-	List *stripeList = StripesForRelfilelocator(RelationPhysicalIdentifier_compat(
-													relation));
+	List *stripeList = StripesForRelfilelocator(relation);
 	int stripeCount = list_length(stripeList);
 	RelationClose(relation);
 

--- a/src/backend/columnar/columnar_metadata.c
+++ b/src/backend/columnar/columnar_metadata.c
@@ -125,7 +125,7 @@ static Oid ColumnarChunkGroupRelationId(void);
 static Oid ColumnarChunkIndexRelationId(void);
 static Oid ColumnarChunkGroupIndexRelationId(void);
 static Oid ColumnarNamespaceId(void);
-static uint64 LookupStorageId(RelFileLocator relfilelocator);
+static uint64 LookupStorageId(Oid relationId, RelFileLocator relfilelocator);
 static uint64 GetHighestUsedRowNumber(uint64 storageId);
 static void DeleteStorageFromColumnarMetadataTable(Oid metadataTableId,
 												   AttrNumber storageIdAtrrNumber,
@@ -606,7 +606,7 @@ ReadColumnarOptions(Oid regclass, ColumnarOptions *options)
  * of columnar.chunk.
  */
 void
-SaveStripeSkipList(RelFileLocator relfilelocator, uint64 stripe,
+SaveStripeSkipList(Oid relid, RelFileLocator relfilelocator, uint64 stripe,
 				   StripeSkipList *chunkList,
 				   TupleDesc tupleDescriptor)
 {
@@ -614,7 +614,7 @@ SaveStripeSkipList(RelFileLocator relfilelocator, uint64 stripe,
 	uint32 chunkIndex = 0;
 	uint32 columnCount = chunkList->columnCount;
 
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(relid, relfilelocator);
 	Oid columnarChunkOid = ColumnarChunkRelationId();
 	Relation columnarChunk = table_open(columnarChunkOid, RowExclusiveLock);
 	ModifyState *modifyState = StartModifyRelation(columnarChunk);
@@ -674,10 +674,10 @@ SaveStripeSkipList(RelFileLocator relfilelocator, uint64 stripe,
  * SaveChunkGroups saves the metadata for given chunk groups in columnar.chunk_group.
  */
 void
-SaveChunkGroups(RelFileLocator relfilelocator, uint64 stripe,
+SaveChunkGroups(Oid relid, RelFileLocator relfilelocator, uint64 stripe,
 				List *chunkGroupRowCounts)
 {
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(relid, relfilelocator);
 	Oid columnarChunkGroupOid = ColumnarChunkGroupRelationId();
 	Relation columnarChunkGroup = table_open(columnarChunkGroupOid, RowExclusiveLock);
 	ModifyState *modifyState = StartModifyRelation(columnarChunkGroup);
@@ -710,7 +710,7 @@ SaveChunkGroups(RelFileLocator relfilelocator, uint64 stripe,
  * ReadStripeSkipList fetches chunk metadata for a given stripe.
  */
 StripeSkipList *
-ReadStripeSkipList(RelFileLocator relfilelocator, uint64 stripe,
+ReadStripeSkipList(Relation rel, uint64 stripe,
 				   TupleDesc tupleDescriptor,
 				   uint32 chunkCount, Snapshot snapshot)
 {
@@ -719,7 +719,8 @@ ReadStripeSkipList(RelFileLocator relfilelocator, uint64 stripe,
 	uint32 columnCount = tupleDescriptor->natts;
 	ScanKeyData scanKey[2];
 
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(RelationPrecomputeOid(rel),
+									   RelationPhysicalIdentifier_compat(rel));
 
 	Oid columnarChunkOid = ColumnarChunkRelationId();
 	Relation columnarChunk = table_open(columnarChunkOid, AccessShareLock);
@@ -1263,9 +1264,10 @@ InsertEmptyStripeMetadataRow(uint64 storageId, uint64 stripeId, uint32 columnCou
  * of the given relfilenode.
  */
 List *
-StripesForRelfilelocator(RelFileLocator relfilelocator)
+StripesForRelfilelocator(Relation rel)
 {
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(RelationPrecomputeOid(rel),
+									   RelationPhysicalIdentifier_compat(rel));
 
 	return ReadDataFileStripeList(storageId, GetTransactionSnapshot());
 }
@@ -1280,15 +1282,34 @@ StripesForRelfilelocator(RelFileLocator relfilelocator)
  * returns 0.
  */
 uint64
-GetHighestUsedAddress(RelFileLocator relfilelocator)
+GetHighestUsedAddress(Relation rel)
 {
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(RelationPrecomputeOid(rel),
+									   RelationPhysicalIdentifier_compat(rel));
 
 	uint64 highestUsedAddress = 0;
 	uint64 highestUsedId = 0;
 	GetHighestUsedAddressAndId(storageId, &highestUsedAddress, &highestUsedId);
 
 	return highestUsedAddress;
+}
+
+
+/*
+ * In case if relid hasn't been defined yet, we should use RelidByRelfilenumber
+ * to get correct relid value.
+ *
+ * Now it is basically used for temp rels, because since PG18(it was backpatched
+ * through PG13) RelidByRelfilenumber skip temp relations and we should use
+ * alternative ways to get relid value in case of temp objects.
+ */
+Oid
+ColumnarRelationId(Oid relid, RelFileLocator relfilelocator)
+{
+	return OidIsValid(relid) ? relid : RelidByRelfilenumber(RelationTablespace_compat(
+																relfilelocator),
+															RelationPhysicalIdentifierNumber_compat(
+																relfilelocator));
 }
 
 
@@ -1595,7 +1616,7 @@ BuildStripeMetadata(Relation columnarStripes, HeapTuple heapTuple)
  * metadata tables.
  */
 void
-DeleteMetadataRows(RelFileLocator relfilelocator)
+DeleteMetadataRows(Relation rel)
 {
 	/*
 	 * During a restore for binary upgrade, metadata tables and indexes may or
@@ -1606,7 +1627,8 @@ DeleteMetadataRows(RelFileLocator relfilelocator)
 		return;
 	}
 
-	uint64 storageId = LookupStorageId(relfilelocator);
+	uint64 storageId = LookupStorageId(RelationPrecomputeOid(rel),
+									   RelationPhysicalIdentifier_compat(rel));
 
 	DeleteStorageFromColumnarMetadataTable(ColumnarStripeRelationId(),
 										   Anum_columnar_stripe_storageid,
@@ -2005,13 +2027,11 @@ ColumnarNamespaceId(void)
  * false if the relation doesn't have a meta page yet.
  */
 static uint64
-LookupStorageId(RelFileLocator relfilelocator)
+LookupStorageId(Oid relid, RelFileLocator relfilelocator)
 {
-	Oid relationId = RelidByRelfilenumber(RelationTablespace_compat(relfilelocator),
-										  RelationPhysicalIdentifierNumber_compat(
-											  relfilelocator));
+	relid = ColumnarRelationId(relid, relfilelocator);
 
-	Relation relation = relation_open(relationId, AccessShareLock);
+	Relation relation = relation_open(relid, AccessShareLock);
 	uint64 storageId = ColumnarStorageGetStorageId(relation, false);
 	table_close(relation, AccessShareLock);
 

--- a/src/backend/columnar/columnar_reader.c
+++ b/src/backend/columnar/columnar_reader.c
@@ -986,8 +986,7 @@ ColumnarTableRowCount(Relation relation)
 {
 	ListCell *stripeMetadataCell = NULL;
 	uint64 totalRowCount = 0;
-	List *stripeList = StripesForRelfilelocator(RelationPhysicalIdentifier_compat(
-													relation));
+	List *stripeList = StripesForRelfilelocator(relation);
 
 	foreach(stripeMetadataCell, stripeList)
 	{
@@ -1015,8 +1014,7 @@ LoadFilteredStripeBuffers(Relation relation, StripeMetadata *stripeMetadata,
 
 	bool *projectedColumnMask = ProjectedColumnMask(columnCount, projectedColumnList);
 
-	StripeSkipList *stripeSkipList = ReadStripeSkipList(RelationPhysicalIdentifier_compat(
-															relation),
+	StripeSkipList *stripeSkipList = ReadStripeSkipList(relation,
 														stripeMetadata->id,
 														tupleDescriptor,
 														stripeMetadata->chunkCount,

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -872,7 +872,7 @@ columnar_relation_set_new_filelocator(Relation rel,
 									 RelationPhysicalIdentifier_compat(rel)),
 								 GetCurrentSubTransactionId());
 
-		DeleteMetadataRows(RelationPhysicalIdentifier_compat(rel));
+		DeleteMetadataRows(rel);
 	}
 
 	*freezeXid = RecentXmin;
@@ -897,7 +897,7 @@ columnar_relation_nontransactional_truncate(Relation rel)
 	NonTransactionDropWriteState(RelationPhysicalIdentifierNumber_compat(relfilelocator));
 
 	/* Delete old relfilenode metadata */
-	DeleteMetadataRows(relfilelocator);
+	DeleteMetadataRows(rel);
 
 	/*
 	 * No need to set new relfilenode, since the table was created in this
@@ -960,8 +960,7 @@ columnar_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	ColumnarOptions columnarOptions = { 0 };
 	ReadColumnarOptions(OldHeap->rd_id, &columnarOptions);
 
-	ColumnarWriteState *writeState = ColumnarBeginWrite(RelationPhysicalIdentifier_compat(
-															NewHeap),
+	ColumnarWriteState *writeState = ColumnarBeginWrite(NewHeap,
 														columnarOptions,
 														targetDesc);
 
@@ -1036,8 +1035,7 @@ NeededColumnsList(TupleDesc tupdesc, Bitmapset *attr_needed)
 static uint64
 ColumnarTableTupleCount(Relation relation)
 {
-	List *stripeList = StripesForRelfilelocator(RelationPhysicalIdentifier_compat(
-													relation));
+	List *stripeList = StripesForRelfilelocator(relation);
 	uint64 tupleCount = 0;
 
 	ListCell *lc = NULL;
@@ -1228,7 +1226,6 @@ static void
 LogRelationStats(Relation rel, int elevel)
 {
 	ListCell *stripeMetadataCell = NULL;
-	RelFileLocator relfilelocator = RelationPhysicalIdentifier_compat(rel);
 	StringInfo infoBuf = makeStringInfo();
 
 	int compressionStats[COMPRESSION_COUNT] = { 0 };
@@ -1239,13 +1236,13 @@ LogRelationStats(Relation rel, int elevel)
 	uint64 droppedChunksWithData = 0;
 	uint64 totalDecompressedLength = 0;
 
-	List *stripeList = StripesForRelfilelocator(relfilelocator);
+	List *stripeList = StripesForRelfilelocator(rel);
 	int stripeCount = list_length(stripeList);
 
 	foreach(stripeMetadataCell, stripeList)
 	{
 		StripeMetadata *stripe = lfirst(stripeMetadataCell);
-		StripeSkipList *skiplist = ReadStripeSkipList(relfilelocator, stripe->id,
+		StripeSkipList *skiplist = ReadStripeSkipList(rel, stripe->id,
 													  RelationGetDescr(rel),
 													  stripe->chunkCount,
 													  GetTransactionSnapshot());
@@ -1381,8 +1378,7 @@ TruncateColumnar(Relation rel, int elevel)
 	 * new stripes be added beyond highestPhysicalAddress while
 	 * we're truncating.
 	 */
-	uint64 newDataReservation = Max(GetHighestUsedAddress(
-										RelationPhysicalIdentifier_compat(rel)) + 1,
+	uint64 newDataReservation = Max(GetHighestUsedAddress(rel) + 1,
 									ColumnarFirstLogicalOffset);
 
 	BlockNumber old_rel_pages = smgrnblocks(RelationGetSmgr(rel), MAIN_FORKNUM);
@@ -2150,7 +2146,7 @@ ColumnarTableDropHook(Oid relid)
 		Relation rel = table_open(relid, AccessExclusiveLock);
 		RelFileLocator relfilelocator = RelationPhysicalIdentifier_compat(rel);
 
-		DeleteMetadataRows(relfilelocator);
+		DeleteMetadataRows(rel);
 		DeleteColumnarTableOptions(rel->rd_id, true);
 
 		MarkRelfilenumberDropped(RelationPhysicalIdentifierNumber_compat(relfilelocator),

--- a/src/backend/columnar/write_state_management.c
+++ b/src/backend/columnar/write_state_management.c
@@ -191,8 +191,7 @@ columnar_init_write_state(Relation relation, TupleDesc tupdesc,
 	ReadColumnarOptions(tupSlotRelationId, &columnarOptions);
 
 	SubXidWriteState *stackEntry = palloc0(sizeof(SubXidWriteState));
-	stackEntry->writeState = ColumnarBeginWrite(RelationPhysicalIdentifier_compat(
-													relation),
+	stackEntry->writeState = ColumnarBeginWrite(relation,
 												columnarOptions,
 												tupdesc);
 	stackEntry->subXid = currentSubXid;

--- a/src/include/columnar/columnar_metadata.h
+++ b/src/include/columnar/columnar_metadata.h
@@ -61,7 +61,7 @@ typedef struct EmptyStripeReservation
 	uint64 stripeFirstRowNumber;
 } EmptyStripeReservation;
 
-extern List * StripesForRelfilelocator(RelFileLocator relfilelocator);
+extern List * StripesForRelfilelocator(Relation rel);
 extern void ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade);
 extern List * ExtractColumnarRelOptions(List *inOptions, List **outColumnarOptions);
 extern void SetColumnarRelOptions(RangeVar *rv, List *reloptions);


### PR DESCRIPTION
Backporting #8235 to release-13.2

PG18 and PG latest minors ignore temporary relations in `RelidByRelfilenumber` (`RelidByRelfilenode` in PG15) Relevant PG commit:
https://github.com/postgres/postgres/commit/86831952

Here we are keeping temp reloids instead of getting it with RelidByRelfilenumber, for example, in some cases, we can directly get reloid from relations, in other cases we keep it in some structures.

Note: there is still an outstanding issue with columnar temp tables in concurrent sessions, that will be fixed in PR
https://github.com/citusdata/citus/pull/8252

(cherry picked from commit daa69bec8ff00ff6415b85d8602601d1b820cf51)

