### PR TITLE
PG18 - add alternative out for multi_mx_hide_shard_names test

### DIFF
--- a/src/test/regress/expected/multi_mx_hide_shard_names.out
+++ b/src/test/regress/expected/multi_mx_hide_shard_names.out
@@ -109,6 +109,7 @@ EXPLAIN (COSTS OFF) INSERT INTO pg_class SELECT * FROM pg_class;
 
 -- Check that query that psql "\d test_table" does gets optimized to an index
 -- scan
+-- PG18+: the psql \d-style regex on pg_class can flip the plan to a Seq Scan
 EXPLAIN (COSTS OFF) SELECT c.oid,
   n.nspname,
   c.relname

--- a/src/test/regress/expected/multi_mx_hide_shard_names_0.out
+++ b/src/test/regress/expected/multi_mx_hide_shard_names_0.out
@@ -109,6 +109,7 @@ EXPLAIN (COSTS OFF) INSERT INTO pg_class SELECT * FROM pg_class;
 
 -- Check that query that psql "\d test_table" does gets optimized to an index
 -- scan
+-- PG18+: the psql \d-style regex on pg_class can flip the plan to a Seq Scan
 EXPLAIN (COSTS OFF) SELECT c.oid,
   n.nspname,
   c.relname

--- a/src/test/regress/sql/multi_mx_hide_shard_names.sql
+++ b/src/test/regress/sql/multi_mx_hide_shard_names.sql
@@ -60,6 +60,7 @@ EXPLAIN (COSTS OFF) INSERT INTO pg_class SELECT * FROM pg_class;
 
 -- Check that query that psql "\d test_table" does gets optimized to an index
 -- scan
+-- PG18+: the psql \d-style regex on pg_class can flip the plan to a Seq Scan
 EXPLAIN (COSTS OFF) SELECT c.oid,
   n.nspname,
   c.relname


### PR DESCRIPTION
fixes #8279

PostgreSQL 18 planner changes (probably AIO and updated cost model) make sequential scans cheaper, so the psql `\d table`-style query that uses a regex on `pg_class.relname` no longer chooses an index scan. This causes a plan difference in the `mx_hide_shard_names` regression test.

This patch adds an alternative out for the multi_mx_hide_shard_names test.
