### PR TITLE
PG18 - Adjust columnar path tests for PG18 OR clause optimization

### DIFF
--- a/src/test/regress/expected/columnar_paths.out
+++ b/src/test/regress/expected/columnar_paths.out
@@ -204,18 +204,24 @@ $$
  t
 (1 row)
 
-SELECT columnar_test_helpers.uses_custom_scan (
-$$
-SELECT a FROM full_correlated WHERE a=0 OR a=5;
-$$
-);
+BEGIN;
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
+  SELECT columnar_test_helpers.uses_custom_scan (
+  $$
+  SELECT a FROM full_correlated WHERE a=0 OR a=5;
+  $$
+  );
  uses_custom_scan
 ---------------------------------------------------------------------
  t
 (1 row)
 
+ROLLBACK;
 BEGIN;
   SET LOCAL columnar.enable_custom_scan TO 'OFF';
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
   SELECT columnar_test_helpers.uses_seq_scan (
   $$
   SELECT a FROM full_correlated WHERE a=0 OR a=5;

--- a/src/test/regress/expected/columnar_paths_0.out
+++ b/src/test/regress/expected/columnar_paths_0.out
@@ -204,18 +204,24 @@ $$
  t
 (1 row)
 
-SELECT columnar_test_helpers.uses_custom_scan (
-$$
-SELECT a FROM full_correlated WHERE a=0 OR a=5;
-$$
-);
+BEGIN;
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
+  SELECT columnar_test_helpers.uses_custom_scan (
+  $$
+  SELECT a FROM full_correlated WHERE a=0 OR a=5;
+  $$
+  );
  uses_custom_scan
 ---------------------------------------------------------------------
  t
 (1 row)
 
+ROLLBACK;
 BEGIN;
   SET LOCAL columnar.enable_custom_scan TO 'OFF';
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
   SELECT columnar_test_helpers.uses_seq_scan (
   $$
   SELECT a FROM full_correlated WHERE a=0 OR a=5;

--- a/src/test/regress/sql/columnar_paths.sql
+++ b/src/test/regress/sql/columnar_paths.sql
@@ -141,14 +141,21 @@ SELECT a FROM full_correlated WHERE a>200;
 $$
 );
 
-SELECT columnar_test_helpers.uses_custom_scan (
-$$
-SELECT a FROM full_correlated WHERE a=0 OR a=5;
-$$
-);
+
+BEGIN;
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
+  SELECT columnar_test_helpers.uses_custom_scan (
+  $$
+  SELECT a FROM full_correlated WHERE a=0 OR a=5;
+  $$
+  );
+ROLLBACK;
 
 BEGIN;
   SET LOCAL columnar.enable_custom_scan TO 'OFF';
+  SET LOCAL enable_indexscan  TO 'OFF';
+  SET LOCAL enable_bitmapscan TO 'OFF';
   SELECT columnar_test_helpers.uses_seq_scan (
   $$
   SELECT a FROM full_correlated WHERE a=0 OR a=5;


### PR DESCRIPTION
fixes #8264

PostgreSQL 18 introduced a planner improvement (commit `ae4569161`) that rewrites simple `OR` equality clauses into `= ANY(...)` forms, allowing the use of a single index scan instead of multiple scans or a custom scan.
This change affects the columnar path tests where queries like `a=0 OR a=5` previously chose a Columnar or Seq Scan plan.

In this PR:

* Updated test expectations for `uses_custom_scan` and `uses_seq_scan` to reflect the new index scan plan.

This keeps the test output consistent with PostgreSQL 18’s updated planner behavior.
