### PR TITLE
Citus upgrade tests (#8237)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "17.6"
-      image_suffix: "-v4df94a0"
+      image_suffix: "-va20872f"
       pg15_version: '{ "major": "15", "full": "15.14" }'
       pg16_version: '{ "major": "16", "full": "16.10" }'
       pg17_version: '{ "major": "17", "full": "17.6" }'
@@ -358,14 +358,20 @@ jobs:
         flags: ${{ env.old_pg_major }}_${{ env.new_pg_major }}_upgrade
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-upgrade:
-    name: PG${{ fromJson(needs.params.outputs.pg15_version).major }} - check-citus-upgrade
+    name: PG${{ fromJson(matrix.pg_version).major }} - check-citus-upgrade
     runs-on: ubuntu-latest
     container:
-      image: "${{ needs.params.outputs.citusupgrade_image_name }}:${{ fromJson(needs.params.outputs.pg15_version).full }}${{ needs.params.outputs.image_suffix }}"
+      image: "${{ needs.params.outputs.citusupgrade_image_name }}:${{ fromJson(matrix.pg_version).full }}${{ needs.params.outputs.image_suffix }}"
       options: --user root
     needs:
     - params
     - build
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version:
+          - ${{ needs.params.outputs.pg15_version }}
+          - ${{ needs.params.outputs.pg16_version }}
     steps:
     - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"
@@ -374,7 +380,7 @@ jobs:
     - name: Install and test citus upgrade
       run: |-
         # run make check-citus-upgrade for all citus versions
-        # the image has ${CITUS_VERSIONS} set with all verions it contains the binaries of
+        # the image has ${CITUS_VERSIONS} set with all versions it contains the binaries of
         for citus_version in ${CITUS_VERSIONS}; do \
           gosu circleci \
             make -C src/test/regress \
@@ -385,7 +391,7 @@ jobs:
               citus-post-tar=${GITHUB_WORKSPACE}/install-$PG_MAJOR.tar; \
         done;
         # run make check-citus-upgrade-mixed for all citus versions
-        # the image has ${CITUS_VERSIONS} set with all verions it contains the binaries of
+        # the image has ${CITUS_VERSIONS} set with all versions it contains the binaries of
         for citus_version in ${CITUS_VERSIONS}; do \
           gosu circleci \
             make -C src/test/regress \

--- a/src/test/regress/expected/upgrade_citus_finish_citus_upgrade.out
+++ b/src/test/regress/expected/upgrade_citus_finish_citus_upgrade.out
@@ -1,31 +1,18 @@
 -- Citus upgrades are finished by calling a procedure
--- Note that pg_catalog.citus_finish_citus_upgrade() behaves differently
--- when last upgrade citus version is less than 11
--- so we have two alternative outputs for this test
-\set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 11
-AS upgrade_test_old_citus_version_lt_11_0;
- upgrade_test_old_citus_version_lt_11_0
----------------------------------------------------------------------
- t
-(1 row)
-
 -- this is a transactional procedure, so rollback should be fine
 BEGIN;
 	CALL citus_finish_citus_upgrade();
-NOTICE:  Preparing all the existing partitioned table indexes
-NOTICE:  Preparing to sync the metadata to all nodes
+NOTICE:  already at the latest distributed schema version (12.1-1)
 ROLLBACK;
 -- do the actual job
 CALL citus_finish_citus_upgrade();
-NOTICE:  Preparing all the existing partitioned table indexes
-NOTICE:  Preparing to sync the metadata to all nodes
+NOTICE:  already at the latest distributed schema version (12.1-1)
 -- show that the upgrade is successfull
 SELECT metadata->>'last_upgrade_version' = extversion
 FROM pg_dist_node_metadata, pg_extension WHERE extname = 'citus';
  ?column?
 ---------------------------------------------------------------------
- t
+ f
 (1 row)
 
 -- idempotent, should be called multiple times

--- a/src/test/regress/expected/upgrade_citus_finish_citus_upgrade_0.out
+++ b/src/test/regress/expected/upgrade_citus_finish_citus_upgrade_0.out
@@ -1,15 +1,4 @@
 -- Citus upgrades are finished by calling a procedure
--- Note that pg_catalog.citus_finish_citus_upgrade() behaves differently
--- when last upgrade citus version is less than 11
--- so we have two alternative outputs for this test
-\set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 11
-AS upgrade_test_old_citus_version_lt_11_0;
- upgrade_test_old_citus_version_lt_11_0
----------------------------------------------------------------------
- f
-(1 row)
-
 -- this is a transactional procedure, so rollback should be fine
 BEGIN;
 	CALL citus_finish_citus_upgrade();

--- a/src/test/regress/expected/upgrade_citus_finish_citus_upgrade_1.out
+++ b/src/test/regress/expected/upgrade_citus_finish_citus_upgrade_1.out
@@ -1,15 +1,4 @@
 -- Citus upgrades are finished by calling a procedure
--- Note that pg_catalog.citus_finish_citus_upgrade() behaves differently
--- when last upgrade citus version is less than 11
--- so we have two alternative outputs for this test
-\set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 11
-AS upgrade_test_old_citus_version_lt_11_0;
- upgrade_test_old_citus_version_lt_11_0
----------------------------------------------------------------------
- f
-(1 row)
-
 -- this is a transactional procedure, so rollback should be fine
 BEGIN;
 	CALL citus_finish_citus_upgrade();

--- a/src/test/regress/sql/upgrade_citus_finish_citus_upgrade.sql
+++ b/src/test/regress/sql/upgrade_citus_finish_citus_upgrade.sql
@@ -1,12 +1,4 @@
 -- Citus upgrades are finished by calling a procedure
-
--- Note that pg_catalog.citus_finish_citus_upgrade() behaves differently
--- when last upgrade citus version is less than 11
--- so we have two alternative outputs for this test
-\set upgrade_test_old_citus_version `echo "$CITUS_OLD_VERSION"`
-SELECT substring(:'upgrade_test_old_citus_version', 'v(\d+)\.\d+\.\d+')::int < 11
-AS upgrade_test_old_citus_version_lt_11_0;
-
 -- this is a transactional procedure, so rollback should be fine
 BEGIN;
 	CALL citus_finish_citus_upgrade();


### PR DESCRIPTION
Expand the citus upgrade tests matrix:
PG15: v11.1.0 v11.3.0 v12.1.10 
PG16: v12.1.10

See https://github.com/citusdata/the-process/pull/174

DESCRIPTION: PR description that will go into the change log, up to 78 characters

Cherry-pick https://github.com/citusdata/citus/commit/aa0ac0af60d8f0b5b42d7d9df55e8431c7b4501c