### PR TITLE
Include SubPlans when checking that a query is still distributed.

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -82,6 +82,7 @@ int PlannerLevel = 0;
 
 static bool ListContainsDistributedTableRTE(List *rangeTableList,
 											bool *maybeHasForeignDistributedTable);
+static bool PlanContainsDistributedSubPlanRTE(List *subPlanList);
 static PlannedStmt * CreateDistributedPlannedStmt(DistributedPlanningContext *
 												  planContext);
 static PlannedStmt * InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
@@ -424,6 +425,49 @@ ListContainsDistributedTableRTE(List *rangeTableList,
 				*maybeHasForeignDistributedTable = true;
 			}
 
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
+ * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the given
+ * subPlanList is a Read Intermediate Result function scan.
+ *
+ * It is used by the check after standard_planner() to determine whether the plan
+ * still requires distributed planning; in addition to checking the range table for
+ * distributed tables, we also need to check whether there are any subplans that
+ * read intermediate results, which indicates a distributed subplan and therefore
+ * that distributed planning is required.
+ */
+static bool
+PlanContainsDistributedSubPlanRTE(List *subPlanList)
+{
+	ListCell *subPlanCell = NULL;
+
+	foreach(subPlanCell, subPlanList)
+	{
+		Node *planRoot = (Node *) lfirst(subPlanCell);
+
+		if (!IsA(planRoot, FunctionScan))
+		{
+			continue;
+		}
+
+		List *functionList = ((FunctionScan *) planRoot)->functions;
+
+		if (functionList == NIL)
+		{
+			continue;
+		}
+
+		RangeTblFunction *rangeTblfunction = (RangeTblFunction *) linitial(functionList);
+
+		if (IsReadIntermediateResultFunction(rangeTblfunction->funcexpr))
+		{
 			return true;
 		}
 	}
@@ -2807,20 +2851,26 @@ CheckPostPlanDistribution(DistributedPlanningContext *planContext, bool
 		#endif
 
 		/*
-		 * The WHERE quals have been eliminated by the Postgres planner, possibly by
-		 * an OR clause that was simplified to TRUE. In such cases, we need to check
-		 * if the planned query still requires distributed planning.
+		 * If the WHERE quals have been eliminated by the Postgres planner, possibly
+		 * by an OR clause that was simplified to TRUE, we need to check if the
+		 * planned query still requires distributed planning.
 		 */
 		if (origQuals != NULL && plannedQuals == NULL)
 		{
-			bool planHasDistTable = ListContainsDistributedTableRTE(
+			/* First check if the plan has a distributed table */
+			bool planHasDistribution = ListContainsDistributedTableRTE(
 				planContext->plan->rtable, NULL);
 
+			/* ..or a distributed subplan */
+			planHasDistribution = planHasDistribution ||
+								  PlanContainsDistributedSubPlanRTE(
+				planContext->plan->subplans);
+
 			/*
-			 * If the Postgres plan has a distributed table, we know for sure that
+			 * The plan has a distributed relation, so we know for sure that
 			 * the query requires distributed planning.
 			 */
-			if (planHasDistTable)
+			if (planHasDistribution)
 			{
 				return true;
 			}
@@ -2833,8 +2883,16 @@ CheckPostPlanDistribution(DistributedPlanningContext *planContext, bool
 			List *rtesPostPlan = ExtractRangeTableEntryList(plannedQuery);
 			if (list_length(rtesPostPlan) < list_length(rangeTableList))
 			{
-				isDistributedQuery = ListContainsDistributedTableRTE(
+				bool hasDistTable = ListContainsDistributedTableRTE(
 					rtesPostPlan, NULL);
+				if (hasDistTable != isDistributedQuery)
+				{
+					ereport(DEBUG4, (errmsg(
+										 "Plan has flipped from distributed to local "
+										 "after Postgres planning, updating distributed to %u",
+										 hasDistTable)));
+					isDistributedQuery = hasDistTable;
+				}
 			}
 		}
 	}

--- a/src/backend/distributed/planner/multi_logical_planner.c
+++ b/src/backend/distributed/planner/multi_logical_planner.c
@@ -81,7 +81,6 @@ static bool FullCompositeFieldList(List *compositeFieldList);
 static bool HasUnsupportedJoinWalker(Node *node, void *context);
 static bool ErrorHintRequired(const char *errorHint, Query *queryTree);
 static bool HasComplexRangeTableType(Query *queryTree);
-static bool IsReadIntermediateResultFunction(Node *node);
 static bool IsReadIntermediateResultArrayFunction(Node *node);
 static bool IsCitusExtraDataContainerFunc(Node *node);
 static bool IsFunctionWithOid(Node *node, Oid funcOid);
@@ -756,7 +755,7 @@ ContainsReadIntermediateResultArrayFunction(Node *node)
  * IsReadIntermediateResultFunction determines whether a given node is a function call
  * to the read_intermediate_result function.
  */
-static bool
+bool
 IsReadIntermediateResultFunction(Node *node)
 {
 	return IsFunctionWithOid(node, CitusReadIntermediateResultFuncId());

--- a/src/include/distributed/multi_logical_planner.h
+++ b/src/include/distributed/multi_logical_planner.h
@@ -205,6 +205,7 @@ extern bool IsTableWithDistKeyRTE(Node *node);
 extern bool IsCitusExtraDataContainerRelation(RangeTblEntry *rte);
 extern bool ContainsReadIntermediateResultFunction(Node *node);
 extern bool ContainsReadIntermediateResultArrayFunction(Node *node);
+extern bool IsReadIntermediateResultFunction(Node *node);
 extern char * FindIntermediateResultIdIfExists(RangeTblEntry *rte);
 extern MultiNode * ParentNode(MultiNode *multiNode);
 extern MultiNode * ChildNode(MultiUnaryNode *multiNode);

--- a/src/test/regress/expected/subquery_in_where.out
+++ b/src/test/regress/expected/subquery_in_where.out
@@ -748,10 +748,11 @@ IN
 	(SELECT
 		user_id
 	FROM
-		users_table);
+		users_table)
+ORDER BY id;
 DEBUG:  generating subplan XXX_1 for subquery SELECT id, value_1 FROM subquery_in_where.local_table
 DEBUG:  generating subplan XXX_2 for subquery SELECT user_id FROM public.users_table
-DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT id, value_1 FROM (SELECT intermediate_result.id, intermediate_result.value_1 FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, value_1 integer)) sub_table WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer)))
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT id, value_1 FROM (SELECT intermediate_result.id, intermediate_result.value_1 FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(id integer, value_1 integer)) sub_table WHERE (id OPERATOR(pg_catalog.=) ANY (SELECT intermediate_result.user_id FROM read_intermediate_result('XXX_2'::text, 'binary'::citus_copy_format) intermediate_result(user_id integer))) ORDER BY id
  id | value_1
 ---------------------------------------------------------------------
   1 |       1
@@ -1253,6 +1254,124 @@ SELECT vkey, pkey FROM t3;
  vkey | pkey
 ---------------------------------------------------------------------
 (0 rows)
+
+-- Test case where citus table is reduced to a distributed subplan
+-- Exposed by issue
+INSERT INTO t0 (vkey, pkey, c0) values
+(1, 10000, make_timestamp(2032, 9, 4, 13, 38, 0)),
+(2, 11000, make_timestamp(2024, 8, 31, 17, 51, 0)),
+(3, 12000, make_timestamp(2028, 4, 1, 3, 32, 0)),
+(4, 13000, make_timestamp(2029, 11, 4, 13, 49, 0)),
+(5, 14000, make_timestamp(2031, 3, 29, 18, 17, 0)),
+(6, 15000, make_timestamp(2030, 5, 17, 11, 32, 0)),
+(7, 16000, make_timestamp(2027, 9, 22, 12, 58, 0)),
+(8, 17000, make_timestamp(2026, 12, 3, 13, 44, 0)),
+(9, 18000, make_timestamp(2028, 2, 24, 14, 05, 0)),
+(10,19000, make_timestamp(2031, 4, 14, 15, 12, 0));
+INSERT INTO t3 (vkey, pkey, c9) values
+(1, 10000, make_timestamp(2032, 9, 4, 13, 38, 0)),
+(2, 11000, make_timestamp(2024, 8, 31, 17, 51, 0)),
+(3, 12000, make_timestamp(2028, 4, 1, 3, 32, 0)),
+(4, 13000, make_timestamp(2029, 11, 4, 13, 49, 0)),
+(5, 14000, make_timestamp(2031, 3, 29, 18, 17, 0)),
+(6, 15000, make_timestamp(2030, 5, 17, 11, 32, 0)),
+(7, 16000, make_timestamp(2027, 9, 22, 12, 58, 0)),
+(8, 17000, make_timestamp(2026, 12, 3, 13, 44, 0)),
+(9, 18000, make_timestamp(2028, 2, 24, 14, 05, 0)),
+(10,19000, make_timestamp(2031, 4, 14, 15, 12, 0));
+-- minimal repro: without the fix, c_1 column is NULL
+SELECT c_1, c_2
+FROM (SELECT
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2
+      FROM t0 AS ref_0
+      WHERE true::bool
+) as subq_0
+WHERE subq_0.c_2 = 7
+ORDER BY c_1, c_2;
+           c_1            | c_2
+---------------------------------------------------------------------
+ Sat Mar 29 18:17:00 2031 |   7
+(1 row)
+
+-- remove redundant WHERE clause => same result set
+SELECT c_1, c_2
+FROM (SELECT
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2
+      FROM t0 AS ref_0
+) as subq_0
+WHERE subq_0.c_2 = 7
+ORDER BY c_1, c_2;
+           c_1            | c_2
+---------------------------------------------------------------------
+ Sat Mar 29 18:17:00 2031 |   7
+(1 row)
+
+-- Repro query from issue #8313
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      WHERE true::bool
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
+           c_0            |           c_1            | c_2 | c_7
+---------------------------------------------------------------------
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   7 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   8 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   9 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |  10 |   1
+(4 rows)
+
+-- Variant of redundant WHERE clause
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      WHERE true::bool or (ref_0.vkey % 3 = 0)
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
+           c_0            |           c_1            | c_2 | c_7
+---------------------------------------------------------------------
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   7 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   8 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   9 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |  10 |   1
+(4 rows)
+
+-- Remove redundant WHERE clause => same result set
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
+           c_0            |           c_1            | c_2 | c_7
+---------------------------------------------------------------------
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   7 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   8 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |   9 |   1
+ Sat Apr 01 03:32:00 2028 | Sat Mar 29 18:17:00 2031 |  10 |   1
+(4 rows)
 
 -- Redundant WHERE clause with distributed parititioned table
 CREATE TABLE a (a int);

--- a/src/test/regress/sql/subquery_in_where.sql
+++ b/src/test/regress/sql/subquery_in_where.sql
@@ -555,7 +555,8 @@ IN
 	(SELECT
 		user_id
 	FROM
-		users_table);
+		users_table)
+ORDER BY id;
 
 -- Use local table in WHERE clause
 SELECT
@@ -929,6 +930,98 @@ where TRUE or (((t3.vkey) >= (select
 
 -- Distributed table t3 is now empty
 SELECT vkey, pkey FROM t3;
+
+-- Test case where citus table is reduced to a distributed subplan
+-- Exposed by issue
+
+INSERT INTO t0 (vkey, pkey, c0) values
+(1, 10000, make_timestamp(2032, 9, 4, 13, 38, 0)),
+(2, 11000, make_timestamp(2024, 8, 31, 17, 51, 0)),
+(3, 12000, make_timestamp(2028, 4, 1, 3, 32, 0)),
+(4, 13000, make_timestamp(2029, 11, 4, 13, 49, 0)),
+(5, 14000, make_timestamp(2031, 3, 29, 18, 17, 0)),
+(6, 15000, make_timestamp(2030, 5, 17, 11, 32, 0)),
+(7, 16000, make_timestamp(2027, 9, 22, 12, 58, 0)),
+(8, 17000, make_timestamp(2026, 12, 3, 13, 44, 0)),
+(9, 18000, make_timestamp(2028, 2, 24, 14, 05, 0)),
+(10,19000, make_timestamp(2031, 4, 14, 15, 12, 0));
+
+INSERT INTO t3 (vkey, pkey, c9) values
+(1, 10000, make_timestamp(2032, 9, 4, 13, 38, 0)),
+(2, 11000, make_timestamp(2024, 8, 31, 17, 51, 0)),
+(3, 12000, make_timestamp(2028, 4, 1, 3, 32, 0)),
+(4, 13000, make_timestamp(2029, 11, 4, 13, 49, 0)),
+(5, 14000, make_timestamp(2031, 3, 29, 18, 17, 0)),
+(6, 15000, make_timestamp(2030, 5, 17, 11, 32, 0)),
+(7, 16000, make_timestamp(2027, 9, 22, 12, 58, 0)),
+(8, 17000, make_timestamp(2026, 12, 3, 13, 44, 0)),
+(9, 18000, make_timestamp(2028, 2, 24, 14, 05, 0)),
+(10,19000, make_timestamp(2031, 4, 14, 15, 12, 0));
+
+-- minimal repro: without the fix, c_1 column is NULL
+SELECT c_1, c_2
+FROM (SELECT
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2
+      FROM t0 AS ref_0
+      WHERE true::bool
+) as subq_0
+WHERE subq_0.c_2 = 7
+ORDER BY c_1, c_2;
+
+-- remove redundant WHERE clause => same result set
+SELECT c_1, c_2
+FROM (SELECT
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2
+      FROM t0 AS ref_0
+) as subq_0
+WHERE subq_0.c_2 = 7
+ORDER BY c_1, c_2;
+
+-- Repro query from issue #8313
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      WHERE true::bool
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
+
+-- Variant of redundant WHERE clause
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      WHERE true::bool or (ref_0.vkey % 3 = 0)
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
+
+-- Remove redundant WHERE clause => same result set
+SELECT c_0, c_1, c_2, c_7
+FROM (SELECT (SELECT c0 FROM t0 ORDER BY vkey LIMIT 1 OFFSET 2) AS c_0,
+             (SELECT c9 FROM t3 ORDER BY vkey limit 1 OFFSET 4) AS c_1,
+             ref_0.vkey as c_2,
+             ref_0.vkey as c_3,
+             (SELECT pg_catalog.min(vkey) FROM t0) AS c_7
+      FROM t0 AS ref_0
+      ORDER BY c_0 DESC, c_1 DESC, c_2 ASC, c_3 ASC, c_7 ASC
+) as subq_0
+where (((select vkey from t3 order by vkey limit 1 offset 6)
+      ) between ((subq_0.c_7)) and (subq_0.c_3))
+order by c_0, c_1, c_2;
 
 -- Redundant WHERE clause with distributed parititioned table
 CREATE TABLE a (a int);


### PR DESCRIPTION
Include SubPlans when checking that a query is still distributed.

DESCRIPTION: tighten distributed plan check to cover distributed subplans.
    
The `distributed_planner()` hook needs to check, after calling `standard_planner()`, if the query still requires distributed planning - this was necessitated by issue #7782, #7783 where the citus tables in a query are optimized away by `standard_planner()`.  However, issue #8313 exposed a case where we incorrectly flag a query as no long needing distributed planning; the query has 
the following format:
``` 
SELECT t0.a1 as c1, 
       (SELECT xx FROM t1 LIMIT 1) as c2
FROM t0
WHERE true::bool
``` 
where the only citus table is `t1`. The scalar subquery is reduced to a `read_intermediate_result()` call after recursive planning of
CTEs and subqueries:
``` 
SELECT t0.a1 as c1, 
       (SELECT .. FROM read_intermediate_result() ... ) as c2
FROM t0
``` 
with the consequence that function `CheckPostPlanDistribution()` does not see any citus tables in the query plan and marks the query as not distributed. The fix enhances `CheckPostPlanDistribution()` to additionally look at the plan's subplan list for a read intermediate result call, and mark the query as needing distributed planning if one is found. The new check uses existing function `IsReadIntermediateResultFunction()` to detect the presence of a distributed subplan. This function is already used by `intermediate_result_pruning.c` to build a list of distributed subplan structs, so can be reused here to determine if
a query still needs distributed planning.
    
Fixes issue: https://github.com/citusdata/citus/issues/8313