### PR TITLE
Add PG17 to build matrix for Citus upgrade tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -310,6 +310,7 @@ jobs:
       matrix:
         pg_version:
           - ${{ needs.params.outputs.pg16_version }}
+          - ${{ needs.params.outputs.pg17_version }}
     steps:
     - uses: actions/checkout@v4
     - uses: "./.github/actions/setup_extension"


### PR DESCRIPTION
As of https://github.com/citusdata/the-process/pull/175, our images already support PG17 for Citus upgrade tests, so let's also test it in our CI.