### PR TITLE
Allow configuring sslkeylogfile using citus.node_conn_info

### DIFF
--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -3083,6 +3083,9 @@ NodeConninfoGucCheckHook(char **newval, void **extra, GucSource source)
 		"sslcompression",
 		"sslcrl",
 		"sslkey",
+#if PG_VERSION_NUM >= PG_VERSION_18
+		"sslkeylogfile",
+#endif
 		"sslmode",
 #if PG_VERSION_NUM >= PG_VERSION_17
 		"sslnegotiation",


### PR DESCRIPTION
Relevant PG commit:
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=2da74d8d6

This parameter could be useful in connection debugging in a Citus distributed environment.

Similar change to:
https://github.com/citusdata/citus/commit/8940665d17fef2282748507c62be8959dc8a4691

Fixes #8416 
