### PR TITLE
Add PG_MODULE_MAGIC_EXT macro for Citus and citus columnar

### DIFF
--- a/src/backend/columnar/mod.c
+++ b/src/backend/columnar/mod.c
@@ -21,7 +21,11 @@
 #include "columnar/columnar_tableam.h"
 
 
+#if PG_VERSION_NUM >= PG_VERSION_18
+PG_MODULE_MAGIC_EXT(.name = "citus_columnar", .version = "14.0devel");
+#else
 PG_MODULE_MAGIC;
+#endif
 
 void _PG_init(void);
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -119,7 +119,11 @@
 #include "distributed/worker_shard_visibility.h"
 
 /* marks shared object as one loadable by the postgres version compiled against */
+#if PG_VERSION_NUM >= PG_VERSION_18
+PG_MODULE_MAGIC_EXT(.name = "citus", .version = "14.0devel");
+#else
 PG_MODULE_MAGIC;
+#endif
 
 ColumnarSupportsIndexAM_type extern_ColumnarSupportsIndexAM = NULL;
 CompressionTypeStr_type extern_CompressionTypeStr = NULL;

--- a/src/test/regress/expected/pg18.out
+++ b/src/test/regress/expected/pg18.out
@@ -3010,6 +3010,16 @@ FROM wal_explain_plan;
 
 DROP TABLE wal_explain_plan;
 SET citus.explain_all_tasks TO default;
+-- PG18 PG_MODULE_MAGIC_EXT MACRO
+-- and new function pg_get_loaded_modules
+-- Relevant PG18 commit: https://github.com/postgres/postgres/commit/9324c8c58
+SELECT * FROM pg_get_loaded_modules() WHERE file_name LIKE 'citus%' ORDER BY module_name;
+    module_name     |  version  |       file_name
+---------------------------------------------------------------------
+ citus              | 14.0devel | citus.so
+ citus_columnar     | 14.0devel | citus_columnar.so
+(2 rows)
+
 -- cleanup with minimum verbosity
 SET client_min_messages TO ERROR;
 RESET search_path;

--- a/src/test/regress/sql/pg18.sql
+++ b/src/test/regress/sql/pg18.sql
@@ -1891,6 +1891,11 @@ FROM wal_explain_plan;
 DROP TABLE wal_explain_plan;
 SET citus.explain_all_tasks TO default;
 
+-- PG18 PG_MODULE_MAGIC_EXT MACRO
+-- and new function pg_get_loaded_modules
+-- Relevant PG18 commit: https://github.com/postgres/postgres/commit/9324c8c58
+SELECT * FROM pg_get_loaded_modules() WHERE file_name LIKE 'citus%' ORDER BY module_name;
+
 -- cleanup with minimum verbosity
 SET client_min_messages TO ERROR;
 RESET search_path;


### PR DESCRIPTION
Relevant PG18 commit:
https://github.com/postgres/postgres/commit/9324c8c58

This commit adds PG_MODULE_MAGIC_EXT info for `citus` and `citus_columnar`.

Tested this by the new PG18 `pg_get_loaded_modules()` function.

Fixes #8417 

Note: this should be taken care of every time we release a new version and bump the citus version.