### PR TITLE
Workflows for n/n-1 tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,6 +241,8 @@ jobs:
       citus_libdir: "/opt/citus-versions/v14.0.0"
       citus_libdir_label: "v14.0.0"
       n_1_mode: "workeronly"
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-citus-coordinator-n-1:
     name: Test Citus Coordinator N-1
     uses: ./.github/workflows/run_tests.yml


### PR DESCRIPTION
Adds workflows to run the following schedules under n/n-1 scenarios:

check-split, check-multi, check-multi-1, check-isolation, check-operations, check-follower-cluster, check-add-backup-node, check-columnar, check-columnar-isolation, check-enterprise, check-enterprise-isolation, check-enterprise-isolation-logicalrep-1, check-enterprise-isolation-logicalrep-2, check-enterprise-isolation-logicalrep-3
