### PR TITLE
Fix type mismatch when COLLATE is used with type cast in distributed …

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -243,7 +243,7 @@ static bool QueryTreeHasImproperForDeparseNodes(Node *inputNode, void *context);
 static Node * AdjustImproperForDeparseNodes(Node *inputNode, void *context);
 static bool IsImproperForDeparseRelabelTypeNode(Node *inputNode);
 static bool IsImproperForDeparseCoerceViaIONode(Node *inputNode);
-static CollateExpr * RelabelTypeToCollateExpr(RelabelType *relabelType);
+static Node * RelabelTypeToCollateExpr(RelabelType *relabelType);
 
 
 /*
@@ -2931,10 +2931,14 @@ SqlTaskList(Job *job)
 
 
 /*
- * RelabelTypeToCollateExpr converts RelabelType's into CollationExpr's.
- * With that, we will be able to pushdown COLLATE's.
+ * RelabelTypeToCollateExpr converts RelabelType nodes for deparsing.
+ * When the RelabelType only changes collation, it produces a CollateExpr.
+ * When it also changes the type (resulttype != argType), the CollateExpr
+ * is wrapped in a new RelabelType with DEFAULT_COLLATION_OID to preserve
+ * the type cast while avoiding re-detection by
+ * IsImproperForDeparseRelabelTypeNode.
  */
-static CollateExpr *
+static Node *
 RelabelTypeToCollateExpr(RelabelType *relabelType)
 {
 	Assert(OidIsValid(relabelType->resultcollid));
@@ -2944,7 +2948,23 @@ RelabelTypeToCollateExpr(RelabelType *relabelType)
 	collateExpr->collOid = relabelType->resultcollid;
 	collateExpr->location = relabelType->location;
 
-	return collateExpr;
+	Oid argType = exprType((Node *) relabelType->arg);
+	if (relabelType->resulttype != argType)
+	{
+		RelabelType *castRelabel = makeNode(RelabelType);
+		castRelabel->arg = (Expr *) collateExpr;
+		castRelabel->resulttype = relabelType->resulttype;
+		castRelabel->resulttypmod = relabelType->resulttypmod;
+
+		/* DEFAULT_COLLATION_OID prevents re-detection by IsImproperForDeparseRelabelTypeNode */
+		castRelabel->resultcollid = DEFAULT_COLLATION_OID;
+		castRelabel->relabelformat = relabelType->relabelformat;
+		castRelabel->location = relabelType->location;
+
+		return (Node *) castRelabel;
+	}
+
+	return (Node *) collateExpr;
 }
 
 

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -85,6 +85,46 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 (1 row)
 
 RESET citus.log_remote_commands;
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+ sum
+---------------------------------------------------------------------
+ 1.5
+(1 row)
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+      c1
+---------------------------------------------------------------------
+ 14.25.58.22
+ 144.150.228.243
+ 22.171.214.19
+(3 rows)
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');

--- a/src/test/regress/sql/distributed_collations.sql
+++ b/src/test/regress/sql/distributed_collations.sql
@@ -45,6 +45,32 @@ SELECT ALL MIN((lower(CAST(test_collate_pushed_down_aggregate.a AS VARCHAR)) COL
     FROM ONLY test_collate_pushed_down_aggregate;
 RESET citus.log_remote_commands;
 
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');


### PR DESCRIPTION
DESCRIPTION: Fixes type mismatch when COLLATE is used with type cast in distributed queries

`RelabelTypeToCollateExpr` was dropping the type cast (e.g. `::VARCHAR`) when converting `RelabelType` nodes to `CollateExpr` for deparsing. Workers received `expr COLLATE "C"` (returning `text`) instead of `(expr COLLATE "C")::varchar`, causing "attribute of type record has wrong type" errors.

Fix: when the `RelabelType` changes both type and collation, preserve the cast by wrapping the `CollateExpr` in a new `RelabelType` with `DEFAULT_COLLATION_OID` to avoid re-detection.

Fixes #8469