### PR TITLE
Support extended stats creation on expressions

### DIFF
--- a/src/backend/distributed/deparser/deparse_statistics_stmts.c
+++ b/src/backend/distributed/deparser/deparse_statistics_stmts.c
@@ -237,6 +237,42 @@ AppendStatTypes(StringInfo buf, CreateStatsStmt *stmt)
 }
 
 
+/* See ruleutils.c in postgres for the logic here. */
+static bool
+looks_like_function(Node *node)
+{
+	if (node == NULL)
+	{
+		return false;           /* probably shouldn't happen */
+	}
+	switch (nodeTag(node))
+	{
+		case T_FuncExpr:
+		{
+			/* OK, unless it's going to deparse as a cast */
+			return (((FuncExpr *) node)->funcformat == COERCE_EXPLICIT_CALL ||
+					((FuncExpr *) node)->funcformat == COERCE_SQL_SYNTAX);
+		}
+
+		case T_NullIfExpr:
+		case T_CoalesceExpr:
+		case T_MinMaxExpr:
+		case T_SQLValueFunction:
+		case T_XmlExpr:
+		{
+			/* these are all accepted by func_expr_common_subexpr */
+			return true;
+		}
+
+		default:
+		{
+			break;
+		}
+	}
+	return false;
+}
+
+
 static void
 AppendColumnNames(StringInfo buf, CreateStatsStmt *stmt)
 {
@@ -272,14 +308,23 @@ AppendColumnNames(StringInfo buf, CreateStatsStmt *stmt)
 				ParseState *pstate = make_parsestate(NULL);
 				AddRangeTableEntryToQueryCompat(pstate, relation);
 				Node *exprCooked = transformExpr(pstate, column->expr,
-												 EXPR_KIND_FUNCTION_DEFAULT);
+												 EXPR_KIND_STATS_EXPRESSION);
 
 				char *relationName = get_rel_name(relOid);
 				List *relationCtx = deparse_context_for(relationName, relOid);
 
 				char *exprSql = deparse_expression(exprCooked, relationCtx, false, false);
 				relation_close(relation, NoLock);
-				appendStringInfoString(buf, exprSql);
+
+				/* Need parens if it's not a bare function call */
+				if (looks_like_function(exprCooked))
+				{
+					appendStringInfoString(buf, exprSql);
+				}
+				else
+				{
+					appendStringInfo(buf, "(%s)", exprSql);
+				}
 			}
 			else
 			{

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -178,11 +178,6 @@ static GucStringAssignHook OldApplicationNameAssignHook = NULL;
  */
 static bool FinishedStartupCitusBackend = false;
 
-/*
- * GUC definition for statistics expressions.
- */
-extern bool EnableUnsafeStatisticsExpressions;
-
 static object_access_hook_type PrevObjectAccessHook = NULL;
 
 static shmem_request_hook_type prev_shmem_request_hook = NULL;
@@ -1621,7 +1616,7 @@ RegisterCitusConfigVariables(void)
 		&EnableUnsafeStatisticsExpressions,
 		false,
 		PGC_USERSET,
-		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+		GUC_STANDARD,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -37,6 +37,7 @@ extern bool EnableLocalReferenceForeignKeys;
 extern bool AllowUnsafeConstraints;
 
 extern bool EnableUnsafeTriggers;
+extern bool EnableUnsafeStatisticsExpressions;
 
 extern int MaxMatViewSizeToAutoRecreate;
 

--- a/src/test/regress/expected/propagate_statistics.out
+++ b/src/test/regress/expected/propagate_statistics.out
@@ -54,25 +54,26 @@ SELECT create_distributed_table ('test_stats3','a');
 (1 row)
 
 -- test creating custom stats with expressions and distributing it.
-CREATE TABLE test_stats_expr (
+CREATE TABLE sc2.test_stats_expr (
 	a int,
-	b int
+	b int,
+	c float8
 );
-CREATE STATISTICS s_expr ON (a + b / 2) FROM test_stats_expr;
+CREATE STATISTICS s_expr ON (a + b / 2) FROM sc2.test_stats_expr;
 -- succeeds since we replicate it into the shards.
-SELECT create_distributed_table('test_stats_expr', 'a');
+SELECT create_distributed_table('sc2.test_stats_expr', 'a');
  create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
 -- fails
-CREATE STATISTICS s_expr_post ON (a - (b * 2)) FROM test_stats_expr;
+CREATE STATISTICS s_expr_post ON (a - (b * 2)),round(c) FROM sc2.test_stats_expr;
 ERROR:  only simple column references are allowed in CREATE STATISTICS
 -- succeeds.
 set citus.enable_unsafe_statistics_expressions TO on;
 -- add another expression stats on the distributed table should work.
-CREATE STATISTICS s_expr_post ON (a - (b * 2)) FROM test_stats_expr;
+CREATE STATISTICS s_expr_post ON (a - (b * 2)), round(c) FROM sc2.test_stats_expr;
 reset citus.enable_unsafe_statistics_expressions;
 -- test dropping statistics
 CREATE TABLE test_stats4 (

--- a/src/test/regress/sql/propagate_statistics.sql
+++ b/src/test/regress/sql/propagate_statistics.sql
@@ -45,23 +45,24 @@ CREATE STATISTICS sc2."neW'Stat" ON a,b FROM test_stats3;
 SELECT create_distributed_table ('test_stats3','a');
 
 -- test creating custom stats with expressions and distributing it.
-CREATE TABLE test_stats_expr (
+CREATE TABLE sc2.test_stats_expr (
 	a int,
-	b int
+	b int,
+	c float8
 );
-CREATE STATISTICS s_expr ON (a + b / 2) FROM test_stats_expr;
+CREATE STATISTICS s_expr ON (a + b / 2) FROM sc2.test_stats_expr;
 
 -- succeeds since we replicate it into the shards.
-SELECT create_distributed_table('test_stats_expr', 'a');
+SELECT create_distributed_table('sc2.test_stats_expr', 'a');
 
 -- fails
-CREATE STATISTICS s_expr_post ON (a - (b * 2)) FROM test_stats_expr;
+CREATE STATISTICS s_expr_post ON (a - (b * 2)),round(c) FROM sc2.test_stats_expr;
 
 -- succeeds.
 set citus.enable_unsafe_statistics_expressions TO on;
 
 -- add another expression stats on the distributed table should work.
-CREATE STATISTICS s_expr_post ON (a - (b * 2)) FROM test_stats_expr;
+CREATE STATISTICS s_expr_post ON (a - (b * 2)), round(c) FROM sc2.test_stats_expr;
 reset citus.enable_unsafe_statistics_expressions;
 
 -- test dropping statistics


### PR DESCRIPTION
DESCRIPTION: Support extended stats creation on expressions
CREATE STATISTICS today gets pushed to the shards only if the statistics is on a column expression. However, PG14 added support for expressions (opExpr, FuncExprs) etc. This change adds support for it under a GUC.
This reuses the same logic as CHECK constraints to parse, transform, and deparse the exprs and add it to the statistics call.