### PR TITLE
Fix crash on create statistics with non-RangeVar type pt2

### DIFF
--- a/src/backend/distributed/deparser/qualify_statistics_stmt.c
+++ b/src/backend/distributed/deparser/qualify_statistics_stmt.c
@@ -34,7 +34,14 @@ QualifyCreateStatisticsStmt(Node *node)
 {
 	CreateStatsStmt *stmt = castNode(CreateStatsStmt, node);
 
-	RangeVar *relation = (RangeVar *) linitial(stmt->relations);
+	Node *relationNode = (Node *) linitial(stmt->relations);
+
+	if (!IsA(relationNode, RangeVar))
+	{
+		return;
+	}
+
+	RangeVar *relation = (RangeVar *) relationNode;
 
 	if (relation->schemaname == NULL)
 	{


### PR DESCRIPTION
Cherry-pick of c5dde4b1154ce140a59a2c2f19be8a41c68e3f81 (only `src/backend/distributed/deparser/qualify_statistics_stmt.c`, as the other files do not exist on this branch).