### PR TITLE
Fix bug  #8470   citus_activate_node and secondary node 

### DIFF
--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -3771,8 +3771,6 @@ ActivateNode(WorkerNode *acivateNode)
 
 	if ( EnableMetadataSync)
 	{
-
-
 		/* send the delete command to all primary nodes with metadata */
 		char *nodeUpdateCommand = NodeStateUpdateCommand(acivateNode->nodeId, true);
 		SendCommandToWorkersWithMetadata(nodeUpdateCommand);

--- a/src/backend/distributed/metadata/node_metadata.c
+++ b/src/backend/distributed/metadata/node_metadata.c
@@ -147,6 +147,7 @@ static BackgroundWorkerHandle * LockPlacementsWithBackgroundWorkersInPrimaryNode
 static int32 CitusAddCloneNode(WorkerNode *primaryWorkerNode,
 							   char *cloneHostname, int32 clonePort);
 static void RemoveCloneNode(WorkerNode *cloneNode);
+static void ActivateNode(WorkerNode *acivateNode);
 
 /* Function definitions go here */
 
@@ -787,6 +788,11 @@ citus_activate_node(PG_FUNCTION_ARGS)
 	if (NodeIsSecondary(workerNode))
 	{
 		EnsureTransactionalMetadataSyncMode();
+
+		ActivateNode(workerNode);
+		TransactionModifiedNodeMetadata = true;
+
+		PG_RETURN_INT32(workerNode->nodeId);
 	}
 
 	/*
@@ -3719,4 +3725,63 @@ SyncNodeMetadata(MetadataSyncContext *context)
 	 * metadata just for activated workers.
 	 */
 	SendOrCollectCommandListToActivatedNodes(context, recreateNodeSnapshotCommandList);
+}
+
+static void
+ActivateNode(WorkerNode *acivateNode)
+{
+	const bool indexOK = true;
+
+	Relation pgDistNode = table_open(DistNodeRelationId(), RowExclusiveLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(pgDistNode);
+
+	ScanKeyData scanKey[1];
+
+
+	Datum *values = palloc0(tupleDescriptor->natts * sizeof(Datum));
+	bool *isnull = palloc0(tupleDescriptor->natts * sizeof(bool));
+	bool *replace = palloc0(tupleDescriptor->natts * sizeof(bool));
+
+	ScanKeyInit(&scanKey[0], Anum_pg_dist_node_nodeid,
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(acivateNode->nodeId));
+
+	SysScanDesc scanDescriptor = systable_beginscan(pgDistNode, DistNodeNodeIdIndexId(),
+													indexOK,
+													NULL, 1, scanKey);
+
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
+	if (!HeapTupleIsValid(heapTuple))
+	{
+		ereport(ERROR, (errmsg("could not find valid entry for node \"%s:%d\"",
+							   acivateNode->workerName, acivateNode->workerPort)));
+	}
+
+	values[Anum_pg_dist_node_isactive - 1] = BoolGetDatum(true);
+	isnull[Anum_pg_dist_node_isactive - 1] = false;
+	replace[Anum_pg_dist_node_isactive - 1] = true;
+
+
+	heapTuple = heap_modify_tuple(heapTuple, tupleDescriptor, values, isnull, replace);
+
+	CatalogTupleUpdate(pgDistNode, &heapTuple->t_self, heapTuple);
+
+	CitusInvalidateRelcacheByRelid(DistNodeRelationId());
+
+	CommandCounterIncrement();
+
+	if ( EnableMetadataSync)
+	{
+
+
+		/* send the delete command to all primary nodes with metadata */
+		char *nodeUpdateCommand = NodeStateUpdateCommand(acivateNode->nodeId, true);
+		SendCommandToWorkersWithMetadata(nodeUpdateCommand);
+	}
+
+	systable_endscan(scanDescriptor);
+	table_close(pgDistNode, NoLock);
+
+	pfree(values);
+	pfree(isnull);
+	pfree(replace);
 }

--- a/src/test/regress/expected/check_activate_secondary_node.out
+++ b/src/test/regress/expected/check_activate_secondary_node.out
@@ -78,3 +78,7 @@ SET citus.metadata_sync_mode TO 'nontransactional';
 SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
 ERROR:  this operation cannot be completed in nontransactional metadata sync mode
 HINT:  SET citus.metadata_sync_mode to 'transactional'
+SET citus.metadata_sync_mode TO 'transactional';
+-- error because the node does not exist
+SELECT 1 FROM citus_activate_node('localhost', 7777);
+ERROR:  node at "localhost:xxxxx" does not exist

--- a/src/test/regress/expected/check_activate_secondary_node.out
+++ b/src/test/regress/expected/check_activate_secondary_node.out
@@ -1,0 +1,80 @@
+\c - - - :master_port
+-- prepare testing
+SELECT citus_set_coordinator_host('localhost', :master_port);
+ citus_set_coordinator_host
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.metadata_sync_mode TO 'transactional';
+-- add inactive secondary node
+SELECT 1 FROM citus_add_secondary_node('localhost', :follower_worker_2_port, 'localhost', :worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+SELECT 1 FROM citus_disable_node('localhost', :follower_worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- check inactive node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND NOT isactive;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+SELECT start_metadata_sync_to_all_nodes();
+ start_metadata_sync_to_all_nodes
+---------------------------------------------------------------------
+ t
+(1 row)
+
+\c - - - :worker_2_port
+-- check inactive node on worker
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND NOT isactive;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+\c - - - :master_port
+-- main test: activate secondary node
+SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- check is active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+\c - - - :worker_2_port
+-- check is active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+\c - - - :worker_1_port
+-- check active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+\c - - - :master_port
+SET citus.metadata_sync_mode TO 'nontransactional';
+-- error this operation cannot be completed in nontransactional metadata sync mode if the GUC citus.metadata_sync_mode set to 'nontransactional'
+SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
+ERROR:  this operation cannot be completed in nontransactional metadata sync mode
+HINT:  SET citus.metadata_sync_mode to 'transactional'

--- a/src/test/regress/multi_follower_schedule
+++ b/src/test/regress/multi_follower_schedule
@@ -8,3 +8,4 @@ test: multi_add_node_from_backup_sync_replica
 # test that no tests leaked intermediate results. This should always be last
 test: ensure_no_intermediate_data_leak
 test: check_mx
+test: check_activate_secondary_node

--- a/src/test/regress/sql/check_activate_secondary_node.sql
+++ b/src/test/regress/sql/check_activate_secondary_node.sql
@@ -39,3 +39,6 @@ SET citus.metadata_sync_mode TO 'nontransactional';
 -- error this operation cannot be completed in nontransactional metadata sync mode if the GUC citus.metadata_sync_mode set to 'nontransactional'
 SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
 
+SET citus.metadata_sync_mode TO 'transactional';
+-- error because the node does not exist 
+SELECT 1 FROM citus_activate_node('localhost', 7777);

--- a/src/test/regress/sql/check_activate_secondary_node.sql
+++ b/src/test/regress/sql/check_activate_secondary_node.sql
@@ -1,0 +1,41 @@
+\c - - - :master_port
+-- prepare testing
+SELECT citus_set_coordinator_host('localhost', :master_port);
+SET citus.metadata_sync_mode TO 'transactional';
+
+-- add inactive secondary node
+SELECT 1 FROM citus_add_secondary_node('localhost', :follower_worker_2_port, 'localhost', :worker_2_port);
+SELECT 1 FROM citus_disable_node('localhost', :follower_worker_2_port);
+
+-- check inactive node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND NOT isactive;
+SELECT start_metadata_sync_to_all_nodes();
+
+
+\c - - - :worker_2_port
+-- check inactive node on worker
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND NOT isactive;
+
+\c - - - :master_port
+
+-- main test: activate secondary node
+SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
+
+
+-- check is active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+
+\c - - - :worker_2_port
+-- check is active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+
+\c - - - :worker_1_port
+-- check active node
+SELECT count(*) FROM pg_dist_node WHERE nodeport=:follower_worker_2_port AND nodename='localhost' AND isactive;
+
+\c - - - :master_port
+SET citus.metadata_sync_mode TO 'nontransactional';
+
+-- error this operation cannot be completed in nontransactional metadata sync mode if the GUC citus.metadata_sync_mode set to 'nontransactional'
+SELECT 1 FROM citus_activate_node('localhost', :follower_worker_2_port);
+


### PR DESCRIPTION
DESCRIPTION: The citus_activate_node() function  does not activate secondary nodes. This function is necessary when failover  switches from secondary node to primary node. You have to do this manually with the UPDATE pg_dist_node command. This patch adds the citus_activate_node command  for secondary nodes.
