### PR TITLE
Outer join removal in citus_tables view

### DIFF
--- a/src/backend/distributed/sql/udfs/citus_tables/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_tables/latest.sql
@@ -24,7 +24,7 @@ citus_tables_create_query=$CTCQ$
         pg_class c ON (p.logicalrelid = c.oid)
     LEFT JOIN
         pg_am a ON (a.oid = c.relam)
-    JOIN
+    LEFT OUTER JOIN
         (
             SELECT ds.logicalrelid AS table_id, SUM(css.size) AS table_size
             FROM citus_shard_sizes() css, pg_dist_shard ds


### PR DESCRIPTION
Hey! I noticed a small issue with the `citus_tables` view: even when selecting just a single column from it (e.g. `table_name`), it still triggers network communication between nodes due to `citus_shard_size()` call within a subquery. I wanted to get rid of that overhead wherever possible.

I replaced the INNER JOIN with a LEFT OUTER JOIN. This lets PostgreSQL's outer join removal optimization kick in, so the join (and the extra network traffic) gets completely skipped when the right-side columns aren't used.
