### PR TITLE
Drain extra bytes before yielding to wait-event loop in ReceiveResults

### DIFF
--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -3986,8 +3986,38 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 													 ALLOCSET_DEFAULT_INITSIZE,
 													 ALLOCSET_DEFAULT_MAXSIZE);
 
-	while (!PQisBusy(connection->pgConn))
+	while (1)
 	{
+		if (PQisBusy(connection->pgConn))
+		{
+			/*
+			 * libpq has no complete row to surface right now.  Before yielding
+			 * back to the wait-event loop in RunDistributedExecution(), make
+			 * one extra non-blocking PQconsumeInput() call.  While we were
+			 * processing the previous batch of rows, the worker may have
+			 * pushed more bytes into the kernel receive buffer; if so, this
+			 * lets us keep draining instead of paying a full event-loop cycle
+			 * (epoll wake + ConnectionStateMachine + CheckConnectionReady) to
+			 * pick up rows that were already on the socket.
+			 *
+			 * For wide-row distributed SELECTs (e.g. PostGIS geometries) this
+			 * collapses what would otherwise be O(rows / batch_size) wait-event
+			 * cycles into a small constant, with the biggest impact on
+			 * deployments where coordinator/worker RTT is non-trivial.
+			 */
+			if (PQconsumeInput(connection->pgConn) == 0)
+			{
+				connection->connectionState = MULTI_CONNECTION_LOST;
+				break;
+			}
+			if (PQisBusy(connection->pgConn))
+			{
+				/* really nothing to drain; yield to the wait-event loop */
+				break;
+			}
+			/* fall through: more rows are available, keep draining */
+		}
+
 		uint32 columnIndex = 0;
 		uint32 rowsProcessed = 0;
 

--- a/src/backend/distributed/executor/adaptive_executor.c
+++ b/src/backend/distributed/executor/adaptive_executor.c
@@ -3990,20 +3990,24 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 	{
 		if (PQisBusy(connection->pgConn))
 		{
+#ifndef LIBPQ_HAS_CHUNK_MODE
+
 			/*
-			 * libpq has no complete row to surface right now.  Before yielding
-			 * back to the wait-event loop in RunDistributedExecution(), make
-			 * one extra non-blocking PQconsumeInput() call.  While we were
-			 * processing the previous batch of rows, the worker may have
-			 * pushed more bytes into the kernel receive buffer; if so, this
-			 * lets us keep draining instead of paying a full event-loop cycle
-			 * (epoll wake + ConnectionStateMachine + CheckConnectionReady) to
-			 * pick up rows that were already on the socket.
+			 * On builds without libpq chunked-rows support (PG <= 16) the
+			 * adaptive executor uses PQsetSingleRowMode, which surfaces
+			 * roughly one row per PQgetResult call.  Wide-row distributed
+			 * SELECTs (e.g. PostGIS geometries) hit PQisBusy() = true many
+			 * thousands of times per query, each time forcing a yield to the
+			 * wait-event loop in RunDistributedExecution().  Before yielding,
+			 * try one extra non-blocking PQconsumeInput(); if the worker has
+			 * pushed more bytes into the kernel buffer while we were
+			 * processing the previous batch of rows we keep draining instead
+			 * of paying for an epoll wake + ConnectionStateMachine pass.
 			 *
-			 * For wide-row distributed SELECTs (e.g. PostGIS geometries) this
-			 * collapses what would otherwise be O(rows / batch_size) wait-event
-			 * cycles into a small constant, with the biggest impact on
-			 * deployments where coordinator/worker RTT is non-trivial.
+			 * On PG17+ libpq exposes PQsetChunkedRowsMode (LIBPQ_HAS_CHUNK_MODE
+			 * is defined) and the adaptive executor batches on the libpq side
+			 * (see #5195), so this extra drain is unnecessary -- a
+			 * PQisBusy=true after a chunk really does mean "yield".
 			 */
 			if (PQconsumeInput(connection->pgConn) == 0)
 			{
@@ -4016,6 +4020,15 @@ ReceiveResults(WorkerSession *session, bool storeRows)
 				break;
 			}
 			/* fall through: more rows are available, keep draining */
+#else
+
+			/*
+			 * Chunked-rows mode amortises libpq overhead over many rows per
+			 * PQgetResult, so an extra non-blocking drain is not worth the
+			 * complexity here -- yield to the wait-event loop as before.
+			 */
+			break;
+#endif
 		}
 
 		uint32 columnIndex = 0;


### PR DESCRIPTION
DESCRIPTION: Reduce wait-event-loop cycles in distributed SELECT result fetching for wide-row workloads

## Motivation

`ReceiveResults()` drains rows from each worker connection until libpq's `PQisBusy()` returns true, then yields back to `RunDistributedExecution()`'s wait-event loop. With single-row mode, libpq surfaces complete rows from its internal recv buffer one at a time, and the loop exits the moment one batch is fully drained.

For **wide-row** distributed SELECTs the batch is small. PostGIS `geometry(POLYGON, 4326)` is a fairly representative case: in my local repro a 16-column table with one geometry column drains ~12 rows per `ReceiveResults` call. While we are processing those 12 rows, the worker keeps streaming bytes — by the time we yield back to the wait-event loop, more bytes are already in the kernel receive buffer.

That makes the round-trip through `WaitEventSetWait → ProcessWaitEvents → ConnectionStateMachine → CheckConnectionReady → TransactionStateMachine → ReceiveResults` pure overhead: we're just waking up to read bytes that were already ours.

## Change

One extra non-blocking `PQconsumeInput()` call before yielding.  If new bytes have shown up since we last drained, keep draining; otherwise yield as before. The yield path is preserved unchanged for the case where the connection genuinely has nothing more right now.

About 30 lines added in `ReceiveResults`, no other files touched, no worker-side changes.

## Measurement

Local 3-node Citus reproduction (1 coordinator + 2 workers, 32-shard table, 3 M synthetic PostGIS polygons). Pool size pinned to 1 to remove parallel-connection noise. Same workload, instrumented build that counts `ReceiveResults` invocations and how often the new extra-drain found more bytes.

| Query                | Before (cycles) | After (cycles) | Reduction | Extra-drain hit rate |
|----------------------|----------------:|---------------:|----------:|---------------------:|
| `SELECT id` 5 K rows    | 32           | 32             | 0 %       | n/a                   |
| `SELECT *`  5 K rows    | 428          | 191            | 55 %      | 60 %                  |
| `SELECT id` 120 K rows  | 288          | 236            | 18 %      | 20 %                  |
| **`SELECT *` 120 K rows** | **10 180** | **155**       | **98.5 %**| **98.8 %**            |

Wall-clock for the 120 K wide-row case dropped 1762 ms → 1413 ms locally (–20 %). Local docker-bridge RTT is ~50 µs, so the per-cycle overhead saved per eliminated cycle is small in absolute terms; on a real LAN where each event-loop cycle is dominated by syscall + network round-trip (ms-order rather than µs-order), the same 65× cycle reduction should translate into a much larger wall-clock saving.

## Why it's safe

The existing yield path is preserved: when `PQisBusy()` returns true *after* the extra `PQconsumeInput()` (i.e. the kernel really has nothing for us right now), we still return to the wait-event loop. We never hold the loop on a connection that has nothing to do.

`PQconsumeInput()` is non-blocking and well-defined to be called multiple times back-to-back; it just returns 1 immediately when there's nothing more to read. The only failure path it adds is the same one we already handle elsewhere — `connection->connectionState = MULTI_CONNECTION_LOST`.

## Relation to issue #7772

Refs https://github.com/citusdata/citus/issues/7772 — the user reports a spatial query running ~100× slower on the coordinator than directly on a worker shard. Among other things, that workload returns ~5 K rows of complex multipolygons, where this loop is invoked ~10 K times per query. The patch is one of the contributions; it does not by itself close the whole gap, since `geometry_recv` per row is still a real CPU cost on wide PostGIS payloads, but it removes the architectural amplifier that turns those per-row costs into per-cycle costs.

## Tests

Happy to add a regression test if maintainers can suggest the right shape — counting `ReceiveResults` invocations across a network involves an instrumentation hook that doesn't exist today, and a pure timing-based test would be too flaky on different setups. One option is to expose the counter behind a debug GUC and assert in a regression test that, for a fixed-workload distributed SELECT, the count is bounded.

## Caveats

- All experimental data is from a local docker-bridge cluster (3 containers on the same Linux host) running Citus built from `main` (the code I changed) plus PostGIS 3.4. I have not measured on a multi-host LAN cluster — the LAN-improvement number above is an extrapolation.
- The patch was developed against Citus 12.1 and rebased onto current `main` for this PR; both bases compile cleanly.
