### PR TITLE
Backport 8543 To Citus 13.2: Add citus_cluster_changes_{block,unblock,block_status} UDFs for clust… #8571

### DIFF
--- a/src/backend/distributed/operations/citus_create_restore_point.c
+++ b/src/backend/distributed/operations/citus_create_restore_point.c
@@ -22,6 +22,7 @@
 #include "utils/builtins.h"
 #include "utils/pg_lsn.h"
 
+#include "distributed/cluster_changes_block.h"
 #include "distributed/connection_management.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
@@ -30,7 +31,6 @@
 
 
 #define CREATE_RESTORE_POINT_COMMAND "SELECT pg_catalog.pg_create_restore_point($1::text)"
-
 
 /* local functions forward declarations */
 static List * OpenConnectionsToAllWorkerNodes(LOCKMODE lockMode);

--- a/src/backend/distributed/operations/cluster_changes_block.c
+++ b/src/backend/distributed/operations/cluster_changes_block.c
@@ -1,0 +1,1116 @@
+/*-------------------------------------------------------------------------
+ *
+ * cluster_changes_block.c
+ *
+ * Implementation of UDFs for blocking distributed writes during LTR backup.
+ *
+ * This file provides three SQL-callable functions:
+ *
+ *   citus_cluster_changes_block(timeout_ms int DEFAULT 300000)
+ *     -> Spawns a background worker that acquires ExclusiveLock on
+ *        pg_dist_transaction, pg_dist_partition, and pg_dist_node on
+ *        the coordinator and all worker nodes.  Returns true when
+ *        locks are held.
+ *
+ *   citus_cluster_changes_unblock()
+ *     -> Signals the background worker to release all locks and exit.
+ *        Returns true on success.
+ *
+ *   citus_cluster_changes_block_status()
+ *     -> Returns a single-row result describing the current block state:
+ *        (state text, worker_pid int, requestor_pid int,
+ *         block_start_time timestamptz, timeout_ms int, node_count int)
+ *
+ * Architecture:
+ *   The actual lock-holding is done by a dedicated background worker
+ *   (CitusClusterChangesBlockWorkerMain).  This ensures locks survive the
+ *   caller's session disconnect.  The background worker communicates
+ *   its state through shared memory (ClusterChangesBlockControlData).
+ *
+ *   The worker auto-releases locks when:
+ *     - citus_cluster_changes_unblock() sets releaseRequested
+ *     - The configured timeout expires
+ *     - A worker-node connection fails
+ *     - The postmaster dies
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+
+#include "access/xact.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lmgr.h"
+#include "storage/lock.h"
+#include "storage/lwlock.h"
+#include "storage/shmem.h"
+#include "utils/builtins.h"
+#include "utils/timestamp.h"
+
+#include "distributed/background_worker_utils.h"
+#include "distributed/citus_safe_lib.h"
+#include "distributed/cluster_changes_block.h"
+#include "distributed/connection_management.h"
+#include "distributed/listutils.h"
+#include "distributed/metadata_cache.h"
+#include "distributed/metadata_utility.h"
+#include "distributed/remote_commands.h"
+#include "distributed/remote_transaction.h"
+#include "distributed/version_compat.h"
+#include "distributed/worker_manager.h"
+
+
+/* SQL-callable function declarations */
+PG_FUNCTION_INFO_V1(citus_cluster_changes_block);
+PG_FUNCTION_INFO_V1(citus_cluster_changes_unblock);
+PG_FUNCTION_INFO_V1(citus_cluster_changes_block_status);
+
+
+/* default and maximum timeout for cluster changes block (5 minutes / 30 minutes) */
+#define CLUSTER_CHANGES_BLOCK_DEFAULT_TIMEOUT_MS 300000
+#define CLUSTER_CHANGES_BLOCK_MAX_TIMEOUT_MS 1800000
+
+/* polling interval while waiting for worker to acquire locks */
+#define CLUSTER_CHANGES_BLOCK_POLL_INTERVAL_MS 100
+
+/* interval for worker to check latch / release conditions */
+#define CLUSTER_CHANGES_BLOCK_WORKER_CHECK_MS 1000
+
+/* maximum iterations to wait for unblock completion: 300 * 100ms = 30s */
+#define CLUSTER_CHANGES_BLOCK_UNBLOCK_MAX_LOOPS 300
+
+
+/* shared memory pointer */
+static ClusterChangesBlockControlData *ClusterChangesBlockControl = NULL;
+
+/* previous shmem_startup_hook */
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+
+/* SIGTERM flag for worker */
+static volatile sig_atomic_t got_sigterm = false;
+
+
+/* forward declarations */
+static List * OpenConnectionsToMetadataWorkersForBlock(LOCKMODE lockMode);
+static void BlockDistributedTransactionsLocally(void);
+static void BlockDistributedTransactionsOnWorkers(List *connectionList,
+												  int timeoutMs,
+												  int *nodeCount);
+static void cluster_changes_block_worker_sigterm(SIGNAL_ARGS);
+static void SetClusterChangesBlockState(ClusterChangesBlockState newState);
+static void ResetClusterChangesBlockShmem(ClusterChangesBlockState newState,
+										  const char *errorMessage);
+
+
+/* ----------------------------------------------------------------
+ * Shared Memory
+ * ---------------------------------------------------------------- */
+
+/*
+ * ClusterChangesBlockShmemSize returns the amount of shared memory needed for
+ * the cluster changes block control structure.
+ */
+size_t
+ClusterChangesBlockShmemSize(void)
+{
+	return sizeof(ClusterChangesBlockControlData);
+}
+
+
+/*
+ * ClusterChangesBlockShmemInit initializes the shared memory for cluster changes block.
+ * Called from citus_shmem_startup_hook or similar.
+ */
+void
+ClusterChangesBlockShmemInit(void)
+{
+	bool alreadyInitialized = false;
+
+	if (prev_shmem_startup_hook != NULL)
+	{
+		prev_shmem_startup_hook();
+	}
+
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
+	ClusterChangesBlockControl =
+		(ClusterChangesBlockControlData *) ShmemInitStruct("Citus Cluster Changes Block",
+														   ClusterChangesBlockShmemSize(),
+														   &alreadyInitialized);
+
+	if (!alreadyInitialized)
+	{
+		ClusterChangesBlockControl->trancheId = LWLockNewTrancheId();
+		strlcpy(ClusterChangesBlockControl->lockTrancheName,
+				"Citus Cluster Changes Block",
+				NAMEDATALEN);
+		LWLockRegisterTranche(ClusterChangesBlockControl->trancheId,
+							  ClusterChangesBlockControl->lockTrancheName);
+		LWLockInitialize(&ClusterChangesBlockControl->lock,
+						 ClusterChangesBlockControl->trancheId);
+
+		ClusterChangesBlockControl->state = CLUSTER_CHANGES_BLOCK_INACTIVE;
+		ClusterChangesBlockControl->workerPid = 0;
+		ClusterChangesBlockControl->requestorPid = 0;
+		ClusterChangesBlockControl->blockStartTime = 0;
+		ClusterChangesBlockControl->timeoutMs = 0;
+		ClusterChangesBlockControl->nodeCount = 0;
+		ClusterChangesBlockControl->errorMessage[0] = '\0';
+		ClusterChangesBlockControl->releaseRequested = false;
+	}
+
+	LWLockRelease(AddinShmemInitLock);
+}
+
+
+/*
+ * InitializeClusterChangesBlock installs the shmem_startup_hook to initialize
+ * cluster changes block shared memory.  Called from _PG_init.
+ */
+void
+InitializeClusterChangesBlock(void)
+{
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = ClusterChangesBlockShmemInit;
+}
+
+
+/* ----------------------------------------------------------------
+ * Helper: State management (caller must NOT hold LWLock)
+ * ---------------------------------------------------------------- */
+static void
+SetClusterChangesBlockState(ClusterChangesBlockState newState)
+{
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+	ClusterChangesBlockControl->state = newState;
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+}
+
+
+/*
+ * ResetClusterChangesBlockShmem clears all transient fields in the control
+ * structure and sets the state to newState (typically INACTIVE or ERROR).
+ *
+ * If errorMessage is non-NULL it is copied into the errorMessage slot;
+ * otherwise the slot is cleared.  Caller must NOT hold the LWLock.
+ *
+ * This is the single point that resets the block-control shmem so we don't
+ * forget a field on any error/cleanup path.
+ */
+static void
+ResetClusterChangesBlockShmem(ClusterChangesBlockState newState,
+							  const char *errorMessage)
+{
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+	ClusterChangesBlockControl->state = newState;
+	ClusterChangesBlockControl->workerPid = 0;
+	ClusterChangesBlockControl->requestorPid = 0;
+	ClusterChangesBlockControl->blockStartTime = 0;
+	ClusterChangesBlockControl->timeoutMs = 0;
+	ClusterChangesBlockControl->nodeCount = 0;
+	ClusterChangesBlockControl->releaseRequested = false;
+	if (errorMessage != NULL)
+	{
+		strlcpy(ClusterChangesBlockControl->errorMessage, errorMessage,
+				sizeof(ClusterChangesBlockControl->errorMessage));
+	}
+	else
+	{
+		ClusterChangesBlockControl->errorMessage[0] = '\0';
+	}
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+}
+
+
+/* ----------------------------------------------------------------
+ * Background Worker: CitusClusterChangesBlockWorkerMain
+ *
+ * Lifecycle:
+ *   1. Connect to database
+ *   2. Open connections to metadata worker nodes
+ *   3. Acquire local ExclusiveLocks (coordinator)
+ *   4. Send LOCK TABLE commands to all metadata workers
+ *   5. Update shared memory -> CLUSTER_CHANGES_BLOCK_ACTIVE
+ *   6. Wait loop: check latch for release / timeout / postmaster death
+ *   7. Close remote connections (rolls back remote transactions,
+ *      releasing remote locks)
+ *   8. Exit (local locks released when transaction ends)
+ * ---------------------------------------------------------------- */
+
+/*
+ * Signal handler for SIGTERM in the background worker.
+ */
+static void
+cluster_changes_block_worker_sigterm(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+
+	got_sigterm = true;
+	SetLatch(MyLatch);
+
+	errno = save_errno;
+}
+
+
+/*
+ * CitusClusterChangesBlockWorkerMain is the entry point for the cluster changes block
+ * background worker.  It acquires locks on the coordinator and all
+ * worker nodes, then holds them until told to release.
+ */
+void
+CitusClusterChangesBlockWorkerMain(Datum main_arg)
+{
+	Oid databaseOid = DatumGetObjectId(main_arg);
+
+	/*
+	 * Extract timeout from bgw_extra.
+	 * Layout: [Oid extensionOwner][int timeoutMs]
+	 * Always populated by RegisterCitusBackgroundWorker.
+	 */
+	int timeoutMs = CLUSTER_CHANGES_BLOCK_DEFAULT_TIMEOUT_MS;
+	memcpy_s(&timeoutMs, sizeof(int),
+			 MyBgworkerEntry->bgw_extra + sizeof(Oid), sizeof(int));
+
+	pqsignal(SIGTERM, cluster_changes_block_worker_sigterm);
+	BackgroundWorkerUnblockSignals();
+
+	/* connect to database */
+	BackgroundWorkerInitializeConnectionByOid(databaseOid, InvalidOid, 0);
+
+	elog(LOG, "cluster changes block worker started (timeout=%dms)", timeoutMs);
+
+	/* start a transaction — locks live until this transaction ends */
+	StartTransactionCommand();
+
+	List *connectionList = NIL;
+
+	PG_TRY();
+	{
+		/* open connections to metadata worker nodes */
+		connectionList = OpenConnectionsToMetadataWorkersForBlock(ShareLock);
+
+		/* begin remote transactions (to bust through pgbouncer) */
+		RemoteTransactionListBegin(connectionList);
+
+		/* acquire local locks on coordinator */
+		BlockDistributedTransactionsLocally();
+
+		/* acquire remote locks on all metadata workers */
+		int nodeCount = 0;
+		BlockDistributedTransactionsOnWorkers(connectionList, timeoutMs,
+											  &nodeCount);
+
+		/* update shared memory: locks acquired */
+		LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+		ClusterChangesBlockControl->state = CLUSTER_CHANGES_BLOCK_ACTIVE;
+		ClusterChangesBlockControl->blockStartTime = GetCurrentTimestamp();
+		ClusterChangesBlockControl->nodeCount = nodeCount;
+		ClusterChangesBlockControl->workerPid = MyProcPid;
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+
+		elog(LOG,
+			 "cluster changes block active: locks held on coordinator + %d worker nodes",
+			 nodeCount);
+
+		/*
+		 * Build a WaitEventSet that monitors:
+		 *   - Each remote connection socket (detect dead workers immediately)
+		 *   - Latch (for release request / SIGTERM wakeup)
+		 *   - Postmaster death
+		 *
+		 * Slot count: one per connection + latch + postmaster death.
+		 */
+		int eventSetSize = list_length(connectionList) + 2;
+		WaitEventSet *waitEventSet =
+			CreateWaitEventSet(WaitEventSetTracker_compat, eventSetSize);
+
+		MultiConnection *conn = NULL;
+		foreach_declared_ptr(conn, connectionList)
+		{
+			int sock = PQsocket(conn->pgConn);
+			if (sock == -1)
+			{
+				FreeWaitEventSet(waitEventSet);
+				ereport(ERROR,
+						(errmsg("cluster changes block: remote connection already "
+								"closed before entering wait loop")));
+			}
+
+			int idx = CitusAddWaitEventSetToSet(waitEventSet,
+												WL_SOCKET_READABLE,
+												sock, NULL,
+												(void *) conn);
+			if (idx == WAIT_EVENT_SET_INDEX_FAILED)
+			{
+				FreeWaitEventSet(waitEventSet);
+				ereport(ERROR,
+						(errmsg("cluster changes block: could not add remote socket "
+								"to wait event set")));
+			}
+		}
+		AddWaitEventToSet(waitEventSet, WL_POSTMASTER_DEATH,
+						  PGINVALID_SOCKET, NULL, NULL);
+		AddWaitEventToSet(waitEventSet, WL_LATCH_SET,
+						  PGINVALID_SOCKET, MyLatch, NULL);
+
+		/*
+		 * Hold locks until release is requested, timeout expires,
+		 * a remote connection fails, or we receive SIGTERM / postmaster death.
+		 */
+		TimestampTz startTime = GetCurrentTimestamp();
+		WaitEvent *events = palloc0(eventSetSize * sizeof(WaitEvent));
+
+		while (!got_sigterm)
+		{
+			int eventCount = WaitEventSetWait(waitEventSet,
+											  CLUSTER_CHANGES_BLOCK_WORKER_CHECK_MS,
+											  events, eventSetSize,
+											  PG_WAIT_EXTENSION);
+
+			for (int i = 0; i < eventCount; i++)
+			{
+				WaitEvent *event = &events[i];
+
+				if (event->events & WL_POSTMASTER_DEATH)
+				{
+					FreeWaitEventSet(waitEventSet);
+					pfree(events);
+					ResetClusterChangesBlockShmem(
+						CLUSTER_CHANGES_BLOCK_ERROR,
+						"postmaster died while holding cluster changes block");
+					proc_exit(1);
+				}
+
+				if (event->events & WL_LATCH_SET)
+				{
+					ResetLatch(MyLatch);
+					continue;
+				}
+
+				if (event->events & WL_SOCKET_READABLE)
+				{
+					/*
+					 * An idle locked connection should never receive data.
+					 * Any readability means the remote end sent something
+					 * unexpected (e.g. termination notice) or the socket
+					 * is broken.
+					 */
+					MultiConnection *failedConn =
+						(MultiConnection *) event->user_data;
+					bool connectionBad = false;
+
+					if (PQconsumeInput(failedConn->pgConn) == 0)
+					{
+						connectionBad = true;
+					}
+					else if (PQstatus(failedConn->pgConn) == CONNECTION_BAD)
+					{
+						connectionBad = true;
+					}
+
+					if (connectionBad)
+					{
+						FreeWaitEventSet(waitEventSet);
+						pfree(events);
+						ereport(ERROR,
+								(errmsg("cluster changes block: lost connection to "
+										"worker node %s:%d",
+										failedConn->hostname,
+										failedConn->port)));
+					}
+				}
+			}
+
+			CHECK_FOR_INTERRUPTS();
+
+			/* check if release was requested */
+			LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+			bool shouldRelease = ClusterChangesBlockControl->releaseRequested;
+			LWLockRelease(&ClusterChangesBlockControl->lock);
+
+			if (shouldRelease)
+			{
+				SetClusterChangesBlockState(CLUSTER_CHANGES_BLOCK_RELEASING);
+				elog(LOG, "cluster changes block: release requested, shutting down");
+				break;
+			}
+
+			/* check timeout */
+			TimestampTz now = GetCurrentTimestamp();
+			long elapsedMs = (long) ((now - startTime) / 1000);
+			if (timeoutMs > 0 && elapsedMs >= timeoutMs)
+			{
+				elog(WARNING,
+					 "cluster changes block: timeout reached (%d ms), auto-releasing",
+					 timeoutMs);
+				break;
+			}
+		}
+
+		FreeWaitEventSet(waitEventSet);
+		pfree(events);
+
+		/* clean up: close remote connections (rolls back remote transactions) */
+		foreach_declared_ptr(conn, connectionList)
+		{
+			ForgetResults(conn);
+			CloseConnection(conn);
+		}
+		connectionList = NIL;
+	}
+	PG_CATCH();
+	{
+		/* on error, clean up connections and report */
+		ErrorData *edata = CopyErrorData();
+		FlushErrorState();
+
+		MultiConnection *conn = NULL;
+		foreach_declared_ptr(conn, connectionList)
+		{
+			ForgetResults(conn);
+			CloseConnection(conn);
+		}
+
+		/*
+		 * SIGTERM-induced errors are controlled shutdowns (e.g. postmaster
+		 * restart), not real failures — report INACTIVE instead of ERROR
+		 * so the state is clean for the next startup.
+		 *
+		 * Use ResetClusterChangesBlockShmem to clear all transient fields
+		 * (workerPid, requestorPid, blockStartTime, timeoutMs, nodeCount,
+		 *  releaseRequested) — proc_exit() below skips the post-PG_END_TRY
+		 * cleanup, so this is our only chance to clean up.
+		 */
+		if (got_sigterm)
+		{
+			ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+		}
+		else
+		{
+			ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_ERROR,
+										  edata->message);
+		}
+
+		FreeErrorData(edata);
+
+		AbortCurrentTransaction();
+
+		elog(LOG, "cluster changes block worker exiting due to %s",
+			 got_sigterm ? "SIGTERM" : "error");
+		proc_exit(got_sigterm ? 0 : 1);
+	}
+	PG_END_TRY();
+
+	/* abort transaction to release local locks */
+	AbortCurrentTransaction();
+
+	/*
+	 * Mark shared memory as inactive — but only if WE are still the recorded
+	 * worker.  This owner-check defends against a race where this worker is
+	 * delayed between the unlocking transaction and this cleanup, and a
+	 * concurrent citus_cluster_changes_block() call has already started a
+	 * successor worker that updated workerPid.  Without this check the late
+	 * cleanup would clobber the successor's ACTIVE state, leaving callers
+	 * unable to observe or release the new block.
+	 */
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+	bool stillOwner = (ClusterChangesBlockControl->workerPid == MyProcPid);
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+
+	if (stillOwner)
+	{
+		ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+	}
+	else
+	{
+		elog(LOG, "cluster changes block worker (pid %d) skipping shmem reset; "
+				  "a successor worker now owns the control block",
+			 MyProcPid);
+	}
+
+	elog(LOG, "cluster changes block worker finished, all locks released");
+	proc_exit(0);
+}
+
+
+/* ----------------------------------------------------------------
+ * Lock acquisition helpers
+ * ---------------------------------------------------------------- */
+
+/*
+ * OpenConnectionsToMetadataWorkersForBlock opens connections to all
+ * remote metadata worker nodes using FORCE_NEW_CONNECTION.
+ *
+ * Unlike citus_create_restore_point (which needs all nodes for
+ * pg_create_restore_point), cluster changes block only needs metadata nodes
+ * for the LOCK TABLE commands.
+ */
+static List *
+OpenConnectionsToMetadataWorkersForBlock(LOCKMODE lockMode)
+{
+	List *connectionList = NIL;
+	int connectionFlags = FORCE_NEW_CONNECTION;
+
+	List *workerNodeList = ActivePrimaryNonCoordinatorNodeList(lockMode);
+
+	WorkerNode *workerNode = NULL;
+	foreach_declared_ptr(workerNode, workerNodeList)
+	{
+		if (!NodeIsPrimaryAndRemote(workerNode) || !workerNode->hasMetadata)
+		{
+			continue;
+		}
+
+		MultiConnection *connection = StartNodeConnection(connectionFlags,
+														  workerNode->workerName,
+														  workerNode->workerPort);
+		MarkRemoteTransactionCritical(connection);
+		connectionList = lappend(connectionList, connection);
+	}
+
+	FinishConnectionListEstablishment(connectionList);
+
+	return connectionList;
+}
+
+
+/*
+ * BlockDistributedTransactionsLocally acquires ExclusiveLock on
+ * pg_dist_node, pg_dist_partition, and pg_dist_transaction on the
+ * coordinator.  Same pattern as citus_create_restore_point.
+ */
+static void
+BlockDistributedTransactionsLocally(void)
+{
+	LockRelationOid(DistNodeRelationId(), ExclusiveLock);
+	LockRelationOid(DistPartitionRelationId(), ExclusiveLock);
+	LockRelationOid(DistTransactionRelationId(), ExclusiveLock);
+}
+
+
+/*
+ * BlockDistributedTransactionsOnWorkers sends LOCK TABLE commands to
+ * all connections (which are already filtered to metadata workers)
+ * to acquire ExclusiveLocks remotely.
+ *
+ * A statement_timeout is set on each connection so that lock acquisition
+ * does not hang indefinitely if a remote node is unresponsive.
+ *
+ * Sets *nodeCount to the number of nodes locked.
+ */
+static void
+BlockDistributedTransactionsOnWorkers(List *connectionList, int timeoutMs,
+									  int *nodeCount)
+{
+	/* set statement_timeout on each remote connection to bound lock wait */
+	char timeoutCommand[128];
+	SafeSnprintf(timeoutCommand, sizeof(timeoutCommand),
+				 "SET LOCAL statement_timeout = %d", timeoutMs);
+
+	MultiConnection *connection = NULL;
+	foreach_declared_ptr(connection, connectionList)
+	{
+		int querySent = SendRemoteCommand(connection, timeoutCommand);
+		if (querySent == 0)
+		{
+			ReportConnectionError(connection, ERROR);
+		}
+	}
+
+	foreach_declared_ptr(connection, connectionList)
+	{
+		PGresult *result = GetRemoteCommandResult(connection, true);
+		if (!IsResponseOK(result))
+		{
+			ReportResultError(connection, result, ERROR);
+		}
+		PQclear(result);
+		ForgetResults(connection);
+	}
+
+	/* send lock commands in parallel */
+	foreach_declared_ptr(connection, connectionList)
+	{
+		int querySent = SendRemoteCommand(connection,
+										  BLOCK_DISTRIBUTED_WRITES_COMMAND);
+		if (querySent == 0)
+		{
+			ReportConnectionError(connection, ERROR);
+		}
+	}
+
+	/* wait for all lock acquisitions */
+	foreach_declared_ptr(connection, connectionList)
+	{
+		PGresult *result = GetRemoteCommandResult(connection, true);
+		if (!IsResponseOK(result))
+		{
+			ReportResultError(connection, result, ERROR);
+		}
+		PQclear(result);
+		ForgetResults(connection);
+	}
+
+	*nodeCount = list_length(connectionList);
+}
+
+
+/* ----------------------------------------------------------------
+ * SQL-callable UDFs
+ * ---------------------------------------------------------------- */
+
+/*
+ * citus_cluster_changes_block blocks distributed 2PC writes across
+ * the entire Citus cluster.  A background worker is spawned to hold
+ * the locks, so they survive if this session disconnects.
+ *
+ * Parameters:
+ *   timeout_ms (int, default 300000) - auto-release after this many ms
+ *
+ * Returns: true when locks are held on all nodes.
+ */
+Datum
+citus_cluster_changes_block(PG_FUNCTION_ARGS)
+{
+	CheckCitusVersion(ERROR);
+	EnsureSuperUser();
+	EnsureCoordinator();
+
+	int timeoutMs = PG_GETARG_INT32(0);
+
+	if (timeoutMs <= 0 || timeoutMs > CLUSTER_CHANGES_BLOCK_MAX_TIMEOUT_MS)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("timeout_ms must be between 1 and %d",
+						CLUSTER_CHANGES_BLOCK_MAX_TIMEOUT_MS)));
+	}
+
+	/*
+	 * Atomically check-and-set under a single LW_EXCLUSIVE acquisition
+	 * to prevent TOCTOU races between concurrent callers.
+	 */
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+	ClusterChangesBlockState currentState = ClusterChangesBlockControl->state;
+
+	/*
+	 * Reject any non-INACTIVE state: spawning a successor worker while a
+	 * previous one is still alive (RELEASING) would violate the singleton
+	 * invariant and the previous worker's late shmem cleanup could clobber
+	 * the successor's state.  ERROR state requires explicit unblock to
+	 * clear so the operator notices the failure.
+	 */
+	if (currentState != CLUSTER_CHANGES_BLOCK_INACTIVE)
+	{
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+
+		switch (currentState)
+		{
+			case CLUSTER_CHANGES_BLOCK_STARTING:
+			case CLUSTER_CHANGES_BLOCK_ACTIVE:
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("a cluster changes block is already active"),
+						 errhint("Use citus_cluster_changes_unblock() to release "
+								 "the existing block first.")));
+				break;
+			}
+
+			case CLUSTER_CHANGES_BLOCK_RELEASING:
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("a cluster changes block release is in progress"),
+						 errhint("Wait for the current release to finish, then "
+								 "retry citus_cluster_changes_block().")));
+				break;
+			}
+
+			case CLUSTER_CHANGES_BLOCK_ERROR:
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("the previous cluster changes block ended in error"),
+						 errhint("Call citus_cluster_changes_unblock() to clear the "
+								 "error state, then retry.")));
+				break;
+			}
+
+			default:
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("cluster changes block is in an unexpected state")));
+				break;
+			}
+		}
+	}
+
+	ClusterChangesBlockControl->state = CLUSTER_CHANGES_BLOCK_STARTING;
+	ClusterChangesBlockControl->requestorPid = MyProcPid;
+	ClusterChangesBlockControl->workerPid = 0;
+	ClusterChangesBlockControl->releaseRequested = false;
+	ClusterChangesBlockControl->errorMessage[0] = '\0';
+	ClusterChangesBlockControl->nodeCount = 0;
+	ClusterChangesBlockControl->timeoutMs = timeoutMs;
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+
+	/* spawn the background worker */
+	char workerName[BGW_MAXLEN];
+	SafeSnprintf(workerName, BGW_MAXLEN,
+				 "Citus Cluster Changes Block Worker: %u", MyDatabaseId);
+
+	CitusBackgroundWorkerConfig config = {
+		.workerName = workerName,
+		.functionName = "CitusClusterChangesBlockWorkerMain",
+		.mainArg = ObjectIdGetDatum(MyDatabaseId),
+		.extensionOwner = CitusExtensionOwner(),
+		.needsNotification = true,
+		.waitForStartup = true,
+		.restartTime = CITUS_BGW_NEVER_RESTART,
+		.startTime = BgWorkerStart_RecoveryFinished,
+		.workerType = "citus_cluster_changes_block",
+		.extraData = &timeoutMs,
+		.extraDataSize = sizeof(int)
+	};
+
+	BackgroundWorkerHandle *handle = RegisterCitusBackgroundWorker(&config);
+	if (!handle)
+	{
+		ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("could not start cluster changes block background worker"),
+				 errhint("Check that max_worker_processes is high enough.")));
+	}
+
+	/*
+	 * Poll shared memory until the worker reports ACTIVE or ERROR.
+	 * The worker was started with waitForStartup=true, so it's
+	 * already running at this point.
+	 */
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+		ClusterChangesBlockState state = ClusterChangesBlockControl->state;
+		char errMsg[256];
+		if (state == CLUSTER_CHANGES_BLOCK_ERROR)
+		{
+			strlcpy(errMsg, ClusterChangesBlockControl->errorMessage, sizeof(errMsg));
+		}
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+
+		if (state == CLUSTER_CHANGES_BLOCK_ACTIVE)
+		{
+			break;
+		}
+
+		if (state == CLUSTER_CHANGES_BLOCK_ERROR)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("cluster changes block worker failed: %s", errMsg)));
+		}
+
+		if (state == CLUSTER_CHANGES_BLOCK_INACTIVE)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("cluster changes block worker exited unexpectedly")));
+		}
+
+		/* still STARTING, check if worker is still alive */
+		pid_t bgwPid;
+		BgwHandleStatus bgwStatus = GetBackgroundWorkerPid(handle, &bgwPid);
+		if (bgwStatus == BGWH_STOPPED)
+		{
+			ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("cluster changes block worker exited unexpectedly "
+							"(crashed or killed)")));
+		}
+
+		/* still STARTING, wait a bit */
+		int rc = WaitLatch(MyLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   CLUSTER_CHANGES_BLOCK_POLL_INTERVAL_MS,
+						   PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+
+		if (rc & WL_POSTMASTER_DEATH)
+		{
+			proc_exit(1);
+		}
+	}
+
+	PG_RETURN_BOOL(true);
+}
+
+
+/*
+ * citus_cluster_changes_unblock signals the background worker to
+ * release all locks and exit.  Can be called from any session.
+ *
+ * Returns:
+ *   true  if the block was released, or if a previous ERROR state was cleared.
+ *   false if no block was active (state was already INACTIVE) or the worker
+ *         did not shut down within the unblock timeout.
+ */
+Datum
+citus_cluster_changes_unblock(PG_FUNCTION_ARGS)
+{
+	CheckCitusVersion(ERROR);
+	EnsureSuperUser();
+	EnsureCoordinator();
+
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+	ClusterChangesBlockState currentState = ClusterChangesBlockControl->state;
+
+	/*
+	 * If the previous block ended in ERROR, no worker is alive — just clear
+	 * the shmem so a fresh block() call can succeed.  This is the only SQL
+	 * path to recover from ERROR without a server restart.
+	 */
+	if (currentState == CLUSTER_CHANGES_BLOCK_ERROR)
+	{
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+		ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+		ereport(NOTICE,
+				(errmsg("cleared cluster changes block error state")));
+		PG_RETURN_BOOL(true);
+	}
+
+	if (currentState != CLUSTER_CHANGES_BLOCK_ACTIVE &&
+		currentState != CLUSTER_CHANGES_BLOCK_STARTING)
+	{
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+		PG_RETURN_BOOL(false);
+	}
+
+	ClusterChangesBlockControl->releaseRequested = true;
+
+	/* wake the worker via its latch if it has a valid PID */
+	pid_t workerPid = ClusterChangesBlockControl->workerPid;
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+
+	if (workerPid > 0)
+	{
+		/*
+		 * Send SIGUSR1 to wake the worker's latch so it checks
+		 * releaseRequested and exits cleanly via the release path.
+		 * This is gentler than SIGTERM and allows the worker to
+		 * transition through CLUSTER_CHANGES_BLOCK_RELEASING state.
+		 */
+		kill(workerPid, SIGUSR1);
+	}
+
+	/*
+	 * Wait for the worker to finish releasing.
+	 * Poll shared memory with a short interval.
+	 */
+	for (int i = 0; i < CLUSTER_CHANGES_BLOCK_UNBLOCK_MAX_LOOPS; i++)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+		ClusterChangesBlockState state = ClusterChangesBlockControl->state;
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+
+		if (state == CLUSTER_CHANGES_BLOCK_INACTIVE)
+		{
+			PG_RETURN_BOOL(true);
+		}
+
+		int rc = WaitLatch(MyLatch,
+						   WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
+						   CLUSTER_CHANGES_BLOCK_POLL_INTERVAL_MS,
+						   PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+
+		if (rc & WL_POSTMASTER_DEATH)
+		{
+			proc_exit(1);
+		}
+	}
+
+	ereport(WARNING,
+			(errmsg("cluster changes block worker did not shut down within 30 seconds")));
+
+	PG_RETURN_BOOL(false);
+}
+
+
+/*
+ * citus_cluster_changes_block_status returns a single row describing the current
+ * state of the cluster changes block.
+ *
+ * Returns: (state text, worker_pid int, requestor_pid int,
+ *           block_start_time timestamptz, timeout_ms int, node_count int)
+ */
+Datum
+citus_cluster_changes_block_status(PG_FUNCTION_ARGS)
+{
+	CheckCitusVersion(ERROR);
+
+	TupleDesc tupleDesc;
+
+	if (get_call_result_type(fcinfo, NULL, &tupleDesc) != TYPEFUNC_COMPOSITE)
+	{
+		elog(ERROR, "return type must be a row type");
+	}
+
+	tupleDesc = BlessTupleDesc(tupleDesc);
+
+	Datum values[6];
+	bool nulls[6];
+	memset(nulls, 0, sizeof(nulls));
+
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+
+	ClusterChangesBlockState currentState = ClusterChangesBlockControl->state;
+	pid_t workerPid = ClusterChangesBlockControl->workerPid;
+
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+
+	/*
+	 * Detect stale state: if the worker is supposed to be alive but its
+	 * process no longer exists (SIGKILL, OOM-killer, etc.), auto-clean
+	 * the shared memory so the system doesn't get permanently stuck.
+	 */
+	if ((currentState == CLUSTER_CHANGES_BLOCK_ACTIVE ||
+		 currentState == CLUSTER_CHANGES_BLOCK_STARTING ||
+		 currentState == CLUSTER_CHANGES_BLOCK_RELEASING ||
+		 currentState == CLUSTER_CHANGES_BLOCK_ERROR) &&
+		workerPid > 0 &&
+		kill(workerPid, 0) == -1 && errno == ESRCH)
+	{
+		/*
+		 * Worker is gone — re-acquire exclusive, double-check that the
+		 * stale state still matches the dead PID, then route the cleanup
+		 * through ResetClusterChangesBlockShmem to keep all reset paths
+		 * consistent.  We release the lock between the check and the
+		 * helper call, but that gap is harmless: any concurrent block()
+		 * is rejected by the != INACTIVE guard, and any concurrent
+		 * stale-cleanup or unblock-from-ERROR also targets INACTIVE so
+		 * the writes are idempotent.
+		 */
+		LWLockAcquire(&ClusterChangesBlockControl->lock, LW_EXCLUSIVE);
+
+		bool needsReset =
+			(ClusterChangesBlockControl->state == CLUSTER_CHANGES_BLOCK_ACTIVE ||
+			 ClusterChangesBlockControl->state == CLUSTER_CHANGES_BLOCK_STARTING ||
+			 ClusterChangesBlockControl->state == CLUSTER_CHANGES_BLOCK_RELEASING ||
+			 ClusterChangesBlockControl->state == CLUSTER_CHANGES_BLOCK_ERROR) &&
+			ClusterChangesBlockControl->workerPid == workerPid;
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+
+		if (needsReset)
+		{
+			elog(WARNING, "cluster changes block: detected stale state (worker PID %d "
+						  "no longer exists), auto-cleaning", workerPid);
+			ResetClusterChangesBlockShmem(CLUSTER_CHANGES_BLOCK_INACTIVE, NULL);
+		}
+
+		LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+		currentState = ClusterChangesBlockControl->state;
+		LWLockRelease(&ClusterChangesBlockControl->lock);
+	}
+
+	LWLockAcquire(&ClusterChangesBlockControl->lock, LW_SHARED);
+
+	/* state */
+	const char *stateStr;
+	switch (ClusterChangesBlockControl->state)
+	{
+		case CLUSTER_CHANGES_BLOCK_INACTIVE:
+		{
+			stateStr = "inactive";
+			break;
+		}
+
+		case CLUSTER_CHANGES_BLOCK_STARTING:
+		{
+			stateStr = "starting";
+			break;
+		}
+
+		case CLUSTER_CHANGES_BLOCK_ACTIVE:
+		{
+			stateStr = "active";
+			break;
+		}
+
+		case CLUSTER_CHANGES_BLOCK_RELEASING:
+		{
+			stateStr = "releasing";
+			break;
+		}
+
+		case CLUSTER_CHANGES_BLOCK_ERROR:
+		{
+			stateStr = "error";
+			break;
+		}
+
+		default:
+		{
+			stateStr = "unknown";
+			break;
+		}
+	}
+	values[0] = CStringGetTextDatum(stateStr);
+
+	/* worker_pid */
+	if (ClusterChangesBlockControl->workerPid > 0)
+	{
+		values[1] = Int32GetDatum(ClusterChangesBlockControl->workerPid);
+	}
+	else
+	{
+		nulls[1] = true;
+	}
+
+	/* requestor_pid */
+	if (ClusterChangesBlockControl->requestorPid > 0)
+	{
+		values[2] = Int32GetDatum(ClusterChangesBlockControl->requestorPid);
+	}
+	else
+	{
+		nulls[2] = true;
+	}
+
+	/* block_start_time */
+	if (ClusterChangesBlockControl->blockStartTime > 0)
+	{
+		values[3] = TimestampTzGetDatum(ClusterChangesBlockControl->blockStartTime);
+	}
+	else
+	{
+		nulls[3] = true;
+	}
+
+	/* timeout_ms */
+	values[4] = Int32GetDatum(ClusterChangesBlockControl->timeoutMs);
+
+	/* node_count */
+	values[5] = Int32GetDatum(ClusterChangesBlockControl->nodeCount);
+
+	LWLockRelease(&ClusterChangesBlockControl->lock);
+
+	HeapTuple tuple = heap_form_tuple(tupleDesc, values, nulls);
+	PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
+}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -57,6 +57,7 @@
 #include "distributed/citus_depended_object.h"
 #include "distributed/citus_nodefuncs.h"
 #include "distributed/citus_safe_lib.h"
+#include "distributed/cluster_changes_block.h"
 #include "distributed/combine_query_planner.h"
 #include "distributed/commands.h"
 #include "distributed/commands/multi_copy.h"
@@ -508,6 +509,7 @@ _PG_init(void)
 
 	InitializeMaintenanceDaemon();
 	InitializeMaintenanceDaemonForMainDb();
+	InitializeClusterChangesBlock();
 
 	/* initialize coordinated transaction management */
 	InitializeTransactionManagement();
@@ -647,6 +649,7 @@ citus_shmem_request(void)
 	RequestAddinShmemSpace(MaintenanceDaemonShmemSize());
 	RequestAddinShmemSpace(CitusQueryStatsSharedMemSize());
 	RequestAddinShmemSpace(LogicalClockShmemSize());
+	RequestAddinShmemSpace(ClusterChangesBlockShmemSize());
 	RequestNamedLWLockTranche(STATS_SHARED_MEM_NAME, 1);
 	RequestAddinShmemSpace(StatCountersShmemSize());
 	RequestNamedLWLockTranche(SAVED_BACKEND_STATS_HASH_LOCK_TRANCHE_NAME, 1);

--- a/src/backend/distributed/sql/citus--13.2-1--13.3-1.sql
+++ b/src/backend/distributed/sql/citus--13.2-1--13.3-1.sql
@@ -9,3 +9,8 @@
 #include "udfs/citus_internal_lock_colocation_id/13.3-1.sql"
 
 #include "udfs/citus_internal_acquire_placement_colocation_lock/13.3-1.sql"
+
+-- cluster changes block UDFs
+#include "udfs/citus_cluster_changes_block/13.3-1.sql"
+#include "udfs/citus_cluster_changes_unblock/13.3-1.sql"
+#include "udfs/citus_cluster_changes_block_status/13.3-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
@@ -9,3 +9,12 @@ DROP FUNCTION IF EXISTS pg_catalog.worker_apply_sequence_command(text, regtype, 
 DROP FUNCTION IF EXISTS citus_internal.lock_colocation_id(int, int);
 
 DROP FUNCTION IF EXISTS citus_internal.acquire_placement_colocation_lock(bigint, int);
+
+-- cluster changes block UDFs
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
+
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block/13.3-1.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block(
+    timeout_ms int DEFAULT 300000)
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block(int)
+IS 'block distributed write transactions, DDL, and topology changes across the Citus cluster';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_block(int) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block/latest.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block(
+    timeout_ms int DEFAULT 300000)
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block(int)
+IS 'block distributed write transactions, DDL, and topology changes across the Citus cluster';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_block(int) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/13.3-1.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block_status(
+    OUT state text,
+    OUT worker_pid int,
+    OUT requestor_pid int,
+    OUT block_start_time timestamptz,
+    OUT timeout_ms int,
+    OUT node_count int)
+RETURNS record
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block_status$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block_status()
+IS 'return the current status of the cluster changes block';
+-- Intentionally readable by PUBLIC: this function only exposes
+-- non-sensitive state (state name, PIDs, timestamps, counts) and is
+-- meant to be observable by monitoring tools without superuser rights.
+-- citus_cluster_changes_block() and citus_cluster_changes_unblock()
+-- are the privileged operations and have REVOKE ALL FROM PUBLIC.

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/latest.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block_status(
+    OUT state text,
+    OUT worker_pid int,
+    OUT requestor_pid int,
+    OUT block_start_time timestamptz,
+    OUT timeout_ms int,
+    OUT node_count int)
+RETURNS record
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block_status$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block_status()
+IS 'return the current status of the cluster changes block';
+-- Intentionally readable by PUBLIC: this function only exposes
+-- non-sensitive state (state name, PIDs, timestamps, counts) and is
+-- meant to be observable by monitoring tools without superuser rights.
+-- citus_cluster_changes_block() and citus_cluster_changes_unblock()
+-- are the privileged operations and have REVOKE ALL FROM PUBLIC.

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/13.3-1.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_unblock()
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_unblock$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_unblock()
+IS 'release the cluster changes block';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_unblock() FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/latest.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_unblock()
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_unblock$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_unblock()
+IS 'release the cluster changes block';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_unblock() FROM PUBLIC;

--- a/src/include/distributed/cluster_changes_block.h
+++ b/src/include/distributed/cluster_changes_block.h
@@ -1,0 +1,109 @@
+/*-------------------------------------------------------------------------
+ *
+ * cluster_changes_block.h
+ *
+ * Declarations for blocking distributed writes during LTR backup.
+ *
+ * The cluster changes block feature allows external backup tools to temporarily
+ * block distributed 2PC writes across the Citus cluster, take a
+ * consistent snapshot on every node, and then release the block.
+ *
+ * Architecture:
+ *   - A dedicated background worker holds the ExclusiveLocks on
+ *     pg_dist_transaction / pg_dist_partition / pg_dist_node on
+ *     coordinator + all worker nodes.
+ *   - Shared memory (ClusterChangesBlockControlData) communicates state
+ *     between the UDF caller, the background worker, and the
+ *     status/unblock UDFs.
+ *   - The background worker auto-releases if timeout expires,
+ *     the requestor backend exits, or a worker connection fails.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CLUSTER_CHANGES_BLOCK_H
+#define CLUSTER_CHANGES_BLOCK_H
+
+#include "postgres.h"
+
+#include "storage/lwlock.h"
+
+
+/*
+ * ClusterChangesBlockState enumerates the lifecycle states of the cluster changes block.
+ */
+typedef enum ClusterChangesBlockState
+{
+	CLUSTER_CHANGES_BLOCK_INACTIVE = 0,  /* no block active */
+	CLUSTER_CHANGES_BLOCK_STARTING,      /* background worker is starting up */
+	CLUSTER_CHANGES_BLOCK_ACTIVE,        /* locks acquired on all nodes */
+	CLUSTER_CHANGES_BLOCK_RELEASING,     /* unblock requested, releasing */
+	CLUSTER_CHANGES_BLOCK_ERROR          /* worker hit an error */
+} ClusterChangesBlockState;
+
+
+/*
+ * ClusterChangesBlockControlData is the shared memory structure that coordinates
+ * the cluster changes block lifecycle between UDF callers and the background worker.
+ *
+ * Protected by the embedded LWLock (lock).
+ */
+typedef struct ClusterChangesBlockControlData
+{
+	/* LWLock tranche info */
+	int trancheId;
+	char lockTrancheName[NAMEDATALEN];
+	LWLock lock;
+
+	/* current state */
+	ClusterChangesBlockState state;
+
+	/* PIDs for lifecycle management */
+	pid_t workerPid;           /* PID of the background worker holding locks */
+	pid_t requestorPid;        /* PID of the backend that requested the block */
+
+	/* timing */
+	TimestampTz blockStartTime;  /* when locks were acquired */
+	int timeoutMs;               /* auto-release timeout in milliseconds */
+
+	/* cluster info */
+	int nodeCount;             /* number of worker nodes locked */
+
+	/* error reporting */
+	char errorMessage[256];    /* error message if state == CLUSTER_CHANGES_BLOCK_ERROR */
+
+	/* signal: set to true by unblock UDF to tell worker to release */
+	bool releaseRequested;
+} ClusterChangesBlockControlData;
+
+
+/*
+ * BLOCK_DISTRIBUTED_WRITES_COMMAND acquires ExclusiveLock on:
+ *   1. pg_dist_transaction — blocks 2PC commit decisions
+ *   2. pg_dist_partition   — blocks DDL on distributed tables
+ *
+ * Used by both citus_cluster_changes_block and citus_create_restore_point
+ * to quiesce distributed writes on remote metadata nodes.
+ *
+ * Note: pg_dist_node is only locked locally on the coordinator (node
+ * management operations are coordinator-only), so it is intentionally
+ * absent from this remote command.
+ */
+#define BLOCK_DISTRIBUTED_WRITES_COMMAND \
+		"LOCK TABLE pg_catalog.pg_dist_transaction IN EXCLUSIVE MODE; " \
+		"LOCK TABLE pg_catalog.pg_dist_partition IN EXCLUSIVE MODE"
+
+
+/* Shared memory sizing and initialization */
+extern size_t ClusterChangesBlockShmemSize(void);
+extern void ClusterChangesBlockShmemInit(void);
+
+/* Call from _PG_init to chain shmem_startup_hook */
+extern void InitializeClusterChangesBlock(void);
+
+/* Background worker entry point */
+extern PGDLLEXPORT void CitusClusterChangesBlockWorkerMain(Datum main_arg);
+
+#endif /* CLUSTER_CHANGES_BLOCK_H */

--- a/src/include/distributed/cluster_changes_block.h
+++ b/src/include/distributed/cluster_changes_block.h
@@ -81,8 +81,8 @@ typedef struct ClusterChangesBlockControlData
 
 /*
  * BLOCK_DISTRIBUTED_WRITES_COMMAND acquires ExclusiveLock on:
- *   1. pg_dist_transaction — blocks 2PC commit decisions
- *   2. pg_dist_partition   — blocks DDL on distributed tables
+ *   1. pg_dist_transaction -- blocks 2PC commit decisions
+ *   2. pg_dist_partition   -- blocks DDL on distributed tables
  *
  * Used by both citus_cluster_changes_block and citus_create_restore_point
  * to quiesce distributed writes on remote metadata nodes.

--- a/src/include/distributed/cluster_changes_block.h
+++ b/src/include/distributed/cluster_changes_block.h
@@ -92,8 +92,8 @@ typedef struct ClusterChangesBlockControlData
  * absent from this remote command.
  */
 #define BLOCK_DISTRIBUTED_WRITES_COMMAND \
-		"LOCK TABLE pg_catalog.pg_dist_transaction IN EXCLUSIVE MODE; " \
-		"LOCK TABLE pg_catalog.pg_dist_partition IN EXCLUSIVE MODE"
+	"LOCK TABLE pg_catalog.pg_dist_transaction IN EXCLUSIVE MODE; " \
+	"LOCK TABLE pg_catalog.pg_dist_partition IN EXCLUSIVE MODE"
 
 
 /* Shared memory sizing and initialization */

--- a/src/test/regress/expected/citus_cluster_changes_block.out
+++ b/src/test/regress/expected/citus_cluster_changes_block.out
@@ -1,0 +1,571 @@
+--
+-- CITUS_CLUSTER_CHANGES_BLOCK
+--
+-- Functional tests for citus_cluster_changes_block(),
+-- citus_cluster_changes_unblock(), and citus_cluster_changes_block_status().
+--
+-- These tests exercise:
+--   * argument validation (timeout_ms range)
+--   * permission enforcement (REVOKE ALL ON FUNCTION ... FROM PUBLIC)
+--   * state-machine transitions (inactive -> starting -> active -> releasing
+--     -> inactive)
+--   * double-block rejection
+--   * idempotent unblock (false when no block is active)
+--   * status output shape and unstable-field masking
+--   * stress / repeated cycle stability (no leaked state)
+--   * stale-state auto-cleanup when the bgworker dies unexpectedly
+--
+CREATE SCHEMA citus_ccb_test;
+SET search_path TO citus_ccb_test;
+-- helper: print status, masking dynamic fields (PIDs, timestamps) so the
+-- expected output is stable across runs.
+CREATE OR REPLACE FUNCTION print_block_status()
+RETURNS TABLE (
+    state                text,
+    has_worker_pid       boolean,
+    has_requestor_pid    boolean,
+    has_block_start_time boolean,
+    timeout_ms           int,
+    node_count           int)
+LANGUAGE SQL AS $$
+    SELECT s.state,
+           (s.worker_pid IS NOT NULL AND s.worker_pid > 0),
+           (s.requestor_pid IS NOT NULL AND s.requestor_pid > 0),
+           (s.block_start_time IS NOT NULL),
+           s.timeout_ms,
+           s.node_count
+    FROM pg_catalog.citus_cluster_changes_block_status() s;
+$$;
+-- helper: poll status() until a target state is reached, with bounded waiting.
+-- Returns the state observed (or raises on timeout).  Used only after
+-- artificially terminating the worker; the normal block/unblock paths return
+-- synchronously and do not need polling.
+CREATE OR REPLACE FUNCTION wait_for_block_state(target_state text,
+                                                max_secs int DEFAULT 30)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+    cur_state text;
+    iters     int := 0;
+    max_iters int := max_secs * 10;
+BEGIN
+    LOOP
+        SELECT state INTO cur_state
+        FROM pg_catalog.citus_cluster_changes_block_status();
+
+        IF cur_state = target_state THEN
+            RETURN cur_state;
+        END IF;
+
+        iters := iters + 1;
+        IF iters >= max_iters THEN
+            RAISE EXCEPTION
+                'state did not reach % within % seconds (last: %)',
+                target_state, max_secs, cur_state;
+        END IF;
+
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+END;
+$$;
+-- ----------------------------------------------------------------
+-- 1. status() returns a single 'inactive' row with NULL dynamic fields
+--    when no block has ever been started.
+-- ----------------------------------------------------------------
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- raw status: confirm dynamic fields are NULL initially
+SELECT state,
+       worker_pid IS NULL                AS worker_pid_is_null,
+       requestor_pid IS NULL             AS requestor_pid_is_null,
+       block_start_time IS NULL          AS start_time_is_null,
+       timeout_ms,
+       node_count
+FROM pg_catalog.citus_cluster_changes_block_status();
+  state   | worker_pid_is_null | requestor_pid_is_null | start_time_is_null | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | t                  | t                     | t                  |          0 |          0
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 2. timeout_ms argument validation
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(0);
+ERROR:  timeout_ms must be between 1 and 1800000
+SELECT pg_catalog.citus_cluster_changes_block(-1);
+ERROR:  timeout_ms must be between 1 and 1800000
+SELECT pg_catalog.citus_cluster_changes_block(1800001);
+ERROR:  timeout_ms must be between 1 and 1800000
+-- still inactive after rejected calls
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+  state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 3. unblock() when nothing is active -> false (no error)
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+  state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 4. Basic block / status / unblock cycle
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- block() returns synchronously after state transitions to ACTIVE,
+-- so this status read is race-free.
+SELECT * FROM print_block_status();
+ state  | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ active | t              | t                 | t                    |      60000 |          2
+(1 row)
+
+-- functional check: the worker must be holding ExclusiveLock on
+-- pg_dist_node, pg_dist_partition, and pg_dist_transaction on the
+-- coordinator.  Verify by inspecting pg_locks for the worker PID.
+SELECT relname, mode, granted
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.pid = (SELECT worker_pid
+               FROM pg_catalog.citus_cluster_changes_block_status())
+  AND l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+ORDER BY relname;
+       relname       |     mode      | granted
+---------------------------------------------------------------------
+ pg_dist_node        | ExclusiveLock | t
+ pg_dist_partition   | ExclusiveLock | t
+ pg_dist_transaction | ExclusiveLock | t
+(3 rows)
+
+-- behavioural check: while the block is held, any operation that
+-- requires a lock conflicting with ExclusiveLock on the locked
+-- catalogs must be blocked.  Use LOCK ... NOWAIT (RowExclusive,
+-- which is what any write/INSERT/UPDATE/DELETE on these catalogs
+-- takes) — it conflicts with ExclusiveLock and fails immediately
+-- when contended, giving a deterministic, non-flaky assertion.
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_partition"
+ROLLBACK;
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_node"
+ROLLBACK;
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_transaction"
+ROLLBACK;
+-- worker-node check (structural): every metadata worker must have
+-- a backend holding ExclusiveLock on pg_dist_partition and
+-- pg_dist_transaction (the bgworker's remote connection on that
+-- node).  pg_dist_node is intentionally NOT locked on workers
+-- (node management is coordinator-only), so we expect exactly 2.
+SELECT nodename, nodeport, result
+FROM run_command_on_workers($cmd$
+    SELECT count(DISTINCT c.relname)::text
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE l.locktype = 'relation'
+      AND l.mode = 'ExclusiveLock'
+      AND l.granted
+      AND c.relname IN ('pg_dist_partition',
+                        'pg_dist_transaction')
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | result
+---------------------------------------------------------------------
+ localhost |    57637 | 2
+ localhost |    57638 | 2
+(2 rows)
+
+-- worker-node check (behavioural): a conflicting RowExclusive lock
+-- attempt on each worker must fail with NOWAIT, proving writes are
+-- actually blocked on workers (not just on the coordinator).  We use
+-- DO blocks because run_command_on_workers runs in autocommit mode
+-- and bare LOCK requires a transaction block.
+SELECT nodename, nodeport, success, result
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | success |                                  result
+---------------------------------------------------------------------
+ localhost |    57637 | f       | ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_partition"
+ localhost |    57638 | f       | ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_partition"
+(2 rows)
+
+SELECT nodename, nodeport, success, result
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | success |                                   result
+---------------------------------------------------------------------
+ localhost |    57637 | f       | ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_transaction"
+ localhost |    57638 | f       | ERROR:  could not obtain lock on relation "pg_catalog.pg_dist_transaction"
+(2 rows)
+
+-- pg_dist_node is NOT locked on workers, so a conflicting lock
+-- attempt there must succeed even while the block is held.
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | success
+---------------------------------------------------------------------
+ localhost |    57637 | t
+ localhost |    57638 | t
+(2 rows)
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- after unblock, the worker is gone so its locks are released.
+-- Confirm by counting any remaining ExclusiveLocks held by a dead PID
+-- (should be zero rows).
+SELECT count(*) AS leftover_locks
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+  AND l.pid <> pg_backend_pid();
+ leftover_locks
+---------------------------------------------------------------------
+              0
+(1 row)
+
+-- behavioural check: after unblock, the same LOCK ... NOWAIT
+-- statements that previously failed must now succeed because no
+-- conflicting lock is held.
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+ROLLBACK;
+-- worker-node check: same conflicting locks must now succeed on
+-- each worker after the bgworker has released its remote locks.
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | success
+---------------------------------------------------------------------
+ localhost |    57637 | t
+ localhost |    57638 | t
+(2 rows)
+
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+ nodename  | nodeport | success
+---------------------------------------------------------------------
+ localhost |    57637 | t
+ localhost |    57638 | t
+(2 rows)
+
+-- unblock() returns synchronously after the worker has set state back
+-- to INACTIVE (or after a 30s warning timeout that is not expected here).
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 5. Default timeout argument
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block();
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT state, timeout_ms
+FROM pg_catalog.citus_cluster_changes_block_status();
+ state  | timeout_ms
+---------------------------------------------------------------------
+ active |     300000
+(1 row)
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 6. Double-block while already ACTIVE -> ERROR (with hint)
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ERROR:  a cluster changes block is already active
+HINT:  Use citus_cluster_changes_unblock() to release the existing block first.
+-- still active after the rejected second call
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+ state
+---------------------------------------------------------------------
+ active
+(1 row)
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 7. Repeated cycles - exercise the worker startup/shutdown path
+--    multiple times to detect any leaked state, stuck locks, or
+--    flaky synchronization.
+-- ----------------------------------------------------------------
+DO $$
+BEGIN
+    FOR i IN 1..5 LOOP
+        PERFORM pg_catalog.citus_cluster_changes_block(60000);
+        IF (SELECT state FROM pg_catalog.citus_cluster_changes_block_status())
+           <> 'active' THEN
+            RAISE EXCEPTION 'iteration %: expected active state', i;
+        END IF;
+        PERFORM pg_catalog.citus_cluster_changes_unblock();
+        IF (SELECT state FROM pg_catalog.citus_cluster_changes_block_status())
+           <> 'inactive' THEN
+            RAISE EXCEPTION 'iteration %: expected inactive state', i;
+        END IF;
+    END LOOP;
+END;
+$$;
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 8. SIGTERM-induced shutdown path: terminate the bgworker directly
+--    and verify the worker performs a clean shutdown that resets
+--    shared-memory state to INACTIVE.
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- terminate the bgworker (SIGTERM) - hits the got_sigterm code path
+SELECT pg_terminate_backend(worker_pid)
+FROM pg_catalog.citus_cluster_changes_block_status();
+ pg_terminate_backend
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- the SIGTERM handler exits the wait loop and the worker resets state
+-- to INACTIVE before exiting.  Wait for that to be observable.
+SELECT wait_for_block_state('inactive');
+ wait_for_block_state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- after SIGTERM cleanup, normal block/unblock must still work
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+ state
+---------------------------------------------------------------------
+ active
+(1 row)
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+  state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+-- ----------------------------------------------------------------
+-- 9. Permission enforcement: REVOKE ALL FROM PUBLIC on block/unblock,
+--    but block_status() is readable by any user.
+-- ----------------------------------------------------------------
+CREATE USER citus_ccb_unprivileged;
+SET ROLE citus_ccb_unprivileged;
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ERROR:  permission denied for function citus_cluster_changes_block
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ERROR:  permission denied for function citus_cluster_changes_unblock
+-- status() is readable
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+  state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+RESET ROLE;
+DROP USER citus_ccb_unprivileged;
+-- ----------------------------------------------------------------
+-- 10. Coordinator-only enforcement (EnsureCoordinator).
+--     Calling block/unblock from a worker node must error.
+--     We invoke via run_command_on_workers so the call executes
+--     directly on the worker.
+-- ----------------------------------------------------------------
+SELECT result FROM run_command_on_workers(
+    $cmd$ SELECT pg_catalog.citus_cluster_changes_block(60000) $cmd$);
+                    result
+---------------------------------------------------------------------
+ ERROR:  operation is not allowed on this node
+ ERROR:  operation is not allowed on this node
+(2 rows)
+
+SELECT result FROM run_command_on_workers(
+    $cmd$ SELECT pg_catalog.citus_cluster_changes_unblock() $cmd$);
+                    result
+---------------------------------------------------------------------
+ ERROR:  operation is not allowed on this node
+ ERROR:  operation is not allowed on this node
+(2 rows)
+
+-- ----------------------------------------------------------------
+-- 11. Timeout-driven auto-release: when timeout_ms elapses while the
+--     block is held, the worker logs a WARNING and auto-releases all
+--     locks without an explicit unblock() call.  We use a short
+--     timeout (2s) — long enough for block() to synchronously observe
+--     the ACTIVE state, short enough to keep the test fast.  The
+--     WARNING is emitted by the bgworker and goes to the server log
+--     (not the client), so it does not affect expected output.
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(2000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+ state
+---------------------------------------------------------------------
+ active
+(1 row)
+
+-- wait for the worker to hit its own timeout, auto-release locks,
+-- and reset state to INACTIVE.  wait_for_block_state polls for up
+-- to 30s, so this is bounded and non-flaky regardless of host load.
+SELECT wait_for_block_state('inactive');
+ wait_for_block_state
+---------------------------------------------------------------------
+ inactive
+(1 row)
+
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- locks must be released after auto-timeout, just like after an
+-- explicit unblock().
+SELECT count(*) AS leftover_locks
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+  AND l.pid <> pg_backend_pid();
+ leftover_locks
+---------------------------------------------------------------------
+              0
+(1 row)
+
+-- a fresh block/unblock cycle must still work after auto-timeout
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+ citus_cluster_changes_block
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+ state
+---------------------------------------------------------------------
+ active
+(1 row)
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+ citus_cluster_changes_unblock
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- final sanity: cluster is fully unblocked at end of test
+SELECT * FROM print_block_status();
+  state   | has_worker_pid | has_requestor_pid | has_block_start_time | timeout_ms | node_count
+---------------------------------------------------------------------
+ inactive | f              | f                 | f                    |          0 |          0
+(1 row)
+
+-- cleanup
+DROP SCHEMA citus_ccb_test CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function print_block_status()
+drop cascades to function wait_for_block_state(text,integer)

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1666,12 +1666,15 @@ ALTER EXTENSION citus UPDATE TO '13.3-1';
 SELECT * FROM multi_extension.print_extension_changes();
  previous_object |                                      current_object
 ---------------------------------------------------------------------
+                 | function citus_cluster_changes_block(integer) boolean
+                 | function citus_cluster_changes_block_status() record
+                 | function citus_cluster_changes_unblock() boolean
                  | function citus_internal.acquire_placement_colocation_lock(bigint,integer) integer
                  | function citus_internal.adjust_identity_column_seq_settings(regclass,bigint,boolean) void
                  | function citus_internal.get_next_colocation_id() bigint
                  | function citus_internal.lock_colocation_id(integer,integer) void
                  | function worker_apply_sequence_command(text,regtype,bigint,boolean) void
-(5 rows)
+(8 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -57,6 +57,9 @@ ORDER BY 1;
  function citus_check_connection_to_node(text,integer)
  function citus_cleanup_orphaned_resources()
  function citus_cleanup_orphaned_shards()
+ function citus_cluster_changes_block(integer)
+ function citus_cluster_changes_block_status()
+ function citus_cluster_changes_unblock()
  function citus_conninfo_cache_invalidate()
  function citus_coordinator_nodeid()
  function citus_copy_shard_placement(bigint,integer,integer,citus.shard_transfer_mode)
@@ -407,6 +410,6 @@ ORDER BY 1;
  view citus_tables
  view pg_dist_shard_placement
  view time_partitions
-(375 rows)
+(378 rows)
 
 DROP TABLE extension_basic_types;

--- a/src/test/regress/multi_1_create_citus_schedule
+++ b/src/test/regress/multi_1_create_citus_schedule
@@ -110,3 +110,10 @@ test: multi_unsupported_worker_operations
 # Will be moved back to multi_1_schedule at Citus 15.
 test: schema_based_sharding_from_workers_a
 test: schema_based_sharding_from_workers_b
+
+# ----------
+# citus_cluster_changes_block tests UDFs introduced in 13.3; not present in the
+# N-1 (13.2-1) extension, so run it only under check-multi-1-create-citus which
+# is not part of the N-1 test matrix. Move back to multi_schedule at Citus 14.
+# ----------
+test: citus_cluster_changes_block

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -1,6 +1,5 @@
 test: multi_test_helpers multi_test_helpers_superuser
 test: multi_cluster_management
-test: citus_cluster_changes_block
 test: create_role_propagation
 test: multi_create_fdw
 test: multi_test_catalog_views

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -1,5 +1,6 @@
 test: multi_test_helpers multi_test_helpers_superuser
 test: multi_cluster_management
+test: citus_cluster_changes_block
 test: create_role_propagation
 test: multi_create_fdw
 test: multi_test_catalog_views

--- a/src/test/regress/sql/citus_cluster_changes_block.sql
+++ b/src/test/regress/sql/citus_cluster_changes_block.sql
@@ -1,0 +1,370 @@
+--
+-- CITUS_CLUSTER_CHANGES_BLOCK
+--
+-- Functional tests for citus_cluster_changes_block(),
+-- citus_cluster_changes_unblock(), and citus_cluster_changes_block_status().
+--
+-- These tests exercise:
+--   * argument validation (timeout_ms range)
+--   * permission enforcement (REVOKE ALL ON FUNCTION ... FROM PUBLIC)
+--   * state-machine transitions (inactive -> starting -> active -> releasing
+--     -> inactive)
+--   * double-block rejection
+--   * idempotent unblock (false when no block is active)
+--   * status output shape and unstable-field masking
+--   * stress / repeated cycle stability (no leaked state)
+--   * stale-state auto-cleanup when the bgworker dies unexpectedly
+--
+
+CREATE SCHEMA citus_ccb_test;
+SET search_path TO citus_ccb_test;
+
+-- helper: print status, masking dynamic fields (PIDs, timestamps) so the
+-- expected output is stable across runs.
+CREATE OR REPLACE FUNCTION print_block_status()
+RETURNS TABLE (
+    state                text,
+    has_worker_pid       boolean,
+    has_requestor_pid    boolean,
+    has_block_start_time boolean,
+    timeout_ms           int,
+    node_count           int)
+LANGUAGE SQL AS $$
+    SELECT s.state,
+           (s.worker_pid IS NOT NULL AND s.worker_pid > 0),
+           (s.requestor_pid IS NOT NULL AND s.requestor_pid > 0),
+           (s.block_start_time IS NOT NULL),
+           s.timeout_ms,
+           s.node_count
+    FROM pg_catalog.citus_cluster_changes_block_status() s;
+$$;
+
+-- helper: poll status() until a target state is reached, with bounded waiting.
+-- Returns the state observed (or raises on timeout).  Used only after
+-- artificially terminating the worker; the normal block/unblock paths return
+-- synchronously and do not need polling.
+CREATE OR REPLACE FUNCTION wait_for_block_state(target_state text,
+                                                max_secs int DEFAULT 30)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+    cur_state text;
+    iters     int := 0;
+    max_iters int := max_secs * 10;
+BEGIN
+    LOOP
+        SELECT state INTO cur_state
+        FROM pg_catalog.citus_cluster_changes_block_status();
+
+        IF cur_state = target_state THEN
+            RETURN cur_state;
+        END IF;
+
+        iters := iters + 1;
+        IF iters >= max_iters THEN
+            RAISE EXCEPTION
+                'state did not reach % within % seconds (last: %)',
+                target_state, max_secs, cur_state;
+        END IF;
+
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 1. status() returns a single 'inactive' row with NULL dynamic fields
+--    when no block has ever been started.
+-- ----------------------------------------------------------------
+SELECT * FROM print_block_status();
+
+-- raw status: confirm dynamic fields are NULL initially
+SELECT state,
+       worker_pid IS NULL                AS worker_pid_is_null,
+       requestor_pid IS NULL             AS requestor_pid_is_null,
+       block_start_time IS NULL          AS start_time_is_null,
+       timeout_ms,
+       node_count
+FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- ----------------------------------------------------------------
+-- 2. timeout_ms argument validation
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(0);
+SELECT pg_catalog.citus_cluster_changes_block(-1);
+SELECT pg_catalog.citus_cluster_changes_block(1800001);
+
+-- still inactive after rejected calls
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- ----------------------------------------------------------------
+-- 3. unblock() when nothing is active -> false (no error)
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_unblock();
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- ----------------------------------------------------------------
+-- 4. Basic block / status / unblock cycle
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+
+-- block() returns synchronously after state transitions to ACTIVE,
+-- so this status read is race-free.
+SELECT * FROM print_block_status();
+
+-- functional check: the worker must be holding ExclusiveLock on
+-- pg_dist_node, pg_dist_partition, and pg_dist_transaction on the
+-- coordinator.  Verify by inspecting pg_locks for the worker PID.
+SELECT relname, mode, granted
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.pid = (SELECT worker_pid
+               FROM pg_catalog.citus_cluster_changes_block_status())
+  AND l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+ORDER BY relname;
+
+-- behavioural check: while the block is held, any operation that
+-- requires a lock conflicting with ExclusiveLock on the locked
+-- catalogs must be blocked.  Use LOCK ... NOWAIT (RowExclusive,
+-- which is what any write/INSERT/UPDATE/DELETE on these catalogs
+-- takes) — it conflicts with ExclusiveLock and fails immediately
+-- when contended, giving a deterministic, non-flaky assertion.
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+ROLLBACK;
+
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+ROLLBACK;
+
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+ROLLBACK;
+
+-- worker-node check (structural): every metadata worker must have
+-- a backend holding ExclusiveLock on pg_dist_partition and
+-- pg_dist_transaction (the bgworker's remote connection on that
+-- node).  pg_dist_node is intentionally NOT locked on workers
+-- (node management is coordinator-only), so we expect exactly 2.
+SELECT nodename, nodeport, result
+FROM run_command_on_workers($cmd$
+    SELECT count(DISTINCT c.relname)::text
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE l.locktype = 'relation'
+      AND l.mode = 'ExclusiveLock'
+      AND l.granted
+      AND c.relname IN ('pg_dist_partition',
+                        'pg_dist_transaction')
+$cmd$)
+ORDER BY nodename, nodeport;
+
+-- worker-node check (behavioural): a conflicting RowExclusive lock
+-- attempt on each worker must fail with NOWAIT, proving writes are
+-- actually blocked on workers (not just on the coordinator).  We use
+-- DO blocks because run_command_on_workers runs in autocommit mode
+-- and bare LOCK requires a transaction block.
+SELECT nodename, nodeport, success, result
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+
+SELECT nodename, nodeport, success, result
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+
+-- pg_dist_node is NOT locked on workers, so a conflicting lock
+-- attempt there must succeed even while the block is held.
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+
+SELECT pg_catalog.citus_cluster_changes_unblock();
+
+-- after unblock, the worker is gone so its locks are released.
+-- Confirm by counting any remaining ExclusiveLocks held by a dead PID
+-- (should be zero rows).
+SELECT count(*) AS leftover_locks
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+  AND l.pid <> pg_backend_pid();
+
+-- behavioural check: after unblock, the same LOCK ... NOWAIT
+-- statements that previously failed must now succeed because no
+-- conflicting lock is held.
+BEGIN;
+LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+LOCK TABLE pg_catalog.pg_dist_node IN ROW EXCLUSIVE MODE NOWAIT;
+LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+ROLLBACK;
+
+-- worker-node check: same conflicting locks must now succeed on
+-- each worker after the bgworker has released its remote locks.
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_partition IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+
+SELECT nodename, nodeport, success
+FROM run_command_on_workers($cmd$
+    DO $body$ BEGIN
+        LOCK TABLE pg_catalog.pg_dist_transaction IN ROW EXCLUSIVE MODE NOWAIT;
+    END $body$;
+$cmd$)
+ORDER BY nodename, nodeport;
+
+-- unblock() returns synchronously after the worker has set state back
+-- to INACTIVE (or after a 30s warning timeout that is not expected here).
+SELECT * FROM print_block_status();
+
+-- ----------------------------------------------------------------
+-- 5. Default timeout argument
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block();
+SELECT state, timeout_ms
+FROM pg_catalog.citus_cluster_changes_block_status();
+SELECT pg_catalog.citus_cluster_changes_unblock();
+
+-- ----------------------------------------------------------------
+-- 6. Double-block while already ACTIVE -> ERROR (with hint)
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+-- still active after the rejected second call
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+SELECT pg_catalog.citus_cluster_changes_unblock();
+
+-- ----------------------------------------------------------------
+-- 7. Repeated cycles - exercise the worker startup/shutdown path
+--    multiple times to detect any leaked state, stuck locks, or
+--    flaky synchronization.
+-- ----------------------------------------------------------------
+DO $$
+BEGIN
+    FOR i IN 1..5 LOOP
+        PERFORM pg_catalog.citus_cluster_changes_block(60000);
+        IF (SELECT state FROM pg_catalog.citus_cluster_changes_block_status())
+           <> 'active' THEN
+            RAISE EXCEPTION 'iteration %: expected active state', i;
+        END IF;
+        PERFORM pg_catalog.citus_cluster_changes_unblock();
+        IF (SELECT state FROM pg_catalog.citus_cluster_changes_block_status())
+           <> 'inactive' THEN
+            RAISE EXCEPTION 'iteration %: expected inactive state', i;
+        END IF;
+    END LOOP;
+END;
+$$;
+SELECT * FROM print_block_status();
+
+-- ----------------------------------------------------------------
+-- 8. SIGTERM-induced shutdown path: terminate the bgworker directly
+--    and verify the worker performs a clean shutdown that resets
+--    shared-memory state to INACTIVE.
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+
+-- terminate the bgworker (SIGTERM) - hits the got_sigterm code path
+SELECT pg_terminate_backend(worker_pid)
+FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- the SIGTERM handler exits the wait loop and the worker resets state
+-- to INACTIVE before exiting.  Wait for that to be observable.
+SELECT wait_for_block_state('inactive');
+SELECT * FROM print_block_status();
+
+-- after SIGTERM cleanup, normal block/unblock must still work
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+SELECT pg_catalog.citus_cluster_changes_unblock();
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- ----------------------------------------------------------------
+-- 9. Permission enforcement: REVOKE ALL FROM PUBLIC on block/unblock,
+--    but block_status() is readable by any user.
+-- ----------------------------------------------------------------
+CREATE USER citus_ccb_unprivileged;
+
+SET ROLE citus_ccb_unprivileged;
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+SELECT pg_catalog.citus_cluster_changes_unblock();
+-- status() is readable
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+RESET ROLE;
+
+DROP USER citus_ccb_unprivileged;
+
+-- ----------------------------------------------------------------
+-- 10. Coordinator-only enforcement (EnsureCoordinator).
+--     Calling block/unblock from a worker node must error.
+--     We invoke via run_command_on_workers so the call executes
+--     directly on the worker.
+-- ----------------------------------------------------------------
+SELECT result FROM run_command_on_workers(
+    $cmd$ SELECT pg_catalog.citus_cluster_changes_block(60000) $cmd$);
+SELECT result FROM run_command_on_workers(
+    $cmd$ SELECT pg_catalog.citus_cluster_changes_unblock() $cmd$);
+
+-- ----------------------------------------------------------------
+-- 11. Timeout-driven auto-release: when timeout_ms elapses while the
+--     block is held, the worker logs a WARNING and auto-releases all
+--     locks without an explicit unblock() call.  We use a short
+--     timeout (2s) — long enough for block() to synchronously observe
+--     the ACTIVE state, short enough to keep the test fast.  The
+--     WARNING is emitted by the bgworker and goes to the server log
+--     (not the client), so it does not affect expected output.
+-- ----------------------------------------------------------------
+SELECT pg_catalog.citus_cluster_changes_block(2000);
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+
+-- wait for the worker to hit its own timeout, auto-release locks,
+-- and reset state to INACTIVE.  wait_for_block_state polls for up
+-- to 30s, so this is bounded and non-flaky regardless of host load.
+SELECT wait_for_block_state('inactive');
+
+SELECT * FROM print_block_status();
+
+-- locks must be released after auto-timeout, just like after an
+-- explicit unblock().
+SELECT count(*) AS leftover_locks
+FROM pg_locks l
+JOIN pg_class c ON c.oid = l.relation
+WHERE l.locktype = 'relation'
+  AND l.mode = 'ExclusiveLock'
+  AND c.relname IN ('pg_dist_node',
+                    'pg_dist_partition',
+                    'pg_dist_transaction')
+  AND l.pid <> pg_backend_pid();
+
+-- a fresh block/unblock cycle must still work after auto-timeout
+SELECT pg_catalog.citus_cluster_changes_block(60000);
+SELECT state FROM pg_catalog.citus_cluster_changes_block_status();
+SELECT pg_catalog.citus_cluster_changes_unblock();
+
+-- final sanity: cluster is fully unblocked at end of test
+SELECT * FROM print_block_status();
+
+-- cleanup
+DROP SCHEMA citus_ccb_test CASCADE;


### PR DESCRIPTION
Backport (https://github.com/citusdata/citus/pull/8543)

Problem
Citus uses Two-Phase Commit (2PC) for distributed write transactions. When taking cluster-wide backups, independent per-node snapshots can capture mid-flight 2PC transactions in inconsistent states, For example a coordinator with the commit record but a worker missing the prepared transaction, leading to irrecoverable data inconsistency on restore.

Solution
Temporarily block distributed 2PC commit decisions and schema/topology changes across the entire cluster while disk snapshots are taken. Acquiring ExclusiveLock on pg_dist_transaction guarantees that all in-flight 2PC transactions have fully completed (including COMMIT PREPARED on every worker) before the lock is granted, and no new commit decisions can begin while it is held, because the 2PC commit path takes RowExclusiveLock on pg_dist_transaction to record the commit, which conflicts with our ExclusiveLock. This creates a clean partition: everything before the lock is fully committed on all nodes; everything after hasn't started.

Read queries and single-shard writes are never blocked. Multi-shard / cross-node writes that go through 2PC are queued (not aborted) and proceed after unblock.

New UDFs
All require superuser and must be called on the coordinator. block/unblock are revoked from PUBLIC; block_status is readable by any role.

citus_cluster_changes_block(timeout_ms int DEFAULT 300000) Spawns a dedicated background worker that acquires ExclusiveLock on pg_dist_node, pg_dist_partition, and pg_dist_transaction on the coordinator, then sends LOCK TABLE … IN EXCLUSIVE MODE for pg_dist_partition and pg_dist_transaction to every metadata worker. (pg_dist_node is intentionally coordinator-only, node management is not delegated.)
Returns true when all locks are held cluster-wide. timeout_ms is bounded 1..1,800,000.

citus_cluster_changes_unblock()
Signals the background worker to release all locks and exit. Can be called from any session.
Returns true on success, false if no block was active (idempotent, never errors).

citus_cluster_changes_block_status()
Returns a single row: (state, worker_pid, requestor_pid, block_start_time, timeout_ms, node_count).
Possible States

inactive
starting
active
releasing
error
Architecture
A dedicated background worker holds a single transaction whose lifetime equals the lock-holding period. This ensures locks survive the caller's session disconnect. All termination paths (explicit release, timeout expiry, SIGTERM, error, postmaster death) end the transaction, guaranteeing locks cannot leak.

The worker uses PostgreSQL's WaitEventSet API to simultaneously monitor its latch (for release / SIGTERM), the postmaster, and every remote connection socket. If any worker-node connection drops, the failure is detected within milliseconds via PQconsumeInput / PQstatus and the block is released with an error.

Shared memory (ClusterChangesBlockControlData, protected by a dedicated LWLock) coordinates state between the UDFs and the worker. The state machine is INACTIVE → STARTING → ACTIVE → RELEASING → INACTIVE (or → ERROR on failure). Concurrent block() calls are serialised under a single LW_EXCLUSIVE acquisition (no TOCTOU). Stale state from a crashed worker is auto-cleaned by block_status() via a kill(pid, 0) liveness check.

Remote lock acquisition is bounded by SET LOCAL statement_timeout on each worker connection, preventing indefinite hangs if a remote node is unresponsive during the LOCK TABLE phase.

The BLOCK_DISTRIBUTED_WRITES_COMMAND macro (shared with citus_create_restore_point) is defined in cluster_changes_block.h to avoid duplication.

Out of scope
This UDF only guarantees no 2PC commit decisions cross the snapshot boundary. WAL flushing, snapshot orchestration, and per-node backup timing remain the operator's responsibility.

Tests
New regression test citus_cluster_changes_block covering happy path, argument validation, permission enforcement, double-block rejection, idempotent unblock, repeated cycles, SIGTERM cleanup, timeout-driven auto-release, and structural + behavioural lock verification on the coordinator and every metadata worker.