### PR TITLE
Add 13.3-1 sql paths for cluster_changes_block UDFs

### DIFF
--- a/src/backend/distributed/sql/citus--13.2-1--13.3-1.sql
+++ b/src/backend/distributed/sql/citus--13.2-1--13.3-1.sql
@@ -9,3 +9,8 @@
 #include "udfs/citus_internal_lock_colocation_id/13.3-1.sql"
 
 #include "udfs/citus_internal_acquire_placement_colocation_lock/13.3-1.sql"
+
+-- cluster changes block UDFs
+#include "udfs/citus_cluster_changes_block/13.3-1.sql"
+#include "udfs/citus_cluster_changes_unblock/13.3-1.sql"
+#include "udfs/citus_cluster_changes_block_status/13.3-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
@@ -9,3 +9,8 @@ DROP FUNCTION IF EXISTS pg_catalog.worker_apply_sequence_command(text, regtype, 
 DROP FUNCTION IF EXISTS citus_internal.lock_colocation_id(int, int);
 
 DROP FUNCTION IF EXISTS citus_internal.acquire_placement_colocation_lock(bigint, int);
+
+-- cluster changes block UDFs
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
+DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block/13.3-1.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block(
+    timeout_ms int DEFAULT 300000)
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block(int)
+IS 'block distributed write transactions, DDL, and topology changes across the Citus cluster';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_block(int) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_block_status/13.3-1.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_block_status(
+    OUT state text,
+    OUT worker_pid int,
+    OUT requestor_pid int,
+    OUT block_start_time timestamptz,
+    OUT timeout_ms int,
+    OUT node_count int)
+RETURNS record
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_block_status$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_block_status()
+IS 'return the current status of the cluster changes block';
+-- Intentionally readable by PUBLIC: this function only exposes
+-- non-sensitive state (state name, PIDs, timestamps, counts) and is
+-- meant to be observable by monitoring tools without superuser rights.
+-- citus_cluster_changes_block() and citus_cluster_changes_unblock()
+-- are the privileged operations and have REVOKE ALL FROM PUBLIC.

--- a/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/13.3-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_cluster_changes_unblock/13.3-1.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION pg_catalog.citus_cluster_changes_unblock()
+RETURNS boolean
+LANGUAGE C STRICT
+AS 'MODULE_PATHNAME', $$citus_cluster_changes_unblock$$;
+COMMENT ON FUNCTION pg_catalog.citus_cluster_changes_unblock()
+IS 'release the cluster changes block';
+REVOKE ALL ON FUNCTION pg_catalog.citus_cluster_changes_unblock() FROM PUBLIC;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1667,12 +1667,15 @@ ALTER EXTENSION citus UPDATE TO '13.3-1';
 SELECT * FROM multi_extension.print_extension_changes();
  previous_object |                                      current_object
 ---------------------------------------------------------------------
+                 | function citus_cluster_changes_block(integer) boolean
+                 | function citus_cluster_changes_block_status() record
+                 | function citus_cluster_changes_unblock() boolean
                  | function citus_internal.acquire_placement_colocation_lock(bigint,integer) integer
                  | function citus_internal.adjust_identity_column_seq_settings(regclass,bigint,boolean) void
                  | function citus_internal.get_next_colocation_id() bigint
                  | function citus_internal.lock_colocation_id(integer,integer) void
                  | function worker_apply_sequence_command(text,regtype,bigint,boolean) void
-(5 rows)
+(8 rows)
 
 -- Test downgrade to 13.3-1 from 14.0-1
 ALTER EXTENSION citus UPDATE TO '14.0-1';
@@ -1688,6 +1691,9 @@ ALTER EXTENSION citus UPDATE TO '14.0-1';
 SELECT * FROM multi_extension.print_extension_changes();
                                       previous_object                                      |                                  current_object
 ---------------------------------------------------------------------
+ function citus_cluster_changes_block(integer) boolean                                     |
+ function citus_cluster_changes_block_status() record                                      |
+ function citus_cluster_changes_unblock() boolean                                          |
  function citus_internal.acquire_placement_colocation_lock(bigint,integer) integer         |
  function citus_internal.adjust_identity_column_seq_settings(regclass,bigint,boolean) void |
  function citus_internal.get_next_colocation_id() bigint                                   |
@@ -1699,7 +1705,7 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                                            | function fix_pre_citus14_colocation_group_collation_mismatches() void
                                                                                            | function worker_binary_partial_agg(oid,anyelement) bytea
                                                                                            | function worker_binary_partial_agg_ffunc(internal) bytea
-(11 rows)
+(14 rows)
 
 -- Test downgrade to 14.0-1 from 14.1-1
 ALTER EXTENSION citus UPDATE TO '14.1-1';


### PR DESCRIPTION
PR #8573 adds citus_cluster_changes_{block,unblock,block_status} UDFs to Citus 13.3-1 on release-13.2. For the upgrade chain 13.2 -> 13.3 -> 14.0 -> 14.1 to land these UDFs at the correct version and remain a no-op across the 14.0 <-> 14.1 transition, the same 13.3-1 sql paths must exist on release-14.0.

DESCRIPTION: PR description that will go into the change log, up to 78 characters
