### PR TITLE
Add changelog for Citus v14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+### citus v14.1.0 (May 14, 2026) ###
+
+* Adds support for running several DDLs for schema-based sharding from any
+  node, including `CREATE SCHEMA`, `DROP SCHEMA`, `ALTER SCHEMA RENAME`,
+  and table-level DDLs on distributed schemas (#8541)
+
+* Adds `citus_cluster_changes_block()`, `citus_cluster_changes_unblock()`,
+  and `citus_cluster_changes_block_status()` UDFs that temporarily block
+  distributed 2PC commit decisions and schema/topology changes across the
+  cluster to allow consistent disk-snapshot backups (#8543, #8571)
+
+* Fixes role propagation error during node activation when one role is used
+  as a grantor for another via `GRANT ... GRANTED BY`, by tracking grantor
+  roles as dependencies so they are propagated before the dependent grants
+  (#8466)
+
+* Fixes a self-deadlock when adding a named constraint on a partitioned
+  table whose auto-generated constraint name on partition shards would
+  exceed `NAMEDATALEN` (#8540, #8560)
+
 ### citus v14.0.1 (April 21, 2026) ###
 
 * Hardens extension SQL against `search_path` attacks by schema-qualifying


### PR DESCRIPTION
Release prep for **citus v14.1.0** from `release-14.0`.

DESCRIPTION: add changelog for 14.1.0

All version-bearing files (`configure.ac`, `configure`, `citus.control`, `citus_columnar.control`, `multi_extension.out` `SHOW citus.version`) were already bumped to 14.1.0 / 14.1-1 in a5ae9f4d9 (Mar 17, 2026), so this PR is a single-file CHANGELOG addition.

### Changelog entries (user-visible only)
- #8541 — schema-based-sharding DDLs from any node
- #8543, #8571 — `citus_cluster_changes_{block,unblock,block_status}` UDFs for snapshot-backup coordination
- #8466 — fix role propagation when `GRANT ... GRANTED BY` introduces grantor deps
- #8540, #8560 — fix self-deadlock on named constraint with long partition shard name

CI/test-infra and version-bump commits intentionally excluded.