### PR TITLE
Fix latent bugs in SortedMergeReScan

### DIFF
--- a/src/backend/distributed/executor/citus_custom_scan.c
+++ b/src/backend/distributed/executor/citus_custom_scan.c
@@ -999,7 +999,16 @@ SortedMergeReScan(CustomScanState *node)
 	CitusReScanCommon(node);
 
 	CitusScanState *scanState = (CitusScanState *) node;
-	SortedMergeAdapterRescan(scanState->mergeAdapter);
+
+	/*
+	 * The adapter is created lazily by AdaptiveExecutor on the first scan
+	 * fetch. If rescan fires before any tuple was fetched (e.g. DECLARE
+	 * followed by COMMIT without any FETCH), there is nothing to rewind.
+	 */
+	if (scanState->mergeAdapter != NULL)
+	{
+		SortedMergeAdapterRescan(scanState->mergeAdapter);
+	}
 }
 
 

--- a/src/backend/distributed/executor/sorted_merge.c
+++ b/src/backend/distributed/executor/sorted_merge.c
@@ -389,9 +389,13 @@ SortedMergeAdapterNext(SortedMergeAdapter *adapter)
  * SortedMergeAdapterRescan resets the adapter to re-read from the beginning.
  * Called from CitusReScan() for cursor WITH HOLD patterns.
  *
- * Cost is O(K log K) to rebuild the heap, which is negligible for typical
- * shard counts (4-64). Both binaryheap_reset() and tuplestore_rescan()
- * are proven APIs used by PostgreSQL's ExecReScanMergeAppend.
+ * We clear the heap and mark the adapter as uninitialized. On the next
+ * SortedMergeAdapterNext() call, the if-branch will rewind each per-task
+ * store, seed the heap with the first tuple from each, and return the
+ * global winner. This avoids the off-by-one bug that would occur if we
+ * seeded here and set initialized=true: the next Next() call would enter
+ * the else-branch and advance the seeded winner before returning it,
+ * silently dropping the first globally-minimal tuple after every rescan.
  */
 void
 SortedMergeAdapterRescan(SortedMergeAdapter *adapter)
@@ -402,19 +406,13 @@ SortedMergeAdapterRescan(SortedMergeAdapter *adapter)
 
 	binaryheap_reset(adapter->heap);
 
-	for (int i = 0; i < adapter->nstores; i++)
-	{
-		tuplestore_rescan(adapter->perTaskStores[i]);
-		if (tuplestore_gettupleslot(adapter->perTaskStores[i], true, false,
-									adapter->mergeCtx.slots[i]))
-		{
-			binaryheap_add_unordered(adapter->heap, Int32GetDatum(i));
-		}
-	}
-	binaryheap_build(adapter->heap);
-
-	adapter->exhausted = binaryheap_empty(adapter->heap);
-	adapter->initialized = true;
+	/*
+	 * Let the next SortedMergeAdapterNext() reseed the heap. For the
+	 * degenerate zero-store case there is nothing to seed and the adapter
+	 * stays exhausted.
+	 */
+	adapter->initialized = (adapter->nstores == 0);
+	adapter->exhausted = (adapter->nstores == 0);
 }
 
 

--- a/src/test/regress/expected/multi_orderby_pushdown.out
+++ b/src/test/regress/expected/multi_orderby_pushdown.out
@@ -3317,13 +3317,20 @@ FETCH ALL FROM rescan_cur_full;
 (17 rows)
 
 CLOSE rescan_cur_full;
--- N3: SCROLL CURSOR WITH HOLD where the cursor is COMMIT-persisted
--- before any FETCH ever ran.  AdaptiveExecutor() and therefore
--- CreatePerTaskDispatchDests() have not been called yet, so
--- scanState->mergeAdapter is NULL at the moment PersistHoldablePortal
--- triggers ExecutorRewind.  SortedMergeReScan() must tolerate a NULL
--- adapter (the same way CitusReScan tolerates a NULL tuplestore) or
--- a segfault would occur once the Material absorber is removed.
+-- N3: Absent-Material scenario -- NULL adapter at rescan time.
+-- In production the Material absorber (inserted by
+-- materialize_finished_plan() in distributed_planner.c) intercepts
+-- PersistHoldablePortal's ExecutorRewind call before it reaches the
+-- Citus custom scan, so this code path is not exercised in normal
+-- operation.  This test is specifically for the *absent-Material*
+-- case: when Material is removed or bypassed, PG calls
+-- SortedMergeReScan() before any FETCH has run.  At that point
+-- AdaptiveExecutor() and CreatePerTaskDispatchDests() have not been
+-- called yet, so scanState->mergeAdapter is NULL.
+-- SortedMergeReScan() must tolerate a NULL adapter (the same way
+-- CitusReScan tolerates a NULL tuplestore) or a segfault occurs.
+-- The FETCH 0 / COMMIT-before-first-row pattern is the minimal
+-- SQL trigger for this NULL state.
 BEGIN;
 DECLARE rescan_cur_zero SCROLL CURSOR WITH HOLD FOR
     SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
@@ -3507,6 +3514,105 @@ FETCH ALL FROM rescan_cur_empty;
 (0 rows)
 
 CLOSE rescan_cur_empty;
+-- N8: SCROLL CURSOR WITH HOLD with FETCH BACKWARD navigation.
+-- Sentinel test for the PG-side Material + holdStore tier.  In
+-- production this scenario never reaches SortedMergeReScan or
+-- SortedMergeAdapterRescan:
+--   * Backward fetches issued before COMMIT are served from
+--     Material's internal tuplestore (ExecInitMaterial strips
+--     EXEC_FLAG_BACKWARD before initialising its child, so the
+--     sorted-merge custom scan never receives a backward direction).
+--   * Backward fetches issued after COMMIT are served by
+--     RunFromStore() over the holdStore without invoking the
+--     executor at all.
+-- The sorted-merge custom scan intentionally withholds
+-- CUSTOMPATH_SUPPORT_BACKWARD_SCAN (see FinalizePlan in
+-- distributed_planner.c) because the streaming adapter is
+-- forward-only, so the Material absorber is required to handle
+-- backward navigation.  This test guards against any future change
+-- that would weaken that absorber and start routing backward
+-- fetches into the Citus custom scan.
+BEGIN;
+DECLARE rescan_cur_back SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+-- Forward fetch establishes a position in the cursor.
+FETCH 5 FROM rescan_cur_back;
+ id
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
+-- Backward fetch before COMMIT: served by Material's tuplestore.
+FETCH BACKWARD 2 FROM rescan_cur_back;
+ id
+---------------------------------------------------------------------
+  4
+  3
+(2 rows)
+
+COMMIT;
+-- Backward fetch after COMMIT: served by holdStore via RunFromStore.
+FETCH BACKWARD 1 FROM rescan_cur_back;
+ id
+---------------------------------------------------------------------
+  2
+(1 row)
+
+-- Forward fetch after COMMIT: also served by holdStore.
+FETCH ALL FROM rescan_cur_back;
+ id
+---------------------------------------------------------------------
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(18 rows)
+
+-- Final backward drain over the holdStore.
+FETCH BACKWARD ALL FROM rescan_cur_back;
+ id
+---------------------------------------------------------------------
+ 20
+ 19
+ 18
+ 17
+ 16
+ 15
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+  4
+  3
+  2
+  1
+(20 rows)
+
+CLOSE rescan_cur_back;
 -- =================================================================
 -- Category O: work_mem stress (Phase B / T18)
 --

--- a/src/test/regress/expected/multi_orderby_pushdown.out
+++ b/src/test/regress/expected/multi_orderby_pushdown.out
@@ -3274,6 +3274,239 @@ SELECT public.explain_filter('EXPLAIN (COSTS OFF, VERBOSE OFF)
                                  ->  Seq Scan on sorted_merge_test_960000 sorted_merge_test
 (11 rows)
 
+-- N2: SCROLL CURSOR WITH HOLD without LIMIT.  Same shape as N1 but
+-- the holdStore must persist the entire post-rescan stream, so any
+-- off-by-one in SortedMergeAdapterRescan() would manifest as a
+-- missing row at the rescan boundary (the global minimum of the
+-- rewound merge).  In production Material absorbs the rescan, so we
+-- expect a full, in-order result.  See the same-day fix in
+-- sorted_merge.c that leaves initialized=false so the next Next()
+-- call reseeds rather than advancing the unread winner.
+BEGIN;
+DECLARE rescan_cur_full SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 3 FROM rescan_cur_full;
+ id
+---------------------------------------------------------------------
+  1
+  2
+  3
+(3 rows)
+
+COMMIT;
+FETCH ALL FROM rescan_cur_full;
+ id
+---------------------------------------------------------------------
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(17 rows)
+
+CLOSE rescan_cur_full;
+-- N3: SCROLL CURSOR WITH HOLD where the cursor is COMMIT-persisted
+-- before any FETCH ever ran.  AdaptiveExecutor() and therefore
+-- CreatePerTaskDispatchDests() have not been called yet, so
+-- scanState->mergeAdapter is NULL at the moment PersistHoldablePortal
+-- triggers ExecutorRewind.  SortedMergeReScan() must tolerate a NULL
+-- adapter (the same way CitusReScan tolerates a NULL tuplestore) or
+-- a segfault would occur once the Material absorber is removed.
+BEGIN;
+DECLARE rescan_cur_zero SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 0 FROM rescan_cur_zero;
+ id
+---------------------------------------------------------------------
+(0 rows)
+
+COMMIT;
+FETCH ALL FROM rescan_cur_zero;
+ id
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+CLOSE rescan_cur_zero;
+-- N4: Multi-column ORDER BY rescan.  Verifies that rescan resets all
+-- per-task stores consistently and that the heap is reseeded in the
+-- right order, including across the multi-key comparator.
+BEGIN;
+DECLARE rescan_cur_multi SCROLL CURSOR WITH HOLD FOR
+    SELECT id, id % 3 AS m FROM sorted_merge_test
+    WHERE id <= 20 ORDER BY id % 3, id;
+FETCH 3 FROM rescan_cur_multi;
+ id | m
+---------------------------------------------------------------------
+  3 | 0
+  6 | 0
+  9 | 0
+(3 rows)
+
+COMMIT;
+FETCH ALL FROM rescan_cur_multi;
+ id | m
+---------------------------------------------------------------------
+ 12 | 0
+ 15 | 0
+ 18 | 0
+  1 | 1
+  4 | 1
+  7 | 1
+ 10 | 1
+ 13 | 1
+ 16 | 1
+ 19 | 1
+  2 | 2
+  5 | 2
+  8 | 2
+ 11 | 2
+ 14 | 2
+ 17 | 2
+ 20 | 2
+(17 rows)
+
+CLOSE rescan_cur_multi;
+-- N5: SCROLL CURSOR WITH HOLD + DESC ordering.  Exercises rescan
+-- with a reversed sort comparator to confirm the same correctness
+-- under inverted SortSupport semantics.
+BEGIN;
+DECLARE rescan_cur_desc SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id DESC;
+FETCH 3 FROM rescan_cur_desc;
+ id
+---------------------------------------------------------------------
+ 20
+ 19
+ 18
+(3 rows)
+
+COMMIT;
+FETCH ALL FROM rescan_cur_desc;
+ id
+---------------------------------------------------------------------
+ 17
+ 16
+ 15
+ 14
+ 13
+ 12
+ 11
+ 10
+  9
+  8
+  7
+  6
+  5
+  4
+  3
+  2
+  1
+(17 rows)
+
+CLOSE rescan_cur_desc;
+-- N6: Repeated single-row fetches after rescan.  Verifies that the
+-- holdStore (populated from the post-rescan stream) returns the
+-- correct sequence one row at a time, then drains the remainder.
+BEGIN;
+DECLARE rescan_cur_single SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 5 FROM rescan_cur_single;
+ id
+---------------------------------------------------------------------
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
+COMMIT;
+FETCH 1 FROM rescan_cur_single;
+ id
+---------------------------------------------------------------------
+  6
+(1 row)
+
+FETCH 1 FROM rescan_cur_single;
+ id
+---------------------------------------------------------------------
+  7
+(1 row)
+
+FETCH 1 FROM rescan_cur_single;
+ id
+---------------------------------------------------------------------
+  8
+(1 row)
+
+FETCH ALL FROM rescan_cur_single;
+ id
+---------------------------------------------------------------------
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(12 rows)
+
+CLOSE rescan_cur_single;
+-- N7: SCROLL CURSOR WITH HOLD over an empty result.  Rescan must
+-- not produce phantom rows when every per-task store is empty, and
+-- no NULL deref / heap underflow should occur.
+BEGIN;
+DECLARE rescan_cur_empty SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id > 100000 ORDER BY id;
+FETCH 1 FROM rescan_cur_empty;
+ id
+---------------------------------------------------------------------
+(0 rows)
+
+COMMIT;
+FETCH ALL FROM rescan_cur_empty;
+ id
+---------------------------------------------------------------------
+(0 rows)
+
+CLOSE rescan_cur_empty;
 -- =================================================================
 -- Category O: work_mem stress (Phase B / T18)
 --

--- a/src/test/regress/sql/multi_orderby_pushdown.sql
+++ b/src/test/regress/sql/multi_orderby_pushdown.sql
@@ -999,6 +999,85 @@ SELECT public.explain_filter('EXPLAIN (COSTS OFF, VERBOSE OFF)
     DECLARE rescan_cur SCROLL CURSOR WITH HOLD FOR
         SELECT id FROM sorted_merge_test ORDER BY id LIMIT 10');
 
+-- N2: SCROLL CURSOR WITH HOLD without LIMIT.  Same shape as N1 but
+-- the holdStore must persist the entire post-rescan stream, so any
+-- off-by-one in SortedMergeAdapterRescan() would manifest as a
+-- missing row at the rescan boundary (the global minimum of the
+-- rewound merge).  In production Material absorbs the rescan, so we
+-- expect a full, in-order result.  See the same-day fix in
+-- sorted_merge.c that leaves initialized=false so the next Next()
+-- call reseeds rather than advancing the unread winner.
+BEGIN;
+DECLARE rescan_cur_full SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 3 FROM rescan_cur_full;
+COMMIT;
+FETCH ALL FROM rescan_cur_full;
+CLOSE rescan_cur_full;
+
+-- N3: SCROLL CURSOR WITH HOLD where the cursor is COMMIT-persisted
+-- before any FETCH ever ran.  AdaptiveExecutor() and therefore
+-- CreatePerTaskDispatchDests() have not been called yet, so
+-- scanState->mergeAdapter is NULL at the moment PersistHoldablePortal
+-- triggers ExecutorRewind.  SortedMergeReScan() must tolerate a NULL
+-- adapter (the same way CitusReScan tolerates a NULL tuplestore) or
+-- a segfault would occur once the Material absorber is removed.
+BEGIN;
+DECLARE rescan_cur_zero SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 0 FROM rescan_cur_zero;
+COMMIT;
+FETCH ALL FROM rescan_cur_zero;
+CLOSE rescan_cur_zero;
+
+-- N4: Multi-column ORDER BY rescan.  Verifies that rescan resets all
+-- per-task stores consistently and that the heap is reseeded in the
+-- right order, including across the multi-key comparator.
+BEGIN;
+DECLARE rescan_cur_multi SCROLL CURSOR WITH HOLD FOR
+    SELECT id, id % 3 AS m FROM sorted_merge_test
+    WHERE id <= 20 ORDER BY id % 3, id;
+FETCH 3 FROM rescan_cur_multi;
+COMMIT;
+FETCH ALL FROM rescan_cur_multi;
+CLOSE rescan_cur_multi;
+
+-- N5: SCROLL CURSOR WITH HOLD + DESC ordering.  Exercises rescan
+-- with a reversed sort comparator to confirm the same correctness
+-- under inverted SortSupport semantics.
+BEGIN;
+DECLARE rescan_cur_desc SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id DESC;
+FETCH 3 FROM rescan_cur_desc;
+COMMIT;
+FETCH ALL FROM rescan_cur_desc;
+CLOSE rescan_cur_desc;
+
+-- N6: Repeated single-row fetches after rescan.  Verifies that the
+-- holdStore (populated from the post-rescan stream) returns the
+-- correct sequence one row at a time, then drains the remainder.
+BEGIN;
+DECLARE rescan_cur_single SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+FETCH 5 FROM rescan_cur_single;
+COMMIT;
+FETCH 1 FROM rescan_cur_single;
+FETCH 1 FROM rescan_cur_single;
+FETCH 1 FROM rescan_cur_single;
+FETCH ALL FROM rescan_cur_single;
+CLOSE rescan_cur_single;
+
+-- N7: SCROLL CURSOR WITH HOLD over an empty result.  Rescan must
+-- not produce phantom rows when every per-task store is empty, and
+-- no NULL deref / heap underflow should occur.
+BEGIN;
+DECLARE rescan_cur_empty SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id > 100000 ORDER BY id;
+FETCH 1 FROM rescan_cur_empty;
+COMMIT;
+FETCH ALL FROM rescan_cur_empty;
+CLOSE rescan_cur_empty;
+
 -- =================================================================
 -- Category O: work_mem stress (Phase B / T18)
 --

--- a/src/test/regress/sql/multi_orderby_pushdown.sql
+++ b/src/test/regress/sql/multi_orderby_pushdown.sql
@@ -1015,13 +1015,20 @@ COMMIT;
 FETCH ALL FROM rescan_cur_full;
 CLOSE rescan_cur_full;
 
--- N3: SCROLL CURSOR WITH HOLD where the cursor is COMMIT-persisted
--- before any FETCH ever ran.  AdaptiveExecutor() and therefore
--- CreatePerTaskDispatchDests() have not been called yet, so
--- scanState->mergeAdapter is NULL at the moment PersistHoldablePortal
--- triggers ExecutorRewind.  SortedMergeReScan() must tolerate a NULL
--- adapter (the same way CitusReScan tolerates a NULL tuplestore) or
--- a segfault would occur once the Material absorber is removed.
+-- N3: Absent-Material scenario -- NULL adapter at rescan time.
+-- In production the Material absorber (inserted by
+-- materialize_finished_plan() in distributed_planner.c) intercepts
+-- PersistHoldablePortal's ExecutorRewind call before it reaches the
+-- Citus custom scan, so this code path is not exercised in normal
+-- operation.  This test is specifically for the *absent-Material*
+-- case: when Material is removed or bypassed, PG calls
+-- SortedMergeReScan() before any FETCH has run.  At that point
+-- AdaptiveExecutor() and CreatePerTaskDispatchDests() have not been
+-- called yet, so scanState->mergeAdapter is NULL.
+-- SortedMergeReScan() must tolerate a NULL adapter (the same way
+-- CitusReScan tolerates a NULL tuplestore) or a segfault occurs.
+-- The FETCH 0 / COMMIT-before-first-row pattern is the minimal
+-- SQL trigger for this NULL state.
 BEGIN;
 DECLARE rescan_cur_zero SCROLL CURSOR WITH HOLD FOR
     SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
@@ -1077,6 +1084,40 @@ FETCH 1 FROM rescan_cur_empty;
 COMMIT;
 FETCH ALL FROM rescan_cur_empty;
 CLOSE rescan_cur_empty;
+
+-- N8: SCROLL CURSOR WITH HOLD with FETCH BACKWARD navigation.
+-- Sentinel test for the PG-side Material + holdStore tier.  In
+-- production this scenario never reaches SortedMergeReScan or
+-- SortedMergeAdapterRescan:
+--   * Backward fetches issued before COMMIT are served from
+--     Material's internal tuplestore (ExecInitMaterial strips
+--     EXEC_FLAG_BACKWARD before initialising its child, so the
+--     sorted-merge custom scan never receives a backward direction).
+--   * Backward fetches issued after COMMIT are served by
+--     RunFromStore() over the holdStore without invoking the
+--     executor at all.
+-- The sorted-merge custom scan intentionally withholds
+-- CUSTOMPATH_SUPPORT_BACKWARD_SCAN (see FinalizePlan in
+-- distributed_planner.c) because the streaming adapter is
+-- forward-only, so the Material absorber is required to handle
+-- backward navigation.  This test guards against any future change
+-- that would weaken that absorber and start routing backward
+-- fetches into the Citus custom scan.
+BEGIN;
+DECLARE rescan_cur_back SCROLL CURSOR WITH HOLD FOR
+    SELECT id FROM sorted_merge_test WHERE id <= 20 ORDER BY id;
+-- Forward fetch establishes a position in the cursor.
+FETCH 5 FROM rescan_cur_back;
+-- Backward fetch before COMMIT: served by Material's tuplestore.
+FETCH BACKWARD 2 FROM rescan_cur_back;
+COMMIT;
+-- Backward fetch after COMMIT: served by holdStore via RunFromStore.
+FETCH BACKWARD 1 FROM rescan_cur_back;
+-- Forward fetch after COMMIT: also served by holdStore.
+FETCH ALL FROM rescan_cur_back;
+-- Final backward drain over the holdStore.
+FETCH BACKWARD ALL FROM rescan_cur_back;
+CLOSE rescan_cur_back;
 
 -- =================================================================
 -- Category O: work_mem stress (Phase B / T18)


### PR DESCRIPTION
# Fix two latent bugs in `SortedMergeAdapterRescan`

## Summary

This PR fixes two correctness/robustness bugs in the sorted-merge rescan callback that surfaced during a pen test of #8529. Both bugs live in code that is unreachable in production because the `materialize_finished_plan` wrapper added in #8529 absorbs every rescan that PostgreSQL would otherwise forward to the sorted-merge `CustomScan`. The fixes harden the defensive rescan path so it produces correct results — and does not crash — if the absorber is ever weakened, removed, or bypassed by a future PG release.

## Background

`SortedMergeAdapter` streams globally-sorted tuples by running a binary min-heap over per-task tuplestores (`sorted_merge.c`). `SortedMergeAdapterNext()` has two branches:

- **First call** (`!initialized`): rewind every per-task store, seed the heap with the first tuple from each, then return the heap's current winner.
- **Subsequent calls** (`initialized`): advance the *previous* winner's store, update the heap, then return the new winner.

`SortedMergeAdapterRescan()` is the rescan callback installed on the sorted-merge `CustomScan`. PostgreSQL invokes it from `ExecutorRewind()` on the only SQL shape that reaches it: a `SCROLL CURSOR WITH HOLD` whose holdable portal is being persisted by `PersistHoldablePortal()` at `COMMIT` time. In production, the Material node inserted by `materialize_finished_plan()` in `distributed_planner.c` absorbs that rescan, so the sorted-merge callback never runs.

## Bug 1 — off-by-one tuple drop after rescan (correctness)

**Where:** `src/backend/distributed/executor/sorted_merge.c::SortedMergeAdapterRescan`

The original implementation pre-seeded the heap with the first tuple from each store and then set `initialized = true`:

```c
for (int i = 0; i < adapter->nstores; i++)
{
    tuplestore_rescan(adapter->perTaskStores[i]);
    if (tuplestore_gettupleslot(adapter->perTaskStores[i], true, false,
                                adapter->mergeCtx.slots[i]))
    {
        binaryheap_add_unordered(adapter->heap, Int32GetDatum(i));
    }
}
binaryheap_build(adapter->heap);

adapter->exhausted = binaryheap_empty(adapter->heap);
adapter->initialized = true;            /* ← problem */
```

Because the adapter is now marked as initialized, the next `SortedMergeAdapterNext()` call enters the `else` branch, treats the freshly-seeded heap winner as a *previous* winner, advances that store and **only then** returns the new winner. The first globally-minimal tuple after every rescan is silently dropped.

### Reproduction (with the Material absorber temporarily removed)

```sql
CREATE TABLE t (id int);
SELECT create_distributed_table('t', 'id');
INSERT INTO t SELECT g FROM generate_series(1, 20) g;

BEGIN;
DECLARE c SCROLL CURSOR WITH HOLD FOR
    SELECT id FROM t ORDER BY id;
FETCH 3 FROM c;   -- 1, 2, 3
COMMIT;           -- PersistHoldablePortal → ExecutorRewind → rescan
FETCH ALL FROM c; -- expected: 4..20  (17 rows)
                  -- actual:   5..20  (16 rows; row 4 dropped)
CLOSE c;
```

### Fix

Don't seed the heap in `Rescan`. Mark the adapter as uninitialized and let the next `Next()` call do its normal first-call seed via the existing `if (!adapter->initialized)` branch, which already rewinds each store, seeds the heap, *and returns* the winner instead of advancing past it:

```c
void
SortedMergeAdapterRescan(SortedMergeAdapter *adapter)
{
    binaryheap_reset(adapter->heap);

    /* Let the next Next() reseed.  Zero-store adapters stay exhausted. */
    adapter->initialized = (adapter->nstores == 0);
    adapter->exhausted   = (adapter->nstores == 0);
}
```

## Bug 2 — NULL-deref crash when rescan fires before any FETCH

**Where:** `src/backend/distributed/executor/citus_custom_scan.c::SortedMergeReScan`

The sorted-merge `CustomScan` runs `AdaptiveExecutor()` (and thus `CreatePerTaskDispatchDests()`, which installs `scanState->mergeAdapter`) **lazily** — only on the first tuple fetched from the scan. So a `SCROLL CURSOR WITH HOLD` that is declared, never fetched from, and then committed will reach `SortedMergeReScan()` with `scanState->mergeAdapter == NULL`.

The previous code dereferenced it unconditionally:

```c
static void
SortedMergeReScan(CustomScanState *node)
{
    elog(WARNING, "unexpected sorted merge rescan");
    CitusReScanCommon(node);
    CitusScanState *scanState = (CitusScanState *) node;
    SortedMergeAdapterRescan(scanState->mergeAdapter);  /* SEGV when NULL */
}
```

### Reproduction (with the Material absorber temporarily removed)

```sql
BEGIN;
DECLARE c SCROLL CURSOR WITH HOLD FOR
    SELECT id FROM t ORDER BY id;
FETCH 0 FROM c;        -- no FETCH ⇒ AdaptiveExecutor never runs
COMMIT;                -- PersistHoldablePortal → rescan → NULL deref ⇒ SIGSEGV
```

### Fix

Guard the adapter pointer before calling rescan, mirroring the existing `CitusReScan()` pattern that already guards `scanState->tuplestorestate`:

```c
static void
SortedMergeReScan(CustomScanState *node)
{
    elog(WARNING, "unexpected sorted merge rescan");
    CitusReScanCommon(node);
    CitusScanState *scanState = (CitusScanState *) node;

    /*
     * The adapter is created lazily by AdaptiveExecutor on the first scan
     * fetch.  If rescan fires before any tuple was fetched (e.g. DECLARE
     * followed by COMMIT without any FETCH), there is nothing to rewind.
     */
    if (scanState->mergeAdapter != NULL)
    {
        SortedMergeAdapterRescan(scanState->mergeAdapter);
    }
}
```

## Test coverage

Added seven new sub-tests (`N2`..`N7`) to the existing `Category N` (SCROLL CURSOR WITH HOLD rescan) section of `src/test/regress/sql/multi_orderby_pushdown.sql`, alongside the pre-existing `N1` test. These document the exact SQL shapes that reproduced the bugs and act as regression guards:

| Test | Shape | Bug it would surface (if Material absorber is removed) |
|------|-------|--------------------------------------------------------|
| `N2` | `WITH HOLD` + `FETCH 3` + `COMMIT` + `FETCH ALL`, no LIMIT | Bug 1 — row at rescan boundary dropped |
| `N3` | `WITH HOLD` + `FETCH 0` + `COMMIT` + `FETCH ALL` | Bug 2 — NULL adapter ⇒ SIGSEGV |
| `N4` | `WITH HOLD` + multi-key `ORDER BY id%3, id` + rescan | Multi-key comparator correctness across rescan |
| `N5` | `WITH HOLD` + `ORDER BY id DESC` + rescan | Inverted comparator correctness across rescan |
| `N6` | `WITH HOLD` + repeated single-row fetches after rescan | holdStore sequencing post-rescan |
| `N7` | `WITH HOLD` over empty result + rescan | Empty-store rescan: no phantoms, no heap underflow |

In production (with `materialize_finished_plan` in place) all of these queries already returned correct results because the Material node absorbed the rescan. They are still kept in the suite as documentation and to catch any future regression where the absorber is changed, weakened, or bypassed by a new PG release. With the absorber temporarily removed during pen-testing, `N2`/`N4`/`N5`/`N6` reproduce the row-drop bug and `N3` reproduces the crash; with the fixes applied (and the absorber still removed) all seven produce correct results.

## Impact

- **Correctness:** No behaviour change visible to users of the unmodified PR. Both bugs were latent under the `materialize_finished_plan` absorber, so no released sorted-merge plan can hit them today.
- **Defensive hardening:** The rescan callback is now self-consistent and crash-safe. A future PG-side change (e.g. the planner choosing not to wrap, or a new portal type that bypasses the wrapper) would no longer silently produce wrong results or crash.
- **No performance change.** The rescan callback's hot work is moved from `Rescan()` into the next `Next()` call (where the existing uninitialized-path code already lives). Zero extra work either way.

## Files changed

- `src/backend/distributed/executor/sorted_merge.c` — Fix Bug 1 in `SortedMergeAdapterRescan`.
- `src/backend/distributed/executor/citus_custom_scan.c` — Fix Bug 2 in `SortedMergeReScan`.
- `src/test/regress/sql/multi_orderby_pushdown.sql` — Add `N2`..`N7` tests under the existing Category N.
- `src/test/regress/expected/multi_orderby_pushdown.out` — Expected output for the new tests.

## Verification

- `make -C src/test/regress check-base EXTRA_TESTS='multi_orderby_pushdown'` passes (15/15 tests, including the new `N2`..`N7`).
- Bug repro under a manually patched build that removes the `materialize_finished_plan` call (used only locally for verification — not part of this PR):
  - **Before fix:** `N2` returns 16 rows instead of 17 (row 4 missing); `N3` SIGSEGVs in `SortedMergeAdapterRescan` on a NULL adapter.
  - **After fix:** `N2`..`N7` all return correct results.
