### PR TITLE
Release 13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+### citus v13.3.0 (May 15, 2026) ###
+
+* Adds support for running several DDLs for schema-based sharding from any
+  node, including `CREATE SCHEMA`, `DROP SCHEMA`, `ALTER SCHEMA RENAME`,
+  and table-level DDLs on distributed schemas (#8541)
+
+* Adds `citus_cluster_changes_block()`, `citus_cluster_changes_unblock()`,
+  and `citus_cluster_changes_block_status()` UDFs that temporarily block
+  distributed 2PC commit decisions and schema/topology changes across the
+  cluster to allow consistent disk-snapshot backups (#8543, #8571)
+
+* Fixes role propagation error during node activation when one role is used
+  as a grantor for another via `GRANT ... GRANTED BY`, by tracking grantor
+  roles as dependencies so they are propagated before the dependent grants
+  (#8466)
+
+* Fixes a self-deadlock when adding a named constraint on a partitioned
+  table whose auto-generated constraint name on partition shards would
+  exceed `NAMEDATALEN` (#8540, #8560)
+
 ### citus v13.2.2 (April 21, 2026) ###
 
 * Hardens extension SQL against `search_path` attacks by schema-qualifying

--- a/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.3-1--13.2-1.sql
@@ -14,7 +14,3 @@ DROP FUNCTION IF EXISTS citus_internal.acquire_placement_colocation_lock(bigint,
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
-
-DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
-DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
-DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();


### PR DESCRIPTION
Adds the CHANGELOG entry for v13.3.0.

This release includes the following backports merged into release-13.2 since v13.2.2:
- #8541 - DDLs for schema-based sharding from any node
- #8543, #8571 - citus_cluster_changes_{block,unblock,block_status} UDFs
- #8466 (via #8579) - role propagation grantor dependencies
- #8540 (via #8575) - deadlock with long partition constraint names

Version bump to 13.3.0 was already done in e8a841d46.