### PR TITLE
ci: add PostgreSQL 19 to Build & Test matrices

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,11 +36,12 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.3"
-      image_suffix: "-v4271d84"
+      image_suffix: "-dev-e11d99c"
       pg16_version: '{ "major": "16", "full": "16.13" }'
       pg17_version: '{ "major": "17", "full": "17.9" }'
       pg18_version: '{ "major": "18", "full": "18.3" }'
-      upgrade_pg_versions: "16.13-17.9-18.3"
+      pg19_version: '{ "major": "19", "full": "19devel" }'
+      upgrade_pg_versions: "16.13-17.9-18.3-19devel"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters
@@ -117,6 +118,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
           - ${{ needs.params.outputs.pg17_version }}
           - ${{ needs.params.outputs.pg18_version }}
+          - ${{ needs.params.outputs.pg19_version }}
     runs-on: ubuntu-latest
     container:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ matrix.image_suffix }}"
@@ -146,7 +148,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-multi-1-create-citus", "check-multi-mx", "check-vanilla", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3", "check-tap"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -164,7 +167,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["check-failure", "check-enterprise-failure", "check-pytest", "check-query-generator"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -182,7 +186,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["installcheck"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -208,6 +213,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
           - ${{ needs.params.outputs.pg17_version }}
           - ${{ needs.params.outputs.pg18_version }}
+          - ${{ needs.params.outputs.pg19_version }}
         parallel: [0,1,2,3,4,5] # workaround for running 6 parallel jobs
     steps:
     - uses: actions/checkout@v5
@@ -258,6 +264,12 @@ jobs:
             new_pg_major: 18
           - old_pg_major: 16
             new_pg_major: 18
+          - old_pg_major: 18
+            new_pg_major: 19
+          - old_pg_major: 17
+            new_pg_major: 19
+          - old_pg_major: 16
+            new_pg_major: 19
     env:
       old_pg_major: ${{ matrix.old_pg_major }}
       new_pg_major: ${{ matrix.new_pg_major }}


### PR DESCRIPTION
Layer PG19 CI on top of pg19-support so the new PG19-enabled `extbuilder`/`exttester`/`failtester`/`pgupgradetester` images are exercised by Build & Test as soon as they land.

## Changes (single file: `.github/workflows/build_and_test.yml`)

- **params**
  - Bump `image_suffix` to `-dev-e11d99c` (PG19-enabled images).
  - Add `pg19_version: '{ "major": "19", "full": "19devel" }'`.
  - Extend `upgrade_pg_versions` to `16.13-17.9-18.3-19devel`.
- **build / test-citus / test-citus-failure / test-citus-cdc / test-arbitrary-configs**: include `pg19_version` in the matrix.
- **test-pg-upgrade**: cover PG16→19, PG17→19, PG18→19 (in addition to existing 16→17, 17→18, 16→18).
- **test-citus-upgrade**: left unchanged — no released Citus binary supports PG19 yet.
- **packaging**: untouched (citus/packaging images for PG19 are out of scope here).

## Notes

- Targeting `pg19-support` so the CI/CD wiring can land independently of build/runtime/regress patches.
- For these jobs to go green the base branch needs the PG19 build support (configure.ac update, source compatibility shims, regress normalizations) — handled in companion PRs.

---
*Generated with the help of GitHub Copilot CLI.*