### PR TITLE
Bump citusdata/mitmproxy fork to close pyOpenSSL CVE alerts

### DIFF
--- a/.devcontainer/src/test/regress/Pipfile
+++ b/.devcontainer/src/test/regress/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [packages]
-mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "70bad9a3c098f605e5f8b25553e5db5334018ff1"}
+mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "main"}
 "aioquic" = ">=1.2.0,<1.3.0"
 "mitmproxy-rs" = ">=0.12.6,<0.13.0"
 argon2-cffi = ">=23.1.0"

--- a/.devcontainer/src/test/regress/Pipfile.lock
+++ b/.devcontainer/src/test/regress/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "912f8e179377d7d34b800be62a5b10c0fa6ecdebc2413d7002f8340679b4c6be"
+            "sha256": "cf490fbbfb0ea18ab6afb83b438c79476782797ac566c76d6e9d96a41a416d8f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -92,11 +92,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:13acff32519542a1736223fb79a715acdebe24286d98e8b164a73085f40da2c4",
-                "sha256:1db9021efadb0d9512ce8ffaf72fcef601c7b73a8807a1bb2ef143dc6b14846d"
+                "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce",
+                "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.11.0"
+            "version": "==3.11.1"
         },
         "attrs": {
             "hashes": [
@@ -292,11 +292,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
-                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+                "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
+                "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.2.25"
+            "version": "==2026.5.20"
         },
         "cffi": {
             "hashes": [
@@ -390,11 +390,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
-                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.2"
+            "version": "==8.4.1"
         },
         "construct": {
             "hashes": [
@@ -478,12 +478,12 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6",
-                "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db"
+                "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90",
+                "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.28.0"
+            "version": "==3.29.0"
         },
         "flask": {
             "hashes": [
@@ -671,7 +671,7 @@
             ],
             "index": "pypi",
             "markers": "python_version >= '3.12'",
-            "ref": "70bad9a3c098f605e5f8b25553e5db5334018ff1",
+            "ref": "df5879516a57ea780e1cc88edaf2051e1d32915f",
             "version": "==12.2.2"
         },
         "mitmproxy-linux": {
@@ -765,11 +765,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pluggy": {
             "hashes": [
@@ -781,12 +781,12 @@
         },
         "psycopg": {
             "hashes": [
-                "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9",
-                "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698"
+                "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a",
+                "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.3.3"
+            "version": "==3.3.4"
         },
         "publicsuffix2": {
             "hashes": [
@@ -847,11 +847,11 @@
         },
         "pyopenssl": {
             "hashes": [
-                "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6",
-                "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"
+                "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70",
+                "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==25.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==26.2.0"
         },
         "pyparsing": {
             "hashes": [
@@ -879,12 +879,12 @@
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5",
-                "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"
+                "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1",
+                "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "pytest-repeat": {
             "hashes": [
@@ -1044,19 +1044,19 @@
         },
         "urwid": {
             "hashes": [
-                "sha256:24be27ffafdb68c09cd95dc21b60ccfd02843320b25ce5feee1708b34fad5a23",
-                "sha256:f188144261224fdfc9b56b4222869bd0eac90fd7895cf1e376129cdc7e13bc84"
+                "sha256:58ddc5c65eb3109b69e2e95469553f9f86070645cc1b553d6ee3fe8dbac2e0ba",
+                "sha256:f6f0381d5656b8b24ee960969927021d858c1f7320771cf8f3ec5b94a139b9b7"
             ],
             "markers": "python_full_version >= '3.9.0'",
-            "version": "==3.0.5"
+            "version": "==4.0.0"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad",
-                "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"
+                "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2",
+                "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.6.0"
+            "version": "==0.7.0"
         },
         "werkzeug": {
             "hashes": [
@@ -1227,11 +1227,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
-                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.2"
+            "version": "==8.4.1"
         },
         "flake8": {
             "hashes": [
@@ -1278,27 +1278,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pathspec": {
             "hashes": [
-                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
-                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+                "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a",
+                "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.4"
+            "version": "==1.1.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
-                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+                "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7",
+                "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.6"
+            "version": "==4.10.0"
         },
         "pycodestyle": {
             "hashes": [

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.3"
-      image_suffix: "-dev-fa732cb"
+      image_suffix: "-v5bd970c"
       pg16_version: '{ "major": "16", "full": "16.13" }'
       pg17_version: '{ "major": "17", "full": "17.9" }'
       pg18_version: '{ "major": "18", "full": "18.3" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.3"
-      image_suffix: "-v4271d84"
+      image_suffix: "-dev-fa732cb"
       pg16_version: '{ "major": "16", "full": "16.13" }'
       pg17_version: '{ "major": "17", "full": "17.9" }'
       pg18_version: '{ "major": "18", "full": "18.3" }'

--- a/src/test/regress/Pipfile
+++ b/src/test/regress/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [packages]
-mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "70bad9a3c098f605e5f8b25553e5db5334018ff1"}
+mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "main"}
 "aioquic" = ">=1.2.0,<1.3.0"
 "mitmproxy-rs" = ">=0.12.6,<0.13.0"
 argon2-cffi = ">=23.1.0"

--- a/src/test/regress/Pipfile.lock
+++ b/src/test/regress/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "912f8e179377d7d34b800be62a5b10c0fa6ecdebc2413d7002f8340679b4c6be"
+            "sha256": "cf490fbbfb0ea18ab6afb83b438c79476782797ac566c76d6e9d96a41a416d8f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -92,11 +92,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:13acff32519542a1736223fb79a715acdebe24286d98e8b164a73085f40da2c4",
-                "sha256:1db9021efadb0d9512ce8ffaf72fcef601c7b73a8807a1bb2ef143dc6b14846d"
+                "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce",
+                "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.11.0"
+            "version": "==3.11.1"
         },
         "attrs": {
             "hashes": [
@@ -292,11 +292,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
-                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+                "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
+                "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.2.25"
+            "version": "==2026.5.20"
         },
         "cffi": {
             "hashes": [
@@ -390,11 +390,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
-                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.2"
+            "version": "==8.4.1"
         },
         "construct": {
             "hashes": [
@@ -478,12 +478,12 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6",
-                "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db"
+                "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90",
+                "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.28.0"
+            "version": "==3.29.0"
         },
         "flask": {
             "hashes": [
@@ -671,7 +671,7 @@
             ],
             "index": "pypi",
             "markers": "python_version >= '3.12'",
-            "ref": "70bad9a3c098f605e5f8b25553e5db5334018ff1",
+            "ref": "df5879516a57ea780e1cc88edaf2051e1d32915f",
             "version": "==12.2.2"
         },
         "mitmproxy-linux": {
@@ -765,11 +765,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pluggy": {
             "hashes": [
@@ -781,12 +781,12 @@
         },
         "psycopg": {
             "hashes": [
-                "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9",
-                "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698"
+                "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a",
+                "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.3.3"
+            "version": "==3.3.4"
         },
         "publicsuffix2": {
             "hashes": [
@@ -847,11 +847,11 @@
         },
         "pyopenssl": {
             "hashes": [
-                "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6",
-                "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"
+                "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70",
+                "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==25.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==26.2.0"
         },
         "pyparsing": {
             "hashes": [
@@ -879,12 +879,12 @@
         },
         "pytest-asyncio": {
             "hashes": [
-                "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5",
-                "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"
+                "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1",
+                "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "pytest-repeat": {
             "hashes": [
@@ -1044,19 +1044,19 @@
         },
         "urwid": {
             "hashes": [
-                "sha256:24be27ffafdb68c09cd95dc21b60ccfd02843320b25ce5feee1708b34fad5a23",
-                "sha256:f188144261224fdfc9b56b4222869bd0eac90fd7895cf1e376129cdc7e13bc84"
+                "sha256:58ddc5c65eb3109b69e2e95469553f9f86070645cc1b553d6ee3fe8dbac2e0ba",
+                "sha256:f6f0381d5656b8b24ee960969927021d858c1f7320771cf8f3ec5b94a139b9b7"
             ],
             "markers": "python_full_version >= '3.9.0'",
-            "version": "==3.0.5"
+            "version": "==4.0.0"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad",
-                "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"
+                "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2",
+                "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.6.0"
+            "version": "==0.7.0"
         },
         "werkzeug": {
             "hashes": [
@@ -1227,11 +1227,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
-                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.2"
+            "version": "==8.4.1"
         },
         "flake8": {
             "hashes": [
@@ -1278,27 +1278,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pathspec": {
             "hashes": [
-                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
-                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+                "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a",
+                "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.4"
+            "version": "==1.1.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
-                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+                "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7",
+                "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.6"
+            "version": "==4.10.0"
         },
         "pycodestyle": {
             "hashes": [


### PR DESCRIPTION
DESCRIPTION: Update mitmproxy fork to lift pyOpenSSL cap; re-lock to 26.2.0 (closes CVE-2026-27459, CVE-2026-27448)

## Summary

Bumps the `mitmproxy` git ref in both Pipfiles from the pinned commit SHA `70bad9a3c098...` to track `citusdata/mitmproxy@main`. After [citusdata/mitmproxy#4](https://github.com/citusdata/mitmproxy/pull/4) (merge of upstream `mitmproxy/mitmproxy@main`), our fork's `main` caps `pyOpenSSL<=27.0.0` (was `<=25.3.0`), unblocking the lockfile from resolving past pyOpenSSL 25.3.0.

Re-locking both Pipfiles via `pipenv lock` resolves `pyopenssl` to **26.2.0**, closing all four currently-open Dependabot security alerts:

| Alert | CVE | Severity | Patched version |
|---|---|---|---|
| [#126](https://github.com/citusdata/citus/security/dependabot/126) / [#125](https://github.com/citusdata/citus/security/dependabot/125) | [CVE-2026-27459](https://nvd.nist.gov/vuln/detail/CVE-2026-27459) ([GHSA-5pwr-322w-8jr4](https://github.com/advisories/GHSA-5pwr-322w-8jr4)) | **High** | `>=26.0.0` |
| [#124](https://github.com/citusdata/citus/security/dependabot/124) / [#123](https://github.com/citusdata/citus/security/dependabot/123) | [CVE-2026-27448](https://nvd.nist.gov/vuln/detail/CVE-2026-27448) ([GHSA-vp96-hxj8-p424](https://github.com/advisories/GHSA-vp96-hxj8-p424)) | Low | `>=26.0.0` |

## Pipfile changes

Single line per file, in both:
- `src/test/regress/Pipfile`
- `.devcontainer/src/test/regress/Pipfile`

```diff
-mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "70bad9a3c098f605e5f8b25553e5db5334018ff1"}
+mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "main"}
```

The `ref="main"` form is supported by pipenv for git deps; the resolved commit SHA (`df5879516a57ea780e1cc88edaf2051e1d32915f` — the merge commit of mitmproxy#4) is pinned in `Pipfile.lock`, preserving reproducibility.

## Lockfile-level changes (re-lock side-effects, no Pipfile pin changes)

| Dep | Before | After | Reason |
|---|---|---|---|
| **mitmproxy** ref | `70bad9a3...` (==12.2.2) | `df5879516a...` (==13.0.0.dev0) | Fork tracking `main` |
| **pyopenssl** | `==25.3.0` | **`==26.2.0`** | Cap lifted; fixes CVEs |
| asgiref | `==3.11.0` | `==3.11.1` | Latest within range |
| certifi | `==2026.2.25` | `==2026.5.20` | Latest within range |
| click | `==8.3.2` | `==8.4.1` | Latest within range |
| filelock | `==3.28.0` | `==3.29.0` | Latest within range |
| packaging | `==26.1` | `==26.2` | Latest within range |
| psycopg | `==3.3.3` | `==3.3.4` | Latest within range |
| pytest-asyncio | `==1.3.0` | `==1.4.0` | Latest within range |
| urwid | `==3.0.5` | `==4.0.0` | Allowed by mitmproxy main's relaxed cap |
| wcwidth | `==0.6.0` | `==0.7.0` | Latest within range |

Per scope direction, no other direct deps were bumped — only the security-driven `mitmproxy` ref change. Other transitive movements above are natural consequences of `pipenv lock --clear` against unchanged version constraints.

## Validation

```bash
$ cd src/test/regress
$ pipenv sync
Installing dependencies from Pipfile.lock (416d8f)...
All dependencies are now up-to-date!

$ pipenv run pip show mitmproxy pyopenssl | grep -E "^Name:|^Version:"
Name: mitmproxy
Version: 13.0.0.dev0
Name: pyOpenSSL
Version: 26.2.0
```

Both `src/test/regress/Pipfile.lock` and `.devcontainer/src/test/regress/Pipfile.lock` are byte-identical, per the convention established in #8488 and #8547.

## Notes
- Lockfiles regenerated with `pipenv lock --clear` (pipenv 2025.0.3, Python 3.12.12).
- Currently-open Dependabot dependency-update bot PRs (#8525, #8526 pyasn1; #8489 werkzeug; #8510, #8511 black) target versions that the existing lockfile already satisfies — they will auto-close on next Dependabot scan without further action.
- Follow-up PR on `citusdata/the-process` will regenerate the three `circleci/images/*/files/etc/requirements.txt` files (which are generated from this `Pipfile.lock` via `pipenv requirements`) once this lands.

Closes #123
Closes #124
Closes #125
Closes #126
