### PR TITLE
PG19: enable PG19beta1 test matrices in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,12 +36,12 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.4"
-      image_suffix: "-dev-e11d99c"
+      image_suffix: "-dev-33b3cf5"
       pg16_version: '{ "major": "16", "full": "16.14" }'
       pg17_version: '{ "major": "17", "full": "17.10" }'
       pg18_version: '{ "major": "18", "full": "18.4" }'
-      pg19_version: '{ "major": "19", "full": "19devel" }'
-      upgrade_pg_versions: "16.14-17.10-18.4-19devel"
+      pg19_version: '{ "major": "19", "full": "19beta1" }'
+      upgrade_pg_versions: "16.14-17.10-18.4-19beta1"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters
@@ -148,7 +148,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-multi-1-create-citus", "check-multi-mx", "check-vanilla", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3", "check-tap"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -166,7 +167,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["check-failure", "check-enterprise-failure", "check-pytest", "check-query-generator"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -184,7 +186,8 @@ jobs:
         [
           ${{ needs.params.outputs.pg16_version }},
           ${{ needs.params.outputs.pg17_version }},
-          ${{ needs.params.outputs.pg18_version }}
+          ${{ needs.params.outputs.pg18_version }},
+          ${{ needs.params.outputs.pg19_version }}
         ]
       make_targets: '["installcheck"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
@@ -210,6 +213,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
           - ${{ needs.params.outputs.pg17_version }}
           - ${{ needs.params.outputs.pg18_version }}
+          - ${{ needs.params.outputs.pg19_version }}
         parallel: [0,1,2,3,4,5] # workaround for running 6 parallel jobs
     steps:
     - uses: actions/checkout@v5
@@ -260,6 +264,10 @@ jobs:
             new_pg_major: 18
           - old_pg_major: 16
             new_pg_major: 18
+          - old_pg_major: 18
+            new_pg_major: 19
+          - old_pg_major: 16
+            new_pg_major: 19
     env:
       old_pg_major: ${{ matrix.old_pg_major }}
       new_pg_major: ${{ matrix.new_pg_major }}


### PR DESCRIPTION
Turns on the PG19beta1 columns across the downstream Build & Test
matrices now that the `build` job already proves PG19 compiles under
`-Werror` and the ruleutils port (#8602) lands the runtime/regress
fixes those suites depend on.

### Changes (`.github/workflows/build_and_test.yml`)

- `test-citus`, `test-citus-failure`, `test-citus-cdc`: add
  `pg19_version` to the `pg_versions` array.
- `test-arbitrary-configs`: add `pg19_version` to `matrix.pg_version`.
- `test-pg-upgrade`: add the `18 -> 19` and `16 -> 19` upgrade pairs
  (adjacent + oldest -> newest, consistent with the existing
  16->17 / 17->18 / 16->18 set).
- `params`: bump `pg19_version` / `upgrade_pg_versions` from `19devel`
  to `19beta1`, and point `image_suffix` at the PG19beta1-enabled
  the-process images (`-dev-33b3cf5`, built from
  citusdata/the-process#222).

### Deliberately not changed

- `test-citus-upgrade` stays at PG16/PG17 — no released Citus binary
  supports PG19, so there is nothing to upgrade *from*.

### Dependencies

- Image set: citusdata/the-process#222 (PG19beta1 via apt) — **green**,
  images published under `-dev-33b3cf5`.
- Runtime/regress fixes: ruleutils port #8602 plus the
  runtime/regress sub-issues must be on `pg19-support` for the new
  cells to pass.

Closes #8615
Part of #8597