### PR TITLE
PG19: fix runtime bugs hit outside the regression suite

### DIFF
--- a/src/backend/distributed/executor/distributed_intermediate_results.c
+++ b/src/backend/distributed/executor/distributed_intermediate_results.c
@@ -255,6 +255,7 @@ CreatePartitioningTupleDest(CitusTableCacheEntry *targetRelation)
 					   TEXTOID, -1, 0);
 	TupleDescInitEntry(tupleDescriptor, (AttrNumber) 3, "rows_written",
 					   INT8OID, -1, 0);
+	TupleDescFinalize(tupleDescriptor);
 
 
 	PartitioningTupleDest *tupleDest = palloc0(sizeof(PartitioningTupleDest));
@@ -671,6 +672,7 @@ ExecuteFetchTaskList(List *taskList)
 	TupleDesc resultDescriptor = CreateTemplateTupleDesc(resultColumnCount);
 
 	TupleDescInitEntry(resultDescriptor, (AttrNumber) 1, "byte_count", INT8OID, -1, 0);
+	TupleDescFinalize(resultDescriptor);
 
 	TupleDestination *tupleDestination = CreateTupleDestNone();
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1753,6 +1753,7 @@ CreateExplainAnlyzeDestination(Task *task, TupleDestination *taskDest)
 	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 2, "duration", FLOAT8OID, 0, 0);
 	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 3, "ntuples", FLOAT8OID, 0, 0);
 	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 4, "nloops", FLOAT8OID, 0, 0);
+	TupleDescFinalize(lastSavedExplainAnalyzeTupDesc);
 
 	tupleDestination->lastSavedExplainAnalyzeTupDesc = lastSavedExplainAnalyzeTupDesc;
 

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -2919,7 +2919,18 @@ OverridePostgresConfigProperties(void)
 
 		if (strcmp(var->name, "application_name") == 0)
 		{
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+			/*
+			 * In PG19, struct config_generic embeds a union of the
+			 * type-specific fields (e.g. _string) rather than being a
+			 * prefix of struct config_string.  Access the embedded
+			 * config_string via the union member.
+			 */
+			struct config_string *stringVar = &var->_string;
+#else
 			struct config_string *stringVar = (struct config_string *) var;
+#endif
 
 			OldApplicationNameAssignHook = stringVar->assign_hook;
 			stringVar->assign_hook = ApplicationNameAssignHook;

--- a/src/backend/distributed/stats/query_stats.c
+++ b/src/backend/distributed/stats/query_stats.c
@@ -810,6 +810,14 @@ BuildExistingQueryIdHash(void)
 		fmgrPGStatStatements->fn_addr,
 		pgStatStatementsOid,
 		commandTypeDatum);
+
+	/*
+	 * PG19 requires TupleDescFinalize() to have been called before a
+	 * TupleDesc is used with slot deformation.  The descriptor returned by
+	 * the SRF is not guaranteed to be finalised; defensive call here is a
+	 * no-op on older majors.
+	 */
+	TupleDescFinalize(statStatementsReturnSet->setDesc);
 	TupleTableSlot *tupleTableSlot = MakeSingleTupleTableSlot(
 		statStatementsReturnSet->setDesc,
 		&TTSOpsMinimalTuple);

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -102,10 +102,13 @@ typedef StringInfo fmStringInfo;
 #define planner(p, s, co, b) ((planner) (p, s, co, b, NULL))
 
 /*
- * PG19 added an `int *fgc_flags` out-parameter to FuncnameGetCandidates.
+ * PG19 added an `int *fgc_flags` out-parameter to FuncnameGetCandidates,
+ * which the callee writes to unconditionally — passing NULL crashes.
+ * Wrap so callers continue to use the old 7-arg signature.
  */
 #define FuncnameGetCandidates(names, nargs, argnames, ev, ed, io, ok) \
-		((FuncnameGetCandidates) (names, nargs, argnames, ev, ed, io, ok, NULL))
+		((FuncnameGetCandidates) (names, nargs, argnames, ev, ed, io, ok, \
+								  &(int) { 0 }))
 
 /*
  * PG19 added trailing `uint16 flags` to ExecInitScanTupleSlot and
@@ -179,6 +182,37 @@ citus_pg19_standard_conforming_strings(void)
 typedef struct RepackStmt ClusterStmt;
 #define T_ClusterStmt T_RepackStmt
 
+/*
+ * PG19 added TupleDesc->firstNonCachedOffsetAttr (an offset cache populated
+ * by TupleDescFinalize()).  BlessTupleDesc() and slot_deform_heap_tuple()
+ * now assert that the cache is initialised.  Citus builds many TupleDescs
+ * by hand (CreateTemplateTupleDesc + TupleDescInitEntry...) and historically
+ * relied on BlessTupleDesc as the "finalise + register" step.  Wrap
+ * BlessTupleDesc so it finalises first; pre-PG19 builds get a no-op
+ * TupleDescFinalize().  Sites that build a TupleDesc and use it with a
+ * slot WITHOUT going through BlessTupleDesc must call TupleDescFinalize()
+ * explicitly (handled at those call sites).
+ */
+#include "funcapi.h"
+
+#include "access/tupdesc.h"
+
+/*
+ * Single-evaluation wrapper: defined before the macro so the call below
+ * resolves to the real BlessTupleDesc(), and so the macro argument is only
+ * evaluated once (a plain comma-expression macro would evaluate it twice,
+ * duplicating any side effects such as BlessTupleDesc(CreateTemplateTupleDesc(...))).
+ */
+static inline TupleDesc
+citus_BlessTupleDesc(TupleDesc td)
+{
+	TupleDescFinalize(td);
+	return BlessTupleDesc(td);
+}
+
+
+#define BlessTupleDesc(td) citus_BlessTupleDesc(td)
+
 #endif /* PG_VERSION_NUM >= PG_VERSION_19 */
 
 #if PG_VERSION_NUM < PG_VERSION_19
@@ -202,6 +236,13 @@ typedef struct RepackStmt ClusterStmt;
  * Provide the same scoped accessor used on PG19 so call sites are uniform.
  */
 #define QueryDescTotalTime(qd) ((qd)->totaltime)
+
+/*
+ * PG19 builds rely on TupleDescFinalize() to populate the offset cache; on
+ * older majors there is no such cache, so provide a no-op for the explicit
+ * call sites that build TupleDescs without going through BlessTupleDesc.
+ */
+#define TupleDescFinalize(td) ((void) 0)
 
 #endif /* PG_VERSION_NUM < PG_VERSION_19 */
 


### PR DESCRIPTION
Stacked PR (PR2 of the PG19 stack). **Base = `pg19-ci-test-matrices` (#8616)**, which is itself stacked on `pg19-ruleutils-port` (#8602) → `pg19-support`. Review/merge in stack order.

Fixes two PG19 runtime crashes that surface in normal Citus operation (outside the regression suite):

1. **`FuncnameGetCandidates()`** gained an `int *fgc_flags` out-parameter that the callee writes to unconditionally. The compat shim passed `NULL` and crashed on every by-name function lookup (e.g. the maintenance daemon). Now passes the address of an int compound literal.
2. **`TupleDesc->firstNonCachedOffsetAttr`**: PG19 added an offset cache that `BlessTupleDesc()` / `slot_deform_heap_tuple()` now assert is populated but no longer populate themselves. `BlessTupleDesc` is wrapped to call `TupleDescFinalize()` first (no-op shim on older majors), with explicit calls added at the four sites that deform hand-built TupleDescs.

Also installs `ApplicationNameAssignHook` via union access on PG19.

Closes #8610
Part of #8597