### PR TITLE
columnar: serialize CREATE INDEX on columnar tables for PG19

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -424,7 +424,7 @@ ErrorIfInvalidRowNumber(uint64 rowNumber)
 static Size
 columnar_parallelscan_estimate(Relation rel)
 {
-	return sizeof(ParallelBlockTableScanDescData);
+	return table_block_parallelscan_estimate(rel);
 }
 
 
@@ -2365,6 +2365,47 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 			break;
 		}
 
+		case T_ReindexStmt:
+		{
+			ReindexStmt *reindexStmt = castNode(ReindexStmt, parsetree);
+
+			/*
+			 * REINDEX on a columnar table rebuilds its index(es) and, just
+			 * like CREATE INDEX, first flushes any pending writes -- which
+			 * updates the stripe reservation entry in columnar.stripe.  That
+			 * update is disallowed inside a parallel operation, so we must
+			 * force a serial build here too (see the T_IndexStmt case above).
+			 *
+			 * Only REINDEX {TABLE,INDEX} target a single relation and can run
+			 * inside a transaction block (hence may carry pending writes).
+			 * REINDEX {SCHEMA,DATABASE,SYSTEM} cannot run in a transaction
+			 * block, so they never have pending writes to flush and need no
+			 * special handling here.
+			 */
+			if (reindexStmt->relation != NULL &&
+				(reindexStmt->kind == REINDEX_OBJECT_TABLE ||
+				 reindexStmt->kind == REINDEX_OBJECT_INDEX))
+			{
+				Oid relationId = RangeVarGetRelid(reindexStmt->relation,
+												  AccessShareLock, true);
+
+				if (OidIsValid(relationId))
+				{
+					Oid heapRelationId =
+						(reindexStmt->kind == REINDEX_OBJECT_INDEX) ?
+						IndexGetRelation(relationId, true) :
+						relationId;
+
+					if (OidIsValid(heapRelationId) &&
+						IsColumnarTableAmTable(heapRelationId))
+					{
+						indexBuildOnColumnar = true;
+					}
+				}
+			}
+			break;
+		}
+
 		case T_CreateStmt:
 		{
 			CreateStmt *createStmt = castNode(CreateStmt, parsetree);
@@ -2453,9 +2494,9 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 	if (indexBuildOnColumnar)
 	{
 		saveNestLevel = NewGUCNestLevel();
-		(void) set_config_option("max_parallel_maintenance_workers", "0",
-								 PGC_USERSET, PGC_S_SESSION,
-								 GUC_ACTION_SAVE, true, 0, false);
+		set_config_option("max_parallel_maintenance_workers", "0",
+						  PGC_USERSET, PGC_S_SESSION,
+						  GUC_ACTION_SAVE, true, 0, false);
 	}
 
 	PG_TRY();

--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -412,24 +412,33 @@ ErrorIfInvalidRowNumber(uint64 rowNumber)
 }
 
 
+/*
+ * Columnar scans are always serial regardless of the parallel scan descriptor
+ * (rs_parallel is stored but never read by the columnar scan path).  We still
+ * provide working parallelscan callbacks so that callers that unconditionally
+ * size and initialize a parallel scan descriptor (for example, PG19's parallel
+ * btree index build path) do not abort.  Delegating to the heap block helpers
+ * is safe: columnar never partitions work using the descriptor, so any state
+ * written there is simply unused.
+ */
 static Size
 columnar_parallelscan_estimate(Relation rel)
 {
-	elog(ERROR, "columnar_parallelscan_estimate not implemented");
+	return sizeof(ParallelBlockTableScanDescData);
 }
 
 
 static Size
 columnar_parallelscan_initialize(Relation rel, ParallelTableScanDesc pscan)
 {
-	elog(ERROR, "columnar_parallelscan_initialize not implemented");
+	return table_block_parallelscan_initialize(rel, pscan);
 }
 
 
 static void
 columnar_parallelscan_reinitialize(Relation rel, ParallelTableScanDesc pscan)
 {
-	elog(ERROR, "columnar_parallelscan_reinitialize not implemented");
+	table_block_parallelscan_reinitialize(rel, pscan);
 }
 
 
@@ -1528,10 +1537,13 @@ columnar_index_build_range_scan(Relation columnarRelation,
 	if (scan)
 	{
 		/*
-		 * Parallel scans on columnar tables are already discardad by
-		 * ColumnarGetRelationInfoHook but be on the safe side.
+		 * Starting with PG19 the planner may hand us a parallel scan descriptor
+		 * even for tables (like columnar) whose AM only supports serial scans.
+		 * Discard it: columnar never partitions index-build work across workers
+		 * and always starts its own serial scan below.  This mirrors how the
+		 * existing serial path ignores any externally supplied scan.
 		 */
-		elog(ERROR, "parallel scans on columnar are not supported");
+		scan = NULL;
 	}
 
 	/*
@@ -2315,6 +2327,7 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 
 	RangeVar *columnarRangeVar = NULL;
 	List *columnarOptions = NIL;
+	bool indexBuildOnColumnar = false;
 
 	switch (nodeTag(parsetree))
 	{
@@ -2337,6 +2350,15 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 										   "index on columnar table %s",
 										   RelationGetRelationName(rel))));
 				}
+
+				/*
+				 * Columnar does not support parallel index build (its scan path is
+				 * always serial and writes during the build would violate parallel
+				 * mode).  Force max_parallel_maintenance_workers to 0 for this
+				 * statement so PG does not spawn workers.  Starting with PG19 the
+				 * default of 2 caused CREATE INDEX on a columnar table to fail.
+				 */
+				indexBuildOnColumnar = true;
 			}
 
 			RelationClose(rel);
@@ -2427,8 +2449,28 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 		CheckCitusColumnarAlterExtensionStmt(parsetree);
 	}
 
-	PrevProcessUtilityHook(pstmt, queryString, false, context,
-						   params, queryEnv, dest, completionTag);
+	int saveNestLevel = -1;
+	if (indexBuildOnColumnar)
+	{
+		saveNestLevel = NewGUCNestLevel();
+		(void) set_config_option("max_parallel_maintenance_workers", "0",
+								 PGC_USERSET, PGC_S_SESSION,
+								 GUC_ACTION_SAVE, true, 0, false);
+	}
+
+	PG_TRY();
+	{
+		PrevProcessUtilityHook(pstmt, queryString, false, context,
+							   params, queryEnv, dest, completionTag);
+	}
+	PG_FINALLY();
+	{
+		if (saveNestLevel >= 0)
+		{
+			AtEOXact_GUC(true, saveNestLevel);
+		}
+	}
+	PG_END_TRY();
 
 	if (columnarOptions != NIL)
 	{

--- a/src/test/regress/expected/columnar_indexes.out
+++ b/src/test/regress/expected/columnar_indexes.out
@@ -574,6 +574,48 @@ BEGIN;
   SET LOCAL max_parallel_workers_per_gather = 4;
   create index on events (event_id);
 COMMIT;
+-- Same scenario as the "events" test above, but exercising REINDEX instead
+-- of CREATE INDEX.  REINDEX on a columnar table must also fall back to a
+-- serial index build: otherwise flushing the pending writes during the
+-- (parallel) reindex would try to update the stripe reservation entry and
+-- error out with "cannot update tuples during a parallel operation".
+create table reindex_events (event_id bigserial, event_time timestamptz default now(), payload text) using columnar;
+-- build the index up front, without any pending writes
+create index on reindex_events (event_id);
+BEGIN;
+  -- this wouldn't flush any data
+  insert into reindex_events (payload) select 'hello-'||s from generate_series(1, 10) s;
+  SET LOCAL debug_parallel_query = regress;
+  SET LOCAL min_parallel_table_scan_size = 1;
+  SET LOCAL parallel_tuple_cost = 0;
+  SET LOCAL max_parallel_workers = 4;
+  SET LOCAL max_parallel_workers_per_gather = 4;
+  REINDEX TABLE reindex_events;
+COMMIT;
+DROP TABLE reindex_events;
+-- Show that the transient max_parallel_maintenance_workers override that we
+-- apply while building/reindexing an index on a columnar table is properly
+-- restored to the user-set value afterwards (both for CREATE INDEX and
+-- REINDEX).
+SET max_parallel_maintenance_workers = 4;
+CREATE TABLE guc_restore_test(a int) USING columnar;
+INSERT INTO guc_restore_test SELECT i FROM generate_series(1,10) i;
+CREATE INDEX ON guc_restore_test (a);
+SHOW max_parallel_maintenance_workers;
+ max_parallel_maintenance_workers
+---------------------------------------------------------------------
+ 4
+(1 row)
+
+REINDEX TABLE guc_restore_test;
+SHOW max_parallel_maintenance_workers;
+ max_parallel_maintenance_workers
+---------------------------------------------------------------------
+ 4
+(1 row)
+
+RESET max_parallel_maintenance_workers;
+DROP TABLE guc_restore_test;
 CREATE TABLE pending_index_scan(i INT UNIQUE) USING columnar;
 BEGIN;
   INSERT INTO pending_index_scan SELECT generate_series(1,100);

--- a/src/test/regress/sql/columnar_indexes.sql
+++ b/src/test/regress/sql/columnar_indexes.sql
@@ -434,6 +434,41 @@ BEGIN;
   create index on events (event_id);
 COMMIT;
 
+-- Same scenario as the "events" test above, but exercising REINDEX instead
+-- of CREATE INDEX.  REINDEX on a columnar table must also fall back to a
+-- serial index build: otherwise flushing the pending writes during the
+-- (parallel) reindex would try to update the stripe reservation entry and
+-- error out with "cannot update tuples during a parallel operation".
+create table reindex_events (event_id bigserial, event_time timestamptz default now(), payload text) using columnar;
+-- build the index up front, without any pending writes
+create index on reindex_events (event_id);
+BEGIN;
+  -- this wouldn't flush any data
+  insert into reindex_events (payload) select 'hello-'||s from generate_series(1, 10) s;
+
+  SET LOCAL debug_parallel_query = regress;
+  SET LOCAL min_parallel_table_scan_size = 1;
+  SET LOCAL parallel_tuple_cost = 0;
+  SET LOCAL max_parallel_workers = 4;
+  SET LOCAL max_parallel_workers_per_gather = 4;
+  REINDEX TABLE reindex_events;
+COMMIT;
+DROP TABLE reindex_events;
+
+-- Show that the transient max_parallel_maintenance_workers override that we
+-- apply while building/reindexing an index on a columnar table is properly
+-- restored to the user-set value afterwards (both for CREATE INDEX and
+-- REINDEX).
+SET max_parallel_maintenance_workers = 4;
+CREATE TABLE guc_restore_test(a int) USING columnar;
+INSERT INTO guc_restore_test SELECT i FROM generate_series(1,10) i;
+CREATE INDEX ON guc_restore_test (a);
+SHOW max_parallel_maintenance_workers;
+REINDEX TABLE guc_restore_test;
+SHOW max_parallel_maintenance_workers;
+RESET max_parallel_maintenance_workers;
+DROP TABLE guc_restore_test;
+
 CREATE TABLE pending_index_scan(i INT UNIQUE) USING columnar;
 BEGIN;
   INSERT INTO pending_index_scan SELECT generate_series(1,100);


### PR DESCRIPTION
Stacked PR (PR3 of the PG19 stack). **Base = `pg19-runtime-fixes` (#8617)** → `pg19-ci-test-matrices` (#8616) → `pg19-ruleutils-port` (#8602) → `pg19-support`. Review/merge in stack order.

PG19 enables parallel `CREATE INDEX` by default (`max_parallel_maintenance_workers` defaults to 2). Columnar's TableAM is always serial — `rs_parallel` is stored but never read, and the build path flushes pending writes, which is disallowed inside a parallel operation. This caused `CREATE INDEX` on columnar tables to fail on PG19.

Three changes (all in `columnar_tableam.c`):

1. **`parallelscan_estimate`/`initialize`/`reinitialize`** now delegate to the `table_block_*` helpers, so callers that unconditionally size and initialize a `ParallelTableScanDesc` (e.g. PG19's parallel btree build) no longer abort. Columnar ignores the descriptor, so the written state is simply unused.
2. **`columnar_index_build_range_scan`** accepts a parallel scan descriptor by discarding it (`scan = NULL`) and running the serial path.
3. **`ColumnarProcessUtility`** forces `max_parallel_maintenance_workers=0` (via `NewGUCNestLevel`/`AtEOXact_GUC` around `PrevProcessUtilityHook`) for `CREATE INDEX` on a columnar AM relation, so the build runs serially.

Closes #8611
Part of #8597