### PR TITLE
Add citus_internal.distribute_object repair UDF

### DIFF
--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -115,6 +115,7 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+
 /*
  * EnsureObjectAndDependenciesExistOnAllNodes is a wrapper around
  * EnsureRequiredObjectSetExistOnAllNodes to ensure the "object itself" (together

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -52,8 +52,8 @@ static void EnsureRequiredObjectSetExistOnAllNodes(const ObjectAddress *target,
 static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target,
 										 bool forceRecreate);
 static char * ObjectExistsOnNodeCommand(const ObjectAddress *target);
-static bool RemoteObjectExists(MultiConnection *connection,
-							   const char *existenceCheckCommand);
+static bool RemoteCommandReturnsRow(MultiConnection *connection,
+									const char *command);
 static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 static bool ShouldPropagateObject(const ObjectAddress *address);
 static char * DropTableIfExistsCommand(Oid relationId);
@@ -227,7 +227,7 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
 										  CitusExtensionOwnerName(), NULL);
 
-		if (forceRecreate || !RemoteObjectExists(connection, existenceCheckCommand))
+		if (forceRecreate || !RemoteCommandReturnsRow(connection, existenceCheckCommand))
 		{
 			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
 																	ddlCommands);
@@ -293,18 +293,18 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
 
 
 /*
- * RemoteObjectExists executes the given existence-check command --built by
- * ObjectExistsOnNodeCommand()-- over the provided connection and returns whether
- * the object exists on the remote node.
+ * RemoteCommandReturnsRow executes the given command over the provided
+ * connection and returns whether it produced at least one row.
  *
- * pg_get_object_address() resolves the object by name and raises an error when
- * it cannot find it. We treat such a statement-level error as "the object does
- * not exist on this node" and only surface connection-level failures as errors.
+ * A statement-level error --for example when the command references an object
+ * that does not exist on the node-- is treated as "no rows returned", so callers
+ * can use this to probe for existence without the command aborting on their
+ * behalf. Only connection-level failures are surfaced as errors.
  */
 static bool
-RemoteObjectExists(MultiConnection *connection, const char *existenceCheckCommand)
+RemoteCommandReturnsRow(MultiConnection *connection, const char *command)
 {
-	int querySent = SendRemoteCommand(connection, existenceCheckCommand);
+	int querySent = SendRemoteCommand(connection, command);
 	if (querySent == 0)
 	{
 		ReportConnectionError(connection, ERROR);
@@ -313,27 +313,27 @@ RemoteObjectExists(MultiConnection *connection, const char *existenceCheckComman
 	bool raiseInterrupts = true;
 	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 
-	bool objectExists = false;
+	bool returnedRow = false;
 	if (IsResponseOK(result))
 	{
-		objectExists = PQntuples(result) > 0;
+		returnedRow = PQntuples(result) > 0;
 	}
 	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
 	{
-		/* we lost the connection while probing, so error out after cleanup */
+		/* we lost the connection while running the command, so error out */
 		PQclear(result);
 		ForgetResults(connection);
 		ReportConnectionError(connection, ERROR);
 	}
 
 	/*
-	 * Otherwise pg_get_object_address() could not resolve the object by name,
-	 * which we interpret as the object being absent on this node.
+	 * Otherwise the command raised a statement-level error, which we treat as
+	 * "no rows returned" so that an existence probe reports the object as absent.
 	 */
 	PQclear(result);
 	ForgetResults(connection);
 
-	return objectExists;
+	return returnedRow;
 }
 
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -10,6 +10,7 @@
 
 #include "postgres.h"
 
+#include "fmgr.h"
 #include "miscadmin.h"
 
 #include "catalog/dependency.h"
@@ -24,7 +25,9 @@
 #include "distributed/listutils.h"
 #include "distributed/metadata/dependency.h"
 #include "distributed/metadata/distobject.h"
+#include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
+#include "distributed/metadata_utility.h"
 #include "distributed/multi_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h"
@@ -44,9 +47,70 @@ static int ObjectAddressComparator(const void *a, const void *b);
 static void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
 static void EnsureRequiredObjectSetExistOnAllNodes(const ObjectAddress *target,
 												   RequiredObjectSet requiredObjectSet);
+static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target);
 static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 static bool ShouldPropagateObject(const ObjectAddress *address);
 static char * DropTableIfExistsCommand(Oid relationId);
+
+PG_FUNCTION_INFO_V1(citus_internal_distribute_object);
+
+/*
+ * citus_internal_distribute_object recreates a single object on all worker nodes
+ * and records it in pg_dist_object on the coordinator and all worker nodes, in an
+ * idempotent manner.
+ *
+ * It is a superuser-only repair tool that is meant to be used when an object that
+ * should have been distributed was not, e.g., due to a bug. Once such an object is
+ * identified, this function can be used to create it as a distributed object across
+ * the cluster.
+ *
+ * Different than the regular object propagation path, this function deliberately
+ * ignores the dependencies of the given object: it only executes the DDL commands
+ * that Citus would use to (re)create the object itself on another node. The caller
+ * is responsible for making sure that the dependencies of the object already exist
+ * on all nodes.
+ */
+Datum
+citus_internal_distribute_object(PG_FUNCTION_ARGS)
+{
+	CheckCitusVersion(ERROR);
+	EnsureCoordinator();
+	EnsureSuperUser();
+
+	Oid classId = PG_GETARG_OID(0);
+	Oid objectId = PG_GETARG_OID(1);
+
+	ObjectAddress *objectAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*objectAddress, classId, objectId);
+
+	/*
+	 * The object must exist on the local node so that we can generate the DDL
+	 * commands to (re)create it on the other nodes.
+	 */
+	if (!ObjectExists(objectAddress))
+	{
+		ereport(ERROR, (errmsg("object with classid %u and objid %u does not exist "
+							   "on the local node", classId, objectId)));
+	}
+
+	/*
+	 * Make sure that Citus knows how to (re)create the object on the other nodes
+	 * before attempting to do so. Otherwise, GetDependencyCreateDDLCommands would
+	 * fail with a hard error for an unsupported object type.
+	 */
+	if (!SupportedDependencyByCitus(objectAddress))
+	{
+		char *objectIdentity =
+			getObjectIdentity(objectAddress, /* missingOk: */ false);
+		ereport(ERROR, (errmsg("cannot distribute object \"%s\"", objectIdentity),
+						errdetail("Citus does not support distributing objects of "
+								  "this type.")));
+	}
+
+	EnsureObjectExistsOnAllNodes(objectAddress);
+
+	PG_RETURN_VOID();
+}
 
 /*
  * EnsureObjectAndDependenciesExistOnAllNodes is a wrapper around
@@ -85,6 +149,70 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
 		return;
 	}
 	EnsureRequiredObjectSetExistOnAllNodes(target, REQUIRE_OBJECT_AND_DEPENDENCIES);
+}
+
+
+/*
+ * EnsureObjectExistsOnAllNodes creates the given object --but not its
+ * dependencies-- on all worker nodes in an idempotent manner and records it in
+ * pg_dist_object on the coordinator and all worker nodes.
+ *
+ * This is a focused variant of EnsureRequiredObjectSetExistOnAllNodes that
+ * deliberately skips all dependency handling; it only (re)creates the object
+ * itself. It is intended to repair objects that should be distributed but are
+ * not, hence it always records the object in pg_dist_object even if there are
+ * no DDL commands to execute on the workers.
+ *
+ * The objects are created via a separate session that is committed directly so
+ * that they are visible to the (current transaction's) metadata connection when
+ * we mark the object distributed below.
+ */
+static void
+EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
+{
+	List *ddlCommands = GetDependencyCreateDDLCommands(target);
+
+	/*
+	 * Make sure that no new nodes are added after this point until the end of the
+	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
+	 * the ExclusiveLock taken by citus_add_node.
+	 * This guarantees that all active nodes will have the object, because they
+	 * will either get it now, or get it in citus_add_node after this transaction
+	 * finishes and the pg_dist_object record becomes visible.
+	 */
+	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
+
+	/*
+	 * Lock the object to be created explicitly to make sure that the same DDL
+	 * command won't be sent multiple times from parallel sessions.
+	 */
+	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
+					   ExclusiveLock);
+
+	if (list_length(ddlCommands) > 0)
+	{
+		/* since we are executing ddl commands, disable propagation, primarily for mx */
+		ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
+
+		WorkerNode *workerNode = NULL;
+		foreach_declared_ptr(workerNode, remoteNodeList)
+		{
+			const char *nodeName = workerNode->workerName;
+			uint32 nodePort = workerNode->workerPort;
+
+			SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
+													  CitusExtensionOwnerName(),
+													  ddlCommands);
+		}
+	}
+
+	/*
+	 * We mark the object distributed after creating it on the remote nodes so
+	 * that MarkObjectDistributedViaSuperUser wouldn't fail. The pg_dist_object
+	 * record is inserted in an idempotent manner (ON CONFLICT DO NOTHING) both on
+	 * the coordinator and on all worker nodes.
+	 */
+	MarkObjectDistributedViaSuperUser(target);
 }
 
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -38,13 +38,6 @@
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
 
-/*
- * Savepoint name used to probe whether an object exists on a remote node without
- * letting a "does not exist" statement-level error abort the surrounding
- * transaction. See RemoteObjectExists().
- */
-#define OBJECT_EXISTENCE_SAVEPOINT_NAME "citus_distribute_object_existence_check"
-
 typedef enum RequiredObjectSet
 {
 	REQUIRE_ONLY_DEPENDENCIES = 1,
@@ -279,9 +272,12 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 
 
 /*
- * ObjectExistsOnNodeCommand returns a query that returns a single row when the
- * given object exists on the node it is executed on, and raises an error
- * otherwise.
+ * ObjectExistsOnNodeCommand returns a query that returns a single boolean row
+ * indicating whether the given object exists on the node it is executed on.
+ *
+ * The probe goes through citus_internal.object_exists(), which traps the error
+ * that pg_get_object_address() would otherwise raise for a missing object, so
+ * the command never errors and is safe to run over a transactional connection.
  *
  * The object is identified by its name --object type, names and args, the same
  * representation that pg_identify_object_as_address() produces-- rather than by
@@ -299,10 +295,8 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
 
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT 1 FROM pg_catalog.pg_get_object_address(%s, ",
+					 "SELECT citus_internal.object_exists(%s, ARRAY[",
 					 quote_literal_cstr(objectType));
-
-	appendStringInfoString(command, "ARRAY[");
 
 	char *objectName = NULL;
 	bool firstName = true;
@@ -335,19 +329,12 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
  * ObjectExistsOnNodeCommand()-- over the provided connection and returns whether
  * the object exists on the remote node.
  *
- * pg_get_object_address() resolves the object by name and raises an error when
- * it cannot find it. Since the connection participates in our coordinated
- * transaction, we run the probe inside a savepoint and roll back to it on a
- * statement-level error so that the surrounding remote transaction stays usable.
- * We treat such an error as "the object does not exist on this node" and only
- * surface connection-level failures as errors.
+ * The command returns a single boolean row and never raises for a missing
+ * object, so we only surface genuine query/connection failures as errors.
  */
 static bool
 RemoteObjectExists(MultiConnection *connection, const char *existenceCheckCommand)
 {
-	ExecuteCriticalRemoteCommand(connection,
-								 "SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
-
 	int querySent = SendRemoteCommand(connection, existenceCheckCommand);
 	if (querySent == 0)
 	{
@@ -356,39 +343,20 @@ RemoteObjectExists(MultiConnection *connection, const char *existenceCheckComman
 
 	bool raiseInterrupts = true;
 	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
+	if (!IsResponseOK(result))
+	{
+		ReportResultError(connection, result, ERROR);
+	}
 
 	bool objectExists = false;
-	if (IsResponseOK(result))
+	if (PQntuples(result) == 1 && PQnfields(result) == 1 &&
+		!PQgetisnull(result, 0, 0))
 	{
-		objectExists = PQntuples(result) > 0;
-
-		PQclear(result);
-		ForgetResults(connection);
-
-		ExecuteCriticalRemoteCommand(connection,
-									 "RELEASE SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
-
-		return objectExists;
+		objectExists = (strcmp(PQgetvalue(result, 0, 0), "t") == 0);
 	}
 
-	if (PQstatus(connection->pgConn) != CONNECTION_OK)
-	{
-		/* we lost the connection while probing, so error out after cleanup */
-		PQclear(result);
-		ForgetResults(connection);
-		ReportConnectionError(connection, ERROR);
-	}
-
-	/*
-	 * Otherwise pg_get_object_address() could not resolve the object by name,
-	 * which we interpret as the object being absent on this node. Roll back to
-	 * the savepoint so that the remote transaction stays usable.
-	 */
 	PQclear(result);
 	ForgetResults(connection);
-
-	ExecuteCriticalRemoteCommand(connection,
-								 "ROLLBACK TO SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
 
 	return objectExists;
 }

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -49,7 +49,8 @@ static int ObjectAddressComparator(const void *a, const void *b);
 static void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
 static void EnsureRequiredObjectSetExistOnAllNodes(const ObjectAddress *target,
 												   RequiredObjectSet requiredObjectSet);
-static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target);
+static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target,
+										 bool forceRecreate);
 static char * ObjectExistsOnNodeCommand(const ObjectAddress *target);
 static bool RemoteObjectExists(MultiConnection *connection,
 							   const char *existenceCheckCommand);
@@ -66,6 +67,9 @@ PG_FUNCTION_INFO_V1(citus_internal_distribute_object);
  * Different than the regular object propagation path, this function deliberately
  * ignores the dependencies of the given object: it only executes the DDL commands
  * that Citus would use to (re)create the object itself on another node.
+ *
+ * By default a node is skipped if it already has the object; pass
+ * force_recreate => true to (re)apply the DDL on every node regardless.
  */
 Datum
 citus_internal_distribute_object(PG_FUNCTION_ARGS)
@@ -76,6 +80,7 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 
 	Oid classId = PG_GETARG_OID(0);
 	Oid objectId = PG_GETARG_OID(1);
+	bool forceRecreate = PG_GETARG_BOOL(2);
 
 	ObjectAddress *objectAddress = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*objectAddress, classId, objectId);
@@ -105,7 +110,7 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 								  "this type.")));
 	}
 
-	EnsureObjectExistsOnAllNodes(objectAddress);
+	EnsureObjectExistsOnAllNodes(objectAddress, forceRecreate);
 
 	PG_RETURN_VOID();
 }
@@ -160,7 +165,10 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
  * only (re)create it on the nodes that are missing it. This way we never hand a
  * "create or replace" style command to a node that already has the object,
  * which --for some object classes-- would otherwise rename the existing object
- * out of the way before recreating it.
+ * out of the way before recreating it. The caller can pass forceRecreate to
+ * skip the per-node existence check and always (re)apply the DDL, which is
+ * useful to sync drift --e.g. role grants/options that were never propagated--
+ * onto nodes that already have the object.
  *
  * We deliberately accept the small TOCTOU window where the object might be
  * created by someone else between our existence check and our own creation
@@ -172,7 +180,7 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
  * mark the object distributed below.
  */
 static void
-EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
+EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 {
 	List *ddlCommands = GetDependencyCreateDDLCommands(target);
 
@@ -191,7 +199,8 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 	 * on a node once, before the loop, so that we deparse the object identity
 	 * only a single time.
 	 */
-	char *existenceCheckCommand = ObjectExistsOnNodeCommand(target);
+	char *existenceCheckCommand =
+		forceRecreate ? NULL : ObjectExistsOnNodeCommand(target);
 
 	/*
 	 * Make sure that no new nodes are added after this point until the end of the
@@ -218,7 +227,7 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
 										  CitusExtensionOwnerName(), NULL);
 
-		if (!RemoteObjectExists(connection, existenceCheckCommand))
+		if (forceRecreate || !RemoteObjectExists(connection, existenceCheckCommand))
 		{
 			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
 																	ddlCommands);

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -161,21 +161,6 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
  * dependencies-- on the worker nodes that are missing it and records it in
  * pg_dist_object on all nodes.
  *
- * For each remote node, we first check whether the object already exists there
- * --resolved by name, so that OID differences between nodes don't matter-- and
- * only (re)create it on the nodes that are missing it. This way we never hand a
- * "create or replace" style command to a node that already has the object,
- * which --for some object classes-- would otherwise rename the existing object
- * out of the way before recreating it. The caller can pass forceRecreate to
- * skip the per-node existence check and always (re)apply the DDL, which is
- * useful to sync drift --e.g. role grants/options that were never propagated--
- * onto nodes that already have the object.
- *
- * We deliberately accept the small TOCTOU window where the object might be
- * created by someone else between our existence check and our own creation
- * attempt: the worst case is that the create command fails loudly, which is
- * acceptable for a superuser-only repair UDF.
- *
  * The object is created via a separate session that is committed directly so
  * that it is visible to the (current transaction's) metadata connection when we
  * mark the object distributed below.

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -16,7 +16,9 @@
 #include "catalog/dependency.h"
 #include "catalog/objectaddress.h"
 #include "commands/extension.h"
+#include "lib/stringinfo.h"
 #include "storage/lmgr.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
 #include "distributed/commands.h"
@@ -48,6 +50,9 @@ static void EnsureDependenciesExistOnAllNodes(const ObjectAddress *target);
 static void EnsureRequiredObjectSetExistOnAllNodes(const ObjectAddress *target,
 												   RequiredObjectSet requiredObjectSet);
 static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target);
+static char * ObjectExistsOnNodeCommand(const ObjectAddress *target);
+static bool RemoteObjectExists(MultiConnection *connection,
+							   const char *existenceCheckCommand);
 static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 static bool ShouldPropagateObject(const ObjectAddress *address);
 static char * DropTableIfExistsCommand(Oid relationId);
@@ -82,7 +87,7 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	if (!ObjectExists(objectAddress))
 	{
 		ereport(ERROR, (errmsg("object with classid %u and objid %u does not exist "
-							   "on the coordinator", classId, objectId)));
+							   "on the local node", classId, objectId)));
 	}
 
 	/*
@@ -147,33 +152,29 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
 
 /*
  * EnsureObjectExistsOnAllNodes creates the given object --but not its
- * dependencies-- on all worker nodes in an idempotent manner and records it in
+ * dependencies-- on the worker nodes that are missing it and records it in
  * pg_dist_object on all nodes.
  *
- * This only (re)creates the object itself.
+ * For each remote node, we first check whether the object already exists there
+ * --resolved by name, so that OID differences between nodes don't matter-- and
+ * only (re)create it on the nodes that are missing it. This way we never hand a
+ * "create or replace" style command to a node that already has the object,
+ * which --for some object classes-- would otherwise rename the existing object
+ * out of the way before recreating it.
  *
- * The objects are created via a separate session that is committed directly so
- * that they are visible to the (current transaction's) metadata connection when
- * we mark the object distributed below.
+ * We deliberately accept the small TOCTOU window where the object might be
+ * created by someone else between our existence check and our own creation
+ * attempt: the worst case is that the create command fails loudly, which is
+ * acceptable for a superuser-only repair UDF.
+ *
+ * The object is created via a separate session that is committed directly so
+ * that it is visible to the (current transaction's) metadata connection when we
+ * mark the object distributed below.
  */
 static void
 EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 {
 	List *ddlCommands = GetDependencyCreateDDLCommands(target);
-
-	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
-	 * the ExclusiveLock taken by citus_add_node.
-	 */
-	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
-
-	/*
-	 * Lock objects to be created explicitly to make sure same DDL command won't
-	 * be sent multiple times from parallel sessions.
-	 */
-	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
-					   ExclusiveLock);
 
 	if (list_length(ddlCommands) == 0)
 	{
@@ -185,18 +186,145 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 	/* since we are executing DDL commands, disable propagation */
 	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
+	/*
+	 * Build the command that we use to check whether the object already exists
+	 * on a node once, before the loop, so that we deparse the object identity
+	 * only a single time.
+	 */
+	char *existenceCheckCommand = ObjectExistsOnNodeCommand(target);
+
+	/*
+	 * Make sure that no new nodes are added after this point until the end of the
+	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
+	 * the ExclusiveLock taken by citus_add_node.
+	 */
+	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
+
+	/*
+	 * Lock the object to be created explicitly to make sure same DDL command
+	 * won't be sent multiple times from parallel sessions.
+	 */
+	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
+					   ExclusiveLock);
+
 	WorkerNode *workerNode = NULL;
 	foreach_declared_ptr(workerNode, remoteNodeList)
 	{
 		const char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
 
-		SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
-												  CitusExtensionOwnerName(),
-												  ddlCommands);
+		int connectionFlags = FORCE_NEW_CONNECTION;
+		MultiConnection *connection =
+			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
+										  CitusExtensionOwnerName(), NULL);
+
+		if (!RemoteObjectExists(connection, existenceCheckCommand))
+		{
+			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
+																	ddlCommands);
+		}
+
+		CloseConnection(connection);
 	}
 
 	MarkObjectDistributedViaSuperUser(target);
+}
+
+
+/*
+ * ObjectExistsOnNodeCommand returns a query that returns a single row when the
+ * given object exists on the node it is executed on, and raises an error
+ * otherwise.
+ *
+ * The object is identified by its name --object type, names and args, the same
+ * representation that pg_identify_object_as_address() produces-- rather than by
+ * its OID, since OIDs are not guaranteed to match across nodes.
+ */
+static char *
+ObjectExistsOnNodeCommand(const ObjectAddress *target)
+{
+	bool missingOk = false;
+	char *objectType = getObjectTypeDescription(target, missingOk);
+
+	List *objectNames = NIL;
+	List *objectArgs = NIL;
+	getObjectIdentityParts(target, &objectNames, &objectArgs, missingOk);
+
+	StringInfo command = makeStringInfo();
+	appendStringInfo(command,
+					 "SELECT 1 FROM pg_catalog.pg_get_object_address(%s, ",
+					 quote_literal_cstr(objectType));
+
+	appendStringInfoString(command, "ARRAY[");
+
+	char *objectName = NULL;
+	bool firstName = true;
+	foreach_declared_ptr(objectName, objectNames)
+	{
+		appendStringInfo(command, "%s%s", firstName ? "" : ", ",
+						 quote_literal_cstr(objectName));
+		firstName = false;
+	}
+
+	appendStringInfoString(command, "]::text[], ARRAY[");
+
+	char *objectArg = NULL;
+	bool firstArg = true;
+	foreach_declared_ptr(objectArg, objectArgs)
+	{
+		appendStringInfo(command, "%s%s", firstArg ? "" : ", ",
+						 quote_literal_cstr(objectArg));
+		firstArg = false;
+	}
+
+	appendStringInfoString(command, "]::text[])");
+
+	return command->data;
+}
+
+
+/*
+ * RemoteObjectExists executes the given existence-check command --built by
+ * ObjectExistsOnNodeCommand()-- over the provided connection and returns whether
+ * the object exists on the remote node.
+ *
+ * pg_get_object_address() resolves the object by name and raises an error when
+ * it cannot find it. We treat such a statement-level error as "the object does
+ * not exist on this node" and only surface connection-level failures as errors.
+ */
+static bool
+RemoteObjectExists(MultiConnection *connection, const char *existenceCheckCommand)
+{
+	int querySent = SendRemoteCommand(connection, existenceCheckCommand);
+	if (querySent == 0)
+	{
+		ReportConnectionError(connection, ERROR);
+	}
+
+	bool raiseInterrupts = true;
+	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
+
+	bool objectExists = false;
+	if (IsResponseOK(result))
+	{
+		objectExists = PQntuples(result) > 0;
+	}
+	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
+	{
+		/* we lost the connection while probing, so error out after cleanup */
+		PQclear(result);
+		ForgetResults(connection);
+		ReportConnectionError(connection, ERROR);
+	}
+
+	/*
+	 * Otherwise pg_get_object_address() could not resolve the object by name,
+	 * which we interpret as the object being absent on this node.
+	 */
+	PQclear(result);
+	ForgetResults(connection);
+
+	return objectExists;
 }
 
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -56,19 +56,11 @@ PG_FUNCTION_INFO_V1(citus_internal_distribute_object);
 
 /*
  * citus_internal_distribute_object recreates a single object on all worker nodes
- * and records it in pg_dist_object on the coordinator and all worker nodes, in an
- * idempotent manner.
- *
- * It is a superuser-only repair tool that is meant to be used when an object that
- * should have been distributed was not, e.g., due to a bug. Once such an object is
- * identified, this function can be used to create it as a distributed object across
- * the cluster.
+ * and records it in pg_dist_object on all nodes.
  *
  * Different than the regular object propagation path, this function deliberately
  * ignores the dependencies of the given object: it only executes the DDL commands
- * that Citus would use to (re)create the object itself on another node. The caller
- * is responsible for making sure that the dependencies of the object already exist
- * on all nodes.
+ * that Citus would use to (re)create the object itself on another node.
  */
 Datum
 citus_internal_distribute_object(PG_FUNCTION_ARGS)
@@ -84,13 +76,13 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	ObjectAddressSet(*objectAddress, classId, objectId);
 
 	/*
-	 * The object must exist on the local node so that we can generate the DDL
+	 * The object must exist on the coordinator so that we can generate the DDL
 	 * commands to (re)create it on the other nodes.
 	 */
 	if (!ObjectExists(objectAddress))
 	{
 		ereport(ERROR, (errmsg("object with classid %u and objid %u does not exist "
-							   "on the local node", classId, objectId)));
+							   "on the coordinator", classId, objectId)));
 	}
 
 	/*
@@ -100,8 +92,9 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	 */
 	if (!SupportedDependencyByCitus(objectAddress))
 	{
+		bool missingOk = false;
 		char *objectIdentity =
-			getObjectIdentity(objectAddress, /* missingOk: */ false);
+			getObjectIdentity(objectAddress, missingOk);
 		ereport(ERROR, (errmsg("cannot distribute object \"%s\"", objectIdentity),
 						errdetail("Citus does not support distributing objects of "
 								  "this type.")));
@@ -155,13 +148,9 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
 /*
  * EnsureObjectExistsOnAllNodes creates the given object --but not its
  * dependencies-- on all worker nodes in an idempotent manner and records it in
- * pg_dist_object on the coordinator and all worker nodes.
+ * pg_dist_object on all nodes.
  *
- * This is a focused variant of EnsureRequiredObjectSetExistOnAllNodes that
- * deliberately skips all dependency handling; it only (re)creates the object
- * itself. It is intended to repair objects that should be distributed but are
- * not, hence it always records the object in pg_dist_object even if there are
- * no DDL commands to execute on the workers.
+ * This only (re)creates the object itself.
  *
  * The objects are created via a separate session that is committed directly so
  * that they are visible to the (current transaction's) metadata connection when
@@ -176,42 +165,37 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 	 * Make sure that no new nodes are added after this point until the end of the
 	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
 	 * the ExclusiveLock taken by citus_add_node.
-	 * This guarantees that all active nodes will have the object, because they
-	 * will either get it now, or get it in citus_add_node after this transaction
-	 * finishes and the pg_dist_object record becomes visible.
 	 */
 	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
 
 	/*
-	 * Lock the object to be created explicitly to make sure that the same DDL
-	 * command won't be sent multiple times from parallel sessions.
+	 * Lock objects to be created explicitly to make sure same DDL command won't
+	 * be sent multiple times from parallel sessions.
 	 */
 	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
 					   ExclusiveLock);
 
-	if (list_length(ddlCommands) > 0)
+	if (list_length(ddlCommands) == 0)
 	{
-		/* since we are executing ddl commands, disable propagation, primarily for mx */
-		ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
-
-		WorkerNode *workerNode = NULL;
-		foreach_declared_ptr(workerNode, remoteNodeList)
-		{
-			const char *nodeName = workerNode->workerName;
-			uint32 nodePort = workerNode->workerPort;
-
-			SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
-													  CitusExtensionOwnerName(),
-													  ddlCommands);
-		}
+		ereport(ERROR, (errmsg("could not generate DDL commands to create object "
+							   "with classid %u and objid %u",
+							   target->classId, target->objectId)));
 	}
+	
+	/* since we are executing DDL commands, disable propagation */
+	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
-	/*
-	 * We mark the object distributed after creating it on the remote nodes so
-	 * that MarkObjectDistributedViaSuperUser wouldn't fail. The pg_dist_object
-	 * record is inserted in an idempotent manner (ON CONFLICT DO NOTHING) both on
-	 * the coordinator and on all worker nodes.
-	 */
+	WorkerNode *workerNode = NULL;
+	foreach_declared_ptr(workerNode, remoteNodeList)
+	{
+		const char *nodeName = workerNode->workerName;
+		uint32 nodePort = workerNode->workerPort;
+
+		SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
+													CitusExtensionOwnerName(),
+													ddlCommands);
+	}
+	
 	MarkObjectDistributedViaSuperUser(target);
 }
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -181,7 +181,7 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 							   "with classid %u and objid %u",
 							   target->classId, target->objectId)));
 	}
-	
+
 	/* since we are executing DDL commands, disable propagation */
 	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
@@ -192,10 +192,10 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target)
 		uint32 nodePort = workerNode->workerPort;
 
 		SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
-													CitusExtensionOwnerName(),
-													ddlCommands);
+												  CitusExtensionOwnerName(),
+												  ddlCommands);
 	}
-	
+
 	MarkObjectDistributedViaSuperUser(target);
 }
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -13,6 +13,7 @@
 #include "fmgr.h"
 #include "miscadmin.h"
 
+#include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/objectaddress.h"
 #include "commands/extension.h"
@@ -75,21 +76,49 @@ Datum
 citus_internal_distribute_object(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
-	EnsureCoordinator();
+
+	/*
+	 * Check for superuser before anything else so that a non-superuser gets the
+	 * "must be superuser" error even when the UDF is invoked on a worker node,
+	 * where EnsureCoordinator() would otherwise fail first.
+	 */
 	EnsureSuperUser();
+	EnsureCoordinator();
+
+	/*
+	 * We create the object on the workers via a separate connection that commits
+	 * immediately, but the pg_dist_object records are written within the caller's
+	 * transaction. Disallow running inside an explicit transaction block so that
+	 * an operator-issued ROLLBACK cannot leave the cluster in a state where the
+	 * workers have the object but no node records it as distributed.
+	 */
+	PreventInTransactionBlock(true, "citus_internal.distribute_object");
+
+	/*
+	 * The pg_dist_object records are only propagated to the other nodes when
+	 * metadata syncing is enabled. Without it we would create the object on the
+	 * workers but record it only on the coordinator, so we refuse to run rather
+	 * than leave the cluster in that half-repaired state.
+	 */
+	if (!EnableMetadataSync)
+	{
+		ereport(ERROR, (errmsg("citus_internal.distribute_object requires "
+							   "citus.enable_metadata_sync to be enabled")));
+	}
 
 	Oid classId = PG_GETARG_OID(0);
 	Oid objectId = PG_GETARG_OID(1);
-	bool forceRecreate = PG_GETARG_BOOL(2);
+	int32 objectSubId = PG_GETARG_INT32(2);
+	bool forceRecreate = PG_GETARG_BOOL(3);
 
-	ObjectAddress *objectAddress = palloc0(sizeof(ObjectAddress));
-	ObjectAddressSet(*objectAddress, classId, objectId);
+	ObjectAddress objectAddress = { 0 };
+	ObjectAddressSubSet(objectAddress, classId, objectId, objectSubId);
 
 	/*
 	 * The object must exist on the coordinator so that we can generate the DDL
 	 * commands to (re)create it on the other nodes.
 	 */
-	if (!ObjectExists(objectAddress))
+	if (!ObjectExists(&objectAddress))
 	{
 		ereport(ERROR, (errmsg("object with classid %u and objid %u does not exist "
 							   "on the local node", classId, objectId)));
@@ -100,17 +129,17 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	 * before attempting to do so. Otherwise, GetDependencyCreateDDLCommands would
 	 * fail with a hard error for an unsupported object type.
 	 */
-	if (!SupportedDependencyByCitus(objectAddress))
+	if (!SupportedDependencyByCitus(&objectAddress))
 	{
 		bool missingOk = false;
 		char *objectIdentity =
-			getObjectIdentity(objectAddress, missingOk);
+			getObjectIdentity(&objectAddress, missingOk);
 		ereport(ERROR, (errmsg("cannot distribute object \"%s\"", objectIdentity),
 						errdetail("Citus does not support distributing objects of "
 								  "this type.")));
 	}
 
-	EnsureObjectExistsOnAllNodes(objectAddress, forceRecreate);
+	EnsureObjectExistsOnAllNodes(&objectAddress, forceRecreate);
 
 	PG_RETURN_VOID();
 }
@@ -172,9 +201,10 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 
 	if (list_length(ddlCommands) == 0)
 	{
-		ereport(ERROR, (errmsg("could not generate DDL commands to create object "
-							   "with classid %u and objid %u",
-							   target->classId, target->objectId)));
+		bool missingOk = false;
+		char *objectIdentity = getObjectIdentity(target, missingOk);
+		ereport(ERROR, (errmsg("could not generate DDL commands to create "
+							   "object \"%s\"", objectIdentity)));
 	}
 
 	/* since we are executing DDL commands, disable propagation */
@@ -214,6 +244,11 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 			SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
 													  CitusExtensionOwnerName(),
 													  ddlCommands);
+		}
+		else
+		{
+			ereport(NOTICE, (errmsg("object already exists on node %s:%d, skipping "
+									"its (re)creation", nodeName, nodePort)));
 		}
 	}
 
@@ -274,23 +309,26 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
 
 
 /*
- * RemoteCommandOnNodeReturnsRow opens an outside-transaction connection to
- * the node identified by nodeName and nodePort, executes the given command
+ * RemoteCommandOnNodeReturnsRow opens a dedicated outside-transaction connection
+ * to the node identified by nodeName and nodePort, executes the given command
  * over it, and returns whether the command produced at least one row.
  *
- * Since the connection is opened with the OUTSIDE_TRANSACTION flag, a
- * statement-level error raised by the command is reported as "no rows returned"
- * and never rolls back the caller's transaction. Only connection-level failures
- * are surfaced as errors.
+ * The connection is opened with OUTSIDE_TRANSACTION | FORCE_NEW_CONNECTION and is
+ * claimed exclusively so that GetNodeUserDatabaseConnection() cannot hand us a
+ * connection that is (or later becomes) part of the caller's coordinated
+ * transaction. This guarantees that a statement-level error raised by the command
+ * -- which we report as "no rows returned" -- never rolls back the caller's
+ * transaction. Only connection-level failures are surfaced as errors.
  */
 static bool
 RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
 							  const char *command)
 {
-	int connectionFlags = OUTSIDE_TRANSACTION;
+	int connectionFlags = OUTSIDE_TRANSACTION | FORCE_NEW_CONNECTION;
 	MultiConnection *connection =
 		GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
 									  CitusExtensionOwnerName(), NULL);
+	ClaimConnectionExclusively(connection);
 
 	int querySent = SendRemoteCommand(connection, command);
 	if (querySent == 0)
@@ -311,6 +349,7 @@ RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
 		/* we lost the connection while running the command, so error out */
 		PQclear(result);
 		ForgetResults(connection);
+		UnclaimConnection(connection);
 		ReportConnectionError(connection, ERROR);
 	}
 
@@ -320,6 +359,7 @@ RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
 	 */
 	PQclear(result);
 	ForgetResults(connection);
+	UnclaimConnection(connection);
 
 	return returnedRow;
 }

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -33,8 +33,6 @@
 #include "distributed/multi_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h"
-#include "distributed/remote_transaction.h"
-#include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
 
@@ -177,13 +175,9 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
  * attempt: the worst case is that the create command fails loudly, which is
  * acceptable for a superuser-only repair UDF.
  *
- * Everything happens within a single coordinated, 2PC transaction: the object
- * creation on the remote nodes and the pg_dist_object records that
- * MarkObjectDistributedViaSuperUser() adds below are committed --or rolled
- * back-- atomically. We do this over the metadata connection to each node and
- * MarkObjectDistributedViaSuperUser() reuses the very same connection, so the
- * freshly created --but not yet committed-- object is visible to the
- * pg_dist_object insert that follows.
+ * The object is created via a separate session that is committed directly so
+ * that it is visible to the (current transaction's) metadata connection when we
+ * mark the object distributed below.
  */
 static void
 EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
@@ -197,7 +191,7 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 							   target->classId, target->objectId)));
 	}
 
-	/* since we are executing DDL commands, disable propagation on the remote node */
+	/* since we are executing DDL commands, disable propagation */
 	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
 	/*
@@ -209,24 +203,11 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 		forceRecreate ? NULL : ObjectExistsOnNodeCommand(target);
 
 	/*
-	 * Do everything within a single coordinated, 2PC transaction so that the
-	 * object creation on the remote nodes and the pg_dist_object records added
-	 * by MarkObjectDistributedViaSuperUser() below are committed atomically.
+	 * Make sure that no new nodes are added after this point until the end of the
+	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
+	 * the ExclusiveLock taken by citus_add_node.
 	 */
-	UseCoordinatedTransaction();
-	Use2PCForCoordinatedTransaction();
-
-	/*
-	 * We target the metadata nodes --and reuse the metadata connection to each
-	 * of them-- so that the same session that creates the object also inserts
-	 * the pg_dist_object record below; otherwise the not-yet-committed object
-	 * wouldn't be visible to the metadata insert.
-	 *
-	 * Taking a RowShareLock on pg_dist_node makes sure that no new node is added
-	 * concurrently until the end of the transaction, as it conflicts with the
-	 * ExclusiveLock taken by citus_add_node.
-	 */
-	List *remoteNodeList = TargetWorkerSetNodeList(REMOTE_METADATA_NODES, RowShareLock);
+	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
 
 	/*
 	 * Lock the object to be created explicitly to make sure same DDL command
@@ -235,36 +216,24 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
 					   ExclusiveLock);
 
-	List *connectionList = NIL;
 	WorkerNode *workerNode = NULL;
 	foreach_declared_ptr(workerNode, remoteNodeList)
 	{
-		int connectionFlags = REQUIRE_METADATA_CONNECTION;
+		const char *nodeName = workerNode->workerName;
+		uint32 nodePort = workerNode->workerPort;
+
+		int connectionFlags = FORCE_NEW_CONNECTION;
 		MultiConnection *connection =
-			StartNodeUserDatabaseConnection(connectionFlags, workerNode->workerName,
-											workerNode->workerPort,
-											CitusExtensionOwnerName(), NULL);
-		MarkRemoteTransactionCritical(connection);
-		connectionList = lappend(connectionList, connection);
-	}
+			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
+										  CitusExtensionOwnerName(), NULL);
 
-	FinishConnectionListEstablishment(connectionList);
-	RemoteTransactionsBeginIfNecessary(connectionList);
-
-	MultiConnection *connection = NULL;
-	foreach_declared_ptr(connection, connectionList)
-	{
-		if (!forceRecreate && RemoteObjectExists(connection, existenceCheckCommand))
+		if (forceRecreate || !RemoteObjectExists(connection, existenceCheckCommand))
 		{
-			/* the node already has the object, leave it untouched */
-			continue;
+			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
+																	ddlCommands);
 		}
 
-		char *command = NULL;
-		foreach_declared_ptr(command, ddlCommands)
-		{
-			ExecuteCriticalRemoteCommand(connection, command);
-		}
+		CloseConnection(connection);
 	}
 
 	MarkObjectDistributedViaSuperUser(target);
@@ -272,12 +241,9 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 
 
 /*
- * ObjectExistsOnNodeCommand returns a query that returns a single boolean row
- * indicating whether the given object exists on the node it is executed on.
- *
- * The probe goes through citus_internal.object_exists(), which traps the error
- * that pg_get_object_address() would otherwise raise for a missing object, so
- * the command never errors and is safe to run over a transactional connection.
+ * ObjectExistsOnNodeCommand returns a query that returns a single row when the
+ * given object exists on the node it is executed on, and raises an error
+ * otherwise.
  *
  * The object is identified by its name --object type, names and args, the same
  * representation that pg_identify_object_as_address() produces-- rather than by
@@ -295,8 +261,10 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
 
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.object_exists(%s, ARRAY[",
+					 "SELECT 1 FROM pg_catalog.pg_get_object_address(%s, ",
 					 quote_literal_cstr(objectType));
+
+	appendStringInfoString(command, "ARRAY[");
 
 	char *objectName = NULL;
 	bool firstName = true;
@@ -329,8 +297,9 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
  * ObjectExistsOnNodeCommand()-- over the provided connection and returns whether
  * the object exists on the remote node.
  *
- * The command returns a single boolean row and never raises for a missing
- * object, so we only surface genuine query/connection failures as errors.
+ * pg_get_object_address() resolves the object by name and raises an error when
+ * it cannot find it. We treat such a statement-level error as "the object does
+ * not exist on this node" and only surface connection-level failures as errors.
  */
 static bool
 RemoteObjectExists(MultiConnection *connection, const char *existenceCheckCommand)
@@ -343,18 +312,24 @@ RemoteObjectExists(MultiConnection *connection, const char *existenceCheckComman
 
 	bool raiseInterrupts = true;
 	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
-	if (!IsResponseOK(result))
-	{
-		ReportResultError(connection, result, ERROR);
-	}
 
 	bool objectExists = false;
-	if (PQntuples(result) == 1 && PQnfields(result) == 1 &&
-		!PQgetisnull(result, 0, 0))
+	if (IsResponseOK(result))
 	{
-		objectExists = (strcmp(PQgetvalue(result, 0, 0), "t") == 0);
+		objectExists = PQntuples(result) > 0;
+	}
+	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
+	{
+		/* we lost the connection while probing, so error out after cleanup */
+		PQclear(result);
+		ForgetResults(connection);
+		ReportConnectionError(connection, ERROR);
 	}
 
+	/*
+	 * Otherwise pg_get_object_address() could not resolve the object by name,
+	 * which we interpret as the object being absent on this node.
+	 */
 	PQclear(result);
 	ForgetResults(connection);
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -316,13 +316,23 @@ RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
 	bool raiseInterrupts = true;
 	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 
-	if (!IsResponseOK(result))
+	bool returnedRow = false;
+	if (IsResponseOK(result))
 	{
-		ReportResultError(connection, result, ERROR);
+		returnedRow = PQntuples(result) > 0;
+	}
+	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
+	{
+		/* we lost the connection while running the command, so error out */
+		PQclear(result);
+		ForgetResults(connection);
+		ReportConnectionError(connection, ERROR);
 	}
 
-	bool returnedRow = PQntuples(result) > 0;
-
+	/*
+	 * Otherwise the command raised a statement-level error, which we treat as
+	 * "no rows returned" so that an existence probe reports the object as absent.
+	 */
 	PQclear(result);
 	ForgetResults(connection);
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -98,7 +98,9 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 	if (!EnableMetadataSync)
 	{
 		ereport(ERROR, (errmsg("citus_internal.distribute_object requires "
-							   "citus.enable_metadata_sync to be enabled")));
+							   "citus.enable_metadata_sync to be enabled"),
+						errhint("Run \"SET citus.enable_metadata_sync TO on\" "
+								"before calling this function.")));
 	}
 
 	Oid classId = PG_GETARG_OID(0);

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -52,8 +52,8 @@ static void EnsureRequiredObjectSetExistOnAllNodes(const ObjectAddress *target,
 static void EnsureObjectExistsOnAllNodes(const ObjectAddress *target,
 										 bool forceRecreate);
 static char * ObjectExistsOnNodeCommand(const ObjectAddress *target);
-static bool RemoteCommandReturnsRow(MultiConnection *connection,
-									const char *command);
+static bool RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
+										  const char *command);
 static List * GetDependencyCreateDDLCommands(const ObjectAddress *dependency);
 static bool ShouldPropagateObject(const ObjectAddress *address);
 static char * DropTableIfExistsCommand(Oid relationId);
@@ -222,18 +222,13 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 		const char *nodeName = workerNode->workerName;
 		uint32 nodePort = workerNode->workerPort;
 
-		int connectionFlags = FORCE_NEW_CONNECTION;
-		MultiConnection *connection =
-			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-										  CitusExtensionOwnerName(), NULL);
-
-		if (forceRecreate || !RemoteCommandReturnsRow(connection, existenceCheckCommand))
+		if (forceRecreate ||
+			!RemoteCommandOnNodeReturnsRow(nodeName, nodePort, existenceCheckCommand))
 		{
-			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
-																	ddlCommands);
+			SendCommandListToWorkerOutsideTransaction(nodeName, nodePort,
+													  CitusExtensionOwnerName(),
+													  ddlCommands);
 		}
-
-		CloseConnection(connection);
 	}
 
 	MarkObjectDistributedViaSuperUser(target);
@@ -293,17 +288,24 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
 
 
 /*
- * RemoteCommandReturnsRow executes the given command over the provided
- * connection and returns whether it produced at least one row.
+ * RemoteCommandOnNodeReturnsRow opens an outside-transaction connection to
+ * the node identified by nodeName and nodePort, executes the given command
+ * over it, and returns whether the command produced at least one row.
  *
- * A statement-level error --for example when the command references an object
- * that does not exist on the node-- is treated as "no rows returned", so callers
- * can use this to probe for existence without the command aborting on their
- * behalf. Only connection-level failures are surfaced as errors.
+ * Since the connection is opened with the OUTSIDE_TRANSACTION flag, a
+ * statement-level error raised by the command is reported as "no rows returned"
+ * and never rolls back the caller's transaction. Only connection-level failures
+ * are surfaced as errors.
  */
 static bool
-RemoteCommandReturnsRow(MultiConnection *connection, const char *command)
+RemoteCommandOnNodeReturnsRow(const char *nodeName, uint32 nodePort,
+							  const char *command)
 {
+	int connectionFlags = OUTSIDE_TRANSACTION;
+	MultiConnection *connection =
+		GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
+									  CitusExtensionOwnerName(), NULL);
+
 	int querySent = SendRemoteCommand(connection, command);
 	if (querySent == 0)
 	{
@@ -313,23 +315,13 @@ RemoteCommandReturnsRow(MultiConnection *connection, const char *command)
 	bool raiseInterrupts = true;
 	PGresult *result = GetRemoteCommandResult(connection, raiseInterrupts);
 
-	bool returnedRow = false;
-	if (IsResponseOK(result))
+	if (!IsResponseOK(result))
 	{
-		returnedRow = PQntuples(result) > 0;
-	}
-	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
-	{
-		/* we lost the connection while running the command, so error out */
-		PQclear(result);
-		ForgetResults(connection);
-		ReportConnectionError(connection, ERROR);
+		ReportResultError(connection, result, ERROR);
 	}
 
-	/*
-	 * Otherwise the command raised a statement-level error, which we treat as
-	 * "no rows returned" so that an existence probe reports the object as absent.
-	 */
+	bool returnedRow = PQntuples(result) > 0;
+
 	PQclear(result);
 	ForgetResults(connection);
 

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -33,8 +33,17 @@
 #include "distributed/multi_executor.h"
 #include "distributed/relation_access_tracking.h"
 #include "distributed/remote_commands.h"
+#include "distributed/remote_transaction.h"
+#include "distributed/transaction_management.h"
 #include "distributed/worker_manager.h"
 #include "distributed/worker_transaction.h"
+
+/*
+ * Savepoint name used to probe whether an object exists on a remote node without
+ * letting a "does not exist" statement-level error abort the surrounding
+ * transaction. See RemoteObjectExists().
+ */
+#define OBJECT_EXISTENCE_SAVEPOINT_NAME "citus_distribute_object_existence_check"
 
 typedef enum RequiredObjectSet
 {
@@ -175,9 +184,13 @@ EnsureObjectAndDependenciesExistOnAllNodes(const ObjectAddress *target)
  * attempt: the worst case is that the create command fails loudly, which is
  * acceptable for a superuser-only repair UDF.
  *
- * The object is created via a separate session that is committed directly so
- * that it is visible to the (current transaction's) metadata connection when we
- * mark the object distributed below.
+ * Everything happens within a single coordinated, 2PC transaction: the object
+ * creation on the remote nodes and the pg_dist_object records that
+ * MarkObjectDistributedViaSuperUser() adds below are committed --or rolled
+ * back-- atomically. We do this over the metadata connection to each node and
+ * MarkObjectDistributedViaSuperUser() reuses the very same connection, so the
+ * freshly created --but not yet committed-- object is visible to the
+ * pg_dist_object insert that follows.
  */
 static void
 EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
@@ -191,7 +204,7 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 							   target->classId, target->objectId)));
 	}
 
-	/* since we are executing DDL commands, disable propagation */
+	/* since we are executing DDL commands, disable propagation on the remote node */
 	ddlCommands = list_concat(list_make1(DISABLE_DDL_PROPAGATION), ddlCommands);
 
 	/*
@@ -203,11 +216,24 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 		forceRecreate ? NULL : ObjectExistsOnNodeCommand(target);
 
 	/*
-	 * Make sure that no new nodes are added after this point until the end of the
-	 * transaction by taking a RowShareLock on pg_dist_node, which conflicts with
-	 * the ExclusiveLock taken by citus_add_node.
+	 * Do everything within a single coordinated, 2PC transaction so that the
+	 * object creation on the remote nodes and the pg_dist_object records added
+	 * by MarkObjectDistributedViaSuperUser() below are committed atomically.
 	 */
-	List *remoteNodeList = ActivePrimaryRemoteNodeList(RowShareLock);
+	UseCoordinatedTransaction();
+	Use2PCForCoordinatedTransaction();
+
+	/*
+	 * We target the metadata nodes --and reuse the metadata connection to each
+	 * of them-- so that the same session that creates the object also inserts
+	 * the pg_dist_object record below; otherwise the not-yet-committed object
+	 * wouldn't be visible to the metadata insert.
+	 *
+	 * Taking a RowShareLock on pg_dist_node makes sure that no new node is added
+	 * concurrently until the end of the transaction, as it conflicts with the
+	 * ExclusiveLock taken by citus_add_node.
+	 */
+	List *remoteNodeList = TargetWorkerSetNodeList(REMOTE_METADATA_NODES, RowShareLock);
 
 	/*
 	 * Lock the object to be created explicitly to make sure same DDL command
@@ -216,24 +242,36 @@ EnsureObjectExistsOnAllNodes(const ObjectAddress *target, bool forceRecreate)
 	LockDatabaseObject(target->classId, target->objectId, target->objectSubId,
 					   ExclusiveLock);
 
+	List *connectionList = NIL;
 	WorkerNode *workerNode = NULL;
 	foreach_declared_ptr(workerNode, remoteNodeList)
 	{
-		const char *nodeName = workerNode->workerName;
-		uint32 nodePort = workerNode->workerPort;
-
-		int connectionFlags = FORCE_NEW_CONNECTION;
+		int connectionFlags = REQUIRE_METADATA_CONNECTION;
 		MultiConnection *connection =
-			GetNodeUserDatabaseConnection(connectionFlags, nodeName, nodePort,
-										  CitusExtensionOwnerName(), NULL);
+			StartNodeUserDatabaseConnection(connectionFlags, workerNode->workerName,
+											workerNode->workerPort,
+											CitusExtensionOwnerName(), NULL);
+		MarkRemoteTransactionCritical(connection);
+		connectionList = lappend(connectionList, connection);
+	}
 
-		if (forceRecreate || !RemoteObjectExists(connection, existenceCheckCommand))
+	FinishConnectionListEstablishment(connectionList);
+	RemoteTransactionsBeginIfNecessary(connectionList);
+
+	MultiConnection *connection = NULL;
+	foreach_declared_ptr(connection, connectionList)
+	{
+		if (!forceRecreate && RemoteObjectExists(connection, existenceCheckCommand))
 		{
-			SendCommandListToWorkerOutsideTransactionWithConnection(connection,
-																	ddlCommands);
+			/* the node already has the object, leave it untouched */
+			continue;
 		}
 
-		CloseConnection(connection);
+		char *command = NULL;
+		foreach_declared_ptr(command, ddlCommands)
+		{
+			ExecuteCriticalRemoteCommand(connection, command);
+		}
 	}
 
 	MarkObjectDistributedViaSuperUser(target);
@@ -298,12 +336,18 @@ ObjectExistsOnNodeCommand(const ObjectAddress *target)
  * the object exists on the remote node.
  *
  * pg_get_object_address() resolves the object by name and raises an error when
- * it cannot find it. We treat such a statement-level error as "the object does
- * not exist on this node" and only surface connection-level failures as errors.
+ * it cannot find it. Since the connection participates in our coordinated
+ * transaction, we run the probe inside a savepoint and roll back to it on a
+ * statement-level error so that the surrounding remote transaction stays usable.
+ * We treat such an error as "the object does not exist on this node" and only
+ * surface connection-level failures as errors.
  */
 static bool
 RemoteObjectExists(MultiConnection *connection, const char *existenceCheckCommand)
 {
+	ExecuteCriticalRemoteCommand(connection,
+								 "SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
+
 	int querySent = SendRemoteCommand(connection, existenceCheckCommand);
 	if (querySent == 0)
 	{
@@ -317,8 +361,17 @@ RemoteObjectExists(MultiConnection *connection, const char *existenceCheckComman
 	if (IsResponseOK(result))
 	{
 		objectExists = PQntuples(result) > 0;
+
+		PQclear(result);
+		ForgetResults(connection);
+
+		ExecuteCriticalRemoteCommand(connection,
+									 "RELEASE SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
+
+		return objectExists;
 	}
-	else if (PQstatus(connection->pgConn) != CONNECTION_OK)
+
+	if (PQstatus(connection->pgConn) != CONNECTION_OK)
 	{
 		/* we lost the connection while probing, so error out after cleanup */
 		PQclear(result);
@@ -328,10 +381,14 @@ RemoteObjectExists(MultiConnection *connection, const char *existenceCheckComman
 
 	/*
 	 * Otherwise pg_get_object_address() could not resolve the object by name,
-	 * which we interpret as the object being absent on this node.
+	 * which we interpret as the object being absent on this node. Roll back to
+	 * the savepoint so that the remote transaction stays usable.
 	 */
 	PQclear(result);
 	ForgetResults(connection);
+
+	ExecuteCriticalRemoteCommand(connection,
+								 "ROLLBACK TO SAVEPOINT " OBJECT_EXISTENCE_SAVEPOINT_NAME);
 
 	return objectExists;
 }

--- a/src/backend/distributed/commands/dependencies.c
+++ b/src/backend/distributed/commands/dependencies.c
@@ -77,11 +77,6 @@ citus_internal_distribute_object(PG_FUNCTION_ARGS)
 {
 	CheckCitusVersion(ERROR);
 
-	/*
-	 * Check for superuser before anything else so that a non-superuser gets the
-	 * "must be superuser" error even when the UDF is invoked on a worker node,
-	 * where EnsureCoordinator() would otherwise fail first.
-	 */
 	EnsureSuperUser();
 	EnsureCoordinator();
 

--- a/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
+++ b/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
@@ -19,3 +19,5 @@ DROP FUNCTION IF EXISTS pg_catalog.worker_apply_sequence_command(text, regtype);
 #include "udfs/citus_cluster_changes_block/15.0-1.sql"
 #include "udfs/citus_cluster_changes_unblock/15.0-1.sql"
 #include "udfs/citus_cluster_changes_block_status/15.0-1.sql"
+
+#include "udfs/citus_internal_distribute_object/15.0-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -27,4 +27,4 @@ DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
 
-DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid);
+DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, boolean);

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -28,4 +28,3 @@ DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
 
 DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, boolean);
-DROP FUNCTION IF EXISTS citus_internal.object_exists(text, text[], text[]);

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -28,3 +28,4 @@ DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
 
 DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, boolean);
+DROP FUNCTION IF EXISTS citus_internal.object_exists(text, text[], text[]);

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -27,4 +27,4 @@ DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
 
-DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, boolean);
+DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, int, boolean);

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -26,3 +26,5 @@ DROP FUNCTION IF EXISTS citus_internal.acquire_placement_colocation_lock(bigint,
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block(int);
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_unblock();
 DROP FUNCTION IF EXISTS pg_catalog.citus_cluster_changes_block_status();
+
+DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid);

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
+    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on '
+       'all nodes in an idempotent manner; a superuser-only tool to repair objects that '
+       'should have been distributed but were not';
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -1,3 +1,26 @@
+CREATE OR REPLACE FUNCTION citus_internal.object_exists(object_type text, object_names text[], object_args text[])
+    RETURNS boolean
+    LANGUAGE plpgsql
+    STABLE
+    AS $function$
+BEGIN
+    -- Resolve the object by its textual identity. pg_get_object_address() raises
+    -- when the object cannot be found, which we trap and report as "not found"
+    -- so that probing existence over a transactional connection never aborts the
+    -- surrounding transaction.
+    PERFORM pg_catalog.pg_get_object_address(object_type, object_names, object_args);
+    RETURN true;
+EXCEPTION
+    WHEN undefined_object OR undefined_function OR undefined_table OR
+         undefined_column OR undefined_parameter OR invalid_schema_name OR
+         wrong_object_type THEN
+        RETURN false;
+END;
+$function$;
+COMMENT ON FUNCTION citus_internal.object_exists(text, text[], text[])
+    IS 'returns whether the object identified by its type/names/args exists on the local node, without raising if it does not';
+REVOKE ALL ON FUNCTION citus_internal.object_exists(text, text[], text[]) FROM PUBLIC;
+
 CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid)
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
-COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, boolean)
     IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
-REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, boolean) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, objsubid int DEFAULT 0, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
-COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, boolean)
-    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
-REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, boolean) FROM PUBLIC;
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean)
+    IS 'recreate the given object (but not its dependencies) on all worker nodes and record it in pg_dist_object on all nodes; the worker DDL and the pg_dist_object writes are not performed atomically';
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -1,26 +1,3 @@
-CREATE OR REPLACE FUNCTION citus_internal.object_exists(object_type text, object_names text[], object_args text[])
-    RETURNS boolean
-    LANGUAGE plpgsql
-    STABLE
-    AS $function$
-BEGIN
-    -- Resolve the object by its textual identity. pg_get_object_address() raises
-    -- when the object cannot be found, which we trap and report as "not found"
-    -- so that probing existence over a transactional connection never aborts the
-    -- surrounding transaction.
-    PERFORM pg_catalog.pg_get_object_address(object_type, object_names, object_args);
-    RETURN true;
-EXCEPTION
-    WHEN undefined_object OR undefined_function OR undefined_table OR
-         undefined_column OR undefined_parameter OR invalid_schema_name OR
-         wrong_object_type THEN
-        RETURN false;
-END;
-$function$;
-COMMENT ON FUNCTION citus_internal.object_exists(text, text[], text[])
-    IS 'returns whether the object identified by its type/names/args exists on the local node, without raising if it does not';
-REVOKE ALL ON FUNCTION citus_internal.object_exists(text, text[], text[]) FROM PUBLIC;
-
 CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/15.0-1.sql
@@ -3,7 +3,5 @@ CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid o
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
 COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
-    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on '
-       'all nodes in an idempotent manner; a superuser-only tool to repair objects that '
-       'should have been distributed but were not';
+    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
 REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
+    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on '
+       'all nodes in an idempotent manner; a superuser-only tool to repair objects that '
+       'should have been distributed but were not';
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -1,3 +1,26 @@
+CREATE OR REPLACE FUNCTION citus_internal.object_exists(object_type text, object_names text[], object_args text[])
+    RETURNS boolean
+    LANGUAGE plpgsql
+    STABLE
+    AS $function$
+BEGIN
+    -- Resolve the object by its textual identity. pg_get_object_address() raises
+    -- when the object cannot be found, which we trap and report as "not found"
+    -- so that probing existence over a transactional connection never aborts the
+    -- surrounding transaction.
+    PERFORM pg_catalog.pg_get_object_address(object_type, object_names, object_args);
+    RETURN true;
+EXCEPTION
+    WHEN undefined_object OR undefined_function OR undefined_table OR
+         undefined_column OR undefined_parameter OR invalid_schema_name OR
+         wrong_object_type THEN
+        RETURN false;
+END;
+$function$;
+COMMENT ON FUNCTION citus_internal.object_exists(text, text[], text[])
+    IS 'returns whether the object identified by its type/names/args exists on the local node, without raising if it does not';
+REVOKE ALL ON FUNCTION citus_internal.object_exists(text, text[], text[]) FROM PUBLIC;
+
 CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid)
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
-COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, boolean)
     IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
-REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, boolean) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -1,7 +1,7 @@
-CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, objsubid int DEFAULT 0, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
-COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, boolean)
-    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
-REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, boolean) FROM PUBLIC;
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean)
+    IS 'recreate the given object (but not its dependencies) on all worker nodes and record it in pg_dist_object on all nodes; the worker DDL and the pg_dist_object writes are not performed atomically';
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) FROM PUBLIC;

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -1,26 +1,3 @@
-CREATE OR REPLACE FUNCTION citus_internal.object_exists(object_type text, object_names text[], object_args text[])
-    RETURNS boolean
-    LANGUAGE plpgsql
-    STABLE
-    AS $function$
-BEGIN
-    -- Resolve the object by its textual identity. pg_get_object_address() raises
-    -- when the object cannot be found, which we trap and report as "not found"
-    -- so that probing existence over a transactional connection never aborts the
-    -- surrounding transaction.
-    PERFORM pg_catalog.pg_get_object_address(object_type, object_names, object_args);
-    RETURN true;
-EXCEPTION
-    WHEN undefined_object OR undefined_function OR undefined_table OR
-         undefined_column OR undefined_parameter OR invalid_schema_name OR
-         wrong_object_type THEN
-        RETURN false;
-END;
-$function$;
-COMMENT ON FUNCTION citus_internal.object_exists(text, text[], text[])
-    IS 'returns whether the object identified by its type/names/args exists on the local node, without raising if it does not';
-REVOKE ALL ON FUNCTION citus_internal.object_exists(text, text[], text[]) FROM PUBLIC;
-
 CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, force_recreate boolean DEFAULT false)
     RETURNS void
     LANGUAGE C STRICT

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/latest.sql
@@ -3,7 +3,5 @@ CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid o
     LANGUAGE C STRICT
     AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
 COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid)
-    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on '
-       'all nodes in an idempotent manner; a superuser-only tool to repair objects that '
-       'should have been distributed but were not';
+    IS 'recreate the given object on all worker nodes and record it in pg_dist_object on all nodes';
 REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid) FROM PUBLIC;

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -1065,6 +1065,12 @@ SELECT success, result FROM master_run_on_worker(ARRAY['localhost']::text[], ARR
  f       | ERROR:  operation is not allowed on this node
 (1 row)
 
+-- It refuses to run when metadata syncing is disabled, and hints how to enable it.
+SET citus.enable_metadata_sync TO OFF;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+ERROR:  citus_internal.distribute_object requires citus.enable_metadata_sync to be enabled
+HINT:  Run "SET citus.enable_metadata_sync TO on" before calling this function.
+RESET citus.enable_metadata_sync;
 -- Cleanup.
 SET client_min_messages TO ERROR;
 DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -7,7 +7,9 @@
 -- manner. Dependencies of the object are deliberately not considered.
 --
 -- For each supported, DDL-generating object type we test:
---   i)   force_recreate := false on a missing object -> created on workers
+--   i)   force_recreate := false on a missing object -> created on the workers
+--        and recorded in pg_dist_object on the coordinator and all worker nodes
+--        (asserted absent before and present after the call)
 --   ii-a) force_recreate := true when it already exists -> no error
 --   ii-b) force_recreate := true after coordinator-only drift -> drift synced
 --   iv)  force_recreate := false on a partially present object (present on the
@@ -36,6 +38,21 @@ SELECT bool_and(result::int = 0) AS fn_missing FROM run_command_on_workers($$SEL
  t
 (1 row)
 
+-- before: the function is not yet recorded in pg_dist_object on any node. We probe
+-- pg_dist_object through a by-name join (rather than a regprocedure cast) so the
+-- query does not error on the workers where the function does not exist yet.
+SELECT count(*) = 0 AS fn_undistributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+ fn_undistributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 0) AS fn_undistributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
+ fn_undistributed_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
  distribute_object
 ---------------------------------------------------------------------
@@ -48,8 +65,15 @@ SELECT bool_and(result::int = 1) AS fn_exists FROM run_command_on_workers($$SELE
  t
 (1 row)
 
-SELECT bool_and(result::int = 1) AS fn_distributed FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object WHERE classid = 'pg_proc'::regclass AND objid = 'distobj.fn(int)'::regprocedure$$);
- fn_distributed
+-- after: the function is recorded in pg_dist_object on the coordinator and every worker.
+SELECT count(*) = 1 AS fn_distributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+ fn_distributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS fn_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
+ fn_distributed_workers
 ---------------------------------------------------------------------
  t
 (1 row)
@@ -652,6 +676,21 @@ SELECT string_agg(result, ',' ORDER BY nodeport) = :'pub_oids' AS pub_v_unchange
 SET citus.enable_metadata_sync TO OFF;
 CREATE ROLE distobj_role CONNECTION LIMIT 3;
 RESET citus.enable_metadata_sync;
+-- before: the role is not yet recorded in pg_dist_object on any node. We probe
+-- pg_dist_object through a by-name join (rather than a regrole cast) so the query
+-- does not error on the workers where the role does not exist yet.
+SELECT count(*) = 0 AS role_undistributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+ role_undistributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 0) AS role_undistributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
+ role_undistributed_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
 SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
  distribute_object
 ---------------------------------------------------------------------
@@ -666,6 +705,19 @@ SELECT bool_and(result::int = 1) AS role_exists FROM run_command_on_workers($$SE
 
 SELECT bool_and(result = '3') AS role_connlimit_synced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
  role_connlimit_synced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- after: the role is recorded in pg_dist_object on the coordinator and every worker.
+SELECT count(*) = 1 AS role_distributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+ role_distributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS role_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
+ role_distributed_workers
 ---------------------------------------------------------------------
  t
 (1 row)

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -6,77 +6,353 @@
 -- pg_dist_object on the coordinator and all worker nodes in an idempotent
 -- manner. Dependencies of the object are deliberately not considered.
 --
+-- For each supported, DDL-generating object type we test:
+--   i)   force_recreate := false on a missing object -> created on workers
+--   ii-a) force_recreate := true when it already exists -> no error
+--   ii-b) force_recreate := true after coordinator-only drift -> drift synced
+-- Table (OCLASS_CLASS) and database (OCLASS_DATABASE) are intentionally excluded.
 SET client_min_messages TO WARNING;
--- Create a function only on the coordinator (metadata sync off), simulating an
--- object that should have been distributed but was not, e.g. due to a bug.
+CREATE SCHEMA distobj;
+SET search_path TO distobj, public;
+-- ---------------------------------------------------------------------------
+-- FUNCTION (OCLASS_PROC)
+-- ---------------------------------------------------------------------------
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION public.dist_obj_repair_fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+CREATE FUNCTION distobj.fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
 RESET citus.enable_metadata_sync;
--- It is not recorded in pg_dist_object on the coordinator ...
-SELECT count(*) AS coordinator_before FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
- coordinator_before
----------------------------------------------------------------------
-                  0
-(1 row)
-
--- ... and it does not exist on any worker node.
-SELECT bool_and(result::int = 0) AS missing_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
- missing_on_all_workers
+SELECT bool_and(result::int = 0) AS fn_missing FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+ fn_missing
 ---------------------------------------------------------------------
  t
 (1 row)
 
--- Repair it: (re)create on all workers and record in pg_dist_object everywhere.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
  distribute_object
 ---------------------------------------------------------------------
 
 (1 row)
 
--- Now it is recorded in pg_dist_object on the coordinator ...
-SELECT count(*) AS coordinator_after FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
- coordinator_after
----------------------------------------------------------------------
-                 1
-(1 row)
-
--- ... it exists on all worker nodes ...
-SELECT bool_and(result::int = 1) AS exists_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
- exists_on_all_workers
+SELECT bool_and(result::int = 1) AS fn_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+ fn_exists
 ---------------------------------------------------------------------
  t
 (1 row)
 
--- ... and it is recorded in pg_dist_object on all worker nodes.
-SELECT bool_and(result::int = 1) AS distributed_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure$$);
- distributed_on_all_workers
+SELECT bool_and(result::int = 1) AS fn_distributed FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object WHERE classid = 'pg_proc'::regclass AND objid = 'distobj.fn(int)'::regprocedure$$);
+ fn_distributed
 ---------------------------------------------------------------------
  t
 (1 row)
 
--- Calling it again is a no-op (idempotent) and does not error.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+-- ii-a: force on an object that already exists everywhere is a no-op.
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
  distribute_object
 ---------------------------------------------------------------------
 
 (1 row)
 
-SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
- coordinator_idempotent
----------------------------------------------------------------------
-                      1
-(1 row)
-
--- force_recreate := true re-applies the DDL on all nodes regardless of whether
--- the object already exists there; still a no-op for pg_dist_object here.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid, force_recreate := true);
+-- ii-b: drift the function on the coordinator, then force-sync to workers.
+SET citus.enable_metadata_sync TO OFF;
+ALTER FUNCTION distobj.fn(int) STRICT;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
  distribute_object
 ---------------------------------------------------------------------
 
 (1 row)
 
+SELECT bool_and(result = 't') AS fn_strict_synced FROM run_command_on_workers($$SELECT proisstrict FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+ fn_strict_synced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- SCHEMA (OCLASS_SCHEMA)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE SCHEMA distobj_s;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS schema_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s'$$);
+ schema_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- COLLATION (OCLASS_COLLATION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE COLLATION distobj.coll (locale = 'C');
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS coll_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll'$$);
+ coll_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- TYPE (OCLASS_TYPE)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE TYPE distobj.ty AS (a int, b text);
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS type_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty'$$);
+ type_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- TEXT SEARCH DICTIONARY / CONFIGURATION (OCLASS_TSDICT / OCLASS_TSCONFIG)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH DICTIONARY distobj.dict (template = simple);
+CREATE TEXT SEARCH CONFIGURATION distobj.cfg (parser = default);
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict'::regdictionary::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS dict_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict'$$);
+ dict_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS cfg_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg'$$);
+ cfg_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- SEQUENCE (OCLASS_CLASS / RELKIND_SEQUENCE)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE SEQUENCE distobj.seq;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS seq_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq' AND relkind = 'S'$$);
+ seq_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- VIEW (OCLASS_CLASS / RELKIND_VIEW)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE VIEW distobj.vw AS SELECT 1 AS a;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS view_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw' AND relkind = 'v'$$);
+ view_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- PUBLICATION (OCLASS_PUBLICATION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE PUBLICATION distobj_pub;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS pub_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub'$$);
+ pub_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid, force_recreate := true) FROM pg_publication WHERE pubname = 'distobj_pub';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- ROLE (OCLASS_ROLE) -- the motivating case: a role created before the
+-- extension that later received ALTERs that never reached all nodes.
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE ROLE distobj_role CONNECTION LIMIT 3;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS role_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role'$$);
+ role_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result = '3') AS role_connlimit_synced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+ role_connlimit_synced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ii-b: alter the role on the coordinator only, then force-sync to workers.
+SET citus.enable_metadata_sync TO OFF;
+ALTER ROLE distobj_role CONNECTION LIMIT 7;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result = '7') AS role_connlimit_resynced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+ role_connlimit_resynced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ---------------------------------------------------------------------------
+-- EXTENSION (OCLASS_EXTENSION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION seg;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'seg';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS ext_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'seg'$$);
+ ext_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid, force_recreate := true) FROM pg_extension WHERE extname = 'seg';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP EXTENSION seg;
+-- ---------------------------------------------------------------------------
+-- FOREIGN SERVER (OCLASS_FOREIGN_SERVER)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER distobj_srv FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost');
+RESET citus.enable_metadata_sync;
+-- The wrapper must exist on workers for the server DDL to succeed.
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'postgres_fdw';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS srv_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$);
+ srv_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid, force_recreate := true) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+DROP SERVER distobj_srv;
+DROP EXTENSION postgres_fdw;
+DROP ROLE distobj_role;
+DROP PUBLICATION distobj_pub;
 -- It errors for an object that does not exist on the local node.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
 ERROR:  object with classid 1255 and objid 0 does not exist on the local node
 -- Cleanup.
-DROP FUNCTION public.dist_obj_repair_fn(int);
+SET client_min_messages TO ERROR;
+DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -1,0 +1,74 @@
+--
+-- CITUS_INTERNAL_DISTRIBUTE_OBJECT
+--
+-- Tests for the superuser-only citus_internal.distribute_object() repair UDF
+-- that (re)creates a single object on all worker nodes and records it in
+-- pg_dist_object on the coordinator and all worker nodes in an idempotent
+-- manner. Dependencies of the object are deliberately not considered.
+--
+SET client_min_messages TO WARNING;
+-- Create a function only on the coordinator (metadata sync off), simulating an
+-- object that should have been distributed but was not, e.g. due to a bug.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION public.dist_obj_repair_fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+-- It is not recorded in pg_dist_object on the coordinator ...
+SELECT count(*) AS coordinator_before FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+ coordinator_before
+---------------------------------------------------------------------
+                  0
+(1 row)
+
+-- ... and it does not exist on any worker node.
+SELECT bool_and(result::int = 0) AS missing_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
+ missing_on_all_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- Repair it: (re)create on all workers and record in pg_dist_object everywhere.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Now it is recorded in pg_dist_object on the coordinator ...
+SELECT count(*) AS coordinator_after FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+ coordinator_after
+---------------------------------------------------------------------
+                 1
+(1 row)
+
+-- ... it exists on all worker nodes ...
+SELECT bool_and(result::int = 1) AS exists_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
+ exists_on_all_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ... and it is recorded in pg_dist_object on all worker nodes.
+SELECT bool_and(result::int = 1) AS distributed_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure$$);
+ distributed_on_all_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- Calling it again is a no-op (idempotent) and does not error.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+ coordinator_idempotent
+---------------------------------------------------------------------
+                      1
+(1 row)
+
+-- It errors for an object that does not exist on the local node.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
+ERROR:  object with classid 1255 and objid 0 does not exist on the local node
+-- Cleanup.
+DROP FUNCTION public.dist_obj_repair_fn(int);

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -10,10 +10,20 @@
 --   i)   force_recreate := false on a missing object -> created on workers
 --   ii-a) force_recreate := true when it already exists -> no error
 --   ii-b) force_recreate := true after coordinator-only drift -> drift synced
+--   iv)  force_recreate := false on a partially present object (present on the
+--        coordinator and a single worker) -> created on the missing workers only
+--   v)   force_recreate := false on an object already present everywhere ->
+--        not recreated on any worker (the by-name object oids stay unchanged)
 -- Table (OCLASS_CLASS) and database (OCLASS_DATABASE) are intentionally excluded.
 SET client_min_messages TO WARNING;
 CREATE SCHEMA distobj;
 SET search_path TO distobj, public;
+-- Capture one active worker so the iv) scenarios below can create an object on a
+-- single node and exercise the "partially present" repair path.
+SELECT nodeport AS one_worker_port
+FROM pg_dist_node
+WHERE isactive AND noderole = 'primary' AND groupid <> 0
+ORDER BY nodeport LIMIT 1 \gset
 -- ---------------------------------------------------------------------------
 -- FUNCTION (OCLASS_PROC)
 -- ---------------------------------------------------------------------------
@@ -67,6 +77,49 @@ SELECT bool_and(result = 't') AS fn_strict_synced FROM run_command_on_workers($$
  t
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION distobj.fn4(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS fn_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE FUNCTION distobj.fn4(int) RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT $1'$$]::text[], false);
+ fn_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS fn_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn4' AND pronamespace = 'distobj'::regnamespace$$);
+ fn_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn4(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS fn_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn4' AND pronamespace = 'distobj'::regnamespace$$);
+ fn_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP FUNCTION distobj.fn4(int);
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS fn_oids FROM run_command_on_workers($$SELECT 'distobj.fn(int)'::regprocedure::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'fn_oids' AS fn_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.fn(int)'::regprocedure::oid::text$$);
+ fn_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- SCHEMA (OCLASS_SCHEMA)
 -- ---------------------------------------------------------------------------
@@ -89,6 +142,49 @@ SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_
  distribute_object
 ---------------------------------------------------------------------
 
+(1 row)
+
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SCHEMA distobj_s4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS schema_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SCHEMA distobj_s4$$]::text[], false);
+ schema_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS schema_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s4'$$);
+ schema_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s4'::regnamespace::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS schema_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s4'$$);
+ schema_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SCHEMA distobj_s4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS schema_oids FROM run_command_on_workers($$SELECT 'distobj_s'::regnamespace::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'schema_oids' AS schema_v_unchanged FROM run_command_on_workers($$SELECT 'distobj_s'::regnamespace::oid::text$$);
+ schema_v_unchanged
+---------------------------------------------------------------------
+ t
 (1 row)
 
 -- ---------------------------------------------------------------------------
@@ -115,6 +211,49 @@ SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.
 
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE COLLATION distobj.coll4 (locale = 'C');
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS coll_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE COLLATION distobj.coll4 (locale = 'C')$$]::text[], false);
+ coll_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS coll_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll4'$$);
+ coll_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll4'::regcollation::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS coll_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll4'$$);
+ coll_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP COLLATION distobj.coll4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS coll_oids FROM run_command_on_workers($$SELECT 'distobj.coll'::regcollation::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'coll_oids' AS coll_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.coll'::regcollation::oid::text$$);
+ coll_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- TYPE (OCLASS_TYPE)
 -- ---------------------------------------------------------------------------
@@ -139,6 +278,49 @@ SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::
 
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TYPE distobj.ty4 AS (a int, b text);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS type_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TYPE distobj.ty4 AS (a int, b text)$$]::text[], false);
+ type_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS type_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty4'$$);
+ type_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty4'::regtype::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS type_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty4'$$);
+ type_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TYPE distobj.ty4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS type_oids FROM run_command_on_workers($$SELECT 'distobj.ty'::regtype::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'type_oids' AS type_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.ty'::regtype::oid::text$$);
+ type_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- TEXT SEARCH DICTIONARY / CONFIGURATION (OCLASS_TSDICT / OCLASS_TSCONFIG)
 -- ---------------------------------------------------------------------------
@@ -154,6 +336,49 @@ SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.di
 
 SELECT bool_and(result::int = 1) AS dict_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict'$$);
  dict_exists
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH DICTIONARY distobj.dict4 (template = simple);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS dict_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TEXT SEARCH DICTIONARY distobj.dict4 (template = simple)$$]::text[], false);
+ dict_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS dict_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict4'$$);
+ dict_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict4'::regdictionary::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS dict_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict4'$$);
+ dict_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TEXT SEARCH DICTIONARY distobj.dict4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS dict_oids FROM run_command_on_workers($$SELECT 'distobj.dict'::regdictionary::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict'::regdictionary::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'dict_oids' AS dict_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.dict'::regdictionary::oid::text$$);
+ dict_v_unchanged
 ---------------------------------------------------------------------
  t
 (1 row)
@@ -174,6 +399,49 @@ SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.
  distribute_object
 ---------------------------------------------------------------------
 
+(1 row)
+
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH CONFIGURATION distobj.cfg4 (parser = default);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS cfg_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TEXT SEARCH CONFIGURATION distobj.cfg4 (parser = default)$$]::text[], false);
+ cfg_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS cfg_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg4'$$);
+ cfg_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg4'::regconfig::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS cfg_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg4'$$);
+ cfg_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TEXT SEARCH CONFIGURATION distobj.cfg4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS cfg_oids FROM run_command_on_workers($$SELECT 'distobj.cfg'::regconfig::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'cfg_oids' AS cfg_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.cfg'::regconfig::oid::text$$);
+ cfg_v_unchanged
+---------------------------------------------------------------------
+ t
 (1 row)
 
 -- ---------------------------------------------------------------------------
@@ -200,6 +468,49 @@ SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'
 
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SEQUENCE distobj.seq4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS seq_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SEQUENCE distobj.seq4$$]::text[], false);
+ seq_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS seq_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq4' AND relkind = 'S'$$);
+ seq_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq4'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS seq_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq4' AND relkind = 'S'$$);
+ seq_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SEQUENCE distobj.seq4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS seq_oids FROM run_command_on_workers($$SELECT 'distobj.seq'::regclass::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'seq_oids' AS seq_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.seq'::regclass::oid::text$$);
+ seq_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- VIEW (OCLASS_CLASS / RELKIND_VIEW)
 -- ---------------------------------------------------------------------------
@@ -224,6 +535,49 @@ SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw':
 
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE VIEW distobj.vw4 AS SELECT 1 AS a;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS view_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE VIEW distobj.vw4 AS SELECT 1 AS a$$]::text[], false);
+ view_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS view_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw4' AND relkind = 'v'$$);
+ view_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw4'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS view_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw4' AND relkind = 'v'$$);
+ view_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP VIEW distobj.vw4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS view_oids FROM run_command_on_workers($$SELECT 'distobj.vw'::regclass::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'view_oids' AS view_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.vw'::regclass::oid::text$$);
+ view_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- PUBLICATION (OCLASS_PUBLICATION)
 -- ---------------------------------------------------------------------------
@@ -246,6 +600,49 @@ SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid, fo
  distribute_object
 ---------------------------------------------------------------------
 
+(1 row)
+
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE PUBLICATION distobj_pub4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS pub_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE PUBLICATION distobj_pub4$$]::text[], false);
+ pub_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS pub_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub4'$$);
+ pub_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub4';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS pub_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub4'$$);
+ pub_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION distobj_pub4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS pub_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_publication WHERE pubname = 'distobj_pub'$$) \gset
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'pub_oids' AS pub_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_publication WHERE pubname = 'distobj_pub'$$);
+ pub_v_unchanged
+---------------------------------------------------------------------
+ t
 (1 row)
 
 -- ---------------------------------------------------------------------------
@@ -289,6 +686,49 @@ SELECT bool_and(result = '7') AS role_connlimit_resynced FROM run_command_on_wor
  t
 (1 row)
 
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE ROLE distobj_role4 CONNECTION LIMIT 3;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS role_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE ROLE distobj_role4 CONNECTION LIMIT 3$$]::text[], false);
+ role_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS role_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role4'$$);
+ role_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role4'::regrole::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS role_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role4'$$);
+ role_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP ROLE distobj_role4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS role_oids FROM run_command_on_workers($$SELECT 'distobj_role'::regrole::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'role_oids' AS role_v_unchanged FROM run_command_on_workers($$SELECT 'distobj_role'::regrole::oid::text$$);
+ role_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
 -- ---------------------------------------------------------------------------
 -- EXTENSION (OCLASS_EXTENSION)
 -- ---------------------------------------------------------------------------
@@ -313,6 +753,49 @@ SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid, forc
 
 (1 row)
 
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS ext_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_extension WHERE extname = 'seg'$$) \gset
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'seg';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'ext_oids' AS ext_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_extension WHERE extname = 'seg'$$);
+ ext_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- iv: a fresh extension present on the coordinator and a single worker -> created on the rest.
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION cube;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS ext_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE EXTENSION cube$$]::text[], false);
+ ext_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS ext_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'cube'$$);
+ ext_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'cube';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS ext_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'cube'$$);
+ ext_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP EXTENSION cube;
 DROP EXTENSION seg;
 -- ---------------------------------------------------------------------------
 -- FOREIGN SERVER (OCLASS_FOREIGN_SERVER)
@@ -346,6 +829,49 @@ SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid,
 
 (1 row)
 
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS srv_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$) \gset
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'srv_oids' AS srv_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$);
+ srv_v_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- iv: a fresh server present on the coordinator and a single worker -> created on the rest.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SERVER distobj_srv4 FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost');
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS srv_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SERVER distobj_srv4 FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost')$$]::text[], false);
+ srv_iv_placed
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS srv_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv4'$$);
+ srv_iv_partial
+---------------------------------------------------------------------
+ f
+(1 row)
+
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv4';
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::int = 1) AS srv_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv4'$$);
+ srv_iv_full
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP SERVER distobj_srv4;
 DROP SERVER distobj_srv;
 DROP EXTENSION postgres_fdw;
 DROP ROLE distobj_role;

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -67,6 +67,14 @@ SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE c
                       1
 (1 row)
 
+-- force_recreate := true re-applies the DDL on all nodes regardless of whether
+-- the object already exists there; still a no-op for pg_dist_object here.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
 -- It errors for an object that does not exist on the local node.
 SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
 ERROR:  object with classid 1255 and objid 0 does not exist on the local node

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -78,11 +78,24 @@ SELECT bool_and(result::int = 1) AS fn_distributed_workers FROM run_command_on_w
  t
 (1 row)
 
--- ii-a: force on an object that already exists everywhere is a no-op.
+-- ii-a: force on an object that already exists everywhere is a no-op and keeps a
+-- single pg_dist_object row on every node (the mark is idempotent).
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
  distribute_object
 ---------------------------------------------------------------------
 
+(1 row)
+
+SELECT count(*) = 1 AS fn_iia_distributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+ fn_iia_distributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS fn_iia_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
+ fn_iia_distributed_workers
+---------------------------------------------------------------------
+ t
 (1 row)
 
 -- ii-b: drift the function on the coordinator, then force-sync to workers.
@@ -718,6 +731,26 @@ SELECT count(*) = 1 AS role_distributed_coordinator FROM pg_dist_object d JOIN p
 
 SELECT bool_and(result::int = 1) AS role_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
  role_distributed_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- ii-a: force on an object that already exists everywhere is a no-op and keeps a
+-- single pg_dist_object row on every node (the mark is idempotent).
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) = 1 AS role_iia_distributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+ role_iia_distributed_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 1) AS role_iia_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
+ role_iia_distributed_workers
 ---------------------------------------------------------------------
  t
 (1 row)

--- a/src/test/regress/expected/citus_internal_distribute_object.out
+++ b/src/test/regress/expected/citus_internal_distribute_object.out
@@ -964,6 +964,107 @@ DROP PUBLICATION distobj_pub;
 -- It errors for an object that does not exist on the local node.
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
 ERROR:  object with classid 1255 and objid 0 does not exist on the local node
+-- ---------------------------------------------------------------------------
+-- force_recreate syncs body drift that the by-name probe cannot detect
+-- ---------------------------------------------------------------------------
+-- The existence probe matches an object by name only, so a worker that has a
+-- same-named object with a drifted definition is treated as "present". Without
+-- force_recreate that drift is left in place; with force_recreate it is synced.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION distobj.fn_drift(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+-- drift the body on a single worker (returns $1 + 100 there)
+SELECT bool_and(success) AS fn_drift_applied FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE OR REPLACE FUNCTION distobj.fn_drift(int) RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT $1 + 100'$$]::text[], false);
+ fn_drift_applied
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- without force_recreate the drifted worker keeps its divergent body
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_or(result = '101') AS fn_drift_remains FROM run_command_on_workers($$SELECT distobj.fn_drift(1)$$);
+ fn_drift_remains
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- with force_recreate the body is re-synced on every worker
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid, force_recreate := true);
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result = '1') AS fn_drift_synced FROM run_command_on_workers($$SELECT distobj.fn_drift(1)$$);
+ fn_drift_synced
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- With client_min_messages raised, the per-node skip NOTICE is visible: the
+-- object is present on every worker after the sync above, so a no-force call
+-- reports that it is skipping the (re)creation on each of them.
+SET client_min_messages TO NOTICE;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+NOTICE:  object already exists on node localhost:xxxxx, skipping its (re)creation
+NOTICE:  object already exists on node localhost:xxxxx, skipping its (re)creation
+ distribute_object
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO WARNING;
+-- ---------------------------------------------------------------------------
+-- negative paths
+-- ---------------------------------------------------------------------------
+-- It errors for an object type that Citus does not know how to distribute at
+-- all (SupportedDependencyByCitus is false, e.g. a materialized view).
+CREATE MATERIALIZED VIEW distobj.unsupported_mv AS SELECT 1 AS a;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.unsupported_mv'::regclass::oid);
+ERROR:  cannot distribute object "distobj.unsupported_mv"
+DETAIL:  Citus does not support distributing objects of this type.
+DROP MATERIALIZED VIEW distobj.unsupported_mv;
+-- It errors for a supported object class that yields no create DDL (a plain,
+-- non-distributed table produces an empty DDL list).
+CREATE TABLE distobj.unsupported_tbl (a int);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.unsupported_tbl'::regclass::oid);
+ERROR:  could not generate DDL commands to create object "distobj.unsupported_tbl"
+DROP TABLE distobj.unsupported_tbl;
+-- A non-superuser without EXECUTE cannot call it (the REVOKE ... FROM PUBLIC
+-- gate). We pass a bare oid literal so that argument evaluation does not require
+-- access to the distobj schema before the function-level permission is checked.
+CREATE ROLE distobj_nonsuper;
+SET ROLE distobj_nonsuper;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+ERROR:  permission denied for function distribute_object
+RESET ROLE;
+-- Even with EXECUTE granted, a non-superuser hits the superuser check.
+GRANT EXECUTE ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) TO distobj_nonsuper;
+SET ROLE distobj_nonsuper;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+ERROR:  operation is not allowed
+HINT:  Run the command with a superuser.
+RESET ROLE;
+REVOKE EXECUTE ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) FROM distobj_nonsuper;
+DROP ROLE distobj_nonsuper;
+-- Running it on a worker node hits the coordinator-only check.
+SELECT success, result FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0)$$]::text[], false);
+ success |                    result
+---------------------------------------------------------------------
+ f       | ERROR:  operation is not allowed on this node
+(1 row)
+
 -- Cleanup.
 SET client_min_messages TO ERROR;
 DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1747,7 +1747,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 ---------------------------------------------------------------------
  function worker_adjust_identity_column_seq_ranges(regclass) void |
  function worker_apply_sequence_command(text,regtype) void        |
-                                                                  | function citus_internal.distribute_object(oid,oid) void
+                                                                  | function citus_internal.distribute_object(oid,oid,boolean) void
 (3 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1747,7 +1747,7 @@ SELECT * FROM multi_extension.print_extension_changes();
 ---------------------------------------------------------------------
  function worker_adjust_identity_column_seq_ranges(regclass) void |
  function worker_apply_sequence_command(text,regtype) void        |
-                                                                  | function citus_internal.distribute_object(oid,oid,boolean) void
+                                                                  | function citus_internal.distribute_object(oid,oid,integer,boolean) void
 (3 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1743,11 +1743,12 @@ SELECT * FROM multi_extension.print_extension_changes();
 -- Snapshot of state at 15.0-1
 ALTER EXTENSION citus UPDATE TO '15.0-1';
 SELECT * FROM multi_extension.print_extension_changes();
-                         previous_object                          | current_object
+                         previous_object                          |                     current_object
 ---------------------------------------------------------------------
  function worker_adjust_identity_column_seq_ranges(regclass) void |
  function worker_apply_sequence_command(text,regtype) void        |
-(2 rows)
+                                                                  | function citus_internal.distribute_object(oid,oid) void
+(3 rows)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -100,7 +100,7 @@ ORDER BY 1;
  function citus_internal.delete_placement_metadata(bigint)
  function citus_internal.delete_shard_metadata(bigint)
  function citus_internal.delete_tenant_schema(oid)
- function citus_internal.distribute_object(oid,oid,boolean)
+ function citus_internal.distribute_object(oid,oid,integer,boolean)
  function citus_internal.find_groupid_for_node(text,integer)
  function citus_internal.get_next_colocation_id()
  function citus_internal.global_blocked_processes()

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -100,6 +100,7 @@ ORDER BY 1;
  function citus_internal.delete_placement_metadata(bigint)
  function citus_internal.delete_shard_metadata(bigint)
  function citus_internal.delete_tenant_schema(oid)
+ function citus_internal.distribute_object(oid,oid)
  function citus_internal.find_groupid_for_node(text,integer)
  function citus_internal.get_next_colocation_id()
  function citus_internal.global_blocked_processes()
@@ -414,6 +415,6 @@ ORDER BY 1;
  view citus_tables
  view pg_dist_shard_placement
  view time_partitions
-(382 rows)
+(383 rows)
 
 DROP TABLE extension_basic_types;

--- a/src/test/regress/expected/upgrade_list_citus_objects.out
+++ b/src/test/regress/expected/upgrade_list_citus_objects.out
@@ -100,7 +100,7 @@ ORDER BY 1;
  function citus_internal.delete_placement_metadata(bigint)
  function citus_internal.delete_shard_metadata(bigint)
  function citus_internal.delete_tenant_schema(oid)
- function citus_internal.distribute_object(oid,oid)
+ function citus_internal.distribute_object(oid,oid,boolean)
  function citus_internal.find_groupid_for_node(text,integer)
  function citus_internal.get_next_colocation_id()
  function citus_internal.global_blocked_processes()

--- a/src/test/regress/multi_1_create_citus_schedule
+++ b/src/test/regress/multi_1_create_citus_schedule
@@ -88,6 +88,7 @@ test: multi_multiuser
 test: stat_counters
 
 test: function_propagation
+test: citus_internal_distribute_object
 test: drop_database
 test: pg16
 test: pg18

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -333,6 +333,59 @@ DROP ROLE distobj_role;
 DROP PUBLICATION distobj_pub;
 -- It errors for an object that does not exist on the local node.
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+-- ---------------------------------------------------------------------------
+-- force_recreate syncs body drift that the by-name probe cannot detect
+-- ---------------------------------------------------------------------------
+-- The existence probe matches an object by name only, so a worker that has a
+-- same-named object with a drifted definition is treated as "present". Without
+-- force_recreate that drift is left in place; with force_recreate it is synced.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION distobj.fn_drift(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+-- drift the body on a single worker (returns $1 + 100 there)
+SELECT bool_and(success) AS fn_drift_applied FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE OR REPLACE FUNCTION distobj.fn_drift(int) RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT $1 + 100'$$]::text[], false);
+-- without force_recreate the drifted worker keeps its divergent body
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+SELECT bool_or(result = '101') AS fn_drift_remains FROM run_command_on_workers($$SELECT distobj.fn_drift(1)$$);
+-- with force_recreate the body is re-synced on every worker
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid, force_recreate := true);
+SELECT bool_and(result = '1') AS fn_drift_synced FROM run_command_on_workers($$SELECT distobj.fn_drift(1)$$);
+-- With client_min_messages raised, the per-node skip NOTICE is visible: the
+-- object is present on every worker after the sync above, so a no-force call
+-- reports that it is skipping the (re)creation on each of them.
+SET client_min_messages TO NOTICE;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn_drift(int)'::regprocedure::oid);
+SET client_min_messages TO WARNING;
+-- ---------------------------------------------------------------------------
+-- negative paths
+-- ---------------------------------------------------------------------------
+-- It errors for an object type that Citus does not know how to distribute at
+-- all (SupportedDependencyByCitus is false, e.g. a materialized view).
+CREATE MATERIALIZED VIEW distobj.unsupported_mv AS SELECT 1 AS a;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.unsupported_mv'::regclass::oid);
+DROP MATERIALIZED VIEW distobj.unsupported_mv;
+-- It errors for a supported object class that yields no create DDL (a plain,
+-- non-distributed table produces an empty DDL list).
+CREATE TABLE distobj.unsupported_tbl (a int);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.unsupported_tbl'::regclass::oid);
+DROP TABLE distobj.unsupported_tbl;
+-- A non-superuser without EXECUTE cannot call it (the REVOKE ... FROM PUBLIC
+-- gate). We pass a bare oid literal so that argument evaluation does not require
+-- access to the distobj schema before the function-level permission is checked.
+CREATE ROLE distobj_nonsuper;
+SET ROLE distobj_nonsuper;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+RESET ROLE;
+-- Even with EXECUTE granted, a non-superuser hits the superuser check.
+GRANT EXECUTE ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) TO distobj_nonsuper;
+SET ROLE distobj_nonsuper;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+RESET ROLE;
+REVOKE EXECUTE ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) FROM distobj_nonsuper;
+DROP ROLE distobj_nonsuper;
+-- Running it on a worker node hits the coordinator-only check.
+SELECT success, result FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0)$$]::text[], false);
 -- Cleanup.
 SET client_min_messages TO ERROR;
 DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -1,0 +1,33 @@
+--
+-- CITUS_INTERNAL_DISTRIBUTE_OBJECT
+--
+-- Tests for the superuser-only citus_internal.distribute_object() repair UDF
+-- that (re)creates a single object on all worker nodes and records it in
+-- pg_dist_object on the coordinator and all worker nodes in an idempotent
+-- manner. Dependencies of the object are deliberately not considered.
+--
+SET client_min_messages TO WARNING;
+-- Create a function only on the coordinator (metadata sync off), simulating an
+-- object that should have been distributed but was not, e.g. due to a bug.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION public.dist_obj_repair_fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+-- It is not recorded in pg_dist_object on the coordinator ...
+SELECT count(*) AS coordinator_before FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+-- ... and it does not exist on any worker node.
+SELECT bool_and(result::int = 0) AS missing_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
+-- Repair it: (re)create on all workers and record in pg_dist_object everywhere.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+-- Now it is recorded in pg_dist_object on the coordinator ...
+SELECT count(*) AS coordinator_after FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+-- ... it exists on all worker nodes ...
+SELECT bool_and(result::int = 1) AS exists_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
+-- ... and it is recorded in pg_dist_object on all worker nodes.
+SELECT bool_and(result::int = 1) AS distributed_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure$$);
+-- Calling it again is a no-op (idempotent) and does not error.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
+SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+-- It errors for an object that does not exist on the local node.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
+-- Cleanup.
+DROP FUNCTION public.dist_obj_repair_fn(int);

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -10,10 +10,20 @@
 --   i)   force_recreate := false on a missing object -> created on workers
 --   ii-a) force_recreate := true when it already exists -> no error
 --   ii-b) force_recreate := true after coordinator-only drift -> drift synced
+--   iv)  force_recreate := false on a partially present object (present on the
+--        coordinator and a single worker) -> created on the missing workers only
+--   v)   force_recreate := false on an object already present everywhere ->
+--        not recreated on any worker (the by-name object oids stay unchanged)
 -- Table (OCLASS_CLASS) and database (OCLASS_DATABASE) are intentionally excluded.
 SET client_min_messages TO WARNING;
 CREATE SCHEMA distobj;
 SET search_path TO distobj, public;
+-- Capture one active worker so the iv) scenarios below can create an object on a
+-- single node and exercise the "partially present" repair path.
+SELECT nodeport AS one_worker_port
+FROM pg_dist_node
+WHERE isactive AND noderole = 'primary' AND groupid <> 0
+ORDER BY nodeport LIMIT 1 \gset
 -- ---------------------------------------------------------------------------
 -- FUNCTION (OCLASS_PROC)
 -- ---------------------------------------------------------------------------
@@ -32,6 +42,19 @@ ALTER FUNCTION distobj.fn(int) STRICT;
 RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
 SELECT bool_and(result = 't') AS fn_strict_synced FROM run_command_on_workers($$SELECT proisstrict FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE FUNCTION distobj.fn4(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS fn_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE FUNCTION distobj.fn4(int) RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT $1'$$]::text[], false);
+SELECT bool_and(result::int = 1) AS fn_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn4' AND pronamespace = 'distobj'::regnamespace$$);
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn4(int)'::regprocedure::oid);
+SELECT bool_and(result::int = 1) AS fn_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn4' AND pronamespace = 'distobj'::regnamespace$$);
+DROP FUNCTION distobj.fn4(int);
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS fn_oids FROM run_command_on_workers($$SELECT 'distobj.fn(int)'::regprocedure::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'fn_oids' AS fn_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.fn(int)'::regprocedure::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- SCHEMA (OCLASS_SCHEMA)
 -- ---------------------------------------------------------------------------
@@ -41,6 +64,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid);
 SELECT bool_and(result::int = 1) AS schema_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s'$$);
 SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SCHEMA distobj_s4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS schema_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SCHEMA distobj_s4$$]::text[], false);
+SELECT bool_and(result::int = 1) AS schema_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s4'$$);
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s4'::regnamespace::oid);
+SELECT bool_and(result::int = 1) AS schema_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s4'$$);
+DROP SCHEMA distobj_s4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS schema_oids FROM run_command_on_workers($$SELECT 'distobj_s'::regnamespace::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'schema_oids' AS schema_v_unchanged FROM run_command_on_workers($$SELECT 'distobj_s'::regnamespace::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- COLLATION (OCLASS_COLLATION)
 -- ---------------------------------------------------------------------------
@@ -50,6 +86,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid);
 SELECT bool_and(result::int = 1) AS coll_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll'$$);
 SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE COLLATION distobj.coll4 (locale = 'C');
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS coll_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE COLLATION distobj.coll4 (locale = 'C')$$]::text[], false);
+SELECT bool_and(result::int = 1) AS coll_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll4'$$);
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll4'::regcollation::oid);
+SELECT bool_and(result::int = 1) AS coll_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll4'$$);
+DROP COLLATION distobj.coll4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS coll_oids FROM run_command_on_workers($$SELECT 'distobj.coll'::regcollation::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'coll_oids' AS coll_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.coll'::regcollation::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- TYPE (OCLASS_TYPE)
 -- ---------------------------------------------------------------------------
@@ -59,6 +108,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid);
 SELECT bool_and(result::int = 1) AS type_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty'$$);
 SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TYPE distobj.ty4 AS (a int, b text);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS type_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TYPE distobj.ty4 AS (a int, b text)$$]::text[], false);
+SELECT bool_and(result::int = 1) AS type_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty4'$$);
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty4'::regtype::oid);
+SELECT bool_and(result::int = 1) AS type_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty4'$$);
+DROP TYPE distobj.ty4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS type_oids FROM run_command_on_workers($$SELECT 'distobj.ty'::regtype::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'type_oids' AS type_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.ty'::regtype::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- TEXT SEARCH DICTIONARY / CONFIGURATION (OCLASS_TSDICT / OCLASS_TSCONFIG)
 -- ---------------------------------------------------------------------------
@@ -68,9 +130,35 @@ CREATE TEXT SEARCH CONFIGURATION distobj.cfg (parser = default);
 RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict'::regdictionary::oid);
 SELECT bool_and(result::int = 1) AS dict_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict'$$);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH DICTIONARY distobj.dict4 (template = simple);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS dict_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TEXT SEARCH DICTIONARY distobj.dict4 (template = simple)$$]::text[], false);
+SELECT bool_and(result::int = 1) AS dict_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict4'$$);
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict4'::regdictionary::oid);
+SELECT bool_and(result::int = 1) AS dict_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict4'$$);
+DROP TEXT SEARCH DICTIONARY distobj.dict4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS dict_oids FROM run_command_on_workers($$SELECT 'distobj.dict'::regdictionary::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict'::regdictionary::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'dict_oids' AS dict_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.dict'::regdictionary::oid::text$$);
 SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid);
 SELECT bool_and(result::int = 1) AS cfg_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg'$$);
 SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH CONFIGURATION distobj.cfg4 (parser = default);
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS cfg_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE TEXT SEARCH CONFIGURATION distobj.cfg4 (parser = default)$$]::text[], false);
+SELECT bool_and(result::int = 1) AS cfg_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg4'$$);
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg4'::regconfig::oid);
+SELECT bool_and(result::int = 1) AS cfg_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg4'$$);
+DROP TEXT SEARCH CONFIGURATION distobj.cfg4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS cfg_oids FROM run_command_on_workers($$SELECT 'distobj.cfg'::regconfig::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'cfg_oids' AS cfg_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.cfg'::regconfig::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- SEQUENCE (OCLASS_CLASS / RELKIND_SEQUENCE)
 -- ---------------------------------------------------------------------------
@@ -80,6 +168,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid);
 SELECT bool_and(result::int = 1) AS seq_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq' AND relkind = 'S'$$);
 SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SEQUENCE distobj.seq4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS seq_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SEQUENCE distobj.seq4$$]::text[], false);
+SELECT bool_and(result::int = 1) AS seq_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq4' AND relkind = 'S'$$);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq4'::regclass::oid);
+SELECT bool_and(result::int = 1) AS seq_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq4' AND relkind = 'S'$$);
+DROP SEQUENCE distobj.seq4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS seq_oids FROM run_command_on_workers($$SELECT 'distobj.seq'::regclass::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'seq_oids' AS seq_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.seq'::regclass::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- VIEW (OCLASS_CLASS / RELKIND_VIEW)
 -- ---------------------------------------------------------------------------
@@ -89,6 +190,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid);
 SELECT bool_and(result::int = 1) AS view_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw' AND relkind = 'v'$$);
 SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid, force_recreate := true);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE VIEW distobj.vw4 AS SELECT 1 AS a;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS view_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE VIEW distobj.vw4 AS SELECT 1 AS a$$]::text[], false);
+SELECT bool_and(result::int = 1) AS view_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw4' AND relkind = 'v'$$);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw4'::regclass::oid);
+SELECT bool_and(result::int = 1) AS view_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw4' AND relkind = 'v'$$);
+DROP VIEW distobj.vw4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS view_oids FROM run_command_on_workers($$SELECT 'distobj.vw'::regclass::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'view_oids' AS view_v_unchanged FROM run_command_on_workers($$SELECT 'distobj.vw'::regclass::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- PUBLICATION (OCLASS_PUBLICATION)
 -- ---------------------------------------------------------------------------
@@ -98,6 +212,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub';
 SELECT bool_and(result::int = 1) AS pub_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub'$$);
 SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid, force_recreate := true) FROM pg_publication WHERE pubname = 'distobj_pub';
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE PUBLICATION distobj_pub4;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS pub_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE PUBLICATION distobj_pub4$$]::text[], false);
+SELECT bool_and(result::int = 1) AS pub_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub4'$$);
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub4';
+SELECT bool_and(result::int = 1) AS pub_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub4'$$);
+DROP PUBLICATION distobj_pub4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS pub_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_publication WHERE pubname = 'distobj_pub'$$) \gset
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub';
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'pub_oids' AS pub_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_publication WHERE pubname = 'distobj_pub'$$);
 -- ---------------------------------------------------------------------------
 -- ROLE (OCLASS_ROLE) -- the motivating case: a role created before the
 -- extension that later received ALTERs that never reached all nodes.
@@ -114,6 +241,19 @@ ALTER ROLE distobj_role CONNECTION LIMIT 7;
 RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid, force_recreate := true);
 SELECT bool_and(result = '7') AS role_connlimit_resynced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+-- iv: present on the coordinator and a single worker -> created on the missing workers.
+SET citus.enable_metadata_sync TO OFF;
+CREATE ROLE distobj_role4 CONNECTION LIMIT 3;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS role_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE ROLE distobj_role4 CONNECTION LIMIT 3$$]::text[], false);
+SELECT bool_and(result::int = 1) AS role_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role4'$$);
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role4'::regrole::oid);
+SELECT bool_and(result::int = 1) AS role_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role4'$$);
+DROP ROLE distobj_role4;
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS role_oids FROM run_command_on_workers($$SELECT 'distobj_role'::regrole::oid::text$$) \gset
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'role_oids' AS role_v_unchanged FROM run_command_on_workers($$SELECT 'distobj_role'::regrole::oid::text$$);
 -- ---------------------------------------------------------------------------
 -- EXTENSION (OCLASS_EXTENSION)
 -- ---------------------------------------------------------------------------
@@ -123,6 +263,19 @@ RESET citus.enable_metadata_sync;
 SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'seg';
 SELECT bool_and(result::int = 1) AS ext_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'seg'$$);
 SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid, force_recreate := true) FROM pg_extension WHERE extname = 'seg';
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS ext_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_extension WHERE extname = 'seg'$$) \gset
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'seg';
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'ext_oids' AS ext_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_extension WHERE extname = 'seg'$$);
+-- iv: a fresh extension present on the coordinator and a single worker -> created on the rest.
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION cube;
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS ext_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE EXTENSION cube$$]::text[], false);
+SELECT bool_and(result::int = 1) AS ext_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'cube'$$);
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'cube';
+SELECT bool_and(result::int = 1) AS ext_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'cube'$$);
+DROP EXTENSION cube;
 DROP EXTENSION seg;
 -- ---------------------------------------------------------------------------
 -- FOREIGN SERVER (OCLASS_FOREIGN_SERVER)
@@ -136,6 +289,19 @@ SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM
 SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
 SELECT bool_and(result::int = 1) AS srv_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$);
 SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid, force_recreate := true) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+-- v: already present on every worker -> not recreated anywhere (oids unchanged).
+SELECT string_agg(result, ',' ORDER BY nodeport) AS srv_oids FROM run_command_on_workers($$SELECT oid::text FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$) \gset
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+SELECT string_agg(result, ',' ORDER BY nodeport) = :'srv_oids' AS srv_v_unchanged FROM run_command_on_workers($$SELECT oid::text FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$);
+-- iv: a fresh server present on the coordinator and a single worker -> created on the rest.
+SET citus.enable_metadata_sync TO OFF;
+CREATE SERVER distobj_srv4 FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost');
+RESET citus.enable_metadata_sync;
+SELECT bool_and(success) AS srv_iv_placed FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SET citus.enable_ddl_propagation TO off; CREATE SERVER distobj_srv4 FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost')$$]::text[], false);
+SELECT bool_and(result::int = 1) AS srv_iv_partial FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv4'$$);
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv4';
+SELECT bool_and(result::int = 1) AS srv_iv_full FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv4'$$);
+DROP SERVER distobj_srv4;
 DROP SERVER distobj_srv;
 DROP EXTENSION postgres_fdw;
 DROP ROLE distobj_role;

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -43,8 +43,11 @@ SELECT bool_and(result::int = 1) AS fn_exists FROM run_command_on_workers($$SELE
 -- after: the function is recorded in pg_dist_object on the coordinator and every worker.
 SELECT count(*) = 1 AS fn_distributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
 SELECT bool_and(result::int = 1) AS fn_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
--- ii-a: force on an object that already exists everywhere is a no-op.
+-- ii-a: force on an object that already exists everywhere is a no-op and keeps a
+-- single pg_dist_object row on every node (the mark is idempotent).
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
+SELECT count(*) = 1 AS fn_iia_distributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+SELECT bool_and(result::int = 1) AS fn_iia_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
 -- ii-b: drift the function on the coordinator, then force-sync to workers.
 SET citus.enable_metadata_sync TO OFF;
 ALTER FUNCTION distobj.fn(int) STRICT;
@@ -252,6 +255,11 @@ SELECT bool_and(result = '3') AS role_connlimit_synced FROM run_command_on_worke
 -- after: the role is recorded in pg_dist_object on the coordinator and every worker.
 SELECT count(*) = 1 AS role_distributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
 SELECT bool_and(result::int = 1) AS role_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
+-- ii-a: force on an object that already exists everywhere is a no-op and keeps a
+-- single pg_dist_object row on every node (the mark is idempotent).
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid, force_recreate := true);
+SELECT count(*) = 1 AS role_iia_distributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+SELECT bool_and(result::int = 1) AS role_iia_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
 -- ii-b: alter the role on the coordinator only, then force-sync to workers.
 SET citus.enable_metadata_sync TO OFF;
 ALTER ROLE distobj_role CONNECTION LIMIT 7;

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -6,31 +6,142 @@
 -- pg_dist_object on the coordinator and all worker nodes in an idempotent
 -- manner. Dependencies of the object are deliberately not considered.
 --
+-- For each supported, DDL-generating object type we test:
+--   i)   force_recreate := false on a missing object -> created on workers
+--   ii-a) force_recreate := true when it already exists -> no error
+--   ii-b) force_recreate := true after coordinator-only drift -> drift synced
+-- Table (OCLASS_CLASS) and database (OCLASS_DATABASE) are intentionally excluded.
 SET client_min_messages TO WARNING;
--- Create a function only on the coordinator (metadata sync off), simulating an
--- object that should have been distributed but was not, e.g. due to a bug.
+CREATE SCHEMA distobj;
+SET search_path TO distobj, public;
+-- ---------------------------------------------------------------------------
+-- FUNCTION (OCLASS_PROC)
+-- ---------------------------------------------------------------------------
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION public.dist_obj_repair_fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
+CREATE FUNCTION distobj.fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
 RESET citus.enable_metadata_sync;
--- It is not recorded in pg_dist_object on the coordinator ...
-SELECT count(*) AS coordinator_before FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
--- ... and it does not exist on any worker node.
-SELECT bool_and(result::int = 0) AS missing_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
--- Repair it: (re)create on all workers and record in pg_dist_object everywhere.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
--- Now it is recorded in pg_dist_object on the coordinator ...
-SELECT count(*) AS coordinator_after FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
--- ... it exists on all worker nodes ...
-SELECT bool_and(result::int = 1) AS exists_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'dist_obj_repair_fn'$$);
--- ... and it is recorded in pg_dist_object on all worker nodes.
-SELECT bool_and(result::int = 1) AS distributed_on_all_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure$$);
--- Calling it again is a no-op (idempotent) and does not error.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
-SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
--- force_recreate := true re-applies the DDL on all nodes regardless of whether
--- the object already exists there; still a no-op for pg_dist_object here.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid, force_recreate := true);
+SELECT bool_and(result::int = 0) AS fn_missing FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
+SELECT bool_and(result::int = 1) AS fn_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+SELECT bool_and(result::int = 1) AS fn_distributed FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object WHERE classid = 'pg_proc'::regclass AND objid = 'distobj.fn(int)'::regprocedure$$);
+-- ii-a: force on an object that already exists everywhere is a no-op.
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
+-- ii-b: drift the function on the coordinator, then force-sync to workers.
+SET citus.enable_metadata_sync TO OFF;
+ALTER FUNCTION distobj.fn(int) STRICT;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
+SELECT bool_and(result = 't') AS fn_strict_synced FROM run_command_on_workers($$SELECT proisstrict FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+-- ---------------------------------------------------------------------------
+-- SCHEMA (OCLASS_SCHEMA)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE SCHEMA distobj_s;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid);
+SELECT bool_and(result::int = 1) AS schema_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_namespace WHERE nspname = 'distobj_s'$$);
+SELECT citus_internal.distribute_object('pg_namespace'::regclass::oid, 'distobj_s'::regnamespace::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- COLLATION (OCLASS_COLLATION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE COLLATION distobj.coll (locale = 'C');
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid);
+SELECT bool_and(result::int = 1) AS coll_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_collation WHERE collname = 'coll'$$);
+SELECT citus_internal.distribute_object('pg_collation'::regclass::oid, 'distobj.coll'::regcollation::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- TYPE (OCLASS_TYPE)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE TYPE distobj.ty AS (a int, b text);
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid);
+SELECT bool_and(result::int = 1) AS type_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_type WHERE typname = 'ty'$$);
+SELECT citus_internal.distribute_object('pg_type'::regclass::oid, 'distobj.ty'::regtype::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- TEXT SEARCH DICTIONARY / CONFIGURATION (OCLASS_TSDICT / OCLASS_TSCONFIG)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE TEXT SEARCH DICTIONARY distobj.dict (template = simple);
+CREATE TEXT SEARCH CONFIGURATION distobj.cfg (parser = default);
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_ts_dict'::regclass::oid, 'distobj.dict'::regdictionary::oid);
+SELECT bool_and(result::int = 1) AS dict_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_dict WHERE dictname = 'dict'$$);
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid);
+SELECT bool_and(result::int = 1) AS cfg_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_ts_config WHERE cfgname = 'cfg'$$);
+SELECT citus_internal.distribute_object('pg_ts_config'::regclass::oid, 'distobj.cfg'::regconfig::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- SEQUENCE (OCLASS_CLASS / RELKIND_SEQUENCE)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE SEQUENCE distobj.seq;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid);
+SELECT bool_and(result::int = 1) AS seq_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'seq' AND relkind = 'S'$$);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.seq'::regclass::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- VIEW (OCLASS_CLASS / RELKIND_VIEW)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE VIEW distobj.vw AS SELECT 1 AS a;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid);
+SELECT bool_and(result::int = 1) AS view_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_class WHERE relname = 'vw' AND relkind = 'v'$$);
+SELECT citus_internal.distribute_object('pg_class'::regclass::oid, 'distobj.vw'::regclass::oid, force_recreate := true);
+-- ---------------------------------------------------------------------------
+-- PUBLICATION (OCLASS_PUBLICATION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE PUBLICATION distobj_pub;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid) FROM pg_publication WHERE pubname = 'distobj_pub';
+SELECT bool_and(result::int = 1) AS pub_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_publication WHERE pubname = 'distobj_pub'$$);
+SELECT citus_internal.distribute_object('pg_publication'::regclass::oid, oid, force_recreate := true) FROM pg_publication WHERE pubname = 'distobj_pub';
+-- ---------------------------------------------------------------------------
+-- ROLE (OCLASS_ROLE) -- the motivating case: a role created before the
+-- extension that later received ALTERs that never reached all nodes.
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE ROLE distobj_role CONNECTION LIMIT 3;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
+SELECT bool_and(result::int = 1) AS role_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role'$$);
+SELECT bool_and(result = '3') AS role_connlimit_synced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+-- ii-b: alter the role on the coordinator only, then force-sync to workers.
+SET citus.enable_metadata_sync TO OFF;
+ALTER ROLE distobj_role CONNECTION LIMIT 7;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid, force_recreate := true);
+SELECT bool_and(result = '7') AS role_connlimit_resynced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+-- ---------------------------------------------------------------------------
+-- EXTENSION (OCLASS_EXTENSION)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION seg;
+RESET citus.enable_metadata_sync;
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'seg';
+SELECT bool_and(result::int = 1) AS ext_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_extension WHERE extname = 'seg'$$);
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid, force_recreate := true) FROM pg_extension WHERE extname = 'seg';
+DROP EXTENSION seg;
+-- ---------------------------------------------------------------------------
+-- FOREIGN SERVER (OCLASS_FOREIGN_SERVER)
+-- ---------------------------------------------------------------------------
+SET citus.enable_metadata_sync TO OFF;
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER distobj_srv FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'localhost');
+RESET citus.enable_metadata_sync;
+-- The wrapper must exist on workers for the server DDL to succeed.
+SELECT citus_internal.distribute_object('pg_extension'::regclass::oid, oid) FROM pg_extension WHERE extname = 'postgres_fdw';
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+SELECT bool_and(result::int = 1) AS srv_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_foreign_server WHERE srvname = 'distobj_srv'$$);
+SELECT citus_internal.distribute_object('pg_foreign_server'::regclass::oid, oid, force_recreate := true) FROM pg_foreign_server WHERE srvname = 'distobj_srv';
+DROP SERVER distobj_srv;
+DROP EXTENSION postgres_fdw;
+DROP ROLE distobj_role;
+DROP PUBLICATION distobj_pub;
 -- It errors for an object that does not exist on the local node.
-SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
 -- Cleanup.
-DROP FUNCTION public.dist_obj_repair_fn(int);
+SET client_min_messages TO ERROR;
+DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -27,6 +27,9 @@ SELECT bool_and(result::int = 1) AS distributed_on_all_workers FROM run_command_
 -- Calling it again is a no-op (idempotent) and does not error.
 SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid);
 SELECT count(*) AS coordinator_idempotent FROM pg_catalog.pg_dist_object WHERE classid = 'pg_catalog.pg_proc'::regclass AND objid = 'public.dist_obj_repair_fn(int)'::regprocedure;
+-- force_recreate := true re-applies the DDL on all nodes regardless of whether
+-- the object already exists there; still a no-op for pg_dist_object here.
+SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 'public.dist_obj_repair_fn(int)'::regprocedure::oid, force_recreate := true);
 -- It errors for an object that does not exist on the local node.
 SELECT citus_internal.distribute_object('pg_catalog.pg_proc'::regclass::oid, 0);
 -- Cleanup.

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -386,6 +386,10 @@ REVOKE EXECUTE ON FUNCTION citus_internal.distribute_object(oid, oid, int, boole
 DROP ROLE distobj_nonsuper;
 -- Running it on a worker node hits the coordinator-only check.
 SELECT success, result FROM master_run_on_worker(ARRAY['localhost']::text[], ARRAY[:one_worker_port]::int[], ARRAY[$$SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0)$$]::text[], false);
+-- It refuses to run when metadata syncing is disabled, and hints how to enable it.
+SET citus.enable_metadata_sync TO OFF;
+SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 0);
+RESET citus.enable_metadata_sync;
 -- Cleanup.
 SET client_min_messages TO ERROR;
 DROP SCHEMA distobj, distobj_s CASCADE;

--- a/src/test/regress/sql/citus_internal_distribute_object.sql
+++ b/src/test/regress/sql/citus_internal_distribute_object.sql
@@ -7,7 +7,9 @@
 -- manner. Dependencies of the object are deliberately not considered.
 --
 -- For each supported, DDL-generating object type we test:
---   i)   force_recreate := false on a missing object -> created on workers
+--   i)   force_recreate := false on a missing object -> created on the workers
+--        and recorded in pg_dist_object on the coordinator and all worker nodes
+--        (asserted absent before and present after the call)
 --   ii-a) force_recreate := true when it already exists -> no error
 --   ii-b) force_recreate := true after coordinator-only drift -> drift synced
 --   iv)  force_recreate := false on a partially present object (present on the
@@ -31,9 +33,16 @@ SET citus.enable_metadata_sync TO OFF;
 CREATE FUNCTION distobj.fn(int) RETURNS int LANGUAGE sql IMMUTABLE AS $fn$ SELECT $1 $fn$;
 RESET citus.enable_metadata_sync;
 SELECT bool_and(result::int = 0) AS fn_missing FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
+-- before: the function is not yet recorded in pg_dist_object on any node. We probe
+-- pg_dist_object through a by-name join (rather than a regprocedure cast) so the
+-- query does not error on the workers where the function does not exist yet.
+SELECT count(*) = 0 AS fn_undistributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+SELECT bool_and(result::int = 0) AS fn_undistributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid);
 SELECT bool_and(result::int = 1) AS fn_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_proc WHERE proname = 'fn' AND pronamespace = 'distobj'::regnamespace$$);
-SELECT bool_and(result::int = 1) AS fn_distributed FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object WHERE classid = 'pg_proc'::regclass AND objid = 'distobj.fn(int)'::regprocedure$$);
+-- after: the function is recorded in pg_dist_object on the coordinator and every worker.
+SELECT count(*) = 1 AS fn_distributed_coordinator FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace;
+SELECT bool_and(result::int = 1) AS fn_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_proc p ON d.objid = p.oid WHERE d.classid = 'pg_proc'::regclass AND p.proname = 'fn' AND p.pronamespace = 'distobj'::regnamespace$$);
 -- ii-a: force on an object that already exists everywhere is a no-op.
 SELECT citus_internal.distribute_object('pg_proc'::regclass::oid, 'distobj.fn(int)'::regprocedure::oid, force_recreate := true);
 -- ii-b: drift the function on the coordinator, then force-sync to workers.
@@ -232,9 +241,17 @@ SELECT string_agg(result, ',' ORDER BY nodeport) = :'pub_oids' AS pub_v_unchange
 SET citus.enable_metadata_sync TO OFF;
 CREATE ROLE distobj_role CONNECTION LIMIT 3;
 RESET citus.enable_metadata_sync;
+-- before: the role is not yet recorded in pg_dist_object on any node. We probe
+-- pg_dist_object through a by-name join (rather than a regrole cast) so the query
+-- does not error on the workers where the role does not exist yet.
+SELECT count(*) = 0 AS role_undistributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+SELECT bool_and(result::int = 0) AS role_undistributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
 SELECT citus_internal.distribute_object('pg_authid'::regclass::oid, 'distobj_role'::regrole::oid);
 SELECT bool_and(result::int = 1) AS role_exists FROM run_command_on_workers($$SELECT count(*) FROM pg_roles WHERE rolname = 'distobj_role'$$);
 SELECT bool_and(result = '3') AS role_connlimit_synced FROM run_command_on_workers($$SELECT rolconnlimit FROM pg_authid WHERE rolname = 'distobj_role'$$);
+-- after: the role is recorded in pg_dist_object on the coordinator and every worker.
+SELECT count(*) = 1 AS role_distributed_coordinator FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role';
+SELECT bool_and(result::int = 1) AS role_distributed_workers FROM run_command_on_workers($$SELECT count(*) FROM pg_dist_object d JOIN pg_authid a ON d.objid = a.oid WHERE d.classid = 'pg_authid'::regclass AND a.rolname = 'distobj_role'$$);
 -- ii-b: alter the role on the coordinator only, then force-sync to workers.
 SET citus.enable_metadata_sync TO OFF;
 ALTER ROLE distobj_role CONNECTION LIMIT 7;


### PR DESCRIPTION
DESCRIPTION: Adds citus_internal.distribute_object() tool that can be used to manually propagate an object to workers.

This is a super-user only UDF that can be used by admins to
re-create an object as distributed in cluster-wide.
