### PR TITLE
PG19: migrate get_relation_info_hook to build_simple_rel_hook

### DIFF
--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -92,6 +92,9 @@ static void AddColumnarScanPath(PlannerInfo *root, RelOptInfo *rel,
 /* helper functions to be used when costing paths or altering them */
 static void RemovePathsByPredicate(RelOptInfo *rel, PathPredicate removePathPredicate);
 static bool IsNotIndexPath(Path *path);
+#if PG_VERSION_NUM >= PG_VERSION_19
+static bool IsIndexOnlyScanPath(Path *path);
+#endif
 static Cost ColumnarIndexScanAdditionalCost(PlannerInfo *root, RelOptInfo *rel,
 											Oid relationId, IndexPath *indexPath);
 static int RelationIdGetNumberOfAttributes(Oid relationId);
@@ -209,11 +212,10 @@ columnar_customscan_init(void)
 #else
 
 	/*
-	 * TODO(PG19, #8614): get_relation_info_hook was removed upstream.
-	 * Re-implement parallel-query/index-only-scan suppression for
-	 * columnar relations through set_rel_pathlist_hook or another
-	 * mechanism. For Phase 1 (build only) the hook is omitted.
-	 * Tracked in #8608.
+	 * PG19 removed get_relation_info_hook, which is where we used to disable
+	 * parallel query and index-only scans for columnar relations.  That
+	 * suppression is re-implemented in ColumnarSetRelPathlistHook for PG19;
+	 * see the version-guarded block there.
 	 */
 #endif
 
@@ -310,6 +312,32 @@ ColumnarSetRelPathlistHook(PlannerInfo *root, RelOptInfo *rel, Index rti,
 
 	if (relation->rd_tableam == GetColumnarTableAmRoutine())
 	{
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+		/*
+		 * PG19 removed get_relation_info_hook, where pre-PG19 builds disable
+		 * parallel query and index-only scans for columnar relations (columnar
+		 * scans are always serial and cannot return tuples from an index).
+		 * Re-apply both here.  set_rel_pathlist_hook runs after path
+		 * generation, so besides forbidding future parallel workers we also
+		 * drop any parallel (partial) paths and any IndexOnlyScan paths that
+		 * were already created, and clear the per-index canreturn flags so the
+		 * paths we add below are costed without index-only-scan capability.
+		 */
+		rel->rel_parallel_workers = 0;
+		rel->consider_parallel = false;
+		rel->partial_pathlist = NIL;
+
+		IndexOptInfo *indexOptInfo = NULL;
+		foreach_declared_ptr(indexOptInfo, rel->indexlist)
+		{
+			memset(indexOptInfo->canreturn, false,
+				   indexOptInfo->ncolumns * sizeof(bool));
+		}
+
+		RemovePathsByPredicate(rel, IsIndexOnlyScanPath);
+#endif
+
 		if (rte->tablesample != NULL)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -424,6 +452,24 @@ IsNotIndexPath(Path *path)
 {
 	return !IsA(path, IndexPath);
 }
+
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+/*
+ * IsIndexOnlyScanPath returns true if given path is an index-only scan path.
+ * Index-only scans are represented as an IndexPath whose pathtype is
+ * T_IndexOnlyScan; columnar cannot return tuples from an index, so these are
+ * removed for columnar relations on PG19.
+ */
+static bool
+IsIndexOnlyScanPath(Path *path)
+{
+	return IsA(path, IndexPath) && path->pathtype == T_IndexOnlyScan;
+}
+
+
+#endif
 
 
 /*

--- a/src/backend/columnar/columnar_customscan.c
+++ b/src/backend/columnar/columnar_customscan.c
@@ -92,9 +92,6 @@ static void AddColumnarScanPath(PlannerInfo *root, RelOptInfo *rel,
 /* helper functions to be used when costing paths or altering them */
 static void RemovePathsByPredicate(RelOptInfo *rel, PathPredicate removePathPredicate);
 static bool IsNotIndexPath(Path *path);
-#if PG_VERSION_NUM >= PG_VERSION_19
-static bool IsIndexOnlyScanPath(Path *path);
-#endif
 static Cost ColumnarIndexScanAdditionalCost(PlannerInfo *root, RelOptInfo *rel,
 											Oid relationId, IndexPath *indexPath);
 static int RelationIdGetNumberOfAttributes(Oid relationId);
@@ -114,6 +111,9 @@ static void ColumnarSetRelPathlistHook(PlannerInfo *root, RelOptInfo *rel, Index
 #if PG_VERSION_NUM < PG_VERSION_19
 static void ColumnarGetRelationInfoHook(PlannerInfo *root, Oid relationObjectId,
 										bool inhparent, RelOptInfo *rel);
+#else
+static void ColumnarBuildSimpleRelHook(PlannerInfo *root, RelOptInfo *rel,
+									   RangeTblEntry *rte);
 #endif
 static Plan * ColumnarScanPath_PlanCustomPath(PlannerInfo *root,
 											  RelOptInfo *rel,
@@ -150,6 +150,8 @@ static Bitmapset * fixup_inherited_columns(Oid parentId, Oid childId, Bitmapset 
 static set_rel_pathlist_hook_type PreviousSetRelPathlistHook = NULL;
 #if PG_VERSION_NUM < PG_VERSION_19
 static get_relation_info_hook_type PreviousGetRelationInfoHook = NULL;
+#else
+static build_simple_rel_hook_type PreviousBuildSimpleRelHook = NULL;
 #endif
 
 static bool EnableColumnarCustomScan = true;
@@ -210,13 +212,8 @@ columnar_customscan_init(void)
 	PreviousGetRelationInfoHook = get_relation_info_hook;
 	get_relation_info_hook = ColumnarGetRelationInfoHook;
 #else
-
-	/*
-	 * PG19 removed get_relation_info_hook, which is where we used to disable
-	 * parallel query and index-only scans for columnar relations.  That
-	 * suppression is re-implemented in ColumnarSetRelPathlistHook for PG19;
-	 * see the version-guarded block there.
-	 */
+	PreviousBuildSimpleRelHook = build_simple_rel_hook;
+	build_simple_rel_hook = ColumnarBuildSimpleRelHook;
 #endif
 
 	/* register customscan specific GUC's */
@@ -312,32 +309,6 @@ ColumnarSetRelPathlistHook(PlannerInfo *root, RelOptInfo *rel, Index rti,
 
 	if (relation->rd_tableam == GetColumnarTableAmRoutine())
 	{
-#if PG_VERSION_NUM >= PG_VERSION_19
-
-		/*
-		 * PG19 removed get_relation_info_hook, where pre-PG19 builds disable
-		 * parallel query and index-only scans for columnar relations (columnar
-		 * scans are always serial and cannot return tuples from an index).
-		 * Re-apply both here.  set_rel_pathlist_hook runs after path
-		 * generation, so besides forbidding future parallel workers we also
-		 * drop any parallel (partial) paths and any IndexOnlyScan paths that
-		 * were already created, and clear the per-index canreturn flags so the
-		 * paths we add below are costed without index-only-scan capability.
-		 */
-		rel->rel_parallel_workers = 0;
-		rel->consider_parallel = false;
-		rel->partial_pathlist = NIL;
-
-		IndexOptInfo *indexOptInfo = NULL;
-		foreach_declared_ptr(indexOptInfo, rel->indexlist)
-		{
-			memset(indexOptInfo->canreturn, false,
-				   indexOptInfo->ncolumns * sizeof(bool));
-		}
-
-		RemovePathsByPredicate(rel, IsIndexOnlyScanPath);
-#endif
-
 		if (rte->tablesample != NULL)
 		{
 			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -347,8 +318,8 @@ ColumnarSetRelPathlistHook(PlannerInfo *root, RelOptInfo *rel, Index rti,
 		if (list_length(rel->partial_pathlist) != 0)
 		{
 			/*
-			 * Parallel scans on columnar tables are already discardad by
-			 * ColumnarGetRelationInfoHook but be on the safe side.
+			 * Parallel scans on columnar tables are already disabled by the
+			 * relation setup hook, but be on the safe side.
 			 */
 			elog(ERROR, "parallel scans on columnar are not supported");
 		}
@@ -394,7 +365,34 @@ ColumnarSetRelPathlistHook(PlannerInfo *root, RelOptInfo *rel, Index rti,
 }
 
 
-#if PG_VERSION_NUM < PG_VERSION_19
+#if PG_VERSION_NUM >= PG_VERSION_19
+static void
+ColumnarBuildSimpleRelHook(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
+{
+	if (PreviousBuildSimpleRelHook)
+	{
+		PreviousBuildSimpleRelHook(root, rel, rte);
+	}
+
+	if (!OidIsValid(rte->relid) || rte->rtekind != RTE_RELATION ||
+		!IsColumnarTableAmTable(rte->relid))
+	{
+		return;
+	}
+
+	/* disable parallel query */
+	rel->rel_parallel_workers = 0;
+
+	/* disable index-only scan */
+	IndexOptInfo *indexOptInfo = NULL;
+	foreach_declared_ptr(indexOptInfo, rel->indexlist)
+	{
+		memset(indexOptInfo->canreturn, false, indexOptInfo->ncolumns * sizeof(bool));
+	}
+}
+
+
+#else
 static void
 ColumnarGetRelationInfoHook(PlannerInfo *root, Oid relationObjectId,
 							bool inhparent, RelOptInfo *rel)
@@ -452,24 +450,6 @@ IsNotIndexPath(Path *path)
 {
 	return !IsA(path, IndexPath);
 }
-
-
-#if PG_VERSION_NUM >= PG_VERSION_19
-
-/*
- * IsIndexOnlyScanPath returns true if given path is an index-only scan path.
- * Index-only scans are represented as an IndexPath whose pathtype is
- * T_IndexOnlyScan; columnar cannot return tuples from an index, so these are
- * removed for columnar relations on PG19.
- */
-static bool
-IsIndexOnlyScanPath(Path *path)
-{
-	return IsA(path, IndexPath) && path->pathtype == T_IndexOnlyScan;
-}
-
-
-#endif
 
 
 /*

--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -2311,6 +2311,27 @@ multi_get_relation_info_hook(PlannerInfo *root, Oid relationObjectId, bool inhpa
 }
 
 
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+/*
+ * multi_build_simple_rel_hook is the PG19 replacement for the removed
+ * get_relation_info_hook. It runs at the end of build_simple_rel() with the
+ * RelOptInfo (indexlist included) already populated, and delegates to
+ * multi_get_relation_info_hook to keep the partitioned-index filtering
+ * behaviour identical across versions.
+ */
+void
+multi_build_simple_rel_hook(PlannerInfo *root, RelOptInfo *rel,
+							RangeTblEntry *rte)
+{
+	/* the delegate ignores these args; it re-derives the RTE from rel->relid */
+	multi_get_relation_info_hook(root, InvalidOid, false, rel);
+}
+
+
+#endif
+
+
 /*
  * TranslatedVars deep copies the translated vars for the given relation index
  * if there is any append rel list.

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -34,6 +34,9 @@
 #include "optimizer/paths.h"
 #include "optimizer/plancat.h"
 #include "optimizer/planner.h"
+#if PG_VERSION_NUM >= PG_VERSION_19
+#include "optimizer/pathnode.h"
+#endif
 #include "port/atomics.h"
 #include "postmaster/postmaster.h"
 #include "replication/walsender.h"
@@ -489,14 +492,7 @@ _PG_init(void)
 #if PG_VERSION_NUM < PG_VERSION_19
 	get_relation_info_hook = multi_get_relation_info_hook;
 #else
-
-	/*
-	 * TODO(PG19 Phase 2): get_relation_info_hook was removed upstream.
-	 * Re-implement the partitioned-table index stripping done by
-	 * multi_get_relation_info_hook through build_simple_rel_hook (see
-	 * the matching TODO in columnar_customscan.c). For Phase 1 (build
-	 * only) the hook is omitted. Tracked in #8608.
-	 */
+	build_simple_rel_hook = multi_build_simple_rel_hook;
 #endif
 	set_join_pathlist_hook = multi_join_restriction_hook;
 	ExecutorStart_hook = CitusExecutorStart;

--- a/src/include/distributed/distributed_planner.h
+++ b/src/include/distributed/distributed_planner.h
@@ -265,6 +265,10 @@ extern void multi_relation_restriction_hook(PlannerInfo *root, RelOptInfo *relOp
 											Index restrictionIndex, RangeTblEntry *rte);
 extern void multi_get_relation_info_hook(PlannerInfo *root, Oid relationObjectId, bool
 										 inhparent, RelOptInfo *rel);
+#if PG_VERSION_NUM >= PG_VERSION_19
+extern void multi_build_simple_rel_hook(PlannerInfo *root, RelOptInfo *rel,
+										RangeTblEntry *rte);
+#endif
 extern void multi_join_restriction_hook(PlannerInfo *root,
 										RelOptInfo *joinrel,
 										RelOptInfo *outerrel,


### PR DESCRIPTION
## What

Restores partitioned-index stripping on PostgreSQL 19, which regressed when PG19 removed the `get_relation_info_hook` that Citus relied on. This is a PG19-only planner-hook migration and a no-op on PG ≤ 18.

The columnar `scan_analyze_next_tuple` signature item from the original scope was already fixed in the build-foundation PR #8601 and is intentionally **not** touched here.

## Why

PG19 dropped `get_relation_info_hook` in favour of `build_simple_rel_hook`. Citus used that hook (`multi_get_relation_info_hook`) to strip partitioned indexes from partitioned-table plans. PR #8601 disabled it on PG19 with a `TODO(PG19 Phase 2)` marker, so index-stripping was temporarily absent on PG19, causing a client-backend crash on partitioned-table planning paths inside the regression suite (`make check`).

## How

- Add a PG19-only `multi_build_simple_rel_hook` in `distributed_planner.c` (prototype in `distributed_planner.h`) matching the `build_simple_rel_hook` signature `(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)`. It delegates straight to the existing `multi_get_relation_info_hook` body, which re-derives the `RangeTblEntry` from `rel->relid` — so the removed `relationObjectId` / `inhparent` arguments are passed as `InvalidOid` / `false` and intentionally ignored, keeping behaviour identical across versions.
- Register it via `build_simple_rel_hook` under `#if PG_VERSION_NUM >= PG_VERSION_19` in `shared_library_init.c`; the old `get_relation_info_hook` assignment is kept under the `#else` arm for PG ≤ 18.

## Files

- `src/backend/distributed/planner/distributed_planner.c`
- `src/include/distributed/distributed_planner.h`
- `src/backend/distributed/shared_library_init.c`

Item 1 (`src/backend/columnar/columnar_tableam.c`) is untouched — already fixed in #8601.

## Scope note

An earlier revision of this PR also carried a `distribution_column.c` `AccessShareLock` change ("item 3"). That fix addresses a **PG16+** `relation_open()` assertion / relcache-lifetime issue that is not PG19-specific, so it has been **split out** into a separate PR targeting `main`. This PR is now scoped solely to the PG19 `build_simple_rel_hook` migration.

## Stacking

Stacked on #8619 — base branch is `pg19-columnar-relinfo`. GitHub will auto-retarget this PR to `pg19-support` once #8619 merges.

## Cross-version gate

- [x] **PG19 (19beta1):** full `-Werror` build green; `partitioned_indexes_create` (+ setup) regress passed, **zero diff** — exercises the partitioned-index planning path and proves the hook is active.
- [x] **PG18 (18.4):** full `-Werror` build green; same focused regress passed, **zero diff** — the pre-PG19 `#else` arm is unchanged and neutral.
- [x] **PG17 (17.10):** the migration is preprocessor-excluded (`#if PG_VERSION_NUM >= PG_VERSION_19`), so PG17 is structurally unaffected; the earlier full-scope gate confirmed a green PG17 `-Werror` build + regress.
- [x] **check-style:** `citus_indent --check` clean on all touched files.

All arms build clean under full `-Werror` (no flag demotion). The change is behaviourally confined to PG19; PG ≤ 18 is preprocessor-excluded and proven regression-neutral.

Part of #8597. Relates to #8608.
