### PR TITLE
Thread real LWLock tranche names through on PG19

### DIFF
--- a/src/backend/distributed/clock/causal_clock.c
+++ b/src/backend/distributed/clock/causal_clock.c
@@ -172,9 +172,8 @@ LogicalClockShmemInit(void)
 		memset(&LogicalClockShmem->clusterClockValue, 0, sizeof(ClusterClock));
 
 		LogicalClockShmem->namedLockTranche.trancheName = "Cluster Clock Setup Tranche";
-		LogicalClockShmem->namedLockTranche.trancheId = LWLockNewTrancheId();
-		LWLockRegisterTranche(LogicalClockShmem->namedLockTranche.trancheId,
-							  LogicalClockShmem->namedLockTranche.trancheName);
+		LogicalClockShmem->namedLockTranche.trancheId =
+			LWLockNewTrancheIdCompat(LogicalClockShmem->namedLockTranche.trancheName);
 		LWLockInitialize(&LogicalClockShmem->clockLock,
 						 LogicalClockShmem->namedLockTranche.trancheId);
 

--- a/src/backend/distributed/connection/shared_connection_stats.c
+++ b/src/backend/distributed/connection/shared_connection_stats.c
@@ -672,12 +672,11 @@ SharedConnectionStatsShmemInit(void)
 
 	if (!alreadyInitialized)
 	{
-		ConnectionStatsSharedState->sharedConnectionHashTrancheId = LWLockNewTrancheId();
 		ConnectionStatsSharedState->sharedConnectionHashTrancheName =
 			"Shared Connection Tracking Hash Tranche";
-		LWLockRegisterTranche(
-			ConnectionStatsSharedState->sharedConnectionHashTrancheId,
-			ConnectionStatsSharedState->sharedConnectionHashTrancheName);
+		ConnectionStatsSharedState->sharedConnectionHashTrancheId =
+			LWLockNewTrancheIdCompat(
+				ConnectionStatsSharedState->sharedConnectionHashTrancheName);
 
 		LWLockInitialize(&ConnectionStatsSharedState->sharedConnectionHashLock,
 						 ConnectionStatsSharedState->sharedConnectionHashTrancheId);

--- a/src/backend/distributed/operations/cluster_changes_block.c
+++ b/src/backend/distributed/operations/cluster_changes_block.c
@@ -149,12 +149,11 @@ ClusterChangesBlockShmemInit(void)
 
 	if (!alreadyInitialized)
 	{
-		ClusterChangesBlockControl->trancheId = LWLockNewTrancheId();
 		strlcpy(ClusterChangesBlockControl->lockTrancheName,
 				"Citus Cluster Changes Block",
 				NAMEDATALEN);
-		LWLockRegisterTranche(ClusterChangesBlockControl->trancheId,
-							  ClusterChangesBlockControl->lockTrancheName);
+		ClusterChangesBlockControl->trancheId =
+			LWLockNewTrancheIdCompat(ClusterChangesBlockControl->lockTrancheName);
 		LWLockInitialize(&ClusterChangesBlockControl->lock,
 						 ClusterChangesBlockControl->trancheId);
 

--- a/src/backend/distributed/shardsplit/shardsplit_shared_memory.c
+++ b/src/backend/distributed/shardsplit/shardsplit_shared_memory.c
@@ -217,7 +217,7 @@ ShardSplitShmemInit(void)
 
 	if (!alreadyInitialized)
 	{
-		char * trancheName pg_attribute_unused() = "Split Shard Setup Tranche";
+		char *trancheName = "Split Shard Setup Tranche";
 
 		NamedLWLockTranche *namedLockTranche =
 			&smData->namedLockTranche;
@@ -226,9 +226,7 @@ ShardSplitShmemInit(void)
 		memset(smData, 0,
 			   sizeof(ShardSplitShmemData));
 
-		namedLockTranche->trancheId = LWLockNewTrancheId();
-
-		LWLockRegisterTranche(namedLockTranche->trancheId, trancheName);
+		namedLockTranche->trancheId = LWLockNewTrancheIdCompat(trancheName);
 		LWLockInitialize(&smData->lock,
 						 namedLockTranche->trancheId);
 

--- a/src/backend/distributed/stats/stat_tenants.c
+++ b/src/backend/distributed/stats/stat_tenants.c
@@ -709,11 +709,9 @@ CreateSharedMemoryForMultiTenantMonitor(void)
 		return monitor;
 	}
 
-	monitor->namedLockTranche.trancheId = LWLockNewTrancheId();
 	monitor->namedLockTranche.trancheName = MonitorTrancheName;
-
-	LWLockRegisterTranche(monitor->namedLockTranche.trancheId,
-						  monitor->namedLockTranche.trancheName);
+	monitor->namedLockTranche.trancheId =
+		LWLockNewTrancheIdCompat(monitor->namedLockTranche.trancheName);
 	LWLockInitialize(&monitor->lock, monitor->namedLockTranche.trancheId);
 
 	HASHCTL info;

--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -545,7 +545,7 @@ BackendManagementShmemInit(void)
 
 	if (!alreadyInitialized)
 	{
-		char * trancheName pg_attribute_unused() = "Backend Management Tranche";
+		char *trancheName = "Backend Management Tranche";
 
 		NamedLWLockTranche *namedLockTranche =
 			&backendManagementShmemData->namedLockTranche;
@@ -554,9 +554,7 @@ BackendManagementShmemInit(void)
 		memset(backendManagementShmemData, 0,
 			   BackendManagementShmemSize());
 
-		namedLockTranche->trancheId = LWLockNewTrancheId();
-
-		LWLockRegisterTranche(namedLockTranche->trancheId, trancheName);
+		namedLockTranche->trancheId = LWLockNewTrancheIdCompat(trancheName);
 		LWLockInitialize(&backendManagementShmemData->lock,
 						 namedLockTranche->trancheId);
 

--- a/src/backend/distributed/utils/maintenanced.c
+++ b/src/backend/distributed/utils/maintenanced.c
@@ -937,10 +937,9 @@ MaintenanceDaemonShmemInit(void)
 	 */
 	if (!alreadyInitialized)
 	{
-		MaintenanceDaemonControl->trancheId = LWLockNewTrancheId();
 		MaintenanceDaemonControl->lockTrancheName = "Citus Maintenance Daemon";
-		LWLockRegisterTranche(MaintenanceDaemonControl->trancheId,
-							  MaintenanceDaemonControl->lockTrancheName);
+		MaintenanceDaemonControl->trancheId =
+			LWLockNewTrancheIdCompat(MaintenanceDaemonControl->lockTrancheName);
 
 		LWLockInitialize(&MaintenanceDaemonControl->lock,
 						 MaintenanceDaemonControl->trancheId);

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -12,6 +12,7 @@
 #define PG_VERSION_COMPAT_H
 
 #include "lib/stringinfo.h"
+#include "storage/lwlock.h"
 
 #include "pg_version_constants.h"
 
@@ -128,15 +129,13 @@ typedef StringInfo fmStringInfo;
 		((ShmemInitHash) ((name), (int64) (max), (info), (flags)))
 
 /*
- * PG19 internalised tranche registration: LWLockNewTrancheId now takes
- * the tranche name and there is no public LWLockRegisterTranche.  Wrap
- * both so existing two-step Citus code keeps compiling.  The temporary
- * name "citus-deferred" is only used until the follow-up in #8609
- * refactors call sites to pass the real tranche name directly to
- * LWLockNewTrancheId().
+ * PG19 changed LWLockNewTrancheId() to take the tranche name directly and
+ * removed the public LWLockRegisterTranche(); tranche names now live in
+ * shared memory and are visible to every backend.  Expose a one-call helper
+ * that forwards the real name.  The PG<=18 counterpart (further below) keeps
+ * the historical allocate-then-register two-step behind the same interface.
  */
-#define LWLockNewTrancheId() ((LWLockNewTrancheId) ("citus-deferred"))
-#define LWLockRegisterTranche(id, name) ((void) 0)
+#define LWLockNewTrancheIdCompat(name) LWLockNewTrancheId(name)
 
 /*
  * PG19 dropped the public NamedLWLockTranche struct from lwlock.h.
@@ -243,6 +242,20 @@ citus_BlessTupleDesc(TupleDesc td)
  * call sites that build TupleDescs without going through BlessTupleDesc.
  */
 #define TupleDescFinalize(td) ((void) 0)
+
+/*
+ * PG<=18 registers tranche names in two steps: allocate the id with
+ * LWLockNewTrancheId(), then associate the name via LWLockRegisterTranche().
+ * Wrap that dance so call sites use the same one-call LWLockNewTrancheIdCompat()
+ * helper as PG19.
+ */
+static inline int
+LWLockNewTrancheIdCompat(const char *name)
+{
+	int trancheId = LWLockNewTrancheId();
+	LWLockRegisterTranche(trancheId, name);
+	return trancheId;
+}
 
 #endif /* PG_VERSION_NUM < PG_VERSION_19 */
 

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -258,6 +258,7 @@ LWLockNewTrancheIdCompat(const char *name)
 	return trancheId;
 }
 
+
 #endif /* PG_VERSION_NUM < PG_VERSION_19 */
 
 #if PG_VERSION_NUM >= PG_VERSION_18

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -32,7 +32,6 @@
 #include "optimizer/planner.h"
 #include "replication/origin.h"
 #include "storage/condition_variable.h"
-#include "storage/lwlock.h"
 #include "storage/lwlocknames.h"
 #include "storage/proc.h"
 #include "storage/shmem.h"

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -253,6 +253,7 @@ static inline int
 LWLockNewTrancheIdCompat(const char *name)
 {
 	int trancheId = LWLockNewTrancheId();
+
 	LWLockRegisterTranche(trancheId, name);
 	return trancheId;
 }


### PR DESCRIPTION
Part of #8597. Closes #8609 _(note: GitHub auto-close won't fire on a non-`main` base)._

## Problem

PG19 internalised LWLock tranche registration: `LWLockNewTrancheId()` now takes the tranche name and returns the id in one step, and the public two-step `LWLockRegisterTranche()` was removed (names now live in shared memory, visible to every backend). The PG19 foundation work (#8601) added a temporary shim that registered **every** Citus tranche under the placeholder name `"citus-deferred"`, so on PG19 every Citus lightweight-lock wait surfaced as `citus-deferred` in `pg_stat_activity.wait_event` — a diagnostics regression vs PG&le;18 (ids stayed unique, so not a correctness bug, hence deferred to this PR).

## Change

- Replace the `citus-deferred` placeholder shim in `pg_version_compat.h` with a single `LWLockNewTrancheIdCompat(name)` helper:
  - **PG19**: macro forwarding the name to one-step `LWLockNewTrancheId(name)`.
  - **PG&le;18**: a `static inline` keeping the historical allocate-then-register two-step behind the same interface.
- Thread the real per-subsystem name through at all 7 call sites and drop the standalone `LWLockRegisterTranche()` calls.
- Remove the `pg_attribute_unused()` markers the foundation work added on the now-used `trancheName` locals (`shardsplit_shared_memory.c`, `backend_data.c`).
- Keep the `NamedLWLockTranche` compat typedef (still required by Citus shmem structs on PG19).

Call sites: `causal_clock.c`, `shared_connection_stats.c`, `shardsplit_shared_memory.c`, `cluster_changes_block.c`, `stat_tenants.c`, `maintenanced.c`, `backend_data.c`.

PG&le;18 behaviour is unchanged (identical allocate-then-register sequence); PG19 now reports the correct per-subsystem tranche name.

## Validation (WSL, pgenv)

Each version built under full `-Werror` (no flag demotion), then a single-node functional check: `CREATE EXTENSION citus`, followed by 16-session contention on the cluster-clock LWLock (`citus_get_node_clock()`) while sampling `pg_stat_activity.wait_event`.

| Version | `-Werror` build | warnings in touched files | `CREATE EXTENSION` | `wait_event` observed | `citus-deferred` |
|---|---|---|---|---|---|
| 17.10 | clean | none | OK | `Cluster Clock Setup Tranche` | 0 |
| 18.4 | clean | none | OK | `Cluster Clock Setup Tranche` | 0 |
| 19beta1 | clean | none | OK | `Cluster Clock Setup Tranche` | 0 |

PG19 confirms the real per-subsystem name now surfaces (no longer `citus-deferred`); PG17/18 confirm the two-step path is regression-neutral. The one runtime-observable tranche (cluster clock) is verified directly; the other six use the identical helper and are covered by the `-Werror` build. Full multi-node regression runs in CI.

---
**Draft** — held for review per the PG19 support effort coordination.
