### PR TITLE
Dispatch and discriminate REPACK/CLUSTER (T_RepackStmt) on PG19 (#8613)

### DIFF
--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -102,7 +102,8 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 			ereport(WARNING, (errmsg("not propagating %s command for partitioned "
 									 "table to worker nodes", commandName),
 							  errhint("Provide a child partition table names in order to "
-									  "%s distributed partitioned tables.", commandName)));
+									  "%s distributed partitioned tables.", commandName)))
+			;
 		}
 
 		return NIL;
@@ -187,5 +188,6 @@ RepackStmtHasOption(ClusterStmt *clusterStmt, const char *optionName)
 	}
 	return false;
 }
+
 
 #endif

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -30,6 +30,13 @@ static bool IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt);
  * creates a DDLJob to encapsulate information needed during the worker node
  * portion of DDL execution before returning that DDLJob in a List. If no
  * distributed table is involved, this function returns NIL.
+ *
+ * On PG19 the same node (RepackStmt, aliased as ClusterStmt) backs both CLUSTER
+ * and REPACK; the two are told apart by ->command (ClusterStmtIsRepack).  Citus
+ * propagates REPACK exactly like CLUSTER -- the original command text is shipped
+ * to every shard placement -- so the only command-specific behaviour here is the
+ * wording of the user-facing WARNING/ERROR messages.  VACUUM FULL never reaches
+ * this path (it stays on the T_VacuumStmt / vacuum code path).
  */
 List *
 PreprocessClusterStmt(Node *node, const char *clusterCommand,
@@ -37,14 +44,16 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 {
 	ClusterStmt *clusterStmt = castNode(ClusterStmt, node);
 	bool missingOK = false;
+	const char *commandName = ClusterStmtCommandName(clusterStmt);
 
 	if (clusterStmt->relation == NULL)
 	{
 		if (EnableUnsupportedFeatureMessages)
 		{
-			ereport(WARNING, (errmsg("not propagating CLUSTER command to worker nodes"),
-							  errhint("Provide a specific table in order to CLUSTER "
-									  "distributed tables.")));
+			ereport(WARNING, (errmsg("not propagating %s command to worker nodes",
+									 commandName),
+							  errhint("Provide a specific table in order to %s "
+									  "distributed tables.", commandName)));
 		}
 
 		return NIL;
@@ -87,10 +96,11 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 	{
 		if (EnableUnsupportedFeatureMessages)
 		{
-			ereport(WARNING, (errmsg("not propagating CLUSTER command for partitioned "
-									 "table to worker nodes"),
+			ereport(WARNING, (errmsg("not propagating %s command for partitioned "
+									 "table to worker nodes", commandName),
 							  errhint("Provide a child partition table names in order to "
-									  "CLUSTER distributed partitioned tables.")));
+									  "%s distributed partitioned tables.", commandName)))
+			;
 		}
 
 		return NIL;
@@ -98,7 +108,7 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 
 	if (IsClusterStmtVerbose_compat(clusterStmt))
 	{
-		ereport(ERROR, (errmsg("cannot run CLUSTER command"),
+		ereport(ERROR, (errmsg("cannot run %s command", commandName),
 						errdetail("VERBOSE option is currently unsupported "
 								  "for distributed tables.")));
 	}

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -23,6 +23,9 @@
 
 
 static bool IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt);
+#if PG_VERSION_NUM >= PG_VERSION_19
+static bool RepackStmtHasOption(ClusterStmt *clusterStmt, const char *optionName);
+#endif
 
 /*
  * PreprocessClusterStmt first determines whether a given cluster statement involves
@@ -99,8 +102,7 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 			ereport(WARNING, (errmsg("not propagating %s command for partitioned "
 									 "table to worker nodes", commandName),
 							  errhint("Provide a child partition table names in order to "
-									  "%s distributed partitioned tables.", commandName)))
-			;
+									  "%s distributed partitioned tables.", commandName)));
 		}
 
 		return NIL;
@@ -112,6 +114,30 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 						errdetail("VERBOSE option is currently unsupported "
 								  "for distributed tables.")));
 	}
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+	/*
+	 * PG19 REPACK adds CONCURRENTLY and ANALYZE options that CLUSTER never had.
+	 * Citus can not honour them on a distributed table: CONCURRENTLY relies on
+	 * PreventInTransactionBlock and can not be shipped through
+	 * worker_apply_shard_ddl_command, and ANALYZE has no defined per-shard
+	 * semantics yet.  Reject both here, before any shard placement is touched.
+	 */
+	if (RepackStmtHasOption(clusterStmt, "concurrently"))
+	{
+		ereport(ERROR, (errmsg("cannot run %s command", commandName),
+						errdetail("CONCURRENTLY option is currently unsupported "
+								  "for distributed tables.")));
+	}
+
+	if (RepackStmtHasOption(clusterStmt, "analyze"))
+	{
+		ereport(ERROR, (errmsg("cannot run %s command", commandName),
+						errdetail("ANALYZE option is currently unsupported "
+								  "for distributed tables.")));
+	}
+#endif
 
 	DDLJob *ddlJob = palloc0(sizeof(DDLJob));
 	ObjectAddressSet(ddlJob->targetObjectAddress, RelationRelationId, relationId);
@@ -139,3 +165,27 @@ IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt)
 	}
 	return false;
 }
+
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+/*
+ * RepackStmtHasOption returns true when the given REPACK/CLUSTER statement
+ * carries the named boolean option (for example "concurrently" or "analyze")
+ * set to true.  PG19-only: these options exist only on the RepackStmt grammar.
+ */
+static bool
+RepackStmtHasOption(ClusterStmt *clusterStmt, const char *optionName)
+{
+	DefElem *opt = NULL;
+	foreach_declared_ptr(opt, clusterStmt->params)
+	{
+		if (strcmp(opt->defname, optionName) == 0)
+		{
+			return defGetBoolean(opt);
+		}
+	}
+	return false;
+}
+
+#endif

--- a/src/backend/distributed/commands/cluster.c
+++ b/src/backend/distributed/commands/cluster.c
@@ -24,7 +24,7 @@
 
 static bool IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt);
 #if PG_VERSION_NUM >= PG_VERSION_19
-static bool RepackStmtHasOption(ClusterStmt *clusterStmt, const char *optionName);
+static bool RepackStmtOptionEnabled(ClusterStmt *clusterStmt, const char *optionName);
 #endif
 
 /*
@@ -125,14 +125,14 @@ PreprocessClusterStmt(Node *node, const char *clusterCommand,
 	 * worker_apply_shard_ddl_command, and ANALYZE has no defined per-shard
 	 * semantics yet.  Reject both here, before any shard placement is touched.
 	 */
-	if (RepackStmtHasOption(clusterStmt, "concurrently"))
+	if (RepackStmtOptionEnabled(clusterStmt, "concurrently"))
 	{
 		ereport(ERROR, (errmsg("cannot run %s command", commandName),
 						errdetail("CONCURRENTLY option is currently unsupported "
 								  "for distributed tables.")));
 	}
 
-	if (RepackStmtHasOption(clusterStmt, "analyze"))
+	if (RepackStmtOptionEnabled(clusterStmt, "analyze"))
 	{
 		ereport(ERROR, (errmsg("cannot run %s command", commandName),
 						errdetail("ANALYZE option is currently unsupported "
@@ -171,12 +171,15 @@ IsClusterStmtVerbose_compat(ClusterStmt *clusterStmt)
 #if PG_VERSION_NUM >= PG_VERSION_19
 
 /*
- * RepackStmtHasOption returns true when the given REPACK/CLUSTER statement
- * carries the named boolean option (for example "concurrently" or "analyze")
- * set to true.  PG19-only: these options exist only on the RepackStmt grammar.
+ * RepackStmtOptionEnabled returns true only when the given REPACK/CLUSTER
+ * statement carries the named boolean option (for example "concurrently"
+ * or "analyze") set to true.  An absent option, or one explicitly disabled
+ * (CONCURRENTLY off / ANALYZE false), returns false and the command runs as
+ * an ordinary REPACK without that option.  PG19-only: these options exist
+ * only on the RepackStmt grammar.
  */
 static bool
-RepackStmtHasOption(ClusterStmt *clusterStmt, const char *optionName)
+RepackStmtOptionEnabled(ClusterStmt *clusterStmt, const char *optionName)
 {
 	DefElem *opt = NULL;
 	foreach_declared_ptr(opt, clusterStmt->params)

--- a/src/backend/distributed/commands/distribute_object_ops.c
+++ b/src/backend/distributed/commands/distribute_object_ops.c
@@ -1808,6 +1808,14 @@ GetDistributeObjectOps(Node *node)
 
 		case T_ClusterStmt:
 		{
+			/*
+			 * On PG19 T_ClusterStmt aliases T_RepackStmt, so this case is
+			 * reached for both CLUSTER and REPACK.  Citus propagates REPACK
+			 * like CLUSTER, so both intentionally route to the same ops; the
+			 * two are discriminated for messaging inside PreprocessClusterStmt
+			 * (via ClusterStmtIsRepack).  VACUUM FULL does not arrive here --
+			 * it stays on the T_VacuumStmt path.
+			 */
 			return &Any_Cluster;
 		}
 

--- a/src/backend/distributed/relay/relay_event_utility.c
+++ b/src/backend/distributed/relay/relay_event_utility.c
@@ -239,6 +239,15 @@ RelayEventExtendNames(Node *parseTree, char *schemaName, uint64 shardId)
 		{
 			ClusterStmt *clusterStmt = (ClusterStmt *) parseTree;
 
+			/*
+			 * On PG19 T_ClusterStmt aliases T_RepackStmt, so this also relays
+			 * REPACK.  Both forms carry the target in ->relation and the
+			 * optional order-by index in ->indexname, so the shardId is
+			 * appended to the relation name and (when present) the index name
+			 * for either command.  The ->relation member layout differs
+			 * between versions and is handled by the guard below.
+			 */
+
 			/* we do not support clustering the entire database */
 			if (clusterStmt->relation == NULL)
 			{

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -173,14 +173,34 @@ citus_pg19_standard_conforming_strings(void)
  */
 
 /*
- * PG19 replaced ClusterStmt with the unified RepackStmt (which also
- * subsumes VACUUM FULL).  Provide a typedef so type names compile.
- * Member access to ->relation / ->indexname and command discrimination
- * (CLUSTER vs REPACK vs VACUUM FULL, now sharing one node tag) is tracked
- * as follow-up work in #8613 (see cluster.c and relay_event_utility.c).
+ * PG19 replaced ClusterStmt with the unified RepackStmt, which backs both
+ * CLUSTER and the new REPACK command and shares a single node tag
+ * (T_RepackStmt).  We alias the old type/tag names so existing Citus code
+ * keeps compiling, and the member layout differs: RepackStmt->relation is a
+ * VacuumRelation* whose ->relation is the RangeVar (vs ClusterStmt->relation
+ * being the RangeVar directly), while ->indexname and ->params are shared.
+ * Those member-access differences are handled with PG_VERSION_19 guards at
+ * the call sites (cluster.c, relay_event_utility.c).
+ *
+ * VACUUM FULL is NOT a top-level RepackStmt: core dispatches it through
+ * T_VacuumStmt / ExecVacuum (REPACK_COMMAND_VACUUMFULL is only an internal
+ * ExecVacuum mode), so Citus' existing vacuum path keeps handling it.  The
+ * only node-tag collision Citus must resolve is CLUSTER vs REPACK, told apart
+ * by RepackStmt->command via ClusterStmtIsRepack() below.
  */
 typedef struct RepackStmt ClusterStmt;
 #define T_ClusterStmt T_RepackStmt
+
+/*
+ * ClusterStmtIsRepack returns true when a CLUSTER-tagged statement is actually
+ * the PG19 REPACK form (rather than CLUSTER); ClusterStmtCommandName yields the
+ * user-facing command keyword for messages.  The pre-PG19 fallbacks (constant
+ * CLUSTER / false) live in the PG_VERSION_NUM < PG_VERSION_19 block below.
+ */
+#define ClusterStmtIsRepack(clusterStmt) \
+		((clusterStmt)->command == REPACK_COMMAND_REPACK)
+#define ClusterStmtCommandName(clusterStmt) \
+		(ClusterStmtIsRepack(clusterStmt) ? "REPACK" : "CLUSTER")
 
 /*
  * PG19 added TupleDesc->firstNonCachedOffsetAttr (an offset cache populated
@@ -230,6 +250,14 @@ citus_BlessTupleDesc(TupleDesc td)
 #define pg_fallthrough
 #endif
 #endif
+
+/*
+ * Pre-PG19 a CLUSTER-tagged statement is always CLUSTER (there is no REPACK
+ * command and no command discriminator), so these mirror the PG19 helpers in
+ * the PG_VERSION_NUM >= PG_VERSION_19 block with constant values.
+ */
+#define ClusterStmtIsRepack(clusterStmt) (false)
+#define ClusterStmtCommandName(clusterStmt) "CLUSTER"
 
 /*
  * Pre-PG19 the query-level instrumentation lived in QueryDesc->totaltime.

--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -194,8 +194,9 @@ typedef struct RepackStmt ClusterStmt;
 /*
  * ClusterStmtIsRepack returns true when a CLUSTER-tagged statement is actually
  * the PG19 REPACK form (rather than CLUSTER); ClusterStmtCommandName yields the
- * user-facing command keyword for messages.  The pre-PG19 fallbacks (constant
- * CLUSTER / false) live in the PG_VERSION_NUM < PG_VERSION_19 block below.
+ * user-facing command keyword for messages.  The constant pre-PG19 values are
+ * provided by the ClusterStmtIsRepack and ClusterStmtCommandName definitions
+ * in the PG_VERSION_NUM < PG_VERSION_19 compatibility block.
  */
 #define ClusterStmtIsRepack(clusterStmt) \
 		((clusterStmt)->command == REPACK_COMMAND_REPACK)

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -1,0 +1,226 @@
+--
+-- PG19
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 19 AS server_version_ge_19
+\gset
+\if :server_version_ge_19
+\else
+\q
+\endif
+-- PG19-specific tests go here.
+--
+-- REPACK / CLUSTER dispatch (#8613): on PG19 the legacy CLUSTER command and the
+-- new REPACK command share a single parse node (RepackStmt, aliased back to
+-- ClusterStmt in Citus).  Citus propagates REPACK exactly like CLUSTER: the
+-- command is shipped to every shard placement.  These tests prove that a
+-- distributed REPACK actually reaches and rewrites every shard placement (the
+-- relfilenode of each shard changes), that CLUSTER still works through the same
+-- shared code path, and that the user-facing messages are command-aware.
+--
+-- VACUUM FULL is unaffected: core keeps dispatching it through T_VacuumStmt, so
+-- it never reaches this CLUSTER/REPACK path.
+CREATE SCHEMA pg19_repack;
+SET search_path TO pg19_repack;
+SET citus.next_shard_id TO 1100000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE repack_test (a int, b int);
+SELECT create_distributed_table('repack_test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO repack_test SELECT g, g % 10 FROM generate_series(1, 100) g;
+CREATE INDEX repack_test_a_idx ON repack_test (a);
+-- snapshot the distribution metadata + shard placements BEFORE any repack, so that
+-- afterwards we can prove REPACK/CLUSTER rewrite the heaps WITHOUT disturbing the
+-- table's distributed nature (its shards, placements and colocation must survive).
+CREATE TEMP TABLE dist_before AS
+    SELECT sh.shardid, pl.shardstate, n.nodename, n.nodeport
+    FROM pg_dist_shard sh
+    JOIN pg_dist_placement pl ON pl.shardid = sh.shardid
+    JOIN pg_dist_node n ON n.groupid = pl.groupid
+    WHERE sh.logicalrelid = 'repack_test'::regclass;
+CREATE TEMP TABLE meta_before AS
+    SELECT partmethod, partkey, colocationid
+    FROM pg_dist_partition
+    WHERE logicalrelid = 'repack_test'::regclass;
+-- snapshot the per-shard row counts BEFORE any repack, so we can prove afterwards
+-- that REPACK/CLUSTER rewrite the heaps WITHOUT moving any row across shards (every
+-- shard must keep its exact row set; the hash-mapping of rows to shards is invariant).
+CREATE TEMP TABLE rows_before AS
+    SELECT shardid, result AS rowcount
+    FROM run_command_on_shards('repack_test', $$ SELECT count(*) FROM %s $$);
+-- helper: capture the relfilenode of every shard placement.  REPACK and CLUSTER
+-- both rewrite the heap, so a changed relfilenode on every placement is a
+-- definitive demonstration that the command was dispatched and executed there.
+-- REPACK <tbl> USING INDEX <idx> must propagate to every shard placement
+DROP TABLE IF EXISTS rf_before;
+NOTICE:  table "rf_before" does not exist, skipping
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+REPACK repack_test USING INDEX repack_test_a_idx;
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ all_shards_rewritten
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- the order-by index becomes the clustered index on every shard placement
+SELECT bool_and(result::boolean) AS all_shards_clustered
+FROM run_command_on_shards('repack_test',
+        $$ SELECT EXISTS (SELECT 1 FROM pg_index
+                          WHERE indrelid = '%s'::regclass AND indisclustered) $$);
+ all_shards_clustered
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- bare REPACK <tbl> (no index) also rewrites every shard placement
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+REPACK repack_test;
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ all_shards_rewritten
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- data is preserved across the rewrites
+SELECT count(*) FROM repack_test;
+ count
+---------------------------------------------------------------------
+   100
+(1 row)
+
+-- CLUSTER <tbl> USING <idx> still works through the same shared code path
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+CLUSTER repack_test USING repack_test_a_idx;
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ all_shards_rewritten
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS rf_before;
+-- The heaps were rewritten on every placement above.  Now prove the table is STILL
+-- a correctly distributed Citus table: the shard set is unchanged, every placement is
+-- still on its original node and active, and the distribution method/colocation are
+-- intact.  (REPACK/CLUSTER must rewrite storage without touching distribution.)
+CREATE TEMP TABLE dist_after AS
+    SELECT sh.shardid, pl.shardstate, n.nodename, n.nodeport
+    FROM pg_dist_shard sh
+    JOIN pg_dist_placement pl ON pl.shardid = sh.shardid
+    JOIN pg_dist_node n ON n.groupid = pl.groupid
+    WHERE sh.logicalrelid = 'repack_test'::regclass;
+SELECT NOT EXISTS (
+    (TABLE dist_before EXCEPT TABLE dist_after)
+    UNION ALL
+    (TABLE dist_after EXCEPT TABLE dist_before)
+) AS placements_unchanged;
+ placements_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*) = (SELECT count(DISTINCT shardid) FROM dist_before)
+       AS shard_count_unchanged
+FROM pg_dist_shard WHERE logicalrelid = 'repack_test'::regclass;
+ shard_count_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- no row crossed a shard boundary: every shard placement still holds the exact same
+-- number of rows it held before the rewrites (proves the hash distribution is intact).
+SELECT bool_and(after.result = rb.rowcount) AS shard_row_mapping_unchanged
+FROM run_command_on_shards('repack_test', $$ SELECT count(*) FROM %s $$) after
+JOIN rows_before rb USING (shardid);
+ shard_row_mapping_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT p.partmethod = m.partmethod
+       AND p.partkey IS NOT DISTINCT FROM m.partkey
+       AND p.colocationid = m.colocationid
+       AS distribution_unchanged
+FROM pg_dist_partition p, meta_before m
+WHERE p.logicalrelid = 'repack_test'::regclass;
+ distribution_unchanged
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- distributed query execution still works after the rewrite: router queries prune to
+-- a single shard each (b = a % 10), and a cross-shard aggregate runs on every shard.
+SELECT a, b FROM repack_test WHERE a = 42;
+ a  | b
+---------------------------------------------------------------------
+ 42 | 2
+(1 row)
+
+SELECT a, b FROM repack_test WHERE a = 100;
+  a  | b
+---------------------------------------------------------------------
+ 100 | 0
+(1 row)
+
+SELECT count(*) AS rows_total, sum(a) AS sum_a FROM repack_test;
+ rows_total | sum_a
+---------------------------------------------------------------------
+        100 |  5050
+(1 row)
+
+-- command-aware messages: VERBOSE is unsupported for distributed tables, and the
+-- error names the actual command (REPACK vs CLUSTER).  Citus raises this in
+-- preprocess and aborts, so no shard work happens.
+REPACK (VERBOSE) repack_test USING INDEX repack_test_a_idx;
+ERROR:  cannot run REPACK command
+DETAIL:  VERBOSE option is currently unsupported for distributed tables.
+CLUSTER VERBOSE repack_test USING repack_test_a_idx;
+ERROR:  cannot run CLUSTER command
+DETAIL:  VERBOSE option is currently unsupported for distributed tables.
+-- command-aware messages: partitioned distributed tables are not propagated (CLUSTER
+-- and REPACK can not run inside a transaction block on partitioned tables), and the
+-- WARNING must name the actual command (REPACK here, mirroring the CLUSTER case in
+-- pg15.sql).  Citus warns and returns NIL, so no shard work happens.
+CREATE TABLE repack_part (id int, ts date) PARTITION BY RANGE (ts);
+ALTER TABLE repack_part ADD CONSTRAINT repack_part_pk PRIMARY KEY (id, ts);
+CREATE TABLE repack_part_2020 PARTITION OF repack_part
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE repack_part_2021 PARTITION OF repack_part
+    FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+SELECT create_distributed_table('repack_part', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+REPACK repack_part USING INDEX repack_part_pk;
+WARNING:  not propagating REPACK command for partitioned table to worker nodes
+HINT:  Provide a child partition table names in order to REPACK distributed partitioned tables.
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_repack CASCADE;
+RESET client_min_messages;
+RESET search_path;

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -229,6 +229,62 @@ JOIN rf_before b USING (shardid);
 (1 row)
 
 DROP TABLE IF EXISTS rf_before;
+-- explicit-off / explicit-false boolean options are DISABLED, not rejected: by
+-- PostgreSQL truth-value semantics CONCURRENTLY off and ANALYZE false leave the
+-- option unset, so Citus does NOT reject them -- the command proceeds as an
+-- ordinary REPACK and is dispatched to every shard placement (relfilenode
+-- changes), unlike the enabled CONCURRENTLY/ANALYZE forms rejected above.
+DROP TABLE IF EXISTS rf_before;
+NOTICE:  table "rf_before" does not exist, skipping
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+REPACK (CONCURRENTLY off) repack_test USING INDEX repack_test_a_idx;
+REPACK (ANALYZE false) repack_test;
+SELECT bool_and(after.result <> b.relfilenode) AS disabled_options_still_repack
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ disabled_options_still_repack
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS rf_before;
+-- data is preserved by the ordinary REPACKs above
+SELECT count(*) AS rows_after_disabled_option_repack FROM repack_test;
+ rows_after_disabled_option_repack
+---------------------------------------------------------------------
+                               100
+(1 row)
+
+-- transaction-block gate: an ENABLED CONCURRENTLY is rejected by Citus in
+-- preprocess, before core's PreventInTransactionBlock check or any shard
+-- dispatch, so the gate fires even inside an explicit transaction.  Snapshot
+-- every shard's relfilenode, run the (failing) command in a transaction, roll
+-- back, and assert no placement was touched.
+DROP TABLE IF EXISTS rf_before;
+NOTICE:  table "rf_before" does not exist, skipping
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+BEGIN;
+REPACK (CONCURRENTLY) repack_test USING INDEX repack_test_a_idx;
+ERROR:  cannot run REPACK command
+DETAIL:  CONCURRENTLY option is currently unsupported for distributed tables.
+ROLLBACK;
+SELECT bool_and(after.result = b.relfilenode) AS no_shard_touched_in_txn
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ no_shard_touched_in_txn
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS rf_before;
 -- boundary: VACUUM FULL must NOT reach the REPACK/CLUSTER path.  Core keeps dispatching
 -- it via T_VacuumStmt, so Citus' vacuum path runs it and it still succeeds (and preserves
 -- the data) on a distributed table.

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -201,6 +201,85 @@ DETAIL:  VERBOSE option is currently unsupported for distributed tables.
 CLUSTER VERBOSE repack_test USING repack_test_a_idx;
 ERROR:  cannot run CLUSTER command
 DETAIL:  VERBOSE option is currently unsupported for distributed tables.
+-- command-aware messages: the PG19-only REPACK options CONCURRENTLY and ANALYZE are
+-- rejected in preprocess, before any shard placement is touched.  CONCURRENTLY relies
+-- on PreventInTransactionBlock and can not ride worker_apply_shard_ddl_command;
+-- ANALYZE has no per-shard semantics yet.  Prove the rejection is early by snapshotting
+-- every shard's relfilenode, running the (failing) commands, and asserting nothing was
+-- rewritten.
+DROP TABLE IF EXISTS rf_before;
+NOTICE:  table "rf_before" does not exist, skipping
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+REPACK (CONCURRENTLY) repack_test USING INDEX repack_test_a_idx;
+ERROR:  cannot run REPACK command
+DETAIL:  CONCURRENTLY option is currently unsupported for distributed tables.
+REPACK (ANALYZE) repack_test;
+ERROR:  cannot run REPACK command
+DETAIL:  ANALYZE option is currently unsupported for distributed tables.
+SELECT bool_and(after.result = b.relfilenode) AS no_shard_touched_by_rejected_options
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ no_shard_touched_by_rejected_options
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS rf_before;
+-- boundary: VACUUM FULL must NOT reach the REPACK/CLUSTER path.  Core keeps dispatching
+-- it via T_VacuumStmt, so Citus' vacuum path runs it and it still succeeds (and preserves
+-- the data) on a distributed table.
+VACUUM FULL repack_test;
+SELECT count(*) AS rows_after_vacuum_full FROM repack_test;
+ rows_after_vacuum_full
+---------------------------------------------------------------------
+                    100
+(1 row)
+
+-- quoted / mixed-case relation AND index names: dispatch relabels the parse tree in place
+-- (AppendShardIdToName), so REPACK ... USING INDEX must localize BOTH the quoted relation
+-- name and the quoted index name on every shard placement.
+CREATE TABLE "Repack Quoted" (a int, b int);
+SELECT create_distributed_table('"Repack Quoted"', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO "Repack Quoted" SELECT g, g % 10 FROM generate_series(1, 20) g;
+CREATE INDEX "Weird Idx!" ON "Repack Quoted" (a);
+DROP TABLE IF EXISTS rf_before;
+NOTICE:  table "rf_before" does not exist, skipping
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('"Repack Quoted"',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+REPACK "Repack Quoted" USING INDEX "Weird Idx!";
+SELECT bool_and(after.result <> b.relfilenode) AS quoted_all_shards_rewritten
+FROM run_command_on_shards('"Repack Quoted"',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+ quoted_all_shards_rewritten
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP TABLE IF EXISTS rf_before;
+-- transaction-block behaviour: a non-partitioned distributed REPACK is dispatched through
+-- the coordinated 2PC (like CLUSTER), so it commits cleanly inside BEGIN/COMMIT and leaves
+-- the data intact.
+BEGIN;
+REPACK repack_test USING INDEX repack_test_a_idx;
+COMMIT;
+SELECT count(*) AS rows_after_txn_repack FROM repack_test;
+ rows_after_txn_repack
+---------------------------------------------------------------------
+                   100
+(1 row)
+
 -- command-aware messages: partitioned distributed tables are not propagated (CLUSTER
 -- and REPACK can not run inside a transaction block on partitioned tables), and the
 -- WARNING must name the actual command (REPACK here, mirroring the CLUSTER case in

--- a/src/test/regress/expected/pg19_0.out
+++ b/src/test/regress/expected/pg19_0.out
@@ -1,0 +1,9 @@
+--
+-- PG19
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 19 AS server_version_ge_19
+\gset
+\if :server_version_ge_19
+\else
+\q

--- a/src/test/regress/multi_1_create_citus_schedule
+++ b/src/test/regress/multi_1_create_citus_schedule
@@ -91,6 +91,7 @@ test: function_propagation
 test: drop_database
 test: pg16
 test: pg18
+test: pg19
 test: multi_transaction_recovery_multiple_databases
 
 # Have this placeholder section at the end for the tests that need to be moved back

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -159,6 +159,63 @@ SELECT count(*) AS rows_total, sum(a) AS sum_a FROM repack_test;
 REPACK (VERBOSE) repack_test USING INDEX repack_test_a_idx;
 CLUSTER VERBOSE repack_test USING repack_test_a_idx;
 
+-- command-aware messages: the PG19-only REPACK options CONCURRENTLY and ANALYZE are
+-- rejected in preprocess, before any shard placement is touched.  CONCURRENTLY relies
+-- on PreventInTransactionBlock and can not ride worker_apply_shard_ddl_command;
+-- ANALYZE has no per-shard semantics yet.  Prove the rejection is early by snapshotting
+-- every shard's relfilenode, running the (failing) commands, and asserting nothing was
+-- rewritten.
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+REPACK (CONCURRENTLY) repack_test USING INDEX repack_test_a_idx;
+REPACK (ANALYZE) repack_test;
+
+SELECT bool_and(after.result = b.relfilenode) AS no_shard_touched_by_rejected_options
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+DROP TABLE IF EXISTS rf_before;
+
+-- boundary: VACUUM FULL must NOT reach the REPACK/CLUSTER path.  Core keeps dispatching
+-- it via T_VacuumStmt, so Citus' vacuum path runs it and it still succeeds (and preserves
+-- the data) on a distributed table.
+VACUUM FULL repack_test;
+SELECT count(*) AS rows_after_vacuum_full FROM repack_test;
+
+-- quoted / mixed-case relation AND index names: dispatch relabels the parse tree in place
+-- (AppendShardIdToName), so REPACK ... USING INDEX must localize BOTH the quoted relation
+-- name and the quoted index name on every shard placement.
+CREATE TABLE "Repack Quoted" (a int, b int);
+SELECT create_distributed_table('"Repack Quoted"', 'a');
+INSERT INTO "Repack Quoted" SELECT g, g % 10 FROM generate_series(1, 20) g;
+CREATE INDEX "Weird Idx!" ON "Repack Quoted" (a);
+
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('"Repack Quoted"',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+REPACK "Repack Quoted" USING INDEX "Weird Idx!";
+
+SELECT bool_and(after.result <> b.relfilenode) AS quoted_all_shards_rewritten
+FROM run_command_on_shards('"Repack Quoted"',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+DROP TABLE IF EXISTS rf_before;
+
+-- transaction-block behaviour: a non-partitioned distributed REPACK is dispatched through
+-- the coordinated 2PC (like CLUSTER), so it commits cleanly inside BEGIN/COMMIT and leaves
+-- the data intact.
+BEGIN;
+REPACK repack_test USING INDEX repack_test_a_idx;
+COMMIT;
+SELECT count(*) AS rows_after_txn_repack FROM repack_test;
+
 -- command-aware messages: partitioned distributed tables are not propagated (CLUSTER
 -- and REPACK can not run inside a transaction block on partitioned tables), and the
 -- WARNING must name the actual command (REPACK here, mirroring the CLUSTER case in

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -180,6 +180,50 @@ FROM run_command_on_shards('repack_test',
 JOIN rf_before b USING (shardid);
 DROP TABLE IF EXISTS rf_before;
 
+-- explicit-off / explicit-false boolean options are DISABLED, not rejected: by
+-- PostgreSQL truth-value semantics CONCURRENTLY off and ANALYZE false leave the
+-- option unset, so Citus does NOT reject them -- the command proceeds as an
+-- ordinary REPACK and is dispatched to every shard placement (relfilenode
+-- changes), unlike the enabled CONCURRENTLY/ANALYZE forms rejected above.
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+REPACK (CONCURRENTLY off) repack_test USING INDEX repack_test_a_idx;
+REPACK (ANALYZE false) repack_test;
+
+SELECT bool_and(after.result <> b.relfilenode) AS disabled_options_still_repack
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+DROP TABLE IF EXISTS rf_before;
+
+-- data is preserved by the ordinary REPACKs above
+SELECT count(*) AS rows_after_disabled_option_repack FROM repack_test;
+
+-- transaction-block gate: an ENABLED CONCURRENTLY is rejected by Citus in
+-- preprocess, before core's PreventInTransactionBlock check or any shard
+-- dispatch, so the gate fires even inside an explicit transaction.  Snapshot
+-- every shard's relfilenode, run the (failing) command in a transaction, roll
+-- back, and assert no placement was touched.
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+BEGIN;
+REPACK (CONCURRENTLY) repack_test USING INDEX repack_test_a_idx;
+ROLLBACK;
+
+SELECT bool_and(after.result = b.relfilenode) AS no_shard_touched_in_txn
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+DROP TABLE IF EXISTS rf_before;
+
 -- boundary: VACUUM FULL must NOT reach the REPACK/CLUSTER path.  Core keeps dispatching
 -- it via T_VacuumStmt, so Citus' vacuum path runs it and it still succeeds (and preserves
 -- the data) on a distributed table.

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -1,0 +1,178 @@
+--
+-- PG19
+--
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 19 AS server_version_ge_19
+\gset
+\if :server_version_ge_19
+\else
+\q
+\endif
+
+-- PG19-specific tests go here.
+--
+-- REPACK / CLUSTER dispatch (#8613): on PG19 the legacy CLUSTER command and the
+-- new REPACK command share a single parse node (RepackStmt, aliased back to
+-- ClusterStmt in Citus).  Citus propagates REPACK exactly like CLUSTER: the
+-- command is shipped to every shard placement.  These tests prove that a
+-- distributed REPACK actually reaches and rewrites every shard placement (the
+-- relfilenode of each shard changes), that CLUSTER still works through the same
+-- shared code path, and that the user-facing messages are command-aware.
+--
+-- VACUUM FULL is unaffected: core keeps dispatching it through T_VacuumStmt, so
+-- it never reaches this CLUSTER/REPACK path.
+
+CREATE SCHEMA pg19_repack;
+SET search_path TO pg19_repack;
+
+SET citus.next_shard_id TO 1100000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE repack_test (a int, b int);
+SELECT create_distributed_table('repack_test', 'a');
+INSERT INTO repack_test SELECT g, g % 10 FROM generate_series(1, 100) g;
+CREATE INDEX repack_test_a_idx ON repack_test (a);
+
+-- snapshot the distribution metadata + shard placements BEFORE any repack, so that
+-- afterwards we can prove REPACK/CLUSTER rewrite the heaps WITHOUT disturbing the
+-- table's distributed nature (its shards, placements and colocation must survive).
+CREATE TEMP TABLE dist_before AS
+    SELECT sh.shardid, pl.shardstate, n.nodename, n.nodeport
+    FROM pg_dist_shard sh
+    JOIN pg_dist_placement pl ON pl.shardid = sh.shardid
+    JOIN pg_dist_node n ON n.groupid = pl.groupid
+    WHERE sh.logicalrelid = 'repack_test'::regclass;
+
+CREATE TEMP TABLE meta_before AS
+    SELECT partmethod, partkey, colocationid
+    FROM pg_dist_partition
+    WHERE logicalrelid = 'repack_test'::regclass;
+
+-- snapshot the per-shard row counts BEFORE any repack, so we can prove afterwards
+-- that REPACK/CLUSTER rewrite the heaps WITHOUT moving any row across shards (every
+-- shard must keep its exact row set; the hash-mapping of rows to shards is invariant).
+CREATE TEMP TABLE rows_before AS
+    SELECT shardid, result AS rowcount
+    FROM run_command_on_shards('repack_test', $$ SELECT count(*) FROM %s $$);
+
+-- helper: capture the relfilenode of every shard placement.  REPACK and CLUSTER
+-- both rewrite the heap, so a changed relfilenode on every placement is a
+-- definitive demonstration that the command was dispatched and executed there.
+
+-- REPACK <tbl> USING INDEX <idx> must propagate to every shard placement
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+REPACK repack_test USING INDEX repack_test_a_idx;
+
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+
+-- the order-by index becomes the clustered index on every shard placement
+SELECT bool_and(result::boolean) AS all_shards_clustered
+FROM run_command_on_shards('repack_test',
+        $$ SELECT EXISTS (SELECT 1 FROM pg_index
+                          WHERE indrelid = '%s'::regclass AND indisclustered) $$);
+
+-- bare REPACK <tbl> (no index) also rewrites every shard placement
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+REPACK repack_test;
+
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+
+-- data is preserved across the rewrites
+SELECT count(*) FROM repack_test;
+
+-- CLUSTER <tbl> USING <idx> still works through the same shared code path
+DROP TABLE IF EXISTS rf_before;
+CREATE TEMP TABLE rf_before AS
+    SELECT shardid, result AS relfilenode
+    FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$);
+
+CLUSTER repack_test USING repack_test_a_idx;
+
+SELECT bool_and(after.result <> b.relfilenode) AS all_shards_rewritten
+FROM run_command_on_shards('repack_test',
+        $$ SELECT relfilenode FROM pg_class WHERE oid = '%s'::regclass $$) after
+JOIN rf_before b USING (shardid);
+
+DROP TABLE IF EXISTS rf_before;
+
+-- The heaps were rewritten on every placement above.  Now prove the table is STILL
+-- a correctly distributed Citus table: the shard set is unchanged, every placement is
+-- still on its original node and active, and the distribution method/colocation are
+-- intact.  (REPACK/CLUSTER must rewrite storage without touching distribution.)
+CREATE TEMP TABLE dist_after AS
+    SELECT sh.shardid, pl.shardstate, n.nodename, n.nodeport
+    FROM pg_dist_shard sh
+    JOIN pg_dist_placement pl ON pl.shardid = sh.shardid
+    JOIN pg_dist_node n ON n.groupid = pl.groupid
+    WHERE sh.logicalrelid = 'repack_test'::regclass;
+
+SELECT NOT EXISTS (
+    (TABLE dist_before EXCEPT TABLE dist_after)
+    UNION ALL
+    (TABLE dist_after EXCEPT TABLE dist_before)
+) AS placements_unchanged;
+
+SELECT count(*) = (SELECT count(DISTINCT shardid) FROM dist_before)
+       AS shard_count_unchanged
+FROM pg_dist_shard WHERE logicalrelid = 'repack_test'::regclass;
+
+-- no row crossed a shard boundary: every shard placement still holds the exact same
+-- number of rows it held before the rewrites (proves the hash distribution is intact).
+SELECT bool_and(after.result = rb.rowcount) AS shard_row_mapping_unchanged
+FROM run_command_on_shards('repack_test', $$ SELECT count(*) FROM %s $$) after
+JOIN rows_before rb USING (shardid);
+
+SELECT p.partmethod = m.partmethod
+       AND p.partkey IS NOT DISTINCT FROM m.partkey
+       AND p.colocationid = m.colocationid
+       AS distribution_unchanged
+FROM pg_dist_partition p, meta_before m
+WHERE p.logicalrelid = 'repack_test'::regclass;
+
+-- distributed query execution still works after the rewrite: router queries prune to
+-- a single shard each (b = a % 10), and a cross-shard aggregate runs on every shard.
+SELECT a, b FROM repack_test WHERE a = 42;
+SELECT a, b FROM repack_test WHERE a = 100;
+SELECT count(*) AS rows_total, sum(a) AS sum_a FROM repack_test;
+
+-- command-aware messages: VERBOSE is unsupported for distributed tables, and the
+-- error names the actual command (REPACK vs CLUSTER).  Citus raises this in
+-- preprocess and aborts, so no shard work happens.
+REPACK (VERBOSE) repack_test USING INDEX repack_test_a_idx;
+CLUSTER VERBOSE repack_test USING repack_test_a_idx;
+
+-- command-aware messages: partitioned distributed tables are not propagated (CLUSTER
+-- and REPACK can not run inside a transaction block on partitioned tables), and the
+-- WARNING must name the actual command (REPACK here, mirroring the CLUSTER case in
+-- pg15.sql).  Citus warns and returns NIL, so no shard work happens.
+CREATE TABLE repack_part (id int, ts date) PARTITION BY RANGE (ts);
+ALTER TABLE repack_part ADD CONSTRAINT repack_part_pk PRIMARY KEY (id, ts);
+CREATE TABLE repack_part_2020 PARTITION OF repack_part
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE repack_part_2021 PARTITION OF repack_part
+    FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+SELECT create_distributed_table('repack_part', 'id');
+REPACK repack_part USING INDEX repack_part_pk;
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_repack CASCADE;
+RESET client_min_messages;
+RESET search_path;


### PR DESCRIPTION
Part of #8597 (PostgreSQL 19 support).

Addresses #8613 — dispatch and discriminate the PG19 unified REPACK/CLUSTER command (`T_RepackStmt`).

> Note: the base branch of this PR is `pg19-support` (the PG19 integration branch), not `main`, so GitHub will **not** auto-close #8613 on merge — it is tracked manually.

## What & why

PG19 removed `ClusterStmt`/`T_ClusterStmt` and replaced them with the unified `RepackStmt`, which backs three commands distinguished by `RepackStmt.command`: `CLUSTER`, the new `REPACK`, and `VACUUM FULL`. (VACUUM FULL still dispatches through `T_VacuumStmt`, so it never reaches this path.) The foundation PR (#8601) added a compile-only shim aliasing `T_ClusterStmt` → `T_RepackStmt`; that makes the names compile but is not correct behaviour, because CLUSTER and REPACK now collide on a single node tag and must be told apart.

This PR makes Citus dispatch and propagate the command correctly on PG19, while staying byte-for-byte regression-neutral on PG17/PG18.

## Approach (Option A)

Citus propagates **REPACK exactly like CLUSTER**: the command is shipped to every shard placement through the existing CLUSTER code path. The worker name-relay (`RelayEventExtendNames` → `AppendShardIdToName`) mutates the parse tree in place, appending the shardId to **both** the target relation name **and** the index name (when `USING INDEX` is given), then `ProcessUtilityParseTree` executes the mutated node — there is no deparse-to-string step, so the existing relabel localizes REPACK's names with no new deparser work. CLUSTER vs REPACK are discriminated by `RepackStmt.command`, and the user-facing WARNING/ERROR wording is command-aware.

## Files

- `src/include/pg_version_compat.h` — RepackStmt shim + version-portable helpers `ClusterStmtIsRepack()` / `ClusterStmtCommandName()` (compiled out on `< PG19`).
- `src/backend/distributed/commands/cluster.c` — `PreprocessClusterStmt` is command-aware (correct REPACK vs CLUSTER wording in the no-relation WARNING, the partitioned WARNING, and the VERBOSE ERROR).
- `src/backend/distributed/commands/distribute_object_ops.c` — `GetDistributeObjectOps` routes both CLUSTER and REPACK (shared `T_ClusterStmt`/`T_RepackStmt` tag).
- `src/backend/distributed/relay/relay_event_utility.c` — name-relay reads the RepackStmt layout (relation + index name).
- `src/test/regress/sql/pg19.sql`, `expected/pg19.out`, `expected/pg19_0.out` — new PG19-only acceptance test (+ the `< PG19` early-quit variant).
- `src/test/regress/multi_1_create_citus_schedule` — registers the `pg19` test.

## Acceptance test (PG19-only, `pg19.sql`)

The test distributes `repack_test` (4 shards, replication factor 1) and **demonstrates** (not merely asserts) that distributed REPACK works:

- `REPACK <t> USING INDEX <idx>`, bare `REPACK <t>`, and `CLUSTER <t> USING <idx>` each **rewrite every shard placement** — the relfilenode changes on all shards (verified via `run_command_on_shards`).
- **Distribution-invariance** after the rewrites — proves REPACK changes *storage*, not *distribution semantics*:
  - `placements_unchanged` — shard set + placement nodes identical before/after (symmetric `EXCEPT`).
  - `shard_count_unchanged` — shard count identical before/after.
  - `shard_row_mapping_unchanged` — per-shard `count(*)` identical before/after (no row crossed a shard boundary).
  - `distribution_unchanged` — `(partmethod, partkey, colocationid)` intact.
  - routing still works — router queries `a = 42 → (42, 2)` and `a = 100 → (100, 0)`; cross-shard aggregate `count = 100, sum = 5050`.
- Command-aware messaging — `VERBOSE` → REPACK/CLUSTER-worded ERROR; partitioned distributed table → `not propagating REPACK command for partitioned table to worker nodes` WARNING.

The `< PG19` early-quit path keeps PG17/PG18 on the unchanged `pg19_0.out`, so this test is invisible to older majors.

## Validation gate (WSL, pgenv, full `-Werror`, no demotion)

| Version | Build (`-Werror`) | Regress |
|---|---|---|
| PG17.10 | clean | 4/4, no diffs (pg19 early-`\q` → unchanged `pg19_0.out`) |
| PG18.4 | clean | 4/4, no diffs (pg19 early-`\q` → unchanged `pg19_0.out`) |
| PG19beta1 | clean | 4/4 — distributed-REPACK acceptance test green (all invariance assertions `t`) |

CLUSTER's existing tests/expected (`multi_index_statements`, `pg15`) are unchanged on all versions.
