### PR TITLE
Add citus.allow_unsafe_insert_select_pushdown for shard-local batched INSERT ... SELECT

### DIFF
--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -117,7 +117,7 @@ RebuildQueryStrings(Job *workerJob)
 				;
 				if (distributionColumnIsShardKeyIdentity)
 				{
-					AddBatchPassThroughNotNullFilter(query, copiedInsertRte,
+					AddShardKeyIdentityNotNullFilter(query, copiedInsertRte,
 													 copiedSubqueryRte);
 				}
 			}

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -109,7 +109,7 @@ RebuildQueryStrings(Job *workerJob)
 			/* there are no restrictions to add for reference and citus local tables */
 			if (IsCitusTableType(shardInterval->relationId, DISTRIBUTED_TABLE))
 			{
-				AddPartitionKeyNotNullFilterToSelect(copiedSubquery);
+				AddPartitionKeyNotNullFilterToSelect(copiedSubquery, false);
 			}
 
 			ReorderInsertSelectTargetLists(query, copiedInsertRte, copiedSubqueryRte);

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -109,7 +109,17 @@ RebuildQueryStrings(Job *workerJob)
 			/* there are no restrictions to add for reference and citus local tables */
 			if (IsCitusTableType(shardInterval->relationId, DISTRIBUTED_TABLE))
 			{
-				AddPartitionKeyNotNullFilterToSelect(copiedSubquery, false);
+				bool distributionColumnIsBatchPassThrough =
+					InsertPartitionColumnIsBatchPassThrough(query, copiedInsertRte,
+															copiedSubqueryRte);
+				AddPartitionKeyNotNullFilterToSelect(copiedSubquery,
+													 distributionColumnIsBatchPassThrough)
+				;
+				if (distributionColumnIsBatchPassThrough)
+				{
+					AddBatchPassThroughNotNullFilter(query, copiedInsertRte,
+													 copiedSubqueryRte);
+				}
 			}
 
 			ReorderInsertSelectTargetLists(query, copiedInsertRte, copiedSubqueryRte);

--- a/src/backend/distributed/planner/deparse_shard_query.c
+++ b/src/backend/distributed/planner/deparse_shard_query.c
@@ -109,13 +109,13 @@ RebuildQueryStrings(Job *workerJob)
 			/* there are no restrictions to add for reference and citus local tables */
 			if (IsCitusTableType(shardInterval->relationId, DISTRIBUTED_TABLE))
 			{
-				bool distributionColumnIsBatchPassThrough =
-					InsertPartitionColumnIsBatchPassThrough(query, copiedInsertRte,
+				bool distributionColumnIsShardKeyIdentity =
+					InsertPartitionColumnIsShardKeyIdentity(query, copiedInsertRte,
 															copiedSubqueryRte);
 				AddPartitionKeyNotNullFilterToSelect(copiedSubquery,
-													 distributionColumnIsBatchPassThrough)
+													 distributionColumnIsShardKeyIdentity)
 				;
-				if (distributionColumnIsBatchPassThrough)
+				if (distributionColumnIsShardKeyIdentity)
 				{
 					AddBatchPassThroughNotNullFilter(query, copiedInsertRte,
 													 copiedSubqueryRte);

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -1263,6 +1263,13 @@ InsertPartitionColumnIsShardKeyIdentity(Query *query, RangeTblEntry *insertRte,
  * source shard key: every value it produces routes back into the same shard as
  * the source row it came from, so - given source and target are colocated - the
  * INSERT ... SELECT stays shard-local and can be pushed down.
+ *
+ * Today the only recognized identity is the batch pass-through
+ * unnest(array_agg(<distribution column>)), but this check is meant to be
+ * extended. Other expressions are identities of their sole argument and could
+ * be recognized here in the future, for example abs(var) when var has an
+ * unsigned type, coalesce(var) / greatest(var) with a single argument, or
+ * var || '' when var is non-NULL.
  */
 static bool
 DistributionColumnIsShardKeyIdentity(Expr *expr, Query *query)
@@ -1765,7 +1772,7 @@ SelectTargetEntryForInsertPartitionColumn(Query *query, RangeTblEntry *insertRte
  * row emitted when a sibling set-returning target in the same projection emits
  * more rows than this pass-through.
  */
-bool
+static bool
 IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query)
 {
 	Query *leafQuery = query;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -960,7 +960,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery,
 		copiedSubquery);
 	if (subqueryRteListProperties->hasDistTableWithShardKey)
 	{
-		AddPartitionKeyNotNullFilterToSelect(copiedSubquery);
+		AddPartitionKeyNotNullFilterToSelect(copiedSubquery, false);
 	}
 
 	/* mark that we don't want the router planner to generate dummy hosts/queries */

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -99,8 +99,8 @@ static TargetEntry * SelectTargetEntryForInsertPartitionColumn(Query *query,
 															   insertTargetEntry);
 static bool DistributionColumnIsShardKeyIdentity(Expr *expr, Query *query);
 static bool IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query);
-static Query * WrapBatchSelectWithNotNullFilter(Query *selectQuery,
-												TargetEntry *distTargetEntry);
+static Query * WrapSelectWithNotNullFilter(Query *selectQuery,
+										   TargetEntry *distTargetEntry);
 static Node * AppendNotNullTest(Node *existingQuals, Expr *arg);
 static DistributedPlan * CreateNonPushableInsertSelectPlan(uint64 planId, Query *parse,
 														   ParamListInfo boundParams);
@@ -992,7 +992,7 @@ RouterModifyTaskForShardInterval(Query *originalQuery,
 											 distributionColumnIsShardKeyIdentity);
 		if (distributionColumnIsShardKeyIdentity)
 		{
-			AddBatchPassThroughNotNullFilter(copiedQuery, copiedInsertRte,
+			AddShardKeyIdentityNotNullFilter(copiedQuery, copiedInsertRte,
 											 copiedSubqueryRte);
 		}
 	}
@@ -1283,32 +1283,32 @@ DistributionColumnIsShardKeyIdentity(Expr *expr, Query *query)
 
 
 /*
- * AddBatchPassThroughNotNullFilter drops rows whose batch pass-through
+ * AddShardKeyIdentityNotNullFilter drops rows whose shard-key identity
  * distribution value came out NULL, by adding a distribution-column IS NOT NULL
  * qual to the pushed-down SELECT.
  *
- * The batch pass-through unnest(array_agg(<dist col>)) emits one value per group
- * row, but a sibling set-returning target in the same projection - e.g. an
- * over-emitting batch UDF unnest(f(array_agg(<other col>))) - can be longer, so
- * PostgreSQL's ProjectSet NULL-pads the shorter distribution-column set. Because
- * the batch path skips AddPartitionKeyNotNullFilterToSelect, without this filter
- * such a NULL (mis-routed) distribution key would be inserted silently. Dropping
- * the NULL row matches how Citus handles a NULL distribution value in a normal
+ * A shard-key identity projection can still yield a NULL distribution value
+ * (for example when a sibling target in the same projection forces PostgreSQL to
+ * NULL-pad the distribution column). Because the identity path skips
+ * AddPartitionKeyNotNullFilterToSelect, without this filter such a NULL
+ * (mis-routed) distribution key would be inserted silently. Dropping the NULL
+ * row matches how Citus handles a NULL distribution value in a normal
  * INSERT ... SELECT (AddPartitionKeyNotNullFilterToSelect).
  *
- * The distribution column can surface in two shapes:
- *   - as a plain Var, when the unnest lives in an inner subquery
- *     (SELECT dist_var, ... FROM ( SELECT unnest(array_agg(dist_col)) dist_var,
- *     ... ) s); the qual is attached to the pushed-down SELECT directly, or
- *   - as a bare set-returning expression projected in the SELECT list
- *     (SELECT unnest(array_agg(dist_col)), ... GROUP BY ...); the SELECT is
- *     wrapped in a pass-through subquery so the column becomes a Var we can
- *     filter.
+ * The main question here is whether the distribution column already surfaces as
+ * a plain Var:
+ *   - if it does, e.g. when it is projected up from an inner subquery
+ *     (SELECT dist_var, ... FROM ( SELECT ... AS dist_var, ... ) s), the qual is
+ *     attached to the pushed-down SELECT directly;
+ *   - if it does not, i.e. it is projected as a bare expression with no Var a
+ *     WHERE clause can reference (SELECT <expr> AS dist_col, ... GROUP BY ...),
+ *     the SELECT is wrapped in a pass-through subquery so the column becomes a
+ *     Var we can filter.
  *
  * Returns true if a filter was added.
  */
 bool
-AddBatchPassThroughNotNullFilter(Query *query, RangeTblEntry *insertRte,
+AddShardKeyIdentityNotNullFilter(Query *query, RangeTblEntry *insertRte,
 								 RangeTblEntry *subqueryRte)
 {
 	Query *selectQuery = subqueryRte->subquery;
@@ -1343,16 +1343,16 @@ AddBatchPassThroughNotNullFilter(Query *query, RangeTblEntry *insertRte,
 	 *       FROM ( <original SELECT> ) citus_insert_select_subquery
 	 *      WHERE dist_col IS NOT NULL
 	 */
-	subqueryRte->subquery = WrapBatchSelectWithNotNullFilter(selectQuery,
-															 distTargetEntry);
+	subqueryRte->subquery = WrapSelectWithNotNullFilter(selectQuery,
+														distTargetEntry);
 	return true;
 }
 
 
 /*
- * WrapBatchSelectWithNotNullFilter wraps the given batch pass-through SELECT in
- * a pass-through subquery and filters out rows whose distribution column (given
- * by distTargetEntry) came out NULL:
+ * WrapSelectWithNotNullFilter wraps the given SELECT in a pass-through subquery
+ * and filters out rows whose distribution column (given by distTargetEntry) came
+ * out NULL:
  *
  *     SELECT <columns> FROM ( <selectQuery> ) citus_insert_select_subquery
  *      WHERE <dist column> IS NOT NULL
@@ -1361,10 +1361,11 @@ AddBatchPassThroughNotNullFilter(Query *query, RangeTblEntry *insertRte,
  * expression, so it has no Var handle a WHERE clause could reference in the
  * original SELECT. Unlike WrapSubquery, this wrapper is a pure pass-through: it
  * references every non-junk output column as an ordinary Var and never lifts
- * expressions to the outer query, so the batch call keeps running on the shard.
+ * expressions to the outer query, so the pushed-down computation keeps running
+ * on the shard.
  */
 static Query *
-WrapBatchSelectWithNotNullFilter(Query *selectQuery, TargetEntry *distTargetEntry)
+WrapSelectWithNotNullFilter(Query *selectQuery, TargetEntry *distTargetEntry)
 {
 	ParseState *pstate = make_parsestate(NULL);
 	Query *wrapperQuery = makeNode(Query);

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -10,6 +10,8 @@
 
 #include "postgres.h"
 
+#include "miscadmin.h"
+
 #include "catalog/pg_class.h"
 #include "catalog/pg_type.h"
 #include "nodes/makefuncs.h"
@@ -26,6 +28,7 @@
 #include "parser/parsetree.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
@@ -94,6 +97,10 @@ static TargetEntry * SelectTargetEntryForInsertPartitionColumn(Query *query,
 															   RangeTblEntry *subqueryRte,
 															   TargetEntry **
 															   insertTargetEntry);
+static bool IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query);
+static Query * WrapBatchSelectWithNotNullFilter(Query *selectQuery,
+												TargetEntry *distTargetEntry);
+static Node * AppendNotNullTest(Node *existingQuals, Expr *arg);
 static DistributedPlan * CreateNonPushableInsertSelectPlan(uint64 planId, Query *parse,
 														   ParamListInfo boundParams);
 static DeferredErrorMessage * NonPushableInsertSelectSupported(Query *insertSelectQuery);
@@ -776,14 +783,16 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 		/* first apply toplevel pushdown checks to SELECT query */
 		error =
 			DeferErrorIfUnsupportedSubqueryPushdown(subquery, plannerRestrictionContext,
-													true, false);
+													true, AllowUnsafeInsertSelectPushdown)
+		;
 		if (error)
 		{
 			return error;
 		}
 
 		/* then apply subquery pushdown checks to SELECT query */
-		error = DeferErrorIfCannotPushdownSubquery(subquery, false, false);
+		error = DeferErrorIfCannotPushdownSubquery(subquery, false,
+												   AllowUnsafeInsertSelectPushdown);
 		if (error)
 		{
 			return error;
@@ -826,11 +835,29 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 								 "table", NULL, NULL);
 		}
 
+		/*
+		 * Ensure that INSERT's partition column comes from SELECT's partition
+		 * column. Normally this requires a plain-Var partition-column match.
+		 * With unsafe INSERT ... SELECT pushdown enabled we additionally accept a
+		 * batch pass-through of the distribution column, i.e.
+		 * unnest(array_agg(dist_key)), which re-emits distribution values verbatim
+		 * from the current shard's rows; combined with the co-location check below,
+		 * those values route back into this shard. Any other derived distribution
+		 * value is still rejected, because it could route rows that belong to a
+		 * different shard.
+		 */
 		if (HasDistributionKey(targetRelationId))
 		{
-			/* ensure that INSERT's partition column comes from SELECT's partition column */
-			error = InsertPartitionColumnMatchesSelect(queryTree, insertRte, subqueryRte,
+			error = InsertPartitionColumnMatchesSelect(queryTree, insertRte,
+													   subqueryRte,
 													   &selectPartitionColumnTableId);
+			if (error && AllowUnsafeInsertSelectPushdown &&
+				InsertPartitionColumnIsBatchPassThrough(queryTree, insertRte,
+														subqueryRte))
+			{
+				error = NULL;
+			}
+
 			if (error)
 			{
 				return error;
@@ -960,7 +987,16 @@ RouterModifyTaskForShardInterval(Query *originalQuery,
 		copiedSubquery);
 	if (subqueryRteListProperties->hasDistTableWithShardKey)
 	{
-		AddPartitionKeyNotNullFilterToSelect(copiedSubquery, false);
+		bool distributionColumnIsBatchPassThrough =
+			InsertPartitionColumnIsBatchPassThrough(copiedQuery, copiedInsertRte,
+													copiedSubqueryRte);
+		AddPartitionKeyNotNullFilterToSelect(copiedSubquery,
+											 distributionColumnIsBatchPassThrough);
+		if (distributionColumnIsBatchPassThrough)
+		{
+			AddBatchPassThroughNotNullFilter(copiedQuery, copiedInsertRte,
+											 copiedSubqueryRte);
+		}
 	}
 
 	/* mark that we don't want the router planner to generate dummy hosts/queries */
@@ -1198,6 +1234,208 @@ ReorderInsertSelectTargetLists(Query *originalQuery, RangeTblEntry *insertRte,
 	subqueryRte->eref->colnames = columnNameList;
 
 	return NULL;
+}
+
+
+/*
+ * InsertPartitionColumnIsBatchPassThrough returns true if the SELECT target
+ * entry that feeds the INSERT's distribution column is a batch pass-through,
+ * i.e. unnest(array_agg(<distribution column>)). See
+ * IsInsertSelectBatchPassThroughDistributionColumn for the exact invariant and
+ * its known limitations.
+ */
+bool
+InsertPartitionColumnIsBatchPassThrough(Query *query, RangeTblEntry *insertRte,
+										RangeTblEntry *subqueryRte)
+{
+	TargetEntry *subqueryTargetEntry =
+		SelectTargetEntryForInsertPartitionColumn(query, insertRte, subqueryRte, NULL);
+	if (subqueryTargetEntry == NULL)
+	{
+		return false;
+	}
+
+	return IsInsertSelectBatchPassThroughDistributionColumn(subqueryTargetEntry->expr,
+															subqueryRte->subquery);
+}
+
+
+/*
+ * AddBatchPassThroughNotNullFilter drops rows whose batch pass-through
+ * distribution value came out NULL, by adding a distribution-column IS NOT NULL
+ * qual to the pushed-down SELECT.
+ *
+ * The batch pass-through unnest(array_agg(<dist col>)) emits one value per group
+ * row, but a sibling set-returning target in the same projection - e.g. an
+ * over-emitting batch UDF unnest(f(array_agg(<other col>))) - can be longer, so
+ * PostgreSQL's ProjectSet NULL-pads the shorter distribution-column set. Because
+ * the batch path skips AddPartitionKeyNotNullFilterToSelect, without this filter
+ * such a NULL (mis-routed) distribution key would be inserted silently. Dropping
+ * the NULL row matches how Citus handles a NULL distribution value in a normal
+ * INSERT ... SELECT (AddPartitionKeyNotNullFilterToSelect).
+ *
+ * The distribution column can surface in two shapes:
+ *   - as a plain Var, when the unnest lives in an inner subquery
+ *     (SELECT dist_var, ... FROM ( SELECT unnest(array_agg(dist_col)) dist_var,
+ *     ... ) s); the qual is attached to the pushed-down SELECT directly, or
+ *   - as a bare set-returning expression projected in the SELECT list
+ *     (SELECT unnest(array_agg(dist_col)), ... GROUP BY ...); the SELECT is
+ *     wrapped in a pass-through subquery so the column becomes a Var we can
+ *     filter.
+ *
+ * Returns true if a filter was added.
+ */
+bool
+AddBatchPassThroughNotNullFilter(Query *query, RangeTblEntry *insertRte,
+								 RangeTblEntry *subqueryRte)
+{
+	Query *selectQuery = subqueryRte->subquery;
+	TargetEntry *distTargetEntry =
+		SelectTargetEntryForInsertPartitionColumn(query, insertRte, subqueryRte, NULL);
+	if (distTargetEntry == NULL)
+	{
+		return false;
+	}
+
+	Expr *distExpr = (Expr *) strip_implicit_coercions((Node *) distTargetEntry->expr);
+	if (IsA(distExpr, Var))
+	{
+		/*
+		 * Outer-subquery shape: the distribution column already surfaces as a
+		 * plain Var (the unnest lives in an inner subquery), so we can attach
+		 * the qual to the pushed-down SELECT directly.
+		 */
+		selectQuery->jointree->quals =
+			AppendNotNullTest(selectQuery->jointree->quals, distExpr);
+		return true;
+	}
+
+	/*
+	 * Flat shape: the distribution column is projected as a bare set-returning
+	 * expression (e.g. unnest(array_agg(<dist col>)) directly in the SELECT
+	 * list), so there is no Var handle a WHERE clause can reference. Wrap the
+	 * SELECT in a pass-through subquery, which turns the set-returning column
+	 * into an ordinary output column, then filter that column for NULL:
+	 *
+	 *     SELECT dist_col, ...
+	 *       FROM ( <original SELECT> ) citus_insert_select_subquery
+	 *      WHERE dist_col IS NOT NULL
+	 */
+	subqueryRte->subquery = WrapBatchSelectWithNotNullFilter(selectQuery,
+															 distTargetEntry);
+	return true;
+}
+
+
+/*
+ * WrapBatchSelectWithNotNullFilter wraps the given batch pass-through SELECT in
+ * a pass-through subquery and filters out rows whose distribution column (given
+ * by distTargetEntry) came out NULL:
+ *
+ *     SELECT <columns> FROM ( <selectQuery> ) citus_insert_select_subquery
+ *      WHERE <dist column> IS NOT NULL
+ *
+ * It is used when the distribution column is projected as a bare set-returning
+ * expression, so it has no Var handle a WHERE clause could reference in the
+ * original SELECT. Unlike WrapSubquery, this wrapper is a pure pass-through: it
+ * references every non-junk output column as an ordinary Var and never lifts
+ * expressions to the outer query, so the batch call keeps running on the shard.
+ */
+static Query *
+WrapBatchSelectWithNotNullFilter(Query *selectQuery, TargetEntry *distTargetEntry)
+{
+	ParseState *pstate = make_parsestate(NULL);
+	Query *wrapperQuery = makeNode(Query);
+	wrapperQuery->commandType = CMD_SELECT;
+
+	Alias *alias = makeAlias("citus_insert_select_subquery", NIL);
+	RangeTblEntry *subqueryRte =
+		RangeTableEntryFromNSItem(
+			addRangeTableEntryForSubquery(pstate, selectQuery, alias,
+										  false /* not LATERAL */,
+										  true /* in FROM clause */));
+	wrapperQuery->rtable = list_make1(subqueryRte);
+	wrapperQuery->rteperminfos = NIL;
+
+	RangeTblRef *rangeTableRef = makeNode(RangeTblRef);
+	rangeTableRef->rtindex = 1;
+
+	List *wrapperTargetList = NIL;
+	Var *distColumnVar = NULL;
+	TargetEntry *innerTargetEntry = NULL;
+	foreach_declared_ptr(innerTargetEntry, selectQuery->targetList)
+	{
+		if (innerTargetEntry->resjunk)
+		{
+			continue;
+		}
+
+		Var *outerVar = makeVar(1 /* single subquery RTE */,
+								innerTargetEntry->resno,
+								exprType((Node *) innerTargetEntry->expr),
+								exprTypmod((Node *) innerTargetEntry->expr),
+								exprCollation((Node *) innerTargetEntry->expr),
+								0);
+
+		TargetEntry *outerTargetEntry =
+			makeTargetEntry((Expr *) outerVar,
+							list_length(wrapperTargetList) + 1,
+							innerTargetEntry->resname,
+							false);
+
+		wrapperTargetList = lappend(wrapperTargetList, outerTargetEntry);
+
+		if (innerTargetEntry == distTargetEntry)
+		{
+			/* the distribution target entry appears exactly once in the list */
+			Assert(distColumnVar == NULL);
+			distColumnVar = outerVar;
+		}
+	}
+
+	/*
+	 * distColumnVar is set only if the loop above matched the (non-resjunk)
+	 * distribution target entry in the wrapper target list. The caller only
+	 * reaches this path for the flat batch pass-through shape where that entry
+	 * is guaranteed to be present, so a NULL here is an internal error: fail
+	 * hard instead of building a NOT NULL test over a NULL Var in a release
+	 * build.
+	 */
+	if (distColumnVar == NULL)
+	{
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("distribution column target entry not found while "
+							   "wrapping the batch INSERT ... SELECT with a NOT "
+							   "NULL filter")));
+	}
+	wrapperQuery->targetList = wrapperTargetList;
+
+	Node *notNullQual = AppendNotNullTest(NULL, (Expr *) distColumnVar);
+	wrapperQuery->jointree = makeFromExpr(list_make1(rangeTableRef), notNullQual);
+
+	return wrapperQuery;
+}
+
+
+/*
+ * AppendNotNullTest returns existingQuals AND (arg IS NOT NULL). When
+ * existingQuals is NULL the bare NOT NULL test is returned.
+ */
+static Node *
+AppendNotNullTest(Node *existingQuals, Expr *arg)
+{
+	NullTest *nullTest = makeNode(NullTest);
+	nullTest->nulltesttype = IS_NOT_NULL;
+	nullTest->arg = (Expr *) copyObject(arg);
+	nullTest->argisrow = false;
+	nullTest->location = -1;
+
+	if (existingQuals == NULL)
+	{
+		return (Node *) nullTest;
+	}
+
+	return make_and_qual(existingQuals, (Node *) nullTest);
 }
 
 
@@ -1477,6 +1715,167 @@ SelectTargetEntryForInsertPartitionColumn(Query *query, RangeTblEntry *insertRte
 	}
 
 	return NULL;
+}
+
+
+/*
+ * IsInsertSelectBatchPassThroughDistributionColumn returns true if the given SELECT target
+ * expression is a batch pass-through of the distribution
+ * column, i.e. it has the shape
+ *
+ *     unnest(array_agg(<partition column>))
+ *
+ * (optionally projected through one or more plain-Var subquery indirections, and
+ * with array_agg allowed to carry an ORDER BY modifier). DISTINCT and FILTER on
+ * the aggregate are rejected: they make the pass-through emit fewer values than
+ * the group has rows, so ProjectSet would NULL-pad the distribution column when a
+ * sibling set-returning target is longer (see the DISTINCT/FILTER guard below).
+ *
+ * The invariant is narrow: unnest(array_agg(<partition column>)) re-emits
+ * distribution values verbatim from source rows of the current shard, so -
+ * given source and target are colocated - each value routes back into this
+ * shard's range. Any intermediate transformation (e.g. unnest(array_agg(dist_key
+ * + 1)) or unnest(f(array_agg(dist_key)))) is rejected because it could produce
+ * values that route to a different shard.
+ *
+ * This shape check alone does not prove the whole INSERT is shard-local. It
+ * assumes the row reaching the INSERT actually carries one of those original
+ * distribution values, and not a targetlist/SRF artifact such as a NULL-padded
+ * row emitted when a sibling set-returning target in the same projection emits
+ * more rows than this pass-through. We cannot rule that out here without also
+ * rejecting the supported batched shape, e.g. unnest(batch_udf(array_agg(col))),
+ * whose row count is a runtime property of the (user) batch function. That
+ * residual is exactly why the enabling GUC is explicitly unsafe and opt-in.
+ */
+bool
+IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query)
+{
+	Query *leafQuery = query;
+
+	/*
+	 * Peel plain-Var subquery projection indirection down to the underlying
+	 * expression. We only follow the simple "SELECT <col> FROM (subquery)"
+	 * projection form; anything else makes us conservatively bail out.
+	 */
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		expr = (Expr *) strip_implicit_coercions((Node *) expr);
+
+		if (!IsA(expr, Var))
+		{
+			break;
+		}
+
+		Var *var = (Var *) expr;
+		if (var->varlevelsup != 0 || var->varattno <= InvalidAttrNumber)
+		{
+			return false;
+		}
+
+		if (var->varno <= 0 || var->varno > list_length(leafQuery->rtable))
+		{
+			return false;
+		}
+
+		RangeTblEntry *rte = rt_fetch(var->varno, leafQuery->rtable);
+		if (rte->rtekind != RTE_SUBQUERY)
+		{
+			return false;
+		}
+
+		Query *subquery = rte->subquery;
+		if (var->varattno > list_length(subquery->targetList))
+		{
+			return false;
+		}
+
+		TargetEntry *targetEntry = list_nth(subquery->targetList, var->varattno - 1);
+		expr = targetEntry->expr;
+		leafQuery = subquery;
+	}
+
+	/* the leaf expression must be unnest(...) over a single array argument */
+	if (!IsA(expr, FuncExpr))
+	{
+		return false;
+	}
+
+	FuncExpr *unnestExpr = (FuncExpr *) expr;
+	if (unnestExpr->funcid != F_UNNEST_ANYARRAY ||
+		list_length(unnestExpr->args) != 1)
+	{
+		return false;
+	}
+
+	/* the unnest argument must be array_agg(...) with no wrapping transform */
+	Expr *unnestArg = (Expr *) strip_implicit_coercions(
+		(Node *) linitial(unnestExpr->args));
+	if (!IsA(unnestArg, Aggref))
+	{
+		return false;
+	}
+
+	Aggref *arrayAgg = (Aggref *) unnestArg;
+	if (arrayAgg->aggfnoid != F_ARRAY_AGG_ANYNONARRAY &&
+		arrayAgg->aggfnoid != F_ARRAY_AGG_ANYARRAY)
+	{
+		return false;
+	}
+
+	/*
+	 * DISTINCT or FILTER make array_agg emit fewer values than the group has
+	 * rows, so this pass-through set-returning expression becomes shorter than a
+	 * sibling set-returning target in the same projection. ProjectSet then
+	 * NULL-pads the distribution column, which would insert a NULL (mis-routed)
+	 * distribution key. A plain array_agg re-emits exactly one value per source
+	 * row, so reject DISTINCT/FILTER here (ORDER BY is fine: it only reorders the
+	 * shard-local values, it does not change their count).
+	 */
+	if (arrayAgg->aggdistinct != NIL || arrayAgg->aggfilter != NULL)
+	{
+		return false;
+	}
+
+	/*
+	 * Locate the single aggregated value argument. ORDER BY keys that differ
+	 * from the aggregated value appear as additional resjunk target entries;
+	 * they only reorder the (shard-local) values and do not affect routing.
+	 */
+	TargetEntry *aggValueTargetEntry = NULL;
+	TargetEntry *aggArgTargetEntry = NULL;
+	foreach_declared_ptr(aggArgTargetEntry, arrayAgg->args)
+	{
+		if (aggArgTargetEntry->resjunk)
+		{
+			continue;
+		}
+
+		if (aggValueTargetEntry != NULL)
+		{
+			/*
+			 * array_agg (the OIDs we matched above) is a single-argument
+			 * aggregate, so a second non-resjunk entry cannot occur for a
+			 * well-formed tree. Assert to catch a broken invariant in debug
+			 * builds, but still bail out gracefully in production: a false
+			 * result only forgoes the optimization, it is never unsafe.
+			 */
+			Assert(false);
+			return false;
+		}
+
+		aggValueTargetEntry = aggArgTargetEntry;
+	}
+
+	if (aggValueTargetEntry == NULL)
+	{
+		return false;
+	}
+
+	/* the aggregated value must be the untransformed source partition column */
+	bool skipOuterVars = false;
+	return IsPartitionColumn(aggValueTargetEntry->expr, leafQuery, skipOuterVars);
 }
 
 

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -89,6 +89,11 @@ static DeferredErrorMessage * InsertPartitionColumnMatchesSelect(Query *query,
 																 subqueryRte,
 																 Oid *
 																 selectPartitionColumnTableId);
+static TargetEntry * SelectTargetEntryForInsertPartitionColumn(Query *query,
+															   RangeTblEntry *insertRte,
+															   RangeTblEntry *subqueryRte,
+															   TargetEntry **
+															   insertTargetEntry);
 static DistributedPlan * CreateNonPushableInsertSelectPlan(uint64 planId, Query *parse,
 														   ParamListInfo boundParams);
 static DeferredErrorMessage * NonPushableInsertSelectSupported(Query *insertSelectQuery);
@@ -1209,211 +1214,13 @@ InsertPartitionColumnMatchesSelect(Query *query, RangeTblEntry *insertRte,
 								   RangeTblEntry *subqueryRte,
 								   Oid *selectPartitionColumnTableId)
 {
-	ListCell *targetEntryCell = NULL;
-	uint32 rangeTableId = 1;
-	Oid insertRelationId = insertRte->relid;
-	Var *insertPartitionColumn = PartitionColumn(insertRelationId, rangeTableId);
 	Query *subquery = subqueryRte->subquery;
-	bool targetTableHasPartitionColumn = false;
 
-	foreach(targetEntryCell, query->targetList)
-	{
-		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
-		List *insertTargetEntryColumnList = pull_var_clause_default((Node *) targetEntry);
-		Var *subqueryPartitionColumn = NULL;
-
-		/*
-		 * We only consider target entries that include a single column. Note that this
-		 * is slightly different than directly checking the whether the targetEntry->expr
-		 * is a var since the var could be wrapped into an implicit/explicit casting.
-		 *
-		 * Also note that we skip the target entry if it does not contain a Var, which
-		 * corresponds to columns with DEFAULT values on the target list.
-		 */
-		if (list_length(insertTargetEntryColumnList) != 1)
-		{
-			continue;
-		}
-
-		Var *insertVar = (Var *) linitial(insertTargetEntryColumnList);
-		AttrNumber originalAttrNo = targetEntry->resno;
-
-		/* skip processing of target table non-partition columns */
-		if (originalAttrNo != insertPartitionColumn->varattno)
-		{
-			continue;
-		}
-
-		/* INSERT query includes the partition column */
-		targetTableHasPartitionColumn = true;
-
-		TargetEntry *subqueryTargetEntry = list_nth(subquery->targetList,
-													insertVar->varattno - 1);
-		Expr *selectTargetExpr = subqueryTargetEntry->expr;
-
-		RangeTblEntry *subqueryPartitionColumnRelationIdRTE = NULL;
-		List *parentQueryList = list_make2(query, subquery);
-		bool skipOuterVars = false;
-		FindReferencedTableColumn(selectTargetExpr,
-								  parentQueryList, subquery,
-								  &subqueryPartitionColumn,
-								  &subqueryPartitionColumnRelationIdRTE,
-								  skipOuterVars);
-		Oid subqueryPartitionColumnRelationId = subqueryPartitionColumnRelationIdRTE ?
-												subqueryPartitionColumnRelationIdRTE->
-												relid :
-												InvalidOid;
-
-		/*
-		 * Corresponding (i.e., in the same ordinal position as the target table's
-		 * partition column) select target entry does not directly belong a table.
-		 * Evaluate its expression type and error out properly.
-		 */
-		if (subqueryPartitionColumnRelationId == InvalidOid)
-		{
-			char *errorDetailTemplate = "Subquery contains %s in the "
-										"same position as the target table's "
-										"partition column.";
-
-			char *exprDescription = "";
-
-			switch (selectTargetExpr->type)
-			{
-				case T_Const:
-				{
-					exprDescription = "a constant value";
-					break;
-				}
-
-				case T_OpExpr:
-				{
-					exprDescription = "an operator";
-					break;
-				}
-
-				case T_FuncExpr:
-				{
-					FuncExpr *subqueryFunctionExpr = (FuncExpr *) selectTargetExpr;
-
-					switch (subqueryFunctionExpr->funcformat)
-					{
-						case COERCE_EXPLICIT_CALL:
-						{
-							exprDescription = "a function call";
-							break;
-						}
-
-						case COERCE_EXPLICIT_CAST:
-						{
-							exprDescription = "an explicit cast";
-							break;
-						}
-
-						case COERCE_IMPLICIT_CAST:
-						{
-							exprDescription = "an implicit cast";
-							break;
-						}
-
-						default:
-						{
-							exprDescription = "a function call";
-							break;
-						}
-					}
-					break;
-				}
-
-				case T_Aggref:
-				{
-					exprDescription = "an aggregation";
-					break;
-				}
-
-				case T_CaseExpr:
-				{
-					exprDescription = "a case expression";
-					break;
-				}
-
-				case T_CoalesceExpr:
-				{
-					exprDescription = "a coalesce expression";
-					break;
-				}
-
-				case T_RowExpr:
-				{
-					exprDescription = "a row expression";
-					break;
-				}
-
-				case T_MinMaxExpr:
-				{
-					exprDescription = "a min/max expression";
-					break;
-				}
-
-				case T_CoerceViaIO:
-				{
-					exprDescription = "an explicit coercion";
-					break;
-				}
-
-				default:
-				{
-					exprDescription =
-						"an expression that is not a simple column reference";
-					break;
-				}
-			}
-
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-								 "cannot perform distributed INSERT INTO ... SELECT "
-								 "because the partition columns in the source table "
-								 "and subquery do not match",
-								 psprintf(errorDetailTemplate, exprDescription),
-								 "Ensure the target table's partition column has a "
-								 "corresponding simple column reference to a distributed "
-								 "table's partition column in the subquery.");
-		}
-
-		/*
-		 * Insert target expression could only be non-var if the select target
-		 * entry does not have the same type (i.e., target column requires casting).
-		 */
-		if (!IsA(targetEntry->expr, Var))
-		{
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-								 "cannot perform distributed INSERT INTO ... SELECT "
-								 "because the partition columns in the source table "
-								 "and subquery do not match",
-								 "The data type of the target table's partition column "
-								 "should exactly match the data type of the "
-								 "corresponding simple column reference in the subquery.",
-								 NULL);
-		}
-
-		/* finally, check that the select target column is a partition column */
-		if (!IsPartitionColumn(selectTargetExpr, subquery, skipOuterVars))
-		{
-			return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
-								 "cannot perform distributed INSERT INTO ... SELECT "
-								 "because the partition columns in the source table "
-								 "and subquery do not match",
-								 "The target table's partition column should correspond "
-								 "to a partition column in the subquery.",
-								 NULL);
-		}
-
-		/* finally, check that the select target column is a partition column */
-		/* we can set the select relation id */
-		*selectPartitionColumnTableId = subqueryPartitionColumnRelationId;
-
-		break;
-	}
-
-	if (!targetTableHasPartitionColumn)
+	TargetEntry *insertTargetEntry = NULL;
+	TargetEntry *subqueryTargetEntry =
+		SelectTargetEntryForInsertPartitionColumn(query, insertRte, subqueryRte,
+												  &insertTargetEntry);
+	if (subqueryTargetEntry == NULL)
 	{
 		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
 							 "cannot perform distributed INSERT INTO ... SELECT "
@@ -1422,6 +1229,251 @@ InsertPartitionColumnMatchesSelect(Query *query, RangeTblEntry *insertRte,
 							 "the query doesn't include the target table's "
 							 "partition column",
 							 NULL);
+	}
+
+	Expr *selectTargetExpr = subqueryTargetEntry->expr;
+
+	Var *subqueryPartitionColumn = NULL;
+	RangeTblEntry *subqueryPartitionColumnRelationIdRTE = NULL;
+	List *parentQueryList = list_make2(query, subquery);
+	bool skipOuterVars = false;
+	FindReferencedTableColumn(selectTargetExpr,
+							  parentQueryList, subquery,
+							  &subqueryPartitionColumn,
+							  &subqueryPartitionColumnRelationIdRTE,
+							  skipOuterVars);
+	Oid subqueryPartitionColumnRelationId = subqueryPartitionColumnRelationIdRTE ?
+											subqueryPartitionColumnRelationIdRTE->relid :
+											InvalidOid;
+
+	/*
+	 * Corresponding (i.e., in the same ordinal position as the target table's
+	 * partition column) select target entry does not directly belong a table.
+	 * Evaluate its expression type and error out properly.
+	 */
+	if (subqueryPartitionColumnRelationId == InvalidOid)
+	{
+		char *errorDetailTemplate = "Subquery contains %s in the "
+									"same position as the target table's "
+									"partition column.";
+
+		char *exprDescription = "";
+
+		switch (selectTargetExpr->type)
+		{
+			case T_Const:
+			{
+				exprDescription = "a constant value";
+				break;
+			}
+
+			case T_OpExpr:
+			{
+				exprDescription = "an operator";
+				break;
+			}
+
+			case T_FuncExpr:
+			{
+				FuncExpr *subqueryFunctionExpr = (FuncExpr *) selectTargetExpr;
+
+				switch (subqueryFunctionExpr->funcformat)
+				{
+					case COERCE_EXPLICIT_CALL:
+					{
+						exprDescription = "a function call";
+						break;
+					}
+
+					case COERCE_EXPLICIT_CAST:
+					{
+						exprDescription = "an explicit cast";
+						break;
+					}
+
+					case COERCE_IMPLICIT_CAST:
+					{
+						exprDescription = "an implicit cast";
+						break;
+					}
+
+					default:
+					{
+						exprDescription = "a function call";
+						break;
+					}
+				}
+				break;
+			}
+
+			case T_Aggref:
+			{
+				exprDescription = "an aggregation";
+				break;
+			}
+
+			case T_CaseExpr:
+			{
+				exprDescription = "a case expression";
+				break;
+			}
+
+			case T_CoalesceExpr:
+			{
+				exprDescription = "a coalesce expression";
+				break;
+			}
+
+			case T_RowExpr:
+			{
+				exprDescription = "a row expression";
+				break;
+			}
+
+			case T_MinMaxExpr:
+			{
+				exprDescription = "a min/max expression";
+				break;
+			}
+
+			case T_CoerceViaIO:
+			{
+				exprDescription = "an explicit coercion";
+				break;
+			}
+
+			default:
+			{
+				exprDescription =
+					"an expression that is not a simple column reference";
+				break;
+			}
+		}
+
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "cannot perform distributed INSERT INTO ... SELECT "
+							 "because the partition columns in the source table "
+							 "and subquery do not match",
+							 psprintf(errorDetailTemplate, exprDescription),
+							 "Ensure the target table's partition column has a "
+							 "corresponding simple column reference to a distributed "
+							 "table's partition column in the subquery.");
+	}
+
+	/*
+	 * Insert target expression could only be non-var if the select target
+	 * entry does not have the same type (i.e., target column requires casting).
+	 */
+	if (!IsA(insertTargetEntry->expr, Var))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "cannot perform distributed INSERT INTO ... SELECT "
+							 "because the partition columns in the source table "
+							 "and subquery do not match",
+							 "The data type of the target table's partition column "
+							 "should exactly match the data type of the "
+							 "corresponding simple column reference in the subquery.",
+							 NULL);
+	}
+
+	/* finally, check that the select target column is a partition column */
+	if (!IsPartitionColumn(selectTargetExpr, subquery, skipOuterVars))
+	{
+		return DeferredError(ERRCODE_FEATURE_NOT_SUPPORTED,
+							 "cannot perform distributed INSERT INTO ... SELECT "
+							 "because the partition columns in the source table "
+							 "and subquery do not match",
+							 "The target table's partition column should correspond "
+							 "to a partition column in the subquery.",
+							 NULL);
+	}
+
+	/* we can set the select relation id */
+	*selectPartitionColumnTableId = subqueryPartitionColumnRelationId;
+
+	return NULL;
+}
+
+
+/*
+ * SelectTargetEntryForInsertPartitionColumn walks the INSERT target list to find
+ * the entry that feeds the target table's distribution column and returns the
+ * corresponding SELECT (subquery) target entry that produces its value. Returns
+ * NULL when the INSERT does not project the distribution column via a single Var.
+ *
+ * When insertTargetEntry is not NULL, it is set to the matching INSERT target
+ * entry so that callers can inspect it if needed.
+ */
+static TargetEntry *
+SelectTargetEntryForInsertPartitionColumn(Query *query, RangeTblEntry *insertRte,
+										  RangeTblEntry *subqueryRte,
+										  TargetEntry **insertTargetEntry)
+{
+	Oid insertRelationId = insertRte->relid;
+	Var *insertPartitionColumn = PartitionColumn(insertRelationId, 1);
+	Query *subquery = subqueryRte->subquery;
+
+	if (insertTargetEntry != NULL)
+	{
+		*insertTargetEntry = NULL;
+	}
+
+	/*
+	 * Single-shard (null distribution key) target tables have no
+	 * distribution column, so there is no INSERT partition column to look
+	 * up.
+	 */
+	if (insertPartitionColumn == NULL)
+	{
+		return NULL;
+	}
+
+	ListCell *targetEntryCell = NULL;
+	foreach(targetEntryCell, query->targetList)
+	{
+		TargetEntry *targetEntry = (TargetEntry *) lfirst(targetEntryCell);
+		List *insertTargetEntryColumnList = pull_var_clause_default((Node *) targetEntry);
+
+		/*
+		 * We only consider target entries that include a single column. Note that
+		 * this is slightly different than directly checking whether the
+		 * targetEntry->expr is a Var since the Var could be wrapped into an
+		 * implicit/explicit casting.
+		 *
+		 * Also note that we skip the target entry if it does not contain a Var,
+		 * which corresponds to columns with DEFAULT values on the target list.
+		 */
+		if (list_length(insertTargetEntryColumnList) != 1)
+		{
+			continue;
+		}
+
+		Var *insertVar = (Var *) linitial(insertTargetEntryColumnList);
+
+		/* skip processing of target table non-partition columns */
+		if (targetEntry->resno != insertPartitionColumn->varattno)
+		{
+			continue;
+		}
+
+		/*
+		 * insertVar->varattno indexes into subquery->targetList via list_nth()
+		 * below, so it must be a valid 1-based ordinary column reference.
+		 * Reject whole-row / system column references (varattno <= 0) as well as
+		 * out-of-range indexes to keep the lookup in bounds.
+		 */
+		if (insertVar->varattno <= 0 ||
+			insertVar->varattno > list_length(subquery->targetList))
+		{
+			return NULL;
+		}
+
+		if (insertTargetEntry != NULL)
+		{
+			*insertTargetEntry = targetEntry;
+		}
+
+		return list_nth(subquery->targetList, insertVar->varattno - 1);
 	}
 
 	return NULL;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -776,14 +776,14 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 		/* first apply toplevel pushdown checks to SELECT query */
 		error =
 			DeferErrorIfUnsupportedSubqueryPushdown(subquery, plannerRestrictionContext,
-													true);
+													true, false);
 		if (error)
 		{
 			return error;
 		}
 
 		/* then apply subquery pushdown checks to SELECT query */
-		error = DeferErrorIfCannotPushdownSubquery(subquery, false);
+		error = DeferErrorIfCannotPushdownSubquery(subquery, false, false);
 		if (error)
 		{
 			return error;

--- a/src/backend/distributed/planner/insert_select_planner.c
+++ b/src/backend/distributed/planner/insert_select_planner.c
@@ -97,6 +97,7 @@ static TargetEntry * SelectTargetEntryForInsertPartitionColumn(Query *query,
 															   RangeTblEntry *subqueryRte,
 															   TargetEntry **
 															   insertTargetEntry);
+static bool DistributionColumnIsShardKeyIdentity(Expr *expr, Query *query);
 static bool IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query);
 static Query * WrapBatchSelectWithNotNullFilter(Query *selectQuery,
 												TargetEntry *distTargetEntry);
@@ -839,12 +840,9 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 		 * Ensure that INSERT's partition column comes from SELECT's partition
 		 * column. Normally this requires a plain-Var partition-column match.
 		 * With unsafe INSERT ... SELECT pushdown enabled we additionally accept a
-		 * batch pass-through of the distribution column, i.e.
-		 * unnest(array_agg(dist_key)), which re-emits distribution values verbatim
-		 * from the current shard's rows; combined with the co-location check below,
-		 * those values route back into this shard. Any other derived distribution
-		 * value is still rejected, because it could route rows that belong to a
-		 * different shard.
+		 * distribution column that is a shard-key identity: a routing-preserving
+		 * projection of the source shard key whose values route back into this
+		 * shard.
 		 */
 		if (HasDistributionKey(targetRelationId))
 		{
@@ -852,7 +850,7 @@ DistributedInsertSelectSupported(Query *queryTree, RangeTblEntry *insertRte,
 													   subqueryRte,
 													   &selectPartitionColumnTableId);
 			if (error && AllowUnsafeInsertSelectPushdown &&
-				InsertPartitionColumnIsBatchPassThrough(queryTree, insertRte,
+				InsertPartitionColumnIsShardKeyIdentity(queryTree, insertRte,
 														subqueryRte))
 			{
 				error = NULL;
@@ -987,12 +985,12 @@ RouterModifyTaskForShardInterval(Query *originalQuery,
 		copiedSubquery);
 	if (subqueryRteListProperties->hasDistTableWithShardKey)
 	{
-		bool distributionColumnIsBatchPassThrough =
-			InsertPartitionColumnIsBatchPassThrough(copiedQuery, copiedInsertRte,
+		bool distributionColumnIsShardKeyIdentity =
+			InsertPartitionColumnIsShardKeyIdentity(copiedQuery, copiedInsertRte,
 													copiedSubqueryRte);
 		AddPartitionKeyNotNullFilterToSelect(copiedSubquery,
-											 distributionColumnIsBatchPassThrough);
-		if (distributionColumnIsBatchPassThrough)
+											 distributionColumnIsShardKeyIdentity);
+		if (distributionColumnIsShardKeyIdentity)
 		{
 			AddBatchPassThroughNotNullFilter(copiedQuery, copiedInsertRte,
 											 copiedSubqueryRte);
@@ -1238,14 +1236,13 @@ ReorderInsertSelectTargetLists(Query *originalQuery, RangeTblEntry *insertRte,
 
 
 /*
- * InsertPartitionColumnIsBatchPassThrough returns true if the SELECT target
- * entry that feeds the INSERT's distribution column is a batch pass-through,
- * i.e. unnest(array_agg(<distribution column>)). See
- * IsInsertSelectBatchPassThroughDistributionColumn for the exact invariant and
- * its known limitations.
+ * InsertPartitionColumnIsShardKeyIdentity returns true if the SELECT target
+ * entry that feeds the INSERT's distribution column is a shard-key identity,
+ * i.e. a routing-preserving projection of the source shard key. See
+ * DistributionColumnIsShardKeyIdentity for the recognized identity forms.
  */
 bool
-InsertPartitionColumnIsBatchPassThrough(Query *query, RangeTblEntry *insertRte,
+InsertPartitionColumnIsShardKeyIdentity(Query *query, RangeTblEntry *insertRte,
 										RangeTblEntry *subqueryRte)
 {
 	TargetEntry *subqueryTargetEntry =
@@ -1255,8 +1252,33 @@ InsertPartitionColumnIsBatchPassThrough(Query *query, RangeTblEntry *insertRte,
 		return false;
 	}
 
-	return IsInsertSelectBatchPassThroughDistributionColumn(subqueryTargetEntry->expr,
-															subqueryRte->subquery);
+	return DistributionColumnIsShardKeyIdentity(subqueryTargetEntry->expr,
+												subqueryRte->subquery);
+}
+
+
+/*
+ * DistributionColumnIsShardKeyIdentity returns true if the given SELECT target
+ * expression projects the INSERT's distribution column as an "identity" of the
+ * source shard key: every value it produces routes back into the same shard as
+ * the source row it came from, so - given source and target are colocated - the
+ * INSERT ... SELECT stays shard-local and can be pushed down.
+ */
+static bool
+DistributionColumnIsShardKeyIdentity(Expr *expr, Query *query)
+{
+	/*
+	 * Batch pass-through: unnest(array_agg(<distribution column>)).
+	 * Any intermediate transformation (e.g. unnest(array_agg(dist_key
+	 * + 1)) or unnest(f(array_agg(dist_key)))) is rejected because it
+	 * could produce values that belong to a different shard.
+	 */
+	if (IsInsertSelectBatchPassThroughDistributionColumn(expr, query))
+	{
+		return true;
+	}
+
+	return false;
 }
 
 
@@ -1734,18 +1756,13 @@ SelectTargetEntryForInsertPartitionColumn(Query *query, RangeTblEntry *insertRte
  * The invariant is narrow: unnest(array_agg(<partition column>)) re-emits
  * distribution values verbatim from source rows of the current shard, so -
  * given source and target are colocated - each value routes back into this
- * shard's range. Any intermediate transformation (e.g. unnest(array_agg(dist_key
- * + 1)) or unnest(f(array_agg(dist_key)))) is rejected because it could produce
- * values that route to a different shard.
+ * shard's range.
  *
  * This shape check alone does not prove the whole INSERT is shard-local. It
  * assumes the row reaching the INSERT actually carries one of those original
  * distribution values, and not a targetlist/SRF artifact such as a NULL-padded
  * row emitted when a sibling set-returning target in the same projection emits
- * more rows than this pass-through. We cannot rule that out here without also
- * rejecting the supported batched shape, e.g. unnest(batch_udf(array_agg(col))),
- * whose row count is a runtime property of the (user) batch function. That
- * residual is exactly why the enabling GUC is explicitly unsafe and opt-in.
+ * more rows than this pass-through.
  */
 bool
 IsInsertSelectBatchPassThroughDistributionColumn(Expr *expr, Query *query)

--- a/src/backend/distributed/planner/merge_planner.c
+++ b/src/backend/distributed/planner/merge_planner.c
@@ -1166,7 +1166,7 @@ DeferErrorIfRoutableMergeNotSupported(Query *query, List *rangeTableList,
 		deferredError =
 			DeferErrorIfUnsupportedSubqueryPushdown(query,
 													plannerRestrictionContext,
-													true);
+													true, false);
 		if (deferredError)
 		{
 			ereport(DEBUG1, (errmsg("Sub-query is not pushable, try repartitioning")));

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -347,9 +347,15 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
  *
  * The function expects and asserts that subquery's target list contains a partition
  * column value. Thus, this function should never be called with reference tables.
+ *
+ * The exception is unsafe INSERT ... SELECT pushdown, where the distribution
+ * column may be a batch pass-through with no plain Var to
+ * filter on; callers signal that case via distributionColumnIsBatchPassThrough so
+ * the filter is skipped.
  */
 void
-AddPartitionKeyNotNullFilterToSelect(Query *subqery)
+AddPartitionKeyNotNullFilterToSelect(Query *subqery, bool
+									 distributionColumnIsBatchPassThrough)
 {
 	List *targetList = subqery->targetList;
 	ListCell *targetEntryCell = NULL;
@@ -367,6 +373,21 @@ AddPartitionKeyNotNullFilterToSelect(Query *subqery)
 			targetPartitionColumnVar = (Var *) targetEntry->expr;
 			break;
 		}
+	}
+
+	/*
+	 * Normally the SELECT projects the distribution column as a plain Var. With
+	 * unsafe INSERT ... SELECT pushdown the distribution column may instead be a
+	 * batch pass-through, i.e. unnest(array_agg(dist_col)).
+	 * In that case there is no plain Var here to attach a NOT NULL filter to, so
+	 * we skip it; the NULL (mis-routed) distribution key is instead dropped at
+	 * runtime by AddBatchPassThroughNotNullFilter. The caller determines whether
+	 * the query has this shape and passes the result in
+	 * distributionColumnIsBatchPassThrough.
+	 */
+	if (targetPartitionColumnVar == NULL && distributionColumnIsBatchPassThrough)
+	{
+		return;
 	}
 
 	/* we should have found target partition column */

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -1342,7 +1342,7 @@ MultiShardUpdateDeleteSupported(Query *originalQuery,
 		errorMessage = DeferErrorIfUnsupportedSubqueryPushdown(
 			originalQuery,
 			plannerRestrictionContext,
-			true);
+			true, false);
 	}
 
 	return errorMessage;

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -381,7 +381,7 @@ AddPartitionKeyNotNullFilterToSelect(Query *subqery, bool
 	 * unnest(array_agg(dist_col)).
 	 * In that case there is no plain Var here to attach a NOT NULL filter to, so
 	 * we skip it; the NULL (mis-routed) distribution key is instead dropped at
-	 * runtime by AddBatchPassThroughNotNullFilter. The caller determines whether
+	 * runtime by AddShardKeyIdentityNotNullFilter. The caller determines whether
 	 * the query has this shape and passes the result in
 	 * distributionColumnIsShardKeyIdentity.
 	 */

--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -349,13 +349,12 @@ ShardIntervalOpExpressions(ShardInterval *shardInterval, Index rteIndex)
  * column value. Thus, this function should never be called with reference tables.
  *
  * The exception is unsafe INSERT ... SELECT pushdown, where the distribution
- * column may be a batch pass-through with no plain Var to
- * filter on; callers signal that case via distributionColumnIsBatchPassThrough so
- * the filter is skipped.
+ * column may be a shard-key identity  with no plain Var to filter on; callers signal
+ * that case via distributionColumnIsShardKeyIdentity so the filter is skipped.
  */
 void
 AddPartitionKeyNotNullFilterToSelect(Query *subqery, bool
-									 distributionColumnIsBatchPassThrough)
+									 distributionColumnIsShardKeyIdentity)
 {
 	List *targetList = subqery->targetList;
 	ListCell *targetEntryCell = NULL;
@@ -378,14 +377,15 @@ AddPartitionKeyNotNullFilterToSelect(Query *subqery, bool
 	/*
 	 * Normally the SELECT projects the distribution column as a plain Var. With
 	 * unsafe INSERT ... SELECT pushdown the distribution column may instead be a
-	 * batch pass-through, i.e. unnest(array_agg(dist_col)).
+	 * shard-key identity - today only the batch pass-through, i.e.
+	 * unnest(array_agg(dist_col)).
 	 * In that case there is no plain Var here to attach a NOT NULL filter to, so
 	 * we skip it; the NULL (mis-routed) distribution key is instead dropped at
 	 * runtime by AddBatchPassThroughNotNullFilter. The caller determines whether
 	 * the query has this shape and passes the result in
-	 * distributionColumnIsBatchPassThrough.
+	 * distributionColumnIsShardKeyIdentity.
 	 */
-	if (targetPartitionColumnVar == NULL && distributionColumnIsBatchPassThrough)
+	if (targetPartitionColumnVar == NULL && distributionColumnIsShardKeyIdentity)
 	{
 		return;
 	}

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -576,11 +576,7 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
  *
  * allowUnsafeShardLocalGroupingForSubqueries is forwarded as-is to
  * DeferErrorIfCannotPushdownSubquery for every subquery checked here. Today it's
- * only set for colocated INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown;
- * when true, the GROUP BY / aggregate / window / DISTINCT merge-step requirements
- * are skipped, assuming those grouping constructs stay shard-local.
- * All other pushdown checks (co-location, joins on the distribution column, recurring
- * tuples, LIMIT/OFFSET) remain enforced.
+ * only set for colocated INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown.
  */
 DeferredErrorMessage *
 DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
@@ -1010,13 +1006,8 @@ CanPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit)
  * limit, we let this query to run, but results could be wrong depending on the
  * features of underlying tables.
  *
- * When allowUnsafeShardLocalGrouping is true, we assume any GROUP BY / aggregate
- * / window / DISTINCT in the subquery can stay within a single shard, so the
- * partition-column requirements that would otherwise force a coordinator merge step
- * are skipped (this flag is forwarded to DeferErrorIfSubqueryRequiresMerge).
- * LIMIT/OFFSET handling is unaffected. The flag today is only set for colocated
- * INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown, where keeping
- * batches shard-local becomes the user's responsibility.
+ * When allowUnsafeShardLocalGrouping is true, some of the partition-column
+ * requirements that would otherwise force a coordinator merge step are skipped.
  */
 DeferredErrorMessage *
 DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit,
@@ -1153,8 +1144,7 @@ FlattenGroupExprs(Query *queryTree)
  * GROUP BY / aggregate / window / DISTINCT are skipped: so we assume these grouping
  * constructs are shard-local, so they do not need a coordinator merge.
  * LIMIT/OFFSET are still rejected, because those require a merge regardless of the
- * distribution column. Today the flag is only ever true for colocated
- * INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown.
+ * distribution column.
  */
 static DeferredErrorMessage *
 DeferErrorIfSubqueryRequiresMerge(Query *subqueryTree, bool lateral,
@@ -1183,13 +1173,6 @@ DeferErrorIfSubqueryRequiresMerge(Query *subqueryTree, bool lateral,
 							   referencedThing);
 	}
 
-	/*
-	 * With unsafe INSERT ... SELECT pushdown the entire subquery executes on a
-	 * single shard (colocation is enforced separately), so grouping / aggregation
-	 * / window / distinct on non-distribution columns stays shard-local and does
-	 * not require a merge step. Skip the partition-column requirements in that
-	 * case.
-	 */
 	if (!allowUnsafeShardLocalGrouping)
 	{
 		/* group clause list must include partition column */

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -80,6 +80,7 @@ typedef struct RelidsReferenceWalkerContext
 /* Config variable managed via guc.c */
 bool SubqueryPushdown = false; /* is subquery pushdown enabled */
 int ValuesMaterializationThreshold = 100;
+bool AllowUnsafeInsertSelectPushdown = false;
 
 /* Local functions forward declarations */
 static bool JoinTreeContainsSubqueryWalker(Node *joinTreeNode, void *context);

--- a/src/backend/distributed/planner/query_pushdown_planning.c
+++ b/src/backend/distributed/planner/query_pushdown_planning.c
@@ -92,7 +92,9 @@ static DeferredErrorMessage * DeferredErrorIfUnsupportedRecurringTuplesJoin(
 static DeferredErrorMessage * DeferErrorIfUnsupportedTableCombination(Query *queryTree);
 static DeferredErrorMessage * DeferErrorIfSubqueryRequiresMerge(Query *subqueryTree, bool
 																lateral,
-																char *referencedThing);
+																char *referencedThing,
+																bool
+																allowUnsafeShardLocalGrouping);
 static bool ExtractSetOperationStatementWalker(Node *node, List **setOperationList);
 static RecurringTuplesType FetchFirstRecurType(PlannerInfo *plannerInfo,
 											   Relids relids);
@@ -550,7 +552,7 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
 	DeferredErrorMessage *subqueryPushdownError = DeferErrorIfUnsupportedSubqueryPushdown(
 		originalQuery,
 		plannerRestrictionContext,
-		false);
+		false, false);
 
 	if (subqueryPushdownError != NULL)
 	{
@@ -570,12 +572,21 @@ SubqueryMultiNodeTree(Query *originalQuery, Query *queryTree,
  * entry list and uses helper functions to check if we can push down subquery
  * to worker nodes. These helper functions returns a deferred error if we
  * cannot push down the subquery.
+ *
+ * allowUnsafeShardLocalGroupingForSubqueries is forwarded as-is to
+ * DeferErrorIfCannotPushdownSubquery for every subquery checked here. Today it's
+ * only set for colocated INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown;
+ * when true, the GROUP BY / aggregate / window / DISTINCT merge-step requirements
+ * are skipped, assuming those grouping constructs stay shard-local.
+ * All other pushdown checks (co-location, joins on the distribution column, recurring
+ * tuples, LIMIT/OFFSET) remain enforced.
  */
 DeferredErrorMessage *
 DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 										PlannerRestrictionContext *
 										plannerRestrictionContext,
-										bool plannerPhase)
+										bool plannerPhase,
+										bool allowUnsafeShardLocalGroupingForSubqueries)
 {
 	bool outerMostQueryHasLimit = false;
 	ListCell *subqueryCell = NULL;
@@ -648,7 +659,8 @@ DeferErrorIfUnsupportedSubqueryPushdown(Query *originalQuery,
 	{
 		Query *subquery = lfirst(subqueryCell);
 		error = DeferErrorIfCannotPushdownSubquery(subquery,
-												   outerMostQueryHasLimit);
+												   outerMostQueryHasLimit,
+												   allowUnsafeShardLocalGroupingForSubqueries);
 		if (error)
 		{
 			return error;
@@ -970,8 +982,8 @@ DeferredErrorIfUnsupportedRecurringTuplesJoin(PlannerRestrictionContext *
 bool
 CanPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit)
 {
-	return DeferErrorIfCannotPushdownSubquery(subqueryTree, outerMostQueryHasLimit) ==
-		   NULL;
+	return DeferErrorIfCannotPushdownSubquery(subqueryTree, outerMostQueryHasLimit,
+											  false) == NULL;
 }
 
 
@@ -996,9 +1008,18 @@ CanPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit)
  * a subquery has a group by on another subquery which includes order by with
  * limit, we let this query to run, but results could be wrong depending on the
  * features of underlying tables.
+ *
+ * When allowUnsafeShardLocalGrouping is true, we assume any GROUP BY / aggregate
+ * / window / DISTINCT in the subquery can stay within a single shard, so the
+ * partition-column requirements that would otherwise force a coordinator merge step
+ * are skipped (this flag is forwarded to DeferErrorIfSubqueryRequiresMerge).
+ * LIMIT/OFFSET handling is unaffected. The flag today is only set for colocated
+ * INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown, where keeping
+ * batches shard-local becomes the user's responsibility.
  */
 DeferredErrorMessage *
-DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit)
+DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLimit,
+								   bool allowUnsafeShardLocalGrouping)
 {
 	bool preconditionsSatisfied = true;
 	char *errorDetail = NULL;
@@ -1027,7 +1048,8 @@ DeferErrorIfCannotPushdownSubquery(Query *subqueryTree, bool outerMostQueryHasLi
 	if (!ContainsReferencesToOuterQuery(subqueryTree))
 	{
 		deferredError = DeferErrorIfSubqueryRequiresMerge(subqueryTree, false,
-														  "another query");
+														  "another query",
+														  allowUnsafeShardLocalGrouping);
 		if (deferredError)
 		{
 			return deferredError;
@@ -1125,10 +1147,18 @@ FlattenGroupExprs(Query *queryTree)
  * DeferErrorIfSubqueryRequiresMerge returns a deferred error if the subquery
  * requires a merge step on the coordinator (e.g. limit, group by non-distribution
  * column, etc.).
+ *
+ * When allowUnsafeShardLocalGrouping is true, the partition-column requirements for
+ * GROUP BY / aggregate / window / DISTINCT are skipped: so we assume these grouping
+ * constructs are shard-local, so they do not need a coordinator merge.
+ * LIMIT/OFFSET are still rejected, because those require a merge regardless of the
+ * distribution column. Today the flag is only ever true for colocated
+ * INSERT ... SELECT under citus.allow_unsafe_insert_select_pushdown.
  */
 static DeferredErrorMessage *
 DeferErrorIfSubqueryRequiresMerge(Query *subqueryTree, bool lateral,
-								  char *referencedThing)
+								  char *referencedThing,
+								  bool allowUnsafeShardLocalGrouping)
 {
 	bool preconditionsSatisfied = true;
 	char *errorDetail = NULL;
@@ -1152,68 +1182,81 @@ DeferErrorIfSubqueryRequiresMerge(Query *subqueryTree, bool lateral,
 							   referencedThing);
 	}
 
-	/* group clause list must include partition column */
-	if (subqueryTree->groupClause)
-	{
-		List *groupClauseList = subqueryTree->groupClause;
-		List *targetEntryList = subqueryTree->targetList;
-		List *groupTargetEntryList = GroupTargetEntryList(groupClauseList,
-														  targetEntryList);
-		bool groupOnPartitionColumn =
-			TargetListOnPartitionColumn(subqueryTree, groupTargetEntryList);
-		if (!groupOnPartitionColumn)
-		{
-			preconditionsSatisfied = false;
-			errorDetail = psprintf("Group by list without partition column is currently "
-								   "unsupported when a %ssubquery references a column "
-								   "from %s", lateralString, referencedThing);
-		}
-	}
-
-	/* we don't support aggregates without group by */
-	if (subqueryTree->hasAggs && (subqueryTree->groupClause == NULL))
-	{
-		preconditionsSatisfied = false;
-		errorDetail = psprintf("Aggregates without group by are currently unsupported "
-							   "when a %ssubquery references a column from %s",
-							   lateralString, referencedThing);
-	}
-
-	/* having clause without group by on partition column is not supported */
-	if (subqueryTree->havingQual && (subqueryTree->groupClause == NULL))
-	{
-		preconditionsSatisfied = false;
-		errorDetail = psprintf("Having qual without group by on partition column is "
-							   "currently unsupported when a %ssubquery references "
-							   "a column from %s", lateralString, referencedThing);
-	}
-
 	/*
-	 * We support window functions when the window function
-	 * is partitioned on distribution column.
+	 * With unsafe INSERT ... SELECT pushdown the entire subquery executes on a
+	 * single shard (colocation is enforced separately), so grouping / aggregation
+	 * / window / distinct on non-distribution columns stays shard-local and does
+	 * not require a merge step. Skip the partition-column requirements in that
+	 * case.
 	 */
-	StringInfo errorInfo = NULL;
-	if (subqueryTree->hasWindowFuncs && !SafeToPushdownWindowFunction(subqueryTree,
-																	  &errorInfo))
+	if (!allowUnsafeShardLocalGrouping)
 	{
-		errorDetail = (char *) errorInfo->data;
-		preconditionsSatisfied = false;
-	}
+		/* group clause list must include partition column */
+		if (subqueryTree->groupClause)
+		{
+			List *groupClauseList = subqueryTree->groupClause;
+			List *targetEntryList = subqueryTree->targetList;
+			List *groupTargetEntryList = GroupTargetEntryList(groupClauseList,
+															  targetEntryList);
+			bool groupOnPartitionColumn =
+				TargetListOnPartitionColumn(subqueryTree, groupTargetEntryList);
+			if (!groupOnPartitionColumn)
+			{
+				preconditionsSatisfied = false;
+				errorDetail = psprintf(
+					"Group by list without partition column is currently "
+					"unsupported when a %ssubquery references a column "
+					"from %s", lateralString, referencedThing);
+			}
+		}
 
-	/* distinct clause list must include partition column */
-	if (subqueryTree->distinctClause)
-	{
-		List *distinctClauseList = subqueryTree->distinctClause;
-		List *targetEntryList = subqueryTree->targetList;
-		List *distinctTargetEntryList = GroupTargetEntryList(distinctClauseList,
-															 targetEntryList);
-		bool distinctOnPartitionColumn =
-			TargetListOnPartitionColumn(subqueryTree, distinctTargetEntryList);
-		if (!distinctOnPartitionColumn)
+		/* we don't support aggregates without group by */
+		if (subqueryTree->hasAggs && (subqueryTree->groupClause == NULL))
 		{
 			preconditionsSatisfied = false;
-			errorDetail = "Distinct on columns without partition column is "
-						  "currently unsupported";
+			errorDetail = psprintf(
+				"Aggregates without group by are currently unsupported "
+				"when a %ssubquery references a column from %s",
+				lateralString, referencedThing);
+		}
+
+		/* having clause without group by on partition column is not supported */
+		if (subqueryTree->havingQual && (subqueryTree->groupClause == NULL))
+		{
+			preconditionsSatisfied = false;
+			errorDetail = psprintf(
+				"Having qual without group by on partition column is "
+				"currently unsupported when a %ssubquery references "
+				"a column from %s", lateralString, referencedThing);
+		}
+
+		/*
+		 * We support window functions when the window function
+		 * is partitioned on distribution column.
+		 */
+		StringInfo errorInfo = NULL;
+		if (subqueryTree->hasWindowFuncs && !SafeToPushdownWindowFunction(subqueryTree,
+																		  &errorInfo))
+		{
+			errorDetail = (char *) errorInfo->data;
+			preconditionsSatisfied = false;
+		}
+
+		/* distinct clause list must include partition column */
+		if (subqueryTree->distinctClause)
+		{
+			List *distinctClauseList = subqueryTree->distinctClause;
+			List *targetEntryList = subqueryTree->targetList;
+			List *distinctTargetEntryList = GroupTargetEntryList(distinctClauseList,
+																 targetEntryList);
+			bool distinctOnPartitionColumn =
+				TargetListOnPartitionColumn(subqueryTree, distinctTargetEntryList);
+			if (!distinctOnPartitionColumn)
+			{
+				preconditionsSatisfied = false;
+				errorDetail = "Distinct on columns without partition column is "
+							  "currently unsupported";
+			}
 		}
 	}
 
@@ -1763,7 +1806,7 @@ DeferredErrorIfUnsupportedLateralSubquery(PlannerInfo *plannerInfo,
 
 			/* property number 3, has a merge step */
 			DeferredErrorMessage *deferredError = DeferErrorIfSubqueryRequiresMerge(
-				rangeTableEntry->subquery, true, recurTypeDescription);
+				rangeTableEntry->subquery, true, recurTypeDescription, false);
 			if (deferredError)
 			{
 				return deferredError;

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1075,7 +1075,17 @@ RegisterCitusConfigVariables(void)
 					 "could route rows that actually belong to a different shard. "
 					 "Colocation is still enforced, but the user takes responsibility "
 					 "for keeping batches order-preserving; otherwise results may be "
-					 "silently incorrect. This is an experimental feature and semantics "
+					 "silently incorrect. Because the relaxed checks also apply to "
+					 "nested subqueries, any grouping, window, or aggregate now runs "
+					 "per shard rather than across the whole table, so a global "
+					 "window/aggregate (e.g. count(*) OVER ()) silently becomes "
+					 "per-shard. Finally, the runtime NOT NULL filter guards only the "
+					 "distribution column, not the other projected values, so a batch "
+					 "UDF that returns fewer values than its input inserts NULLs into "
+					 "those value columns; the distribution column itself is never NULL "
+					 "here, since a NULL-padded key is dropped by that filter. The "
+					 "user must ensure the batch produces exactly one value per input "
+					 "row. This is an experimental feature and semantics "
 					 "may change in future releases."),
 		&AllowUnsafeInsertSelectPushdown,
 		false,

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1058,6 +1058,28 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.allow_unsafe_insert_select_pushdown",
+		gettext_noop("Allows pushdown of otherwise-unsafe colocated "
+					 "INSERT ... SELECT queries."),
+		gettext_noop("When enabled, Citus relaxes safety checks (GROUP BY / window / "
+					 "aggregate / DISTINCT constructs on non-distribution columns) "
+					 "for colocated INSERT ... SELECT, so that batching and any batch "
+					 "UDF call run on the shards instead of pulling data to the "
+					 "coordinator. The INSERT's distribution column may then be a "
+					 "provably shard-local unnest(array_agg(<distribution column>)); "
+					 "any other derived distribution value is still rejected, since it "
+					 "could route rows that actually belong to a different shard. "
+					 "Colocation is still enforced, but the user takes responsibility "
+					 "for keeping batches order-preserving; otherwise results may be "
+					 "silently incorrect. This is an experimental feature and semantics "
+					 "may change in future releases."),
+		&AllowUnsafeInsertSelectPushdown,
+		false,
+		PGC_USERSET,
+		GUC_STANDARD,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.allow_unsafe_locks_from_workers",
 		gettext_noop("Enables acquiring a distributed lock from a worker "
 					 "when the coordinator is not in the metadata"),

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1076,7 +1076,7 @@ RegisterCitusConfigVariables(void)
 		&AllowUnsafeInsertSelectPushdown,
 		false,
 		PGC_USERSET,
-		GUC_STANDARD,
+		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -46,7 +46,7 @@ extern DistributedPlan * CreateInsertSelectIntoLocalTablePlan(uint64 planId,
 extern char * InsertSelectResultIdPrefix(uint64 planId);
 extern bool PlanningInsertSelect(void);
 extern Query * WrapSubquery(Query *subquery);
-extern bool InsertPartitionColumnIsBatchPassThrough(Query *query,
+extern bool InsertPartitionColumnIsShardKeyIdentity(Query *query,
 													RangeTblEntry *insertRte,
 													RangeTblEntry *subqueryRte);
 extern bool AddBatchPassThroughNotNullFilter(Query *query,

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -46,6 +46,12 @@ extern DistributedPlan * CreateInsertSelectIntoLocalTablePlan(uint64 planId,
 extern char * InsertSelectResultIdPrefix(uint64 planId);
 extern bool PlanningInsertSelect(void);
 extern Query * WrapSubquery(Query *subquery);
+extern bool InsertPartitionColumnIsBatchPassThrough(Query *query,
+													RangeTblEntry *insertRte,
+													RangeTblEntry *subqueryRte);
+extern bool AddBatchPassThroughNotNullFilter(Query *query,
+											 RangeTblEntry *insertRte,
+											 RangeTblEntry *subqueryRte);
 
 
 #endif /* INSERT_SELECT_PLANNER_H */

--- a/src/include/distributed/insert_select_planner.h
+++ b/src/include/distributed/insert_select_planner.h
@@ -49,7 +49,7 @@ extern Query * WrapSubquery(Query *subquery);
 extern bool InsertPartitionColumnIsShardKeyIdentity(Query *query,
 													RangeTblEntry *insertRte,
 													RangeTblEntry *subqueryRte);
-extern bool AddBatchPassThroughNotNullFilter(Query *query,
+extern bool AddShardKeyIdentityNotNullFilter(Query *query,
 											 RangeTblEntry *insertRte,
 											 RangeTblEntry *subqueryRte);
 

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -80,7 +80,7 @@ extern RangeTblEntry * ExtractResultRelationRTEOrError(Query *query);
 extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
 extern bool IsMultiRowInsert(Query *query);
 extern void AddPartitionKeyNotNullFilterToSelect(Query *subqery,
-												 bool distributionColumnIsBatchPassThrough
+												 bool distributionColumnIsShardKeyIdentity
 												 );
 extern bool UpdateOrDeleteOrMergeQuery(Query *query);
 extern bool IsMergeQuery(Query *query);

--- a/src/include/distributed/multi_router_planner.h
+++ b/src/include/distributed/multi_router_planner.h
@@ -79,7 +79,9 @@ extern RangeTblEntry * ExtractResultRelationRTE(Query *query);
 extern RangeTblEntry * ExtractResultRelationRTEOrError(Query *query);
 extern RangeTblEntry * ExtractDistributedInsertValuesRTE(Query *query);
 extern bool IsMultiRowInsert(Query *query);
-extern void AddPartitionKeyNotNullFilterToSelect(Query *subqery);
+extern void AddPartitionKeyNotNullFilterToSelect(Query *subqery,
+												 bool distributionColumnIsBatchPassThrough
+												 );
 extern bool UpdateOrDeleteOrMergeQuery(Query *query);
 extern bool IsMergeQuery(Query *query);
 

--- a/src/include/distributed/query_pushdown_planning.h
+++ b/src/include/distributed/query_pushdown_planning.h
@@ -22,6 +22,7 @@
 /* Config variables managed via guc.c */
 extern bool SubqueryPushdown;
 extern int ValuesMaterializationThreshold;
+extern bool AllowUnsafeInsertSelectPushdown;
 extern bool AllowAggregateWorkerCombineOnInternalTypes;
 
 

--- a/src/include/distributed/query_pushdown_planning.h
+++ b/src/include/distributed/query_pushdown_planning.h
@@ -44,10 +44,14 @@ extern DeferredErrorMessage * DeferErrorIfUnsupportedSubqueryPushdown(Query *
 																	  PlannerRestrictionContext
 																	  *
 																	  plannerRestrictionContext,
-																	  bool plannerPhase);
+																	  bool plannerPhase,
+																	  bool
+																	  allowUnsafeShardLocalGroupingForSubqueries);
 extern DeferredErrorMessage * DeferErrorIfCannotPushdownSubquery(Query *subqueryTree,
 																 bool
-																 outerMostQueryHasLimit);
+																 outerMostQueryHasLimit,
+																 bool
+																 allowUnsafeShardLocalGrouping);
 extern DeferredErrorMessage * DeferErrorIfUnsupportedUnionQuery(Query *queryTree);
 extern bool IsJsonTableRTE(RangeTblEntry *rte);
 extern bool IsOuterJoinExpr(Node *node);

--- a/src/test/regress/expected/allow_unsafe_insert_select_pushdown.out
+++ b/src/test/regress/expected/allow_unsafe_insert_select_pushdown.out
@@ -1,0 +1,1234 @@
+--
+-- ALLOW_UNSAFE_INSERT_SELECT_PUSHDOWN
+--
+-- Tests citus.allow_unsafe_insert_select_pushdown, which lets a colocated
+-- INSERT .. SELECT push GROUP BY / window / DISTINCT batching and a batch UDF
+-- down to the shards instead of pulling rows to the coordinator.
+--
+-- The distribution column of the target must still come from the source
+-- distribution column unchanged: either as a plain Var, or as the provably
+-- shard-local batch pass-through unnest(array_agg(dist_col)). Any other derived
+-- distribution value (an arithmetic/function transform, or a transform wrapped
+-- inside the array_agg) is rejected even with the GUC enabled, because it could
+-- route a row to a different shard.
+--
+CREATE SCHEMA allow_unsafe_insert_select_pushdown;
+SET search_path = allow_unsafe_insert_select_pushdown;
+SET citus.next_shard_id TO 14000000;
+SET citus.shard_count = 4;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE dist(text_id int, text_col text);
+CREATE TABLE res(text_id int, val int);
+SELECT create_distributed_table('dist', 'text_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('res', 'text_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist SELECT g, 't' || g FROM generate_series(1, 500) g;
+-- a batched UDF: returns one value per input, mimicking a batched API call.
+-- immutable + parallel safe, like a real batch UDF.
+CREATE FUNCTION batch_transform(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT array_agg(length(x)) FROM unnest(t) x $$;
+SELECT create_distributed_function('batch_transform(text[])');
+NOTICE:  procedure allow_unsafe_insert_select_pushdown.batch_transform is already distributed
+DETAIL:  Citus distributes procedures with CREATE [PROCEDURE|FUNCTION|AGGREGATE] commands
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+-- default off: batching is done after pulling rows to the coordinator
+-- (explain_filter strips the PG18-only "Window:" line so the plan is
+--  comparable across supported Postgres versions)
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+-- now the batching and UDF call run on the shards
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                 explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on s
+                     Filter: (s.id IS NOT NULL)
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: ((row_number() OVER (?) - 1) / 100)
+                                 ->  WindowAgg
+                                       ->  Seq Scan on dist_14000000 dist
+(13 rows)
+
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+-- every text_id should be matched to the right value
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Positive per-branch coverage. Each construct below used to force a
+-- coordinator merge (or was rejected outright). With the GUC enabled the whole
+-- colocated INSERT .. SELECT is pushed to the shards because the distribution
+-- column is either a plain partition-column Var or the unnest(array_agg(text_id))
+-- batch pass-through. The pushed-down plan is a Custom Scan (Citus Adaptive)
+-- whose task runs the INSERT on a shard, with no Distributed Subplan /
+-- intermediate results. explain_filter keeps the plan comparable across
+-- Postgres versions.
+-- ---------------------------------------------------------------------
+-- the batched benchmark shape: bucket rows into fixed-size batches with
+-- row_number()/batch_size, array_agg each batch (id and text in the same
+-- order), call the batch UDF once per batch, then unnest back to one row per id.
+-- This is the query the GUC is meant to push down to the shards.
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT
+    unnest(array_agg(text_id ORDER BY text_id)) id,
+    unnest(batch_transform(array_agg(text_col ORDER BY text_id))) val
+  FROM (
+    SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist
+  ) q
+  GROUP BY batch
+) s
+$$, true);
+                                    explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on s
+                     Filter: (s.id IS NOT NULL)
+                     ->  ProjectSet
+                           ->  GroupAggregate
+                                 Group Key: q.batch
+                                 ->  Sort
+                                       Sort Key: q.batch, q.text_id
+                                       ->  Subquery Scan on q
+                                             ->  WindowAgg
+                                                   ->  Seq Scan on dist_14000000 dist
+(16 rows)
+
+-- branch: GROUP BY on a non-distribution column, distribution column projected
+-- as the unnest(array_agg(text_id)) batch pass-through
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+                                explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on citus_insert_select_subquery
+                     Filter: (citus_insert_select_subquery.unnest IS NOT NULL)
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: (dist.text_id % 10)
+                                 ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+-- branch: aggregates without GROUP BY
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col))) FROM dist
+$$, true);
+                                explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on citus_insert_select_subquery
+                     Filter: (citus_insert_select_subquery.unnest IS NOT NULL)
+                     ->  ProjectSet
+                           ->  Aggregate
+                                 ->  Seq Scan on dist_14000000 dist
+(11 rows)
+
+-- branch: HAVING without GROUP BY on the distribution column
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist HAVING count(*) > 0
+$$, true);
+                                explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on citus_insert_select_subquery
+                     Filter: (citus_insert_select_subquery.unnest IS NOT NULL)
+                     ->  ProjectSet
+                           ->  Aggregate
+                                 Filter: (count(*) > 0)
+                                 ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+-- branch: window function not partitioned on the distribution column, with the
+-- distribution column projected as a plain partition-column Var
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, row_number() OVER (ORDER BY text_col) FROM dist
+$$, true);
+                           explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on "*SELECT*"
+                     ->  WindowAgg
+                           ->  Sort
+                                 Sort Key: dist.text_col
+                                 ->  Seq Scan on dist_14000000 dist
+                                       Filter: (text_id IS NOT NULL)
+(12 rows)
+
+-- combination: GROUP BY + DISTINCT, distribution column as the batch pass-through
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT unnest(array_agg(text_id)), unnest(array_agg(length(text_col)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+                                                   explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on citus_insert_select_subquery
+                     Filter: (citus_insert_select_subquery.unnest IS NOT NULL)
+                     ->  HashAggregate
+                           Group Key: unnest((array_agg(dist.text_id))), unnest((array_agg(length(dist.text_col))))
+                           ->  ProjectSet
+                                 ->  HashAggregate
+                                       Group Key: (dist.text_id % 10)
+                                       ->  Seq Scan on dist_14000000 dist
+(14 rows)
+
+-- combination: window + GROUP BY, relaxed constructs living in nested subqueries
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, v FROM (
+  SELECT unnest(array_agg(text_id)) id, unnest(batch_transform(array_agg(text_col))) v
+  FROM (SELECT text_id, text_col, row_number() OVER (ORDER BY text_col) rn FROM dist) q
+  GROUP BY rn % 5
+) s
+$$, true);
+                                    explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on s
+                     Filter: (s.id IS NOT NULL)
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: (q.rn % '5'::bigint)
+                                 ->  Subquery Scan on q
+                                       ->  WindowAgg
+                                             ->  Sort
+                                                   Sort Key: dist.text_col
+                                                   ->  Seq Scan on dist_14000000 dist
+(16 rows)
+
+-- ---------------------------------------------------------------------
+-- Executed coverage for the relaxed positive branches: the plans above only
+-- assert pushdown; run two of them for real to confirm the shard-local batching
+-- keeps each row's value matched to its own distribution key.
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+-- aggregate without GROUP BY: each shard aggregates all its rows into one group
+-- and the unnest zip-back keeps text_id matched to length(text_col)
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col))) FROM dist;
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM res;
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- window not partitioned on the distribution column: the distribution column is
+-- a plain Var, so every text_id is routed to its own shard exactly once
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT text_id, row_number() OVER (ORDER BY text_col) FROM dist;
+SELECT count(*), count(DISTINCT text_id) AS distinct_ids,
+       count(*) FILTER (WHERE text_id IS NULL) AS null_keys FROM res;
+ count | distinct_ids | null_keys
+---------------------------------------------------------------------
+   500 |          500 |         0
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Negative coverage: pattern requirement. With the GUC enabled the batching
+-- relaxations still fire, but the distribution column is a *transformed* value
+-- rather than the source partition column, so the query is not pushed down and
+-- falls back to a coordinator merge -- identical to the GUC-disabled plan.
+-- ---------------------------------------------------------------------
+-- distribution column derived by arithmetic on the partition column
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id + 0, length(text_col) FROM dist
+$$, true);
+                         explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: repartition
+   ->  Custom Scan (Citus Adaptive)
+         Task Count: 4
+         Tasks Shown: One of 4
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Seq Scan on dist_14000000 dist
+(8 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id + 0, length(text_col) FROM dist
+$$, true);
+                         explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: repartition
+   ->  Custom Scan (Citus Adaptive)
+         Task Count: 4
+         Tasks Shown: One of 4
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Seq Scan on dist_14000000 dist
+(8 rows)
+
+-- distribution column derived from a non-distribution column (DISTINCT)
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT length(text_col), text_id % 7 FROM dist
+$$, true);
+                            explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  HashAggregate
+         Group Key: remote_scan.text_id, remote_scan.val
+         ->  Custom Scan (Citus Adaptive)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=xxxxx dbname=regression
+                     ->  HashAggregate
+                           Group Key: length(text_col), (text_id % 7)
+                           ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT length(text_col), text_id % 7 FROM dist
+$$, true);
+                            explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  HashAggregate
+         Group Key: remote_scan.text_id, remote_scan.val
+         ->  Custom Scan (Citus Adaptive)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=xxxxx dbname=regression
+                     ->  HashAggregate
+                           Group Key: length(text_col), (text_id % 7)
+                           ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+-- distribution column derived from a non-distribution column, one subquery down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT k, k FROM (
+  SELECT DISTINCT length(text_col) k FROM dist
+) s
+$$, true);
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  HashAggregate
+                     Group Key: remote_scan.k
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  HashAggregate
+                                       Group Key: length(text_col)
+                                       ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Function Scan on read_intermediate_result intermediate_result
+(19 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT k, k FROM (
+  SELECT DISTINCT length(text_col) k FROM dist
+) s
+$$, true);
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  HashAggregate
+                     Group Key: remote_scan.k
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  HashAggregate
+                                       Group Key: length(text_col)
+                                       ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Function Scan on read_intermediate_result intermediate_result
+(19 rows)
+
+-- the batched benchmark shape, but with the distribution column transformed
+-- *inside* array_agg (unnest(array_agg(text_id + 1))): the batch pass-through no
+-- longer carries the untransformed partition column, so the same shape that
+-- pushes down above is now rejected and falls back to a coordinator merge
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+-- the batched benchmark shape, but with a transform wrapping array_agg for the
+-- distribution column (unnest(batch_transform(array_agg(text_col)))): the unnest
+-- argument must be a bare array_agg of the partition column, so this is rejected
+-- too and falls back to a coordinator merge
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(batch_transform(array_agg(text_col))) id,
+         unnest(array_agg(text_id)) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(batch_transform(array_agg(text_col))) id,
+         unnest(array_agg(text_id)) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+-- ---------------------------------------------------------------------
+-- Runtime behavior of the rejected transform shapes.
+--
+-- Both transform shapes rejected above keep the set-returning unnest() inside
+-- a subquery, so they fall back to a coordinator merge and still execute
+-- correctly (each id stays matched to its own value).
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+-- id = text_id + 1 and val = length('t' || text_id), so val = length('t' || (id - 1))
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || (text_id - 1))) AS ok
+FROM res;
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Pre-existing limitation, NOT specific to this GUC: a set-returning function
+-- left in the *top-level* target list of a non-pushed-down INSERT .. SELECT
+-- (flat, or fed from a CTE) surfaces PostgreSQL's opaque "set-valued function
+-- called in context that cannot accept a set" error. The Citus coordinator
+-- INSERT .. SELECT path does not replicate PostgreSQL's split_pathtarget_at_srfs()
+-- (ProjectSet insertion), so the unnest() is left where PostgreSQL's executor
+-- cannot evaluate it. This reproduces with the GUC off, and on a plain
+-- distributed SELECT too. Tracked in
+-- https://github.com/citusdata/citus/issues/2265; pinned here so a future fix
+-- (a clearer error, or actual support) is caught.
+-- ---------------------------------------------------------------------
+-- flat set-returning function in the top-level target list, GUC on
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id + 1)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+ERROR:  set-valued function called in context that cannot accept a set
+-- same shape with the GUC off: the error is pre-existing, not caused by the GUC
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id + 1)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+ERROR:  set-valued function called in context that cannot accept a set
+-- a CTE-wrapped batch source hits the same limitation
+WITH b AS (SELECT text_id, text_col FROM dist)
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM b GROUP BY text_id % 10;
+ERROR:  set-valued function called in context that cannot accept a set
+-- not specific to INSERT .. SELECT: the same set-returning function over an
+-- aggregate errors in a plain distributed SELECT as well (#2265)
+SELECT unnest(array_agg(text_id)) FROM dist;
+ERROR:  set-valued function called in context that cannot accept a set
+-- ---------------------------------------------------------------------
+-- Negative coverage: FILTER / DISTINCT on the batch pass-through array_agg.
+-- The distribution-column pass-through unnest(array_agg(text_id)) is only
+-- safe when the array_agg emits exactly one element per group row. A FILTER
+-- or DISTINCT clause on that array_agg can emit fewer elements, so when a
+-- sibling set-returning column is longer PostgreSQL's ProjectSet NULL-pads
+-- the shorter distribution-column set -- silently producing NULL (mis-routed)
+-- partition keys. Such an array_agg is therefore rejected even with the GUC
+-- enabled and falls back to a coordinator merge, which re-routes each row and
+-- enforces the not-NULL partition-column invariant. ORDER BY inside array_agg
+-- only reorders (never drops) elements and stays pushed down (covered above).
+-- ---------------------------------------------------------------------
+-- FILTER on the distribution-column array_agg: not pushed down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                          explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Function Scan on read_intermediate_result intermediate_result
+(20 rows)
+
+-- DISTINCT on the distribution-column array_agg: not pushed down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(DISTINCT text_id)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                             explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  GroupAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Sort
+                                       Sort Key: intermediate_result.b, intermediate_result.text_id
+                                       ->  Function Scan on read_intermediate_result intermediate_result
+(22 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(DISTINCT text_id)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+                                             explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  WindowAgg
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Subquery Scan on s
+                     ->  ProjectSet
+                           ->  GroupAggregate
+                                 Group Key: intermediate_result.b
+                                 ->  Sort
+                                       Sort Key: intermediate_result.b, intermediate_result.text_id
+                                       ->  Function Scan on read_intermediate_result intermediate_result
+(22 rows)
+
+-- the FILTER shape rejected above, run for real under the GUC: the coordinator
+-- fallback re-routes each row and raises the not-NULL partition-column error
+-- instead of silently inserting NULL (mis-routed) partition keys
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+ERROR:  the partition column of table allow_unsafe_insert_select_pushdown.res cannot be NULL
+SELECT count(*) AS rows_with_null_key FROM res WHERE text_id IS NULL;
+ rows_with_null_key
+---------------------------------------------------------------------
+                  0
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Correctness of the pushed-down batches.
+-- ---------------------------------------------------------------------
+-- correctness for a GROUP BY batch: per-shard aggregation keeps each text_id
+-- matched to its own value
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- correctness for the batched benchmark shape: every text_id keeps its own value
+-- after batching, the UDF call, and the unnest zip-back
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT
+    unnest(array_agg(text_id ORDER BY text_id)) id,
+    unnest(batch_transform(array_agg(text_col ORDER BY text_id))) val
+  FROM (
+    SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist
+  ) q
+  GROUP BY batch
+) s;
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Runtime NULL-key drop: an over-emitting batch UDF returns more elements than
+-- the distribution-column array_agg, so PostgreSQL's ProjectSet NULL-pads the
+-- (shorter) distribution column. The pushed-down plan filters those rows out
+-- (distribution column IS NOT NULL) so no NULL (mis-routed) partition key is
+-- inserted, while every real text_id keeps its own value. Both shapes are
+-- covered: the outer-subquery shape (distribution column is a plain Var,
+-- filtered in place) and the flat shape (distribution column is the unnest
+-- set-returning expression, filtered via a pass-through subquery wrapper).
+-- ---------------------------------------------------------------------
+-- a batch UDF that emits one extra element per batch (appends a trailing 0),
+-- mimicking a batched API call whose output is longer than its input
+CREATE FUNCTION batch_transform_over(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT (SELECT array_agg(length(x)) FROM unnest(t) x) || 0 $$;
+SELECT create_distributed_function('batch_transform_over(text[])');
+NOTICE:  procedure allow_unsafe_insert_select_pushdown.batch_transform_over is already distributed
+DETAIL:  Citus distributes procedures with CREATE [PROCEDURE|FUNCTION|AGGREGATE] commands
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+-- outer-subquery shape: the distribution column is a plain Var, so the
+-- IS NOT NULL filter is attached to the pushed-down SELECT directly
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id ORDER BY text_id)) id,
+         unnest(batch_transform_over(array_agg(text_col ORDER BY text_id))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist) q
+  GROUP BY batch
+) s
+$$, true);
+                                    explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on s
+                     Filter: (s.id IS NOT NULL)
+                     ->  ProjectSet
+                           ->  GroupAggregate
+                                 Group Key: q.batch
+                                 ->  Sort
+                                       Sort Key: q.batch, q.text_id
+                                       ->  Subquery Scan on q
+                                             ->  WindowAgg
+                                                   ->  Seq Scan on dist_14000000 dist
+(16 rows)
+
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id ORDER BY text_id)) id,
+         unnest(batch_transform_over(array_agg(text_col ORDER BY text_id))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist) q
+  GROUP BY batch
+) s;
+-- no NULL (mis-routed) key inserted; all 500 rows kept their value
+SELECT count(*) FILTER (WHERE text_id IS NULL) AS rows_with_null_key,
+       count(*) AS rows,
+       count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res;
+ rows_with_null_key | rows | ok
+---------------------------------------------------------------------
+                  0 |  500 | 500
+(1 row)
+
+-- flat shape: the distribution column is the bare unnest set-returning
+-- expression, so the SELECT is wrapped in a pass-through subquery whose
+-- IS NOT NULL filter drops the NULL-padded rows
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id ORDER BY text_id)),
+       unnest(batch_transform_over(array_agg(text_col ORDER BY text_id)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+                                   explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14000004 citus_table_alias
+               ->  Subquery Scan on citus_insert_select_subquery
+                     Filter: (citus_insert_select_subquery.unnest IS NOT NULL)
+                     ->  ProjectSet
+                           ->  GroupAggregate
+                                 Group Key: ((dist.text_id % 10))
+                                 ->  Sort
+                                       Sort Key: ((dist.text_id % 10)), dist.text_id
+                                       ->  Seq Scan on dist_14000000 dist
+(14 rows)
+
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id ORDER BY text_id)),
+       unnest(batch_transform_over(array_agg(text_col ORDER BY text_id)))
+FROM dist GROUP BY text_id % 10;
+-- no NULL (mis-routed) key inserted; all 500 rows kept their value
+SELECT count(*) FILTER (WHERE text_id IS NULL) AS rows_with_null_key,
+       count(*) AS rows,
+       count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res;
+ rows_with_null_key | rows | ok
+---------------------------------------------------------------------
+                  0 |  500 | 500
+(1 row)
+
+-- ---------------------------------------------------------------------
+-- Negative coverage: constructs the GUC never relaxes.
+-- ---------------------------------------------------------------------
+-- reference table target: the GUC does not apply. The plan is a coordinator
+-- merge whether the GUC is disabled or enabled (identical), unlike the
+-- distributed-target cases above which push down once the GUC is enabled.
+CREATE TABLE ref(text_id int, val int);
+SELECT create_reference_table('ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO ref(text_id, val)
+SELECT text_id % 10, count(*)::int FROM dist GROUP BY text_id % 10
+$$, true);
+                            explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  HashAggregate
+         Group Key: remote_scan.text_id
+         ->  Custom Scan (Citus Adaptive)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=xxxxx dbname=regression
+                     ->  HashAggregate
+                           Group Key: (text_id % 10)
+                           ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO ref(text_id, val)
+SELECT text_id % 10, count(*)::int FROM dist GROUP BY text_id % 10
+$$, true);
+                            explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  HashAggregate
+         Group Key: remote_scan.text_id
+         ->  Custom Scan (Citus Adaptive)
+               Task Count: 4
+               Tasks Shown: One of 4
+               ->  Task
+                     Node: host=localhost port=xxxxx dbname=regression
+                     ->  HashAggregate
+                           Group Key: (text_id % 10)
+                           ->  Seq Scan on dist_14000000 dist
+(12 rows)
+
+-- volatile functions: the GUC relaxes only grouping / partition-column matching,
+-- never volatility. A volatile function in the SELECT is still not pushed to the
+-- shards with the GUC enabled -- it falls back to a coordinator plan, identical
+-- to the GUC-disabled case.
+CREATE FUNCTION volatile_transform(t text) RETURNS int
+LANGUAGE sql VOLATILE AS $$ SELECT length(t) $$;
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, volatile_transform(text_col) FROM dist
+$$, true);
+                         explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: repartition
+   ->  Custom Scan (Citus Adaptive)
+         Task Count: 4
+         Tasks Shown: One of 4
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Seq Scan on dist_14000000 dist
+(8 rows)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, volatile_transform(text_col) FROM dist
+$$, true);
+                         explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: repartition
+   ->  Custom Scan (Citus Adaptive)
+         Task Count: 4
+         Tasks Shown: One of 4
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Seq Scan on dist_14000000 dist
+(8 rows)
+
+-- a LIMIT forces a coordinator merge even with the GUC enabled and an otherwise
+-- pushdown-eligible plan (grouped on the distribution column); LIMIT/OFFSET are
+-- never relaxed
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT text_id id, count(*)::int val FROM dist GROUP BY text_id LIMIT 100
+) s
+$$, true);
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  Limit
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  Limit
+                                       ->  HashAggregate
+                                             Group Key: text_id
+                                             ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Function Scan on read_intermediate_result intermediate_result
+(19 rows)
+
+-- ... and likewise for OFFSET
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT text_id id, count(*)::int val FROM dist GROUP BY text_id OFFSET 5
+) s
+$$, true);
+                                  explain_filter
+---------------------------------------------------------------------
+ Custom Scan (Citus INSERT ... SELECT)
+   INSERT/SELECT method: pull to coordinator
+   ->  Custom Scan (Citus Adaptive)
+         ->  Distributed Subplan XXX_1
+               ->  Limit
+                     ->  Custom Scan (Citus Adaptive)
+                           Task Count: 4
+                           Tasks Shown: One of 4
+                           ->  Task
+                                 Node: host=localhost port=xxxxx dbname=regression
+                                 ->  HashAggregate
+                                       Group Key: text_id
+                                       ->  Seq Scan on dist_14000000 dist
+         Task Count: 1
+         Tasks Shown: All
+         ->  Task
+               Node: host=localhost port=xxxxx dbname=regression
+               ->  Function Scan on read_intermediate_result intermediate_result
+(18 rows)
+
+-- ---------------------------------------------------------------------
+-- Positive coverage: common INSERT .. SELECT wrappers keep routing correctly
+-- with the GUC on -- RETURNING, ON CONFLICT DO UPDATE and a PREPARE/EXECUTE
+-- generic plan.
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+-- RETURNING the batched rows (consumed by a wrapping CTE so the output stays
+-- deterministic): every returned row keeps its own value
+TRUNCATE res;
+WITH ins AS (
+  INSERT INTO res(text_id, val)
+  SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+  FROM dist GROUP BY text_id % 10
+  RETURNING text_id, val
+)
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM ins;
+ count | ok
+---------------------------------------------------------------------
+   500 | 500
+(1 row)
+
+-- ON CONFLICT DO UPDATE on a primary-key target: the relaxed window shape (plain
+-- distribution-column Var) routes every row to its own shard and updates it
+CREATE TABLE res_pk(text_id int PRIMARY KEY, val int);
+SELECT create_distributed_table('res_pk', 'text_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO res_pk SELECT g, -1 FROM generate_series(1, 500) g;
+INSERT INTO res_pk(text_id, val)
+SELECT text_id, (row_number() OVER (ORDER BY text_col))::int FROM dist
+ON CONFLICT (text_id) DO UPDATE SET val = EXCLUDED.val;
+SELECT count(*), count(DISTINCT text_id) AS distinct_ids,
+       count(*) FILTER (WHERE val = -1) AS not_updated FROM res_pk;
+ count | distinct_ids | not_updated
+---------------------------------------------------------------------
+   500 |          500 |           0
+(1 row)
+
+DROP TABLE res_pk;
+-- PREPARE / EXECUTE: the same batch shape keeps routing correctly under a
+-- generic plan (>5 executions force the generic plan)
+TRUNCATE res;
+PREPARE batch_ins(int) AS
+  INSERT INTO res(text_id, val)
+  SELECT id, val FROM (
+    SELECT unnest(array_agg(text_id)) id, unnest(batch_transform(array_agg(text_col))) val
+    FROM dist WHERE text_id % 10 = $1 GROUP BY text_id % 10
+  ) s;
+EXECUTE batch_ins(0);
+EXECUTE batch_ins(1);
+EXECUTE batch_ins(2);
+EXECUTE batch_ins(3);
+EXECUTE batch_ins(4);
+EXECUTE batch_ins(5);
+EXECUTE batch_ins(6);
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM res;
+ count | ok
+---------------------------------------------------------------------
+   350 | 350
+(1 row)
+
+DEALLOCATE batch_ins;
+SET client_min_messages TO WARNING;
+DROP SCHEMA allow_unsafe_insert_select_pushdown CASCADE;

--- a/src/test/regress/expected/pg18.out
+++ b/src/test/regress/expected/pg18.out
@@ -3165,6 +3165,80 @@ drop cascades to type product_rating
 drop cascades to table product_ratings
 drop cascades to table record_arg_t
 -- END: PG18: MIN/MAX aggregate OID resolution for ANYARRAY and RECORD
+-- PG18: shard-local INSERT .. SELECT batching pushdown
+-- (citus.allow_unsafe_insert_select_pushdown). This mirrors a case from
+-- allow_unsafe_insert_select_pushdown.sql, which wraps EXPLAIN in
+-- public.explain_filter so the plan is comparable across supported Postgres
+-- versions. Here we keep the raw EXPLAIN output because this file only runs on
+-- PG18+, so we exercise the real plan including the PG18-only WindowAgg
+-- "Window:" line.
+CREATE SCHEMA pg18_insert_select_pushdown;
+SET search_path TO pg18_insert_select_pushdown;
+SET citus.next_shard_id TO 14100000;
+SET citus.shard_count = 4;
+SET citus.shard_replication_factor = 1;
+CREATE TABLE dist(text_id int, text_col text);
+CREATE TABLE res(text_id int, val int);
+SELECT create_distributed_table('dist', 'text_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('res', 'text_id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dist SELECT g, 't' || g FROM generate_series(1, 500) g;
+-- a batch UDF: returns one value per input, mimicking a batched API call.
+-- immutable + parallel safe, like a real batch UDF.
+CREATE FUNCTION batch_transform(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT array_agg(length(x)) FROM unnest(t) x $$;
+SELECT create_distributed_function('batch_transform(text[])');
+NOTICE:  procedure pg18_insert_select_pushdown.batch_transform is already distributed
+DETAIL:  Citus distributes procedures with CREATE [PROCEDURE|FUNCTION|AGGREGATE] commands
+ create_distributed_function
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+-- the batching and batch UDF run on the shards; the raw PG18 plan
+-- includes the WindowAgg "Window:" line
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+                                   QUERY PLAN
+---------------------------------------------------------------------
+ Custom Scan (Citus Adaptive)
+   Task Count: 4
+   Tasks Shown: One of 4
+   ->  Task
+         Node: host=localhost port=xxxxx dbname=regression
+         ->  Insert on res_14100004 citus_table_alias
+               ->  Subquery Scan on s
+                     Filter: (s.id IS NOT NULL)
+                     ->  ProjectSet
+                           ->  HashAggregate
+                                 Group Key: ((row_number() OVER (?) - 1) / 100)
+                                 ->  WindowAgg
+                                       Window: w1 AS (ROWS UNBOUNDED PRECEDING)
+                                       ->  Seq Scan on dist_14100000 dist
+(14 rows)
+
+RESET citus.allow_unsafe_insert_select_pushdown;
+DROP SCHEMA pg18_insert_select_pushdown CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table dist
+drop cascades to table res
+drop cascades to function batch_transform(text[])
+SET search_path TO pg18_nn;
 -- cleanup with minimum verbosity
 SET client_min_messages TO ERROR;
 RESET search_path;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -19,6 +19,7 @@ test: multi_behavioral_analytics_basics multi_behavioral_analytics_single_shard_
 # We don't parallelize the following test with the ones above because they're
 # not idempotent and hence causing flaky test detection check to fail.
 test: multi_insert_select_non_pushable_queries multi_insert_select
+test: allow_unsafe_insert_select_pushdown
 
 test: multi_shard_update_delete recursive_dml_with_different_planners_executors
 test: insert_select_repartition window_functions dml_recursive multi_insert_select_window

--- a/src/test/regress/sql/allow_unsafe_insert_select_pushdown.sql
+++ b/src/test/regress/sql/allow_unsafe_insert_select_pushdown.sql
@@ -1,0 +1,597 @@
+--
+-- ALLOW_UNSAFE_INSERT_SELECT_PUSHDOWN
+--
+-- Tests citus.allow_unsafe_insert_select_pushdown, which lets a colocated
+-- INSERT .. SELECT push GROUP BY / window / DISTINCT batching and a batch UDF
+-- down to the shards instead of pulling rows to the coordinator.
+--
+-- The distribution column of the target must still come from the source
+-- distribution column unchanged: either as a plain Var, or as the provably
+-- shard-local batch pass-through unnest(array_agg(dist_col)). Any other derived
+-- distribution value (an arithmetic/function transform, or a transform wrapped
+-- inside the array_agg) is rejected even with the GUC enabled, because it could
+-- route a row to a different shard.
+--
+CREATE SCHEMA allow_unsafe_insert_select_pushdown;
+SET search_path = allow_unsafe_insert_select_pushdown;
+SET citus.next_shard_id TO 14000000;
+SET citus.shard_count = 4;
+SET citus.shard_replication_factor = 1;
+
+CREATE TABLE dist(text_id int, text_col text);
+CREATE TABLE res(text_id int, val int);
+SELECT create_distributed_table('dist', 'text_id');
+SELECT create_distributed_table('res', 'text_id');
+
+INSERT INTO dist SELECT g, 't' || g FROM generate_series(1, 500) g;
+
+-- a batched UDF: returns one value per input, mimicking a batched API call.
+-- immutable + parallel safe, like a real batch UDF.
+CREATE FUNCTION batch_transform(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT array_agg(length(x)) FROM unnest(t) x $$;
+SELECT create_distributed_function('batch_transform(text[])');
+
+-- default off: batching is done after pulling rows to the coordinator
+-- (explain_filter strips the PG18-only "Window:" line so the plan is
+--  comparable across supported Postgres versions)
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+
+-- now the batching and UDF call run on the shards
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+
+-- every text_id should be matched to the right value
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+
+-- ---------------------------------------------------------------------
+-- Positive per-branch coverage. Each construct below used to force a
+-- coordinator merge (or was rejected outright). With the GUC enabled the whole
+-- colocated INSERT .. SELECT is pushed to the shards because the distribution
+-- column is either a plain partition-column Var or the unnest(array_agg(text_id))
+-- batch pass-through. The pushed-down plan is a Custom Scan (Citus Adaptive)
+-- whose task runs the INSERT on a shard, with no Distributed Subplan /
+-- intermediate results. explain_filter keeps the plan comparable across
+-- Postgres versions.
+-- ---------------------------------------------------------------------
+
+-- the batched benchmark shape: bucket rows into fixed-size batches with
+-- row_number()/batch_size, array_agg each batch (id and text in the same
+-- order), call the batch UDF once per batch, then unnest back to one row per id.
+-- This is the query the GUC is meant to push down to the shards.
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT
+    unnest(array_agg(text_id ORDER BY text_id)) id,
+    unnest(batch_transform(array_agg(text_col ORDER BY text_id))) val
+  FROM (
+    SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist
+  ) q
+  GROUP BY batch
+) s
+$$, true);
+
+-- branch: GROUP BY on a non-distribution column, distribution column projected
+-- as the unnest(array_agg(text_id)) batch pass-through
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+
+-- branch: aggregates without GROUP BY
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col))) FROM dist
+$$, true);
+
+-- branch: HAVING without GROUP BY on the distribution column
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist HAVING count(*) > 0
+$$, true);
+
+-- branch: window function not partitioned on the distribution column, with the
+-- distribution column projected as a plain partition-column Var
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, row_number() OVER (ORDER BY text_col) FROM dist
+$$, true);
+
+-- combination: GROUP BY + DISTINCT, distribution column as the batch pass-through
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT unnest(array_agg(text_id)), unnest(array_agg(length(text_col)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+
+-- combination: window + GROUP BY, relaxed constructs living in nested subqueries
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, v FROM (
+  SELECT unnest(array_agg(text_id)) id, unnest(batch_transform(array_agg(text_col))) v
+  FROM (SELECT text_id, text_col, row_number() OVER (ORDER BY text_col) rn FROM dist) q
+  GROUP BY rn % 5
+) s
+$$, true);
+
+-- ---------------------------------------------------------------------
+-- Executed coverage for the relaxed positive branches: the plans above only
+-- assert pushdown; run two of them for real to confirm the shard-local batching
+-- keeps each row's value matched to its own distribution key.
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+
+-- aggregate without GROUP BY: each shard aggregates all its rows into one group
+-- and the unnest zip-back keeps text_id matched to length(text_col)
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col))) FROM dist;
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM res;
+
+-- window not partitioned on the distribution column: the distribution column is
+-- a plain Var, so every text_id is routed to its own shard exactly once
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT text_id, row_number() OVER (ORDER BY text_col) FROM dist;
+SELECT count(*), count(DISTINCT text_id) AS distinct_ids,
+       count(*) FILTER (WHERE text_id IS NULL) AS null_keys FROM res;
+
+-- ---------------------------------------------------------------------
+-- Negative coverage: pattern requirement. With the GUC enabled the batching
+-- relaxations still fire, but the distribution column is a *transformed* value
+-- rather than the source partition column, so the query is not pushed down and
+-- falls back to a coordinator merge -- identical to the GUC-disabled plan.
+-- ---------------------------------------------------------------------
+
+-- distribution column derived by arithmetic on the partition column
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id + 0, length(text_col) FROM dist
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id + 0, length(text_col) FROM dist
+$$, true);
+
+-- distribution column derived from a non-distribution column (DISTINCT)
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT length(text_col), text_id % 7 FROM dist
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT DISTINCT length(text_col), text_id % 7 FROM dist
+$$, true);
+
+-- distribution column derived from a non-distribution column, one subquery down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT k, k FROM (
+  SELECT DISTINCT length(text_col) k FROM dist
+) s
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT k, k FROM (
+  SELECT DISTINCT length(text_col) k FROM dist
+) s
+$$, true);
+
+-- the batched benchmark shape, but with the distribution column transformed
+-- *inside* array_agg (unnest(array_agg(text_id + 1))): the batch pass-through no
+-- longer carries the untransformed partition column, so the same shape that
+-- pushes down above is now rejected and falls back to a coordinator merge
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+-- the batched benchmark shape, but with a transform wrapping array_agg for the
+-- distribution column (unnest(batch_transform(array_agg(text_col)))): the unnest
+-- argument must be a bare array_agg of the partition column, so this is rejected
+-- too and falls back to a coordinator merge
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(batch_transform(array_agg(text_col))) id,
+         unnest(array_agg(text_id)) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(batch_transform(array_agg(text_col))) id,
+         unnest(array_agg(text_id)) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+-- ---------------------------------------------------------------------
+-- Runtime behavior of the rejected transform shapes.
+--
+-- Both transform shapes rejected above keep the set-returning unnest() inside
+-- a subquery, so they fall back to a coordinator merge and still execute
+-- correctly (each id stays matched to its own value).
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id + 1)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+-- id = text_id + 1 and val = length('t' || text_id), so val = length('t' || (id - 1))
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || (text_id - 1))) AS ok
+FROM res;
+
+-- ---------------------------------------------------------------------
+-- Pre-existing limitation, NOT specific to this GUC: a set-returning function
+-- left in the *top-level* target list of a non-pushed-down INSERT .. SELECT
+-- (flat, or fed from a CTE) surfaces PostgreSQL's opaque "set-valued function
+-- called in context that cannot accept a set" error. The Citus coordinator
+-- INSERT .. SELECT path does not replicate PostgreSQL's split_pathtarget_at_srfs()
+-- (ProjectSet insertion), so the unnest() is left where PostgreSQL's executor
+-- cannot evaluate it. This reproduces with the GUC off, and on a plain
+-- distributed SELECT too. Tracked in
+-- https://github.com/citusdata/citus/issues/2265; pinned here so a future fix
+-- (a clearer error, or actual support) is caught.
+-- ---------------------------------------------------------------------
+
+-- flat set-returning function in the top-level target list, GUC on
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id + 1)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+
+-- same shape with the GUC off: the error is pre-existing, not caused by the GUC
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id + 1)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+
+-- a CTE-wrapped batch source hits the same limitation
+WITH b AS (SELECT text_id, text_col FROM dist)
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM b GROUP BY text_id % 10;
+
+-- not specific to INSERT .. SELECT: the same set-returning function over an
+-- aggregate errors in a plain distributed SELECT as well (#2265)
+SELECT unnest(array_agg(text_id)) FROM dist;
+
+-- ---------------------------------------------------------------------
+-- Negative coverage: FILTER / DISTINCT on the batch pass-through array_agg.
+-- The distribution-column pass-through unnest(array_agg(text_id)) is only
+-- safe when the array_agg emits exactly one element per group row. A FILTER
+-- or DISTINCT clause on that array_agg can emit fewer elements, so when a
+-- sibling set-returning column is longer PostgreSQL's ProjectSet NULL-pads
+-- the shorter distribution-column set -- silently producing NULL (mis-routed)
+-- partition keys. Such an array_agg is therefore rejected even with the GUC
+-- enabled and falls back to a coordinator merge, which re-routes each row and
+-- enforces the not-NULL partition-column invariant. ORDER BY inside array_agg
+-- only reorders (never drops) elements and stays pushed down (covered above).
+-- ---------------------------------------------------------------------
+
+-- FILTER on the distribution-column array_agg: not pushed down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+-- DISTINCT on the distribution-column array_agg: not pushed down
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(DISTINCT text_id)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(DISTINCT text_id)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s
+$$, true);
+
+-- the FILTER shape rejected above, run for real under the GUC: the coordinator
+-- fallback re-routes each row and raises the not-NULL partition-column error
+-- instead of silently inserting NULL (mis-routed) partition keys
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id) FILTER (WHERE text_id % 2 = 0)) id,
+         unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+SELECT count(*) AS rows_with_null_key FROM res WHERE text_id IS NULL;
+
+-- ---------------------------------------------------------------------
+-- Correctness of the pushed-down batches.
+-- ---------------------------------------------------------------------
+
+-- correctness for a GROUP BY batch: per-shard aggregation keeps each text_id
+-- matched to its own value
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+FROM dist GROUP BY text_id % 10;
+
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+
+-- correctness for the batched benchmark shape: every text_id keeps its own value
+-- after batching, the UDF call, and the unnest zip-back
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT
+    unnest(array_agg(text_id ORDER BY text_id)) id,
+    unnest(batch_transform(array_agg(text_col ORDER BY text_id))) val
+  FROM (
+    SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist
+  ) q
+  GROUP BY batch
+) s;
+
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res JOIN dist USING (text_id);
+
+-- ---------------------------------------------------------------------
+-- Runtime NULL-key drop: an over-emitting batch UDF returns more elements than
+-- the distribution-column array_agg, so PostgreSQL's ProjectSet NULL-pads the
+-- (shorter) distribution column. The pushed-down plan filters those rows out
+-- (distribution column IS NOT NULL) so no NULL (mis-routed) partition key is
+-- inserted, while every real text_id keeps its own value. Both shapes are
+-- covered: the outer-subquery shape (distribution column is a plain Var,
+-- filtered in place) and the flat shape (distribution column is the unnest
+-- set-returning expression, filtered via a pass-through subquery wrapper).
+-- ---------------------------------------------------------------------
+
+-- a batch UDF that emits one extra element per batch (appends a trailing 0),
+-- mimicking a batched API call whose output is longer than its input
+CREATE FUNCTION batch_transform_over(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT (SELECT array_agg(length(x)) FROM unnest(t) x) || 0 $$;
+SELECT create_distributed_function('batch_transform_over(text[])');
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+
+-- outer-subquery shape: the distribution column is a plain Var, so the
+-- IS NOT NULL filter is attached to the pushed-down SELECT directly
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id ORDER BY text_id)) id,
+         unnest(batch_transform_over(array_agg(text_col ORDER BY text_id))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist) q
+  GROUP BY batch
+) s
+$$, true);
+
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT unnest(array_agg(text_id ORDER BY text_id)) id,
+         unnest(batch_transform_over(array_agg(text_col ORDER BY text_id))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 batch FROM dist) q
+  GROUP BY batch
+) s;
+-- no NULL (mis-routed) key inserted; all 500 rows kept their value
+SELECT count(*) FILTER (WHERE text_id IS NULL) AS rows_with_null_key,
+       count(*) AS rows,
+       count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res;
+
+-- flat shape: the distribution column is the bare unnest set-returning
+-- expression, so the SELECT is wrapped in a pass-through subquery whose
+-- IS NOT NULL filter drops the NULL-padded rows
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id ORDER BY text_id)),
+       unnest(batch_transform_over(array_agg(text_col ORDER BY text_id)))
+FROM dist GROUP BY text_id % 10
+$$, true);
+
+TRUNCATE res;
+INSERT INTO res(text_id, val)
+SELECT unnest(array_agg(text_id ORDER BY text_id)),
+       unnest(batch_transform_over(array_agg(text_col ORDER BY text_id)))
+FROM dist GROUP BY text_id % 10;
+-- no NULL (mis-routed) key inserted; all 500 rows kept their value
+SELECT count(*) FILTER (WHERE text_id IS NULL) AS rows_with_null_key,
+       count(*) AS rows,
+       count(*) FILTER (WHERE val = length('t' || text_id)) AS ok
+FROM res;
+
+-- ---------------------------------------------------------------------
+-- Negative coverage: constructs the GUC never relaxes.
+-- ---------------------------------------------------------------------
+
+-- reference table target: the GUC does not apply. The plan is a coordinator
+-- merge whether the GUC is disabled or enabled (identical), unlike the
+-- distributed-target cases above which push down once the GUC is enabled.
+CREATE TABLE ref(text_id int, val int);
+SELECT create_reference_table('ref');
+
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO ref(text_id, val)
+SELECT text_id % 10, count(*)::int FROM dist GROUP BY text_id % 10
+$$, true);
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO ref(text_id, val)
+SELECT text_id % 10, count(*)::int FROM dist GROUP BY text_id % 10
+$$, true);
+
+-- volatile functions: the GUC relaxes only grouping / partition-column matching,
+-- never volatility. A volatile function in the SELECT is still not pushed to the
+-- shards with the GUC enabled -- it falls back to a coordinator plan, identical
+-- to the GUC-disabled case.
+CREATE FUNCTION volatile_transform(t text) RETURNS int
+LANGUAGE sql VOLATILE AS $$ SELECT length(t) $$;
+
+SET citus.allow_unsafe_insert_select_pushdown TO off;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, volatile_transform(text_col) FROM dist
+$$, true);
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT text_id, volatile_transform(text_col) FROM dist
+$$, true);
+
+-- a LIMIT forces a coordinator merge even with the GUC enabled and an otherwise
+-- pushdown-eligible plan (grouped on the distribution column); LIMIT/OFFSET are
+-- never relaxed
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT text_id id, count(*)::int val FROM dist GROUP BY text_id LIMIT 100
+) s
+$$, true);
+
+-- ... and likewise for OFFSET
+SELECT public.explain_filter($$
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT text_id id, count(*)::int val FROM dist GROUP BY text_id OFFSET 5
+) s
+$$, true);
+
+-- ---------------------------------------------------------------------
+-- Positive coverage: common INSERT .. SELECT wrappers keep routing correctly
+-- with the GUC on -- RETURNING, ON CONFLICT DO UPDATE and a PREPARE/EXECUTE
+-- generic plan.
+-- ---------------------------------------------------------------------
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+
+-- RETURNING the batched rows (consumed by a wrapping CTE so the output stays
+-- deterministic): every returned row keeps its own value
+TRUNCATE res;
+WITH ins AS (
+  INSERT INTO res(text_id, val)
+  SELECT unnest(array_agg(text_id)), unnest(batch_transform(array_agg(text_col)))
+  FROM dist GROUP BY text_id % 10
+  RETURNING text_id, val
+)
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM ins;
+
+-- ON CONFLICT DO UPDATE on a primary-key target: the relaxed window shape (plain
+-- distribution-column Var) routes every row to its own shard and updates it
+CREATE TABLE res_pk(text_id int PRIMARY KEY, val int);
+SELECT create_distributed_table('res_pk', 'text_id');
+INSERT INTO res_pk SELECT g, -1 FROM generate_series(1, 500) g;
+INSERT INTO res_pk(text_id, val)
+SELECT text_id, (row_number() OVER (ORDER BY text_col))::int FROM dist
+ON CONFLICT (text_id) DO UPDATE SET val = EXCLUDED.val;
+SELECT count(*), count(DISTINCT text_id) AS distinct_ids,
+       count(*) FILTER (WHERE val = -1) AS not_updated FROM res_pk;
+DROP TABLE res_pk;
+
+-- PREPARE / EXECUTE: the same batch shape keeps routing correctly under a
+-- generic plan (>5 executions force the generic plan)
+TRUNCATE res;
+PREPARE batch_ins(int) AS
+  INSERT INTO res(text_id, val)
+  SELECT id, val FROM (
+    SELECT unnest(array_agg(text_id)) id, unnest(batch_transform(array_agg(text_col))) val
+    FROM dist WHERE text_id % 10 = $1 GROUP BY text_id % 10
+  ) s;
+EXECUTE batch_ins(0);
+EXECUTE batch_ins(1);
+EXECUTE batch_ins(2);
+EXECUTE batch_ins(3);
+EXECUTE batch_ins(4);
+EXECUTE batch_ins(5);
+EXECUTE batch_ins(6);
+SELECT count(*), count(*) FILTER (WHERE val = length('t' || text_id)) AS ok FROM res;
+DEALLOCATE batch_ins;
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA allow_unsafe_insert_select_pushdown CASCADE;

--- a/src/test/regress/sql/pg18.sql
+++ b/src/test/regress/sql/pg18.sql
@@ -2007,6 +2007,49 @@ DROP SCHEMA pg18_minmax CASCADE;
 -- END: PG18: MIN/MAX aggregate OID resolution for ANYARRAY and RECORD
 
 
+-- PG18: shard-local INSERT .. SELECT batching pushdown
+-- (citus.allow_unsafe_insert_select_pushdown). This mirrors a case from
+-- allow_unsafe_insert_select_pushdown.sql, which wraps EXPLAIN in
+-- public.explain_filter so the plan is comparable across supported Postgres
+-- versions. Here we keep the raw EXPLAIN output because this file only runs on
+-- PG18+, so we exercise the real plan including the PG18-only WindowAgg
+-- "Window:" line.
+CREATE SCHEMA pg18_insert_select_pushdown;
+SET search_path TO pg18_insert_select_pushdown;
+SET citus.next_shard_id TO 14100000;
+SET citus.shard_count = 4;
+SET citus.shard_replication_factor = 1;
+
+CREATE TABLE dist(text_id int, text_col text);
+CREATE TABLE res(text_id int, val int);
+SELECT create_distributed_table('dist', 'text_id');
+SELECT create_distributed_table('res', 'text_id');
+
+INSERT INTO dist SELECT g, 't' || g FROM generate_series(1, 500) g;
+
+-- a batch UDF: returns one value per input, mimicking a batched API call.
+-- immutable + parallel safe, like a real batch UDF.
+CREATE FUNCTION batch_transform(t text[]) RETURNS int[]
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$ SELECT array_agg(length(x)) FROM unnest(t) x $$;
+SELECT create_distributed_function('batch_transform(text[])');
+
+SET citus.allow_unsafe_insert_select_pushdown TO on;
+
+-- the batching and batch UDF run on the shards; the raw PG18 plan
+-- includes the WindowAgg "Window:" line
+EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
+SELECT id, val FROM (
+  SELECT b, unnest(array_agg(text_id)) id,
+            unnest(batch_transform(array_agg(text_col))) val
+  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
+  GROUP BY b
+) s;
+
+RESET citus.allow_unsafe_insert_select_pushdown;
+DROP SCHEMA pg18_insert_select_pushdown CASCADE;
+SET search_path TO pg18_nn;
+
+
 -- cleanup with minimum verbosity
 SET client_min_messages TO ERROR;
 RESET search_path;


### PR DESCRIPTION
DESCRIPTION: Adds `citus.allow_unsafe_insert_select_pushdown` to allow maybe unsafe shard-local batched `INSERT .. SELECT ..`


Some workloads want to call an expensive, batch-oriented UDF from a colocated
`INSERT … SELECT` — e.g. `process_array(text[])`, which returns something
per element, in order. The natural way to use it is to batch rows with `array_agg`
(+ a window function to form batches), call the UDF once per batch, then `unnest`
the result back to one row per input and insert it.

On a distributed table this SELECT looks like it "requires a merge" (e.g., GROUP
BY / window on a non-distribution column), so Citus today falls back to
**pull-to-coordinator**: it pulls every shard's rows to the coordinator, batches
there, and calls the UDF there. That defeats the purpose — the batching and the
expensive call should run **on the shards**.

## What this adds

With `citus.allow_unsafe_insert_select_pushdown` (default `off`), for a
**colocated** `INSERT … SELECT`, it relaxes the merge-step checks that would
otherwise cause pull-to-coordinator, so the whole SELECT — grouping, window,
and the batch UDF — is pushed down and runs shard-local, one task per shard.

Concretely, when the GUC is on:

- GROUP BY / aggregates / HAVING / window / DISTINCT on non-distribution columns
  no longer force a merge step — for the top-level SELECT and the subqueries.
- The INSERT's distribution-column target entry no longer has to match a SELECT
  partition column as a plain `Var`. Instead it may be any **shard-key identity**
  — an expression that provably reproduces this shard's distribution-column values
  unchanged, so the generated rows hash right back into this shard's range. The
  concept is factored as a gate so identity-preserving shapes can be recognized
  centrally (and extended later); **today the only recognized shard-key identity
  is a provably shard-local batch pass-through of the distribution column**, i.e.
  `unnest(array_agg(dist_key))`. `InsertPartitionColumnMatchesSelect` is skipped
  only when such a shard-key identity is detected. Because those values are read
  straight from this shard's rows and — since source and target are colocated —
  hash right back into this shard's range, routing stays correct. The NOT NULL
  filter Citus normally injects on that column is re-added at runtime (see the
  safety net below) so a NULL-padded row can never be misrouted.

**However, the following are still enforced:**

- **The distribution value must be the `unnest(array_agg(dist_key))` pass-through
  (or a plain `Var`).** Any *other* derived distribution value — e.g.
  `dist_key + 1`, `length(text_col)`, or `unnest(f(array_agg(dist_key)))` — is
  still rejected even with the GUC on, because it could produce values that hash
  to a different shard and silently misroute rows.
- **The pass-through `array_agg` must emit one value per group row.** `DISTINCT`
  or `FILTER (...)` on that aggregate — e.g.
  `unnest(array_agg(dist_key) FILTER (WHERE ...))` or
  `unnest(array_agg(DISTINCT dist_key))` — can emit fewer values than the batch
  has rows. These shapes are rejected and fall back to a coordinator merge, which
  re-routes each row and raises the usual not-NULL partition-column error instead
  of corrupting data. (`ORDER BY` inside `array_agg` stays allowed — it only
  reorders values, never drops them.)
- **Colocation** of the INSERT target and all SELECT source relations is fully
  enforced. This is what keeps every batch shard-local, and is the reason the
  relaxation is sound rather than arbitrary.
- **Volatile functions** are still rejected from pushdown (the batch UDF is
  expected to be immutable, so this ban is not relaxed).
- **LIMIT/OFFSET** is still rejected.

### Safety net: drop NULL partition keys at runtime

Even for the accepted `unnest(array_agg(dist_key))` pass-through, a *sibling*
set-returning target in the same projection can be longer than the
distribution-column set — e.g. an over-emitting batch UDF that returns more
elements than its input. PostgreSQL's `ProjectSet` then NULL-pads the shorter
distribution-column set, which would insert a NULL (mis-routed) partition key.

Because the batch path skips the NOT NULL filter Citus normally injects, the
pushdown now re-adds a distribution-column `IS NOT NULL` qual to the shard SELECT
so those NULL-padded rows are dropped, matching how a normal `INSERT … SELECT`
handles a NULL distribution value. Both shapes are covered:

- **outer-subquery shape** — the distribution column surfaces as a plain `Var`
  (the `unnest` lives in an inner subquery), so the qual is attached to the
  pushed-down SELECT in place.
- **flat shape** — the distribution column is the bare `unnest(...)`
  set-returning expression projected directly in the SELECT list, so there is no
  `Var` handle for a WHERE clause. The SELECT is wrapped in a pure pass-through
  subquery (`citus_insert_select_subquery`) that turns the column into an ordinary
  `Var`, then filtered. The wrapper never lifts expressions to the outer query, so
  the batch call keeps running on the shard.

Within those guardrails the user still takes responsibility for making each batch
order-preserving (e.g. `array_agg(... ORDER BY ...)`) so generated rows line up.

### Semantics you must be aware of

- **Grouping/window/aggregates run per shard, not table-wide.** The relaxation
  also applies to nested subqueries, so any grouping, window, or aggregate is
  evaluated independently on each shard. A global window/aggregate written as if
  it saw the whole table — e.g. `count(*) OVER ()` or
  `row_number() OVER (ORDER BY text_id)` — silently produces *per-shard* results.
  This is expected for the batching use case (each shard batches its own rows) but
  is a real behavior change to keep in mind.
- **The batch UDF must emit exactly one value per input row.** The runtime
  NOT NULL filter above guards only the distribution column, not the sibling
  projected values. An *under-emitting* batch UDF (returns fewer elements than its
  input) makes `ProjectSet` NULL-pad the value column, and those rows — with a
  valid distribution key but a NULL value — are inserted as-is (a NULL value can
  be legitimate, so it can't be filtered like a NULL key). Ensure the batch is 1:1
  with its input.

## EXPLAIN — before / after

The batch shape: bucket rows into fixed-size batches with
`(row_number() OVER () - 1) / batch_size`, `array_agg` each batch, call the batch
UDF once per batch, then `unnest` back to one row per id.

Default (`off`) — batching happens after pulling every shard's rows to the
coordinator, so the window scan runs a distributed subplan and the grouping +
UDF run in a single coordinator task over the intermediate results:

```
EXPLAIN (COSTS OFF) INSERT INTO res(text_id, val)
SELECT id, val FROM (
  SELECT b, unnest(array_agg(text_id)) id,
            unnest(batch_transform(array_agg(text_col))) val
  FROM (SELECT text_id, text_col, (row_number() OVER () - 1) / 100 b FROM dist) q
  GROUP BY b
) s;

 Custom Scan (Citus INSERT ... SELECT)
   INSERT/SELECT method: pull to coordinator
   ->  Custom Scan (Citus Adaptive)
         ->  Distributed Subplan XXX_1
               ->  WindowAgg
                     ->  Custom Scan (Citus Adaptive)
                           Task Count: 4
                           Tasks Shown: One of 4
                           ->  Task
                                 ->  Seq Scan on dist_14000000 dist
         Task Count: 1
         ->  Task
               ->  Subquery Scan on s
                     ->  ProjectSet
                           ->  HashAggregate
                                 Group Key: intermediate_result.b
                                 ->  Function Scan on read_intermediate_result intermediate_result
```

With `citus.allow_unsafe_insert_select_pushdown = on` — the window, grouping,
the batch UDF, and the INSERT all run shard-local, one task per shard, with no
distributed subplan / intermediate results. The distribution-column
`IS NOT NULL` safety filter appears on the shard SELECT:

```
 Custom Scan (Citus Adaptive)
   Task Count: 4
   Tasks Shown: One of 4
   ->  Task
         ->  Insert on res_14000004 citus_table_alias
               ->  Subquery Scan on s
                     Filter: (s.id IS NOT NULL)
                     ->  ProjectSet
                           ->  HashAggregate
                                 Group Key: ((row_number() OVER (?) - 1) / 100)
                                 ->  WindowAgg
                                       ->  Seq Scan on dist_14000000 dist
```
