### PR TITLE
Enforce object ownership for more citus-internal UDFs (Backport #8587 to release-12.1)

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -3615,6 +3615,12 @@ citus_internal_delete_placement_metadata(PG_FUNCTION_ARGS)
 	PG_ENSURE_ARGNOTNULL(0, "placement_id");
 	int64 placementId = PG_GETARG_INT64(0);
 
+	bool missingOk = false;
+	GroupShardPlacement *placement = LookupGroupPlacementByPlacementId(placementId,
+																	   missingOk);
+
+	EnsureShardOwner(placement->shardId, missingOk);
+
 	if (!ShouldSkipMetadataChecks())
 	{
 		/* this UDF is not allowed allowed for executing as a separate command */
@@ -3986,6 +3992,14 @@ citus_internal_add_tenant_schema(PG_FUNCTION_ARGS)
 	PG_ENSURE_ARGNOTNULL(1, "colocation_id");
 	uint32 colocationId = PG_GETARG_INT32(1);
 
+	EnsureSchemaOwner(schemaId);
+
+	if (!ShouldSkipMetadataChecks())
+	{
+		/* this UDF is not allowed allowed for executing as a separate command */
+		EnsureCoordinatorInitiatedOperation();
+	}
+
 	InsertTenantSchemaLocally(schemaId, colocationId);
 
 	PG_RETURN_VOID();
@@ -4007,6 +4021,14 @@ citus_internal_delete_tenant_schema(PG_FUNCTION_ARGS)
 
 	PG_ENSURE_ARGNOTNULL(0, "schema_id");
 	Oid schemaId = PG_GETARG_OID(0);
+
+	EnsureSchemaOwner(schemaId);
+
+	if (!ShouldSkipMetadataChecks())
+	{
+		/* this UDF is not allowed allowed for executing as a separate command */
+		EnsureCoordinatorInitiatedOperation();
+	}
 
 	DeleteTenantSchemaLocally(schemaId);
 
@@ -4035,6 +4057,8 @@ citus_internal_update_none_dist_table_metadata(PG_FUNCTION_ARGS)
 
 	PG_ENSURE_ARGNOTNULL(3, "auto_converted");
 	bool autoConverted = PG_GETARG_BOOL(3);
+
+	EnsureTableOwner(relationId);
 
 	if (!ShouldSkipMetadataChecks())
 	{

--- a/src/backend/distributed/metadata/metadata_utility.c
+++ b/src/backend/distributed/metadata/metadata_utility.c
@@ -1667,6 +1667,52 @@ AllShardPlacementsOnNodeGroup(int32 groupId)
 
 
 /*
+ * LookupGroupPlacementByPlacementId finds the shard placement for
+ * given placementId from the catalog and returns GroupShardPlacement
+ * for it.
+ */
+GroupShardPlacement *
+LookupGroupPlacementByPlacementId(int64 placementId, bool missingOk)
+{
+	ScanKeyData scanKey[1];
+	int scanKeyCount = 1;
+	bool indexOK = true;
+
+	Relation pgPlacement = table_open(DistPlacementRelationId(), AccessShareLock);
+
+	ScanKeyInit(&scanKey[0], Anum_pg_dist_placement_placementid,
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(placementId));
+
+	SysScanDesc scanDescriptor = systable_beginscan(pgPlacement,
+													DistPlacementPlacementidIndexId(),
+													indexOK,
+													NULL, scanKeyCount, scanKey);
+
+	HeapTuple heapTuple = systable_getnext(scanDescriptor);
+	if (!HeapTupleIsValid(heapTuple))
+	{
+		if (!missingOk)
+		{
+			ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("could not find any shard placement "
+								   "with id " INT64_FORMAT,
+								   placementId)));
+		}
+
+		return NULL;
+	}
+
+	GroupShardPlacement *placement =
+		TupleToGroupShardPlacement(RelationGetDescr(pgPlacement), heapTuple);
+
+	systable_endscan(scanDescriptor);
+	table_close(pgPlacement, NoLock);
+
+	return placement;
+}
+
+
+/*
  * TupleToGroupShardPlacement takes in a heap tuple from pg_dist_placement,
  * and converts this tuple to in-memory struct. The function assumes the
  * caller already has locks on the tuple, and doesn't perform any locking.

--- a/src/include/distributed/metadata_utility.h
+++ b/src/include/distributed/metadata_utility.h
@@ -338,6 +338,8 @@ extern ShardPlacement * ActiveShardPlacement(uint64 shardId, bool missingOk);
 extern WorkerNode * ActiveShardPlacementWorkerNode(uint64 shardId);
 extern List * BuildShardPlacementList(int64 shardId);
 extern List * AllShardPlacementsOnNodeGroup(int32 groupId);
+extern GroupShardPlacement * LookupGroupPlacementByPlacementId(int64 placementId,
+															   bool missingOk);
 extern List * GroupShardPlacementsForTableOnGroup(Oid relationId, int32 groupId);
 extern void LookupTaskPlacementHostAndPort(ShardPlacement *taskPlacement, char **nodeName,
 										   int *nodePort);

--- a/src/test/regress/expected/create_ref_dist_from_citus_local.out
+++ b/src/test/regress/expected/create_ref_dist_from_citus_local.out
@@ -372,7 +372,7 @@ ROLLBACK;
 SELECT pg_catalog.citus_internal_update_none_dist_table_metadata(1, 't', 1, true);
 ERROR:  This is an internal Citus function can only be used in a distributed transaction
 SELECT pg_catalog.citus_internal_delete_placement_metadata(1);
-ERROR:  This is an internal Citus function can only be used in a distributed transaction
+ERROR:  could not find any shard placement with id 1
 CREATE ROLE test_user_create_ref_dist WITH LOGIN;
 GRANT ALL ON SCHEMA create_ref_dist_from_citus_local TO test_user_create_ref_dist;
 ALTER SYSTEM SET citus.enable_manual_metadata_changes_for_user TO 'test_user_create_ref_dist';

--- a/src/test/regress/expected/metadata_sync_helpers.out
+++ b/src/test/regress/expected/metadata_sync_helpers.out
@@ -1284,7 +1284,7 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SET application_name to 'citus_internal gpid=10000000001';
 	-- with an ugly trick, update the vartype of table from int to bigint
 	-- so that making two tables colocated fails
-	-- include varnullingrels for PG16
+    -- include varnullingrels for PG16
     SHOW server_version \gset
     SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
     \gset
@@ -1373,6 +1373,223 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT citus_internal_add_partition_metadata ('test_8'::regclass, 'h', 'text_col', 500, 's');
 ERROR:  cannot colocate tables test_8 and test_7
 ROLLBACK;
+-- add a placement for super_user_table (shard xxxxx) as superuser so that
+-- we can test delete_placement_metadata for a placement we do not own below
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	WITH placement_data(shardid, shardlength, groupid, placementid) AS
+		(VALUES (1420007, 0::bigint, get_node_id(), 1500100))
+	SELECT pg_catalog.citus_internal_add_placement_metadata(shardid, shardlength, groupid, placementid) FROM placement_data;
+ citus_internal_add_placement_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+COMMIT;
+\c - postgres - :master_port
+GRANT CREATE ON DATABASE regression TO metadata_sync_helper_role;
+\c - metadata_sync_helper_role - :master_port
+-- create a schema owned by metadata_sync_helper_role so that the preliminary
+-- tests below can pass the owner check and fail on EnsureCitusInitiatedOperation()
+SET citus.enable_schema_based_sharding TO ON;
+CREATE SCHEMA tenant_schema_helper_owned;
+RESET citus.enable_schema_based_sharding;
+-- create a regular schema owned by metadata_sync_helper_role
+CREATE SCHEMA regular_helper_schema;
+\c - metadata_sync_helper_role - :worker_1_port
+SET search_path TO metadata_sync_helpers;
+-- The following tests call the metadata helpers outside of a distributed
+-- transaction (i.e. without setting application_name to citus_internal),
+-- so they all should fail on EnsureCitusInitiatedOperation().
+SELECT pg_catalog.citus_internal_delete_placement_metadata(1500000);
+ERROR:  This is an internal Citus function can only be used in a distributed transaction
+SELECT pg_catalog.citus_internal_add_tenant_schema('tenant_schema_helper_owned'::regnamespace, 10);
+ERROR:  This is an internal Citus function can only be used in a distributed transaction
+SELECT pg_catalog.citus_internal_delete_tenant_schema('tenant_schema_helper_owned'::regnamespace);
+ERROR:  This is an internal Citus function can only be used in a distributed transaction
+SELECT pg_catalog.citus_internal_update_none_dist_table_metadata('test_2'::regclass, 's', 10, false);
+ERROR:  This is an internal Citus function can only be used in a distributed transaction
+-- citus_internal_delete_placement_metadata fails for non-existing placement
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_placement_metadata(123123123);
+ERROR:  could not find any shard placement with id 123123123
+ROLLBACK;
+-- citus_internal_delete_placement_metadata fails for non-owner user
+-- (placement xxxxx is for super_user_table's shard which we do not own)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_placement_metadata(1500100);
+ERROR:  must be owner of table super_user_table
+ROLLBACK;
+-- citus_internal_add_tenant_schema fails for non-existing schema
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for schema N" to "schema with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_add_tenant_schema(123123123, 10);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for schema ([0-9]+)', 'schema with OID \1 does not exist');
+	END;
+	$$;
+ERROR:  schema with OID 123123123 does not exist
+ROLLBACK;
+-- citus_internal_add_tenant_schema fails for non-owner user
+-- (public schema is not owned by metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_add_tenant_schema('public'::regnamespace, 10);
+ERROR:  must be owner of schema public
+ROLLBACK;
+-- citus_internal_delete_tenant_schema fails for non-existing schema
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for schema N" to "schema with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_delete_tenant_schema(123123123);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for schema ([0-9]+)', 'schema with OID \1 does not exist');
+	END;
+	$$;
+ERROR:  schema with OID 123123123 does not exist
+ROLLBACK;
+-- citus_internal_delete_tenant_schema fails for non-owner user
+-- (public schema is not owned by metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_tenant_schema('public'::regnamespace);
+ERROR:  must be owner of schema public
+ROLLBACK;
+-- citus_internal_delete_tenant_schema fails for a schema that is not a tenant schema
+-- (metadata_sync_helpers schema is owned by metadata_sync_helper_role here but not
+-- registered in pg_dist_schema)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize the schema oid in the error message so the test is stable
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_delete_tenant_schema('regular_helper_schema'::regnamespace);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, '[0-9]+', 'XXX', 'g');
+	END;
+	$$;
+ERROR:  could not find tuple for tenant schema XXX
+ROLLBACK;
+-- citus_internal_update_none_dist_table_metadata fails for non-existing table
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for relation N" to "relation with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_update_none_dist_table_metadata(123123123, 's', 10, false);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for relation ([0-9]+)', 'relation with OID \1 does not exist');
+	END;
+	$$;
+ERROR:  relation with OID XXXX does not exist
+ROLLBACK;
+-- citus_internal_update_none_dist_table_metadata fails for non-owner user
+-- (super_user_table is owned by postgres, not metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_update_none_dist_table_metadata('super_user_table'::regclass, 's', 10, false);
+ERROR:  must be owner of table super_user_table
+ROLLBACK;
+-- citus_internal_update_none_dist_table_metadata fails for a table that is not
+-- a Citus table (not_a_citus_table is owned by metadata_sync_helper_role but
+-- does not have a pg_dist_partition entry)
+CREATE TABLE not_a_citus_table(col_1 int);
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+ assign_distributed_transaction_id
+---------------------------------------------------------------------
+
+(1 row)
+
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize the relation oid in the error message so the test is stable
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_update_none_dist_table_metadata('not_a_citus_table'::regclass, 's', 10, false);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, '[0-9]+', 'XXX', 'g');
+	END;
+	$$;
+ERROR:  relation with oid XXX is not a Citus table
+ROLLBACK;
+DROP TABLE not_a_citus_table;
 -- we don't need the table/schema anymore
 -- connect back as super user to drop everything
 \c - postgres - :worker_1_port
@@ -1384,6 +1601,7 @@ DELETE FROM pg_dist_partition WHERE logicalrelid IN ('test_ref'::regclass, 'test
 \c - - - :master_port
 -- cleanup
 SET client_min_messages TO ERROR;
+DROP SCHEMA regular_helper_schema, tenant_schema_helper_owned CASCADE;
 DROP OWNED BY metadata_sync_helper_role;
 DROP ROLE metadata_sync_helper_role;
 DROP SCHEMA metadata_sync_helpers CASCADE;

--- a/src/test/regress/sql/metadata_sync_helpers.sql
+++ b/src/test/regress/sql/metadata_sync_helpers.sql
@@ -863,6 +863,168 @@ BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SELECT citus_internal_add_partition_metadata ('test_8'::regclass, 'h', 'text_col', 500, 's');
 ROLLBACK;
 
+-- add a placement for super_user_table (shard 1420007) as superuser so that
+-- we can test delete_placement_metadata for a placement we do not own below
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	WITH placement_data(shardid, shardlength, groupid, placementid) AS
+		(VALUES (1420007, 0::bigint, get_node_id(), 1500100))
+	SELECT pg_catalog.citus_internal_add_placement_metadata(shardid, shardlength, groupid, placementid) FROM placement_data;
+COMMIT;
+
+\c - postgres - :master_port
+GRANT CREATE ON DATABASE regression TO metadata_sync_helper_role;
+
+\c - metadata_sync_helper_role - :master_port
+
+-- create a schema owned by metadata_sync_helper_role so that the preliminary
+-- tests below can pass the owner check and fail on EnsureCitusInitiatedOperation()
+SET citus.enable_schema_based_sharding TO ON;
+CREATE SCHEMA tenant_schema_helper_owned;
+RESET citus.enable_schema_based_sharding;
+
+-- create a regular schema owned by metadata_sync_helper_role
+CREATE SCHEMA regular_helper_schema;
+
+\c - metadata_sync_helper_role - :worker_1_port
+
+SET search_path TO metadata_sync_helpers;
+
+-- The following tests call the metadata helpers outside of a distributed
+-- transaction (i.e. without setting application_name to citus_internal),
+-- so they all should fail on EnsureCitusInitiatedOperation().
+
+SELECT pg_catalog.citus_internal_delete_placement_metadata(1500000);
+SELECT pg_catalog.citus_internal_add_tenant_schema('tenant_schema_helper_owned'::regnamespace, 10);
+SELECT pg_catalog.citus_internal_delete_tenant_schema('tenant_schema_helper_owned'::regnamespace);
+SELECT pg_catalog.citus_internal_update_none_dist_table_metadata('test_2'::regclass, 's', 10, false);
+
+-- citus_internal_delete_placement_metadata fails for non-existing placement
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_placement_metadata(123123123);
+ROLLBACK;
+
+-- citus_internal_delete_placement_metadata fails for non-owner user
+-- (placement 1500100 is for super_user_table's shard which we do not own)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_placement_metadata(1500100);
+ROLLBACK;
+
+-- citus_internal_add_tenant_schema fails for non-existing schema
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for schema N" to "schema with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_add_tenant_schema(123123123, 10);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for schema ([0-9]+)', 'schema with OID \1 does not exist');
+	END;
+	$$;
+ROLLBACK;
+
+-- citus_internal_add_tenant_schema fails for non-owner user
+-- (public schema is not owned by metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_add_tenant_schema('public'::regnamespace, 10);
+ROLLBACK;
+
+-- citus_internal_delete_tenant_schema fails for non-existing schema
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for schema N" to "schema with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_delete_tenant_schema(123123123);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for schema ([0-9]+)', 'schema with OID \1 does not exist');
+	END;
+	$$;
+ROLLBACK;
+
+-- citus_internal_delete_tenant_schema fails for non-owner user
+-- (public schema is not owned by metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_delete_tenant_schema('public'::regnamespace);
+ROLLBACK;
+
+-- citus_internal_delete_tenant_schema fails for a schema that is not a tenant schema
+-- (metadata_sync_helpers schema is owned by metadata_sync_helper_role here but not
+-- registered in pg_dist_schema)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize the schema oid in the error message so the test is stable
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_delete_tenant_schema('regular_helper_schema'::regnamespace);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, '[0-9]+', 'XXX', 'g');
+	END;
+	$$;
+ROLLBACK;
+
+-- citus_internal_update_none_dist_table_metadata fails for non-existing table
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize "cache lookup failed for relation N" to "relation with OID N does not exist"
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_update_none_dist_table_metadata(123123123, 's', 10, false);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, 'cache lookup failed for relation ([0-9]+)', 'relation with OID \1 does not exist');
+	END;
+	$$;
+ROLLBACK;
+
+-- citus_internal_update_none_dist_table_metadata fails for non-owner user
+-- (super_user_table is owned by postgres, not metadata_sync_helper_role)
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	SELECT pg_catalog.citus_internal_update_none_dist_table_metadata('super_user_table'::regclass, 's', 10, false);
+ROLLBACK;
+
+-- citus_internal_update_none_dist_table_metadata fails for a table that is not
+-- a Citus table (not_a_citus_table is owned by metadata_sync_helper_role but
+-- does not have a pg_dist_partition entry)
+CREATE TABLE not_a_citus_table(col_1 int);
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SELECT assign_distributed_transaction_id(0, 8, '2021-07-09 15:41:55.542377+02');
+	SET application_name to 'citus_internal gpid=10000000001';
+	\set VERBOSITY terse
+	-- normalize the relation oid in the error message so the test is stable
+	DO $$
+	BEGIN
+		PERFORM pg_catalog.citus_internal_update_none_dist_table_metadata('not_a_citus_table'::regclass, 's', 10, false);
+	EXCEPTION WHEN OTHERS THEN
+		RAISE EXCEPTION '%', regexp_replace(SQLERRM, '[0-9]+', 'XXX', 'g');
+	END;
+	$$;
+ROLLBACK;
+DROP TABLE not_a_citus_table;
+
 -- we don't need the table/schema anymore
 -- connect back as super user to drop everything
 \c - postgres - :worker_1_port
@@ -875,6 +1037,7 @@ DELETE FROM pg_dist_partition WHERE logicalrelid IN ('test_ref'::regclass, 'test
 \c - - - :master_port
 -- cleanup
 SET client_min_messages TO ERROR;
+DROP SCHEMA regular_helper_schema, tenant_schema_helper_owned CASCADE;
 DROP OWNED BY metadata_sync_helper_role;
 DROP ROLE metadata_sync_helper_role;
 DROP SCHEMA metadata_sync_helpers CASCADE;


### PR DESCRIPTION
Backport of #8587 to `release-12.1`.

Cherry-picked (`-x`) the security fix that enforces object ownership for more citus-internal UDFs. Author (Onur Tirtir) preserved.

### Adaptations for 12.1
- Resolved a cherry-pick conflict and adapted the SQL regression test for schema renames present on this branch.
- Mapped the 13.2 C API `EnsureCitusInitiatedOperation()` to the 12.1 equivalent `EnsureCoordinatorInitiatedOperation()`.

### Verification
- Native build on PG 16.14 (WSL): GREEN.
- Affected regressions: **9/9 PASS**, no `regression.diffs`.

Original PR: #8587