### PR TITLE
ci: run check-arbitrary-configs on github-hosted runners (release-12.1)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -239,7 +239,7 @@ jobs:
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
   test-arbitrary-configs:
     name: PG${{ fromJson(matrix.pg_version).major }} - check-arbitrary-configs-${{ matrix.parallel }}
-    runs-on: ["self-hosted", "1ES.Pool=1es-gha-citusdata-pool"]
+    runs-on: ubuntu-latest
     container:
       image: "${{ matrix.image_name }}:${{ fromJson(matrix.pg_version).full }}${{ needs.params.outputs.image_suffix }}"
       options: --user root


### PR DESCRIPTION
## Problem
The 1ES self-hosted pool (`1es-gha-citusdata-pool`) is no longer dispatching jobs, so the **required** `check-arbitrary-configs` jobs sit `QUEUED` indefinitely. This blocks **every** open release-12.1 PR (#8519, #8328, #8306, #8626, #8627) from merging despite all other required checks passing.

## Fix
Flip the `test-arbitrary-configs` job's `runs-on` from the dead self-hosted 1ES pool to `ubuntu-latest` — a one-line backport of the config already shipping on `main`.

## Why it is safe
- `main` already runs this exact job/suite/container on `ubuntu-latest`.
- Required-check **names** (`PG14 - check-arbitrary-configs-0`, ...) derive from the job `name:`, not `runs-on`, so branch protection is unaffected.
- AC was the **only** job still pinned to the self-hosted pool; everything else already runs github-hosted.

## Rollout
Merge this first, then "Update branch" on the 5 open PRs so they inherit the fix and their AC checks run on github-hosted runners.

Unblocks the release-12.1 serial-merge queue.
