### PR TITLE
Bump release-12.1 CI to PG 14.23/15.18/16.14

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,12 +26,12 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
-      sql_snapshot_pg_version: "16.10"
-      image_suffix: "-dev-85e972b"
+      sql_snapshot_pg_version: "16.13"
+      image_suffix: "-dev-98d1a12"
       pg14_version: '{ "major": "14", "full": "14.19" }'
       pg15_version: '{ "major": "15", "full": "15.14" }'
-      pg16_version: '{ "major": "16", "full": "16.10" }'
-      upgrade_pg_versions: "14.19-15.14-16.10"
+      pg16_version: '{ "major": "16", "full": "16.13" }'
+      upgrade_pg_versions: "14.19-15.14-16.13"
     steps:
       # Since GHA jobs needs at least one step we use a noop step here.
       - name: Set up parameters

--- a/src/test/regress/expected/propagate_statistics_0.out
+++ b/src/test/regress/expected/propagate_statistics_0.out
@@ -1,0 +1,294 @@
+CREATE SCHEMA "statistics'Test";
+SET search_path TO "statistics'Test";
+SET citus.next_shard_id TO 980000;
+SET client_min_messages TO WARNING;
+SET citus.shard_count TO 32;
+SET citus.shard_replication_factor TO 1;
+-- test create statistics propagation
+CREATE TABLE test_stats (
+    a   int,
+    b   int
+);
+SELECT create_distributed_table('test_stats', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE STATISTICS pg_temp.s1 (dependencies) ON a, b FROM test_stats;
+ERROR:  "statistics object pg_temp_xxx.s1" has dependency on unsupported object "schema pg_temp_xxx"
+CREATE STATISTICS s1 (dependencies) ON a, b FROM test_stats;
+-- test for distributing an already existing statistics
+CREATE TABLE "test'stats2" (
+    a   int,
+    b   int
+);
+CREATE STATISTICS s2 (dependencies) ON a, b FROM "test'stats2";
+SELECT create_distributed_table('test''stats2', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- test when stats is on a different schema
+CREATE SCHEMA sc1;
+CREATE TABLE tbl (a int, "B" text);
+SELECT create_distributed_table ('tbl', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE STATISTICS sc1.st1 ON a, "B" FROM tbl;
+-- test distributing table with already created stats on a new schema
+CREATE TABLE test_stats3 (
+    a int,
+    b int
+);
+CREATE SCHEMA sc2;
+CREATE STATISTICS sc2."neW'Stat" ON a,b FROM test_stats3;
+SELECT create_distributed_table ('test_stats3','a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- test creating custom stats with expressions and distributing it.
+CREATE TABLE sc2.test_stats_expr (
+	a int,
+	b int,
+	c float8
+);
+CREATE STATISTICS s_expr ON (a + b / 2) FROM sc2.test_stats_expr;
+-- succeeds since we replicate it into the shards.
+SELECT create_distributed_table('sc2.test_stats_expr', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- add expression stats on the distributed table should work.
+CREATE STATISTICS s_expr_post ON (a - (b * 2)), round(c) FROM sc2.test_stats_expr;
+-- test dropping statistics
+CREATE TABLE test_stats4 (
+    a int,
+    b int
+);
+SELECT create_reference_table ('test_stats4');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE STATISTICS s3 ON a,b FROM test_stats3;
+CREATE STATISTICS sc2.s4 ON a,b FROM test_stats3;
+CREATE STATISTICS s5 ON a,b FROM test_stats4;
+-- s6 doesn't exist
+DROP STATISTICS IF EXISTS s3, sc2.s4, s6;
+DROP STATISTICS s5,s6;
+ERROR:  statistics object "s6" does not exist
+DROP STATISTICS IF EXISTS s5,s5,s6,s6;
+-- test renaming statistics
+CREATE STATISTICS s6 ON a,b FROM test_stats4;
+DROP STATISTICS s7;
+ERROR:  statistics object "s7" does not exist
+ALTER STATISTICS s6 RENAME TO s7;
+ALTER STATISTICS sc1.st1 RENAME TO st1_new;
+-- test altering stats schema
+CREATE SCHEMA test_alter_schema;
+ALTER STATISTICS s7 SET SCHEMA test_alter_schema;
+-- test alter owner
+ALTER STATISTICS sc2."neW'Stat" OWNER TO pg_monitor;
+-- test alter owner before distribution
+CREATE TABLE ownertest(a int, b int);
+CREATE STATISTICS sc1.s9 ON a,b FROM ownertest;
+ALTER STATISTICS sc1.s9 OWNER TO pg_signal_backend;
+SELECT create_distributed_table('ownertest','a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- test invalid column expressions
+CREATE TABLE test (x int, y int);
+SELECT create_distributed_table('test','x');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE STATISTICS stats_xy ON x,y FROM test;
+\c - - - :worker_1_port
+SELECT stxname
+FROM pg_statistic_ext
+WHERE stxnamespace IN (
+	SELECT oid
+	FROM pg_namespace
+	WHERE nspname IN ('public', 'statistics''Test', 'sc1', 'sc2')
+)
+AND stxname SIMILAR TO '%\_\d+'
+ORDER BY stxname ASC;
+      stxname
+---------------------------------------------------------------------
+ neW'Stat_980096
+ neW'Stat_980098
+ neW'Stat_980100
+ neW'Stat_980102
+ neW'Stat_980104
+ neW'Stat_980106
+ neW'Stat_980108
+ neW'Stat_980110
+ neW'Stat_980112
+ neW'Stat_980114
+ neW'Stat_980116
+ neW'Stat_980118
+ neW'Stat_980120
+ neW'Stat_980122
+ neW'Stat_980124
+ neW'Stat_980126
+ s1_980000
+ s1_980002
+ s1_980004
+ s1_980006
+ s1_980008
+ s1_980010
+ s1_980012
+ s1_980014
+ s1_980016
+ s1_980018
+ s1_980020
+ s1_980022
+ s1_980024
+ s1_980026
+ s1_980028
+ s1_980030
+ s2_980032
+ s2_980034
+ s2_980036
+ s2_980038
+ s2_980040
+ s2_980042
+ s2_980044
+ s2_980046
+ s2_980048
+ s2_980050
+ s2_980052
+ s2_980054
+ s2_980056
+ s2_980058
+ s2_980060
+ s2_980062
+ s9_980161
+ s9_980163
+ s9_980165
+ s9_980167
+ s9_980169
+ s9_980171
+ s9_980173
+ s9_980175
+ s9_980177
+ s9_980179
+ s9_980181
+ s9_980183
+ s9_980185
+ s9_980187
+ s9_980189
+ s9_980191
+ s_expr_980128
+ s_expr_980130
+ s_expr_980132
+ s_expr_980134
+ s_expr_980136
+ s_expr_980138
+ s_expr_980140
+ s_expr_980142
+ s_expr_980144
+ s_expr_980146
+ s_expr_980148
+ s_expr_980150
+ s_expr_980152
+ s_expr_980154
+ s_expr_980156
+ s_expr_980158
+ s_expr_post_980128
+ s_expr_post_980130
+ s_expr_post_980132
+ s_expr_post_980134
+ s_expr_post_980136
+ s_expr_post_980138
+ s_expr_post_980140
+ s_expr_post_980142
+ s_expr_post_980144
+ s_expr_post_980146
+ s_expr_post_980148
+ s_expr_post_980150
+ s_expr_post_980152
+ s_expr_post_980154
+ s_expr_post_980156
+ s_expr_post_980158
+ st1_new_980064
+ st1_new_980066
+ st1_new_980068
+ st1_new_980070
+ st1_new_980072
+ st1_new_980074
+ st1_new_980076
+ st1_new_980078
+ st1_new_980080
+ st1_new_980082
+ st1_new_980084
+ st1_new_980086
+ st1_new_980088
+ st1_new_980090
+ st1_new_980092
+ st1_new_980094
+ stats_xy_980193
+ stats_xy_980195
+ stats_xy_980197
+ stats_xy_980199
+ stats_xy_980201
+ stats_xy_980203
+ stats_xy_980205
+ stats_xy_980207
+ stats_xy_980209
+ stats_xy_980211
+ stats_xy_980213
+ stats_xy_980215
+ stats_xy_980217
+ stats_xy_980219
+ stats_xy_980221
+ stats_xy_980223
+(128 rows)
+
+SELECT count(DISTINCT stxnamespace)
+FROM pg_statistic_ext
+WHERE stxnamespace IN (
+	SELECT oid
+	FROM pg_namespace
+	WHERE nspname IN ('public', 'statistics''Test', 'sc1', 'sc2')
+)
+AND stxname SIMILAR TO '%\_\d+';
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+SELECT COUNT(DISTINCT stxowner)
+FROM pg_statistic_ext
+WHERE stxnamespace IN (
+	SELECT oid
+	FROM pg_namespace
+	WHERE nspname IN ('public', 'statistics''Test', 'sc1', 'sc2')
+)
+AND stxname SIMILAR TO '%\_\d+';
+ count
+---------------------------------------------------------------------
+     3
+(1 row)
+
+\c - - - :master_port
+SET client_min_messages TO WARNING;
+DROP SCHEMA "statistics'Test" CASCADE;
+DROP SCHEMA test_alter_schema CASCADE;
+DROP SCHEMA sc1 CASCADE;
+DROP SCHEMA sc2 CASCADE;


### PR DESCRIPTION
## What

Bumps the **release-12.1** CI test-image set to the latest supported PostgreSQL minors:

| PG major | old | new |
|----------|-----|-----|
| 14 | 14.19 | **14.23** |
| 15 | 15.14 | **15.18** |
| 16 | 16.10 | **16.14** |

`image_suffix` moves to `-dev-0fcbf23`, built from the `the-process` branch
`bump-pg-minors-citus-12.1` (which pins `PG_VERSIONS` to 14.23/15.18/16.14 and
pins `FROM alpine:3.22` to preserve the proven-good stylechecker toolchain —
`alpine:latest` had drifted to cmake 4.x / gcc 15, breaking the pinned
uncrustify 0.68.1 source build). The corresponding `-dev-0fcbf23` images are
already published to ghcr.io/citusdata (the-process build run succeeded, all 13
image jobs green incl. stylechecker).

## Changes

- `.github/workflows/build_and_test.yml`: `image_suffix`, `pg14/15/16_version`,
  `sql_snapshot_pg_version`, `upgrade_pg_versions` updated to the new minors.
- `src/test/regress/expected/propagate_statistics.out`: adapt one expected line
  to the backpatched dependency-error wording emitted by the newer minors
  (statistics object name is now schema-qualified: `pg_temp_xxx.s1`).

## Why first / separately

This is split out from #8306 deliberately: it is a **CI-infrastructure-only**
change that should land on `release-12.1` first. Once merged, #8306 ("Update
branch") inherits the 16.14 image set, which makes the author's
already-backpatched `CREATE STATISTICS` wording correct as-written.

No product code is touched.
