### PR TITLE
Set 14.2.0 as upcoming version; run N-1 tests against 14.1.0 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,12 +35,12 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
-      sql_snapshot_pg_version: "18.3"
+      sql_snapshot_pg_version: "18.4"
       image_suffix: "-dev-9490d30"
-      pg16_version: '{ "major": "16", "full": "16.13" }'
-      pg17_version: '{ "major": "17", "full": "17.9" }'
-      pg18_version: '{ "major": "18", "full": "18.3" }'
-      upgrade_pg_versions: "16.13-17.9-18.3"
+      pg16_version: '{ "major": "16", "full": "16.14" }'
+      pg17_version: '{ "major": "17", "full": "17.10" }'
+      pg18_version: '{ "major": "18", "full": "18.4" }'
+      upgrade_pg_versions: "16.14-17.10-18.4"
     steps:
       # Since GHA jobs need at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.4"
-      image_suffix: "-dev-9490d30"
+      image_suffix: "-vf4adc47"
       pg16_version: '{ "major": "16", "full": "16.14" }'
       pg17_version: '{ "major": "17", "full": "17.10" }'
       pg18_version: '{ "major": "18", "full": "18.4" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.33"
       sql_snapshot_pg_version: "18.3"
-      image_suffix: "-v4271d84"
+      image_suffix: "-dev-9490d30"
       pg16_version: '{ "major": "16", "full": "16.13" }'
       pg17_version: '{ "major": "17", "full": "17.9" }'
       pg18_version: '{ "major": "18", "full": "18.3" }'
@@ -204,8 +204,8 @@ jobs:
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
       image_name: ${{ needs.params.outputs.test_image_name }}
-      citus_libdir: "/opt/citus-versions/v14.0.1"
-      citus_libdir_label: "v14.0.1"
+      citus_libdir: "/opt/citus-versions/v14.1.0"
+      citus_libdir_label: "v14.1.0"
       n_1_mode: "all"
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -223,7 +223,7 @@ jobs:
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
       image_name: ${{ needs.params.outputs.test_image_name }}
-      citus_version: "14.0-1"
+      citus_version: "14.1-1"
       n_1_mode: "all"
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -241,9 +241,9 @@ jobs:
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
       image_name: ${{ needs.params.outputs.test_image_name }}
-      citus_version: "14.0-1"
-      citus_libdir: "/opt/citus-versions/v14.0.1"
-      citus_libdir_label: "v14.0.1"
+      citus_version: "14.1-1"
+      citus_libdir: "/opt/citus-versions/v14.1.0"
+      citus_libdir_label: "v14.1.0"
       n_1_mode: "workeronly"
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -261,9 +261,9 @@ jobs:
       make_targets: '["check-split", "check-multi", "check-multi-1", "check-isolation", "check-operations", "check-follower-cluster", "check-add-backup-node", "check-columnar", "check-columnar-isolation", "check-enterprise", "check-enterprise-isolation", "check-enterprise-isolation-logicalrep-1", "check-enterprise-isolation-logicalrep-2", "check-enterprise-isolation-logicalrep-3"]'
       image_suffix: ${{ needs.params.outputs.image_suffix }}
       image_name: ${{ needs.params.outputs.test_image_name }}
-      citus_version: "14.0-1"
-      citus_libdir: "/opt/citus-versions/v14.0.1"
-      citus_libdir_label: "v14.0.1"
+      citus_version: "14.1-1"
+      citus_libdir: "/opt/citus-versions/v14.1.0"
+      citus_libdir_label: "v14.1.0"
       n_1_mode: "coordinatoronly"
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Validation experiment — NOT a version bump

This PR consumes **the-process #228**'s dev images (image suffix `-dev-9490d30`, with `/opt/citus-versions/v14.1.0` baked in) to validate whether the **latent #8587 N-1 gap** reproduces on the **14.x line**, mirroring citus #8632 on the 13.x line.

Part B only — `.github/workflows/build_and_test.yml` (10 lines):
- `image_suffix`: `-v4271d84` → `-dev-9490d30`
- All 4 N-1 jobs: `citus_libdir` → `/opt/citus-versions/v14.1.0`, `citus_libdir_label` → `v14.1.0`, `citus_version` → `14.1-1`

No changes to `configure.ac`, control files, or SQL stubs.

## Expected result (prediction)

The N-1 slot on the 14.x line is **PG18**. Prediction:

| Job | n_1_mode | Prediction |
|---|---|---|
| Lib N-1 / PG18 `check-multi-1` | all | **FAIL** |
| Coordinator N-1 / PG18 `check-multi-1` | coordinatoronly | **FAIL** |
| Worker N-1 / PG18 | workeronly | PASS |
| SQL N-1 / PG18 | (SQL only) | PASS |

### Why — the 2 reds are pre-existing / orthogonal to the image bump

Regress test `create_ref_dist_from_citus_local`, line `SELECT citus_internal.delete_placement_metadata(1);`:
- The expected `.out` encodes **post-#8587** behavior (`could not find any shard placement with id 1`).
- The N-1 image `.so` (both **v14.0.1 and v14.1.0**) is **pre-#8587** and emits `This is an internal Citus function can only be used in a distributed transaction`.

Only **coordinator-side** loads of the N-1 `.so` diverge, so **Lib N-1** and **Coordinator N-1** fail while **Worker N-1** and **SQL N-1** pass. Because the error string is identical for v14.0.1 and v14.1.0, the image bump does not cause the failure — it is a **latent #8587 gap**, the same pre-existing condition accepted on 13.x in #8632.

## Do not merge

Observe-only. This PR exists to run the N-1 jobs (which only run on `pull_request`) and confirm the pass/fail matrix above.
