### PR TITLE
ci: add nightly full-cassert workflow

### DIFF
--- a/.devcontainer/pgenv/config/default.conf
+++ b/.devcontainer/pgenv/config/default.conf
@@ -3,6 +3,8 @@ PGENV_MAKE_OPTIONS=(-s)
 PGENV_CONFIGURE_OPTIONS=(
     --enable-debug
     --enable-depend
+    # .github/workflows/nightly_cassert.yml inherits this config (via setup_cassert_pg).
+    # Do not drop --enable-cassert — the nightly relies on it (and now hard-fails if it's gone).
     --enable-cassert
     --enable-tap-tests
     'CFLAGS=-ggdb -Og -g3 -fno-omit-frame-pointer -DUSE_VALGRIND'

--- a/.github/actions/setup_cassert_pg/action.yml
+++ b/.github/actions/setup_cassert_pg/action.yml
@@ -1,0 +1,81 @@
+name: setup_cassert_pg
+description: >-
+  Build an --enable-cassert PostgreSQL via pgenv (with -DUSE_VALGRIND dropped) and build & install
+  the citus extension against it. Mirrors the devcontainer developer flow on a bare runner so the
+  nightly cassert suites exercise PG-core asserts and Citus's own Assert().
+inputs:
+  pg_full:
+    description: "Full PG version pgenv should build, e.g. 16.14 / 17.10 / 18.4 / 19beta1"
+    required: true
+outputs:
+  pgenv_bindir:
+    description: "bindir of the freshly built cassert PG (version-specific pgenv prefix)"
+    value: ${{ steps.build_citus.outputs.bindir }}
+runs:
+  using: composite
+  steps:
+    - name: Install build dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          bison flex gcc make perl pkg-config \
+          libreadline-dev zlib1g-dev libssl-dev libxml2-dev libxslt1-dev \
+          uuid-dev libicu-dev liblz4-dev libzstd-dev libcurl4-gnutls-dev \
+          libipc-run-perl python3 python3-pip pipenv
+
+    - name: Restore pgenv (cassert PG) cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.pgenv
+        # Bust the cache when the PG version OR the pgenv cassert config changes.
+        key: pgenv-cassert-${{ runner.os }}-${{ inputs.pg_full }}-${{ hashFiles('.devcontainer/pgenv/config/default.conf') }}
+
+    - name: Build cassert PostgreSQL (USE_VALGRIND dropped)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -d "$HOME/.pgenv" ]; then
+          git clone --branch v1.3.2 --depth 1 https://github.com/theory/pgenv.git "$HOME/.pgenv"
+        fi
+        mkdir -p "$HOME/.pgenv/config"
+        # Single source of truth: take the devcontainer cassert config and rewrite the CFLAGS line.
+        # This removes both -DUSE_VALGRIND and -ggdb while pinning the decided flags, and keeps
+        # --enable-debug --enable-cassert --enable-tap-tests + ssl/xml/xslt/uuid=e2fs/icu/lz4.
+        cp .devcontainer/pgenv/config/default.conf "$HOME/.pgenv/config/default.conf"
+        # Defensive: strip any CR so bash can `source` the config. No-op on a normal Linux
+        # (LF) checkout; needed if the runner checked out with autocrlf (e.g. self-hosted Windows).
+        sed -i 's/\r$//' "$HOME/.pgenv/config/default.conf"
+        sed -i "s|'CFLAGS=[^']*'|'CFLAGS=-Og -g3 -fno-omit-frame-pointer'|" \
+          "$HOME/.pgenv/config/default.conf"
+        echo "----- effective pgenv default.conf -----"
+        cat "$HOME/.pgenv/config/default.conf"
+        export PATH="$HOME/.pgenv/bin:$PATH"
+        MAKEFLAGS="-j $(nproc)" pgenv build "${{ inputs.pg_full }}"
+
+    - name: Build & install citus against cassert PG
+      id: build_citus
+      shell: bash
+      run: |
+        set -euo pipefail
+        export PATH="$HOME/.pgenv/bin:$HOME/.pgenv/pgsql/bin:$PATH"
+        pgenv switch "${{ inputs.pg_full }}"
+        PG_CONFIG="$HOME/.pgenv/pgsql/bin/pg_config"
+        BINDIR="$("$PG_CONFIG" --bindir)"
+        echo "Using PG_CONFIG=$PG_CONFIG (bindir=$BINDIR)"
+        echo "bindir=$BINDIR" >> "$GITHUB_OUTPUT"
+        # Persist for subsequent workflow steps: pgenv bin must shadow any system PG.
+        echo "$HOME/.pgenv/bin"       >> "$GITHUB_PATH"
+        echo "$HOME/.pgenv/pgsql/bin" >> "$GITHUB_PATH"
+        echo "PG_CONFIG=$PG_CONFIG"   >> "$GITHUB_ENV"
+        # psycopg (failure + citus-upgrade harnesses) loads libpq from the pgenv prefix, not system.
+        echo "LD_LIBRARY_PATH=$("$PG_CONFIG" --libdir):${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+        # configure bakes bindir/libdir into Makefile.global, so `make check-*` auto-uses this PG.
+        ./configure PG_CONFIG="$PG_CONFIG" --without-pg-version-check
+        make -j"$(nproc)" all
+        # Installs into the $HOME pgenv prefix for this version -> no sudo, no clobber across versions.
+        make install
+        ulimit -c unlimited || true

--- a/.github/actions/setup_cassert_pg/action.yml
+++ b/.github/actions/setup_cassert_pg/action.yml
@@ -46,9 +46,6 @@ runs:
         # This removes both -DUSE_VALGRIND and -ggdb while pinning the decided flags, and keeps
         # --enable-debug --enable-cassert --enable-tap-tests + ssl/xml/xslt/uuid=e2fs/icu/lz4.
         cp .devcontainer/pgenv/config/default.conf "$HOME/.pgenv/config/default.conf"
-        # Defensive: strip any CR so bash can `source` the config. No-op on a normal Linux
-        # (LF) checkout; needed if the runner checked out with autocrlf (e.g. self-hosted Windows).
-        sed -i 's/\r$//' "$HOME/.pgenv/config/default.conf"
         sed -i "s|'CFLAGS=[^']*'|'CFLAGS=-Og -g3 -fno-omit-frame-pointer'|" \
           "$HOME/.pgenv/config/default.conf"
         echo "----- effective pgenv default.conf -----"
@@ -78,4 +75,3 @@ runs:
         make -j"$(nproc)" all
         # Installs into the $HOME pgenv prefix for this version -> no sudo, no clobber across versions.
         make install
-        ulimit -c unlimited || true

--- a/.github/actions/setup_cassert_pg/action.yml
+++ b/.github/actions/setup_cassert_pg/action.yml
@@ -63,6 +63,10 @@ runs:
         PG_CONFIG="$HOME/.pgenv/pgsql/bin/pg_config"
         BINDIR="$("$PG_CONFIG" --bindir)"
         echo "Using PG_CONFIG=$PG_CONFIG (bindir=$BINDIR)"
+        # Guard: assertions are the entire point of this nightly. If the inherited devcontainer
+        # config ever loses --enable-cassert, fail loudly instead of silently running asserts-off.
+        "$PG_CONFIG" --configure | grep -q -- '--enable-cassert' \
+          || { echo "FATAL: built PG is not --enable-cassert; refusing to run nightly without asserts"; exit 1; }
         echo "bindir=$BINDIR" >> "$GITHUB_OUTPUT"
         # Persist for subsequent workflow steps: pgenv bin must shadow any system PG.
         echo "$HOME/.pgenv/bin"       >> "$GITHUB_PATH"

--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -1,0 +1,218 @@
+name: Nightly cassert
+run-name: Nightly cassert (${{ github.ref_name }})
+
+# Full-suite Citus run against an --enable-cassert PostgreSQL build (PG 16/17/18).
+# Purpose: surface PG-core asserts and Citus's own Assert() that the normal PGDG-image PR
+# pipeline cannot catch. First runs are EXPECTED to be RED across all majors as pre-existing
+# asserts surface -- that is the intended signal, not a regression gate.
+#
+# The version matrix lives in the `params` job below (single source of truth, mirroring
+# build_and_test.yml). The `pg19-support` branch adapts this by adding the 19beta1 row + the
+# 18->19 upgrade pair, the same way 19 support is layered onto the other test suites.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'          # 03:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write                  # required by the failure-issue job
+
+concurrency:
+  group: nightly-cassert-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  # ---- version matrix: single source of truth (mirrors build_and_test.yml's params job) ----
+  # FUTURE SEAM: when the-process/versions.yml becomes the org-wide SSOT, replace these literal
+  # outputs with a step that fetches/parses that file, so the nightly DERIVES versions instead of
+  # restating them. Until then this job is the one place to bump the cassert matrix.
+  params:
+    name: Initialize parameters
+    runs-on: ubuntu-latest
+    outputs:
+      pg_versions: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.9" }, { "major": "18", "full": "18.3" }]'
+      pg_upgrade_pairs: '[{ "old": "16", "old_full": "16.13", "new": "17", "new_full": "17.9" }, { "old": "17", "old_full": "17.9", "new": "18", "new_full": "18.3" }]'
+      citus_upgrade_pg: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.9" }]'
+      citus_old_version: "v14.0.1"  # 14.0-1 chains to MASTER (15.0); 14.1 has no path to 15.0 yet
+    steps:
+      - name: Set up parameters
+        run: echo 'noop'
+
+  # ---- regular suites: one job per (major x suite-group) ----
+  test:
+    needs: params
+    name: cassert PG${{ matrix.pg.major }} - ${{ matrix.group }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ${{ fromJson(needs.params.outputs.pg_versions) }}
+        group: [ regress, isolation, columnar, failure, tap ]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup_cassert_pg
+        with:
+          pg_full: ${{ matrix.pg.full }}
+      - name: Install failure-suite python env (mitmproxy fork)
+        if: ${{ matrix.group == 'failure' }}
+        shell: bash
+        run: ( cd src/test/regress && pipenv install --deploy )
+      - name: Run ${{ matrix.group }}
+        shell: bash
+        timeout-minutes: 90
+        run: |
+          set -euo pipefail
+          case "${{ matrix.group }}" in
+            regress)
+              make -C src/test/regress \
+                check-multi check-multi-1 check-multi-1-create-citus check-multi-mx \
+                check-split check-operations check-follower-cluster \
+                check-vanilla check-enterprise ;;
+            isolation)
+              make -C src/test/regress \
+                check-isolation check-enterprise-isolation check-columnar-isolation ;;
+            columnar)
+              make -C src/test/regress check-columnar ;;
+            failure)
+              ( cd src/test/regress && pipenv run make check-failure check-enterprise-failure ) ;;
+            tap)
+              make -C src/test/regress check-tap ;;
+          esac
+      - uses: ./.github/actions/save_logs_and_results
+        if: always()
+        with:
+          folder: cassert_${{ matrix.pg.major }}_${{ matrix.group }}
+
+  # ---- pg-upgrade: needs TWO cassert majors per job (citus installed into both prefixes) ----
+  pg-upgrade:
+    needs: params
+    name: cassert PG${{ matrix.old }}-PG${{ matrix.new }} - pg-upgrade
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.params.outputs.pg_upgrade_pairs) }}
+    steps:
+      - uses: actions/checkout@v5
+      # Build BOTH majors via pgenv; each call also builds+installs citus into that version's prefix.
+      # The cache for each version overlays additively into ~/.pgenv, so both prefixes coexist.
+      - uses: ./.github/actions/setup_cassert_pg
+        with:
+          pg_full: ${{ matrix.old_full }}
+      - uses: ./.github/actions/setup_cassert_pg
+        with:
+          pg_full: ${{ matrix.new_full }}
+      - name: check-pg-upgrade (with and without columnar)
+        shell: bash
+        timeout-minutes: 90
+        run: |
+          set -euo pipefail
+          OLD="$HOME/.pgenv/pgsql-${{ matrix.old_full }}/bin"
+          NEW="$HOME/.pgenv/pgsql-${{ matrix.new_full }}/bin"
+          make -C src/test/regress check-pg-upgrade \
+            old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=false
+          make -C src/test/regress check-pg-upgrade \
+            old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=true
+      - name: Copy pg_upgrade logs for newData dir
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p /tmp/pg_upgrade_newData_logs
+          if ls src/test/regress/tmp_upgrade/newData/*.log 1> /dev/null 2>&1; then
+            cp src/test/regress/tmp_upgrade/newData/*.log /tmp/pg_upgrade_newData_logs
+          fi
+      - uses: ./.github/actions/save_logs_and_results
+        if: always()
+        with:
+          folder: cassert_${{ matrix.old }}_${{ matrix.new }}_pg_upgrade
+
+  # ---- citus-upgrade: build the old citus from a git tag against the cassert PG (local variant) ----
+  citus-upgrade:
+    needs: params
+    name: cassert PG${{ matrix.pg.major }} - citus-upgrade
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ${{ fromJson(needs.params.outputs.citus_upgrade_pg) }}
+    env:
+      # Old Citus built from the git tag against the cassert PG, then upgraded to HEAD.
+      citus_old_version: ${{ needs.params.outputs.citus_old_version }}
+      CI: ""   # local variant builds the old-version tarball; CI=true would demand prebuilt tars
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0          # tags needed to build the old citus version
+      - uses: ./.github/actions/setup_cassert_pg
+        with:
+          pg_full: ${{ matrix.pg.full }}
+      - name: Install python env for upgrade harness
+        shell: bash
+        run: ( cd src/test/regress && pipenv install --deploy )
+      - name: check-citus-upgrade-local (+ mixed)
+        shell: bash
+        timeout-minutes: 90
+        run: |
+          set -euo pipefail
+          BIN="$HOME/.pgenv/pgsql/bin"
+          ( cd src/test/regress && pipenv run make -C . check-citus-upgrade-local \
+              bindir="$BIN" citus-old-version="${citus_old_version}" )
+          ( cd src/test/regress && pipenv run make -C . check-citus-upgrade-mixed-local \
+              bindir="$BIN" citus-old-version="${citus_old_version}" )
+      - uses: ./.github/actions/save_logs_and_results
+        if: always()
+        with:
+          folder: cassert_${{ matrix.pg.major }}_citus_upgrade
+
+  # ---- failure notification: open/append a dated GitHub issue if anything failed ----
+  notify:
+    name: Open issue on failure
+    needs: [ test, pg-upgrade, citus-upgrade ]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const day = new Date().toISOString().slice(0, 10);
+            const title = `Nightly cassert failures (${day})`;
+            const label = 'nightly-cassert';
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'Nightly full-cassert run failed.',
+              '',
+              `Run: ${url}`,
+              '',
+              'First runs are EXPECTED red as pre-existing PG-core and Citus asserts surface.',
+              'This is the intended signal, not a regression gate.',
+            ].join('\n');
+            const found = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+            const existing = found.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -175,8 +175,6 @@ jobs:
     needs: [ test, pg-upgrade, citus-upgrade ]
     if: failure()
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## What

Adds a **nightly full-cassert CI workflow** that builds an assertion-enabled (`--enable-cassert`) PostgreSQL on-the-fly, rebuilds Citus against it, and runs the full test suites. This surfaces PG-core asserts and Citus's own `Assert()` failures that the normal PGDG-image PR pipeline cannot catch.

> **First runs are EXPECTED to be RED** across all majors as pre-existing asserts surface. That is the intended signal, not a regression gate.

## How

Two files, `.github/`-only (no changes to test suites or `the-process`):

- **`.github/actions/setup_cassert_pg/action.yml`** — composite action that reuses the existing pgenv cassert machinery (`.devcontainer/pgenv/config/default.conf`), **drops `-DUSE_VALGRIND`**, builds cassert PG with `-Og -g3 -fno-omit-frame-pointer`, caches `~/.pgenv` (keyed on PG version + config hash), then builds + installs Citus against that `pg_config`.
- **`.github/workflows/nightly_cassert.yml`** — `cron '0 3 * * *'` UTC + `workflow_dispatch`. A single `params` job is the version SSOT (mirrors `build_and_test.yml`); jobs run regress / isolation / columnar / failure / tap / pg-upgrade / citus-upgrade against the cassert build. Opens/updates a dated `nightly-cassert` issue on failure.

## Matrix

- PG **16.13 / 17.9 / 18.3** (main's pins).
- pg-upgrade pairs 16→17, 17→18.
- citus-upgrade-local on 16, 17 (old Citus `v14.0.1` — the only version with a working upgrade path to master).

## Validation

pgenv cassert PG builds + Citus smoke build + citus-upgrade-local Q4 path validated locally under WSL (Ubuntu-22.04).

## Notes

- **Base is `main`.** The `pg19-support` branch will adapt this later (add the 19beta1 row + 18→19 upgrade pair), the same way 19 support is layered onto the other suites.
- Workflow-only, independent of the in-flight PG19 PR stack.

Draft while first-run signal is triaged.
