### PR TITLE
Add citus.enable_or_clause_arm_pruning for per-shard OR-arm pruning

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -31,6 +31,7 @@
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "commands/sequence.h"
+#include "common/hashfn.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/pathnodes.h"
@@ -48,6 +49,7 @@
 #include "utils/datum.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
+#include "utils/hsearch.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
@@ -190,11 +192,14 @@ static Task * QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 static List * SqlTaskList(Job *job);
 static void PruneOrClausesForTaskFragments(Query *taskQuery,
 										   List *fragmentCombination,
-										   List **armShardMemo);
+										   HTAB **armShardMemo);
 static Node * PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId,
-									 uint64 shardId, List **armShardMemo);
+									 uint64 shardId, HTAB **armShardMemo);
 static List * ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
-									   List **armShardMemo);
+									   HTAB **armShardMemo);
+static bool ShardListContainsShardId(List *shardIntervalList, uint64 shardId);
+static uint32 ArmShardMemoHash(const void *key, Size keysize);
+static int ArmShardMemoMatch(const void *key1, const void *key2, Size keysize);
 static bool DependsOnHashPartitionJob(Job *job);
 static uint32 AnchorRangeTableId(List *rangeTableList);
 static List * BaseRangeTableIdList(List *rangeTableList);
@@ -2905,10 +2910,10 @@ SqlTaskList(Job *job)
 	 * Memo of each OR arm's reachable shard set, shared across all tasks of this
 	 * job. An arm's reachability depends only on (relation, range table id, arm
 	 * expression), not on which task we are building, so we compute it once per
-	 * distinct arm here instead of once per shard. Only used when
-	 * EnableOrClauseArmPruning is set.
+	 * distinct arm here instead of once per shard. Created lazily on first use,
+	 * and only when EnableOrClauseArmPruning is set.
 	 */
-	List *armShardMemo = NIL;
+	HTAB *armShardMemo = NULL;
 
 	foreach(fragmentCombinationCell, fragmentCombinationList)
 	{
@@ -2969,15 +2974,28 @@ SqlTaskList(Job *job)
 
 
 /*
- * ArmShardMemoEntry caches the shard set an OR arm can reach for a given
- * (relation, range table id), so PruneShards is run once per distinct arm
- * rather than once per shard. See PruneOrClausesForTaskFragments.
+ * ArmShardMemoKey identifies an OR arm's reachability question: the shard set
+ * that arm can reach for (relationId, rangeTableId). It is the lookup key of
+ * the armShardMemo hash table. Arm equality uses the regular node equal(), so
+ * structurally identical arms from different per-task query copies share an
+ * entry. Must be the first field of ArmShardMemoEntry.
  */
-typedef struct ArmShardMemoEntry
+typedef struct ArmShardMemoKey
 {
 	Oid relationId;
 	Index rangeTableId;
 	Node *arm;
+} ArmShardMemoKey;
+
+
+/*
+ * ArmShardMemoEntry caches the shard set an OR arm can reach, so PruneShards is
+ * run once per distinct arm rather than once per (shard x arm). Lookups are
+ * O(1) via a hash of the arm expression; see ReachableShardListForArm.
+ */
+typedef struct ArmShardMemoEntry
+{
+	ArmShardMemoKey key;
 	List *shardIntervalList;
 } ArmShardMemoEntry;
 
@@ -2995,7 +3013,7 @@ typedef struct ArmShardMemoEntry
  */
 static void
 PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
-							   List **armShardMemo)
+							   HTAB **armShardMemo)
 {
 	Node *quals = taskQuery->jointree->quals;
 	if (quals == NULL)
@@ -3035,62 +3053,6 @@ PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
 
 
 /*
- * ReachableShardListForArm returns the list of ShardIntervals that the given OR
- * arm cannot be proven to exclude for (relationId, rangeTableId), i.e. the
- * shards on which the arm might match a row. Results are memoized in
- * *armShardMemo because reachability depends only on the arm expression and the
- * relation, not on which task we are currently building.
- */
-static List *
-ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
-						 List **armShardMemo)
-{
-	ArmShardMemoEntry *memoEntry = NULL;
-	foreach_declared_ptr(memoEntry, *armShardMemo)
-	{
-		if (memoEntry->relationId == relationId &&
-			memoEntry->rangeTableId == rangeTableId &&
-			equal(memoEntry->arm, arm))
-		{
-			return memoEntry->shardIntervalList;
-		}
-	}
-
-	List *armClauseList = make_ands_implicit((Expr *) arm);
-	List *shardIntervalList = PruneShards(relationId, rangeTableId, armClauseList, NULL);
-
-	ArmShardMemoEntry *newEntry = palloc0(sizeof(ArmShardMemoEntry));
-	newEntry->relationId = relationId;
-	newEntry->rangeTableId = rangeTableId;
-	newEntry->arm = arm;
-	newEntry->shardIntervalList = shardIntervalList;
-	*armShardMemo = lappend(*armShardMemo, newEntry);
-
-	return shardIntervalList;
-}
-
-
-/*
- * ShardListContainsShardId returns whether shardId appears in the given list
- * of ShardIntervals.
- */
-static bool
-ShardListContainsShardId(List *shardIntervalList, uint64 shardId)
-{
-	ShardInterval *shardInterval = NULL;
-	foreach_declared_ptr(shardInterval, shardIntervalList)
-	{
-		if (shardInterval->shardId == shardId)
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
-/*
  * PruneUnreachableOrArms walks a (sub)qualification and removes the arms of
  * top-level OR expressions that cannot match any row on the given shard.
  *
@@ -3102,7 +3064,7 @@ ShardListContainsShardId(List *shardIntervalList, uint64 shardId)
  */
 static Node *
 PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 shardId,
-					   List **armShardMemo)
+					   HTAB **armShardMemo)
 {
 	if (qual == NULL)
 	{
@@ -3179,6 +3141,131 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 	}
 
 	return qual;
+}
+
+
+/*
+ * ReachableShardListForArm returns the list of ShardIntervals that the given OR
+ * arm cannot be proven to exclude for (relationId, rangeTableId), i.e. the
+ * shards on which the arm might match a row. Results are memoized in
+ * *armShardMemo because reachability depends only on the arm expression and the
+ * relation, not on which task we are currently building.
+ *
+ * The memo is a hash table keyed on (relationId, rangeTableId, arm) so each
+ * lookup is O(1) in the number of distinct arms; this matters because a single
+ * top-level OR can have very many arms (e.g. ORM-generated composite-key batch
+ * reads), and SqlTaskList probes every arm once per shard. The table is created
+ * lazily on the first arm so queries without an eligible OR pay nothing.
+ */
+static List *
+ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
+						 HTAB **armShardMemo)
+{
+	if (*armShardMemo == NULL)
+	{
+		HASHCTL info;
+		memset(&info, 0, sizeof(info));
+		info.keysize = sizeof(ArmShardMemoKey);
+		info.entrysize = sizeof(ArmShardMemoEntry);
+		info.hash = ArmShardMemoHash;
+		info.match = ArmShardMemoMatch;
+		info.hcxt = CurrentMemoryContext;
+
+		*armShardMemo = hash_create("Or arm shard memo", 32, &info,
+									HASH_ELEM | HASH_FUNCTION | HASH_COMPARE |
+									HASH_CONTEXT);
+	}
+
+	ArmShardMemoKey lookupKey;
+	memset(&lookupKey, 0, sizeof(lookupKey));
+	lookupKey.relationId = relationId;
+	lookupKey.rangeTableId = rangeTableId;
+	lookupKey.arm = arm;
+
+	bool found = false;
+	ArmShardMemoEntry *entry = hash_search(*armShardMemo, &lookupKey, HASH_FIND,
+										   &found);
+	if (found)
+	{
+		return entry->shardIntervalList;
+	}
+
+	/*
+	 * Compute the shard list before inserting the entry so the memo is never
+	 * left holding an entry with an uninitialized value (e.g. if PruneShards
+	 * throws).
+	 */
+	List *armClauseList = make_ands_implicit((Expr *) arm);
+	List *shardIntervalList = PruneShards(relationId, rangeTableId, armClauseList, NULL);
+
+	entry = hash_search(*armShardMemo, &lookupKey, HASH_ENTER, &found);
+	entry->shardIntervalList = shardIntervalList;
+
+	return shardIntervalList;
+}
+
+
+/*
+ * ArmShardMemoHash hashes an ArmShardMemoKey. The arm expression is hashed via
+ * its canonical serialized form so that structurally identical arms (which
+ * ArmShardMemoMatch treats as equal) land in the same bucket.
+ */
+static uint32
+ArmShardMemoHash(const void *key, Size keysize)
+{
+	const ArmShardMemoKey *memoKey = (const ArmShardMemoKey *) key;
+
+	char *armString = nodeToString(memoKey->arm);
+	uint32 hashValue = hash_bytes((const unsigned char *) armString,
+								  strlen(armString));
+	pfree(armString);
+
+	hashValue = hash_combine(hashValue, hash_uint32((uint32) memoKey->relationId));
+	hashValue = hash_combine(hashValue, hash_uint32((uint32) memoKey->rangeTableId));
+
+	return hashValue;
+}
+
+
+/*
+ * ArmShardMemoMatch compares two ArmShardMemoKeys, returning 0 when they are
+ * equal. Arm equality uses node equal() so hash collisions never produce a
+ * wrong memo hit.
+ */
+static int
+ArmShardMemoMatch(const void *key1, const void *key2, Size keysize)
+{
+	const ArmShardMemoKey *memoKey1 = (const ArmShardMemoKey *) key1;
+	const ArmShardMemoKey *memoKey2 = (const ArmShardMemoKey *) key2;
+
+	if (memoKey1->relationId == memoKey2->relationId &&
+		memoKey1->rangeTableId == memoKey2->rangeTableId &&
+		equal(memoKey1->arm, memoKey2->arm))
+	{
+		return 0;
+	}
+
+	return 1;
+}
+
+
+/*
+ * ShardListContainsShardId returns whether shardId appears in the given list
+ * of ShardIntervals.
+ */
+static bool
+ShardListContainsShardId(List *shardIntervalList, uint64 shardId)
+{
+	ShardInterval *shardInterval = NULL;
+	foreach_declared_ptr(shardInterval, shardIntervalList)
+	{
+		if (shardInterval->shardId == shardId)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -3052,7 +3052,7 @@ PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
 
 
 /*
- * PruneUnreachableOrArms walks a (sub)qualification and removes the arms of
+ * PruneUnreachableOrArms walks a (sub)qual and removes the arms of
  * top-level OR expressions that cannot match any row on the given shard.
  *
  * For each arm of an OR, we run the regular shard-pruning machinery

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -95,10 +95,9 @@ int TaskAssignmentPolicy = TASK_ASSIGNMENT_GREEDY;
 bool EnableUniqueJobIds = true;
 
 /*
- * EnableOrClauseArmPruning controls whether, when generating a per-shard task
- * query, we drop the arms of top-level OR clauses that cannot match any row on
- * the task's shard (because they constrain the distribution column to a value
- * that prunes to a different shard).
+ * EnableOrClauseArmPruning controls whether we drop the arms of top-level OR
+ * clauses that cannot match any row on the task's shard (because they constrain
+ * the distribution column to a value that prunes to a different shard).
  */
 bool EnableOrClauseArmPruning = true;
 
@@ -192,14 +191,14 @@ static Task * QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 static List * SqlTaskList(Job *job);
 static void PruneOrClausesForTaskFragments(Query *taskQuery,
 										   List *fragmentCombination,
-										   HTAB **armShardMemo);
+										   HTAB **armShardHash);
 static Node * PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId,
-									 uint64 shardId, HTAB **armShardMemo);
+									 uint64 shardId, HTAB **armShardHash);
 static List * ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
-									   HTAB **armShardMemo);
+									   HTAB **armShardHash);
 static bool ShardListContainsShardId(List *shardIntervalList, uint64 shardId);
-static uint32 ArmShardMemoHash(const void *key, Size keysize);
-static int ArmShardMemoMatch(const void *key1, const void *key2, Size keysize);
+static uint32 ArmShardHashFn(const void *key, Size keysize);
+static int ArmShardMatchFn(const void *key1, const void *key2, Size keysize);
 static bool DependsOnHashPartitionJob(Job *job);
 static uint32 AnchorRangeTableId(List *rangeTableList);
 static List * BaseRangeTableIdList(List *rangeTableList);
@@ -2907,13 +2906,13 @@ SqlTaskList(Job *job)
 	ListCell *fragmentCombinationCell = NULL;
 
 	/*
-	 * Memo of each OR arm's reachable shard set, shared across all tasks of this
+	 * Cache of each OR arm's reachable shard set, shared across all tasks of this
 	 * job. An arm's reachability depends only on (relation, range table id, arm
 	 * expression), not on which task we are building, so we compute it once per
 	 * distinct arm here instead of once per shard. Created lazily on first use,
 	 * and only when EnableOrClauseArmPruning is set.
 	 */
-	HTAB *armShardMemo = NULL;
+	HTAB *armShardHash = NULL;
 
 	foreach(fragmentCombinationCell, fragmentCombinationList)
 	{
@@ -2938,7 +2937,7 @@ SqlTaskList(Job *job)
 		if (EnableOrClauseArmPruning)
 		{
 			PruneOrClausesForTaskFragments(taskQuery, fragmentCombination,
-										   &armShardMemo);
+										   &armShardHash);
 		}
 
 		UpdateRangeTableAlias(fragmentRangeTableList, fragmentCombination);
@@ -2974,30 +2973,30 @@ SqlTaskList(Job *job)
 
 
 /*
- * ArmShardMemoKey identifies an OR arm's reachability question: the shard set
+ * ArmShardHashKey identifies an OR arm's reachability question: the shard set
  * that arm can reach for (relationId, rangeTableId). It is the lookup key of
- * the armShardMemo hash table. Arm equality uses the regular node equal(), so
+ * the armShardHash table. Arm equality uses the regular node equal(), so
  * structurally identical arms from different per-task query copies share an
- * entry. Must be the first field of ArmShardMemoEntry.
+ * entry. Must be the first field of ArmShardHashEntry.
  */
-typedef struct ArmShardMemoKey
+typedef struct ArmShardHashKey
 {
 	Oid relationId;
 	Index rangeTableId;
 	Node *arm;
-} ArmShardMemoKey;
+} ArmShardHashKey;
 
 
 /*
- * ArmShardMemoEntry caches the shard set an OR arm can reach, so PruneShards is
+ * ArmShardHashEntry caches the shard set an OR arm can reach, so PruneShards is
  * run once per distinct arm rather than once per (shard x arm). Lookups are
  * O(1) via a hash of the arm expression; see ReachableShardListForArm.
  */
-typedef struct ArmShardMemoEntry
+typedef struct ArmShardHashEntry
 {
-	ArmShardMemoKey key;
+	ArmShardHashKey key;
 	List *shardIntervalList;
-} ArmShardMemoEntry;
+} ArmShardHashEntry;
 
 
 /*
@@ -3008,12 +3007,12 @@ typedef struct ArmShardMemoEntry
  * constrain that relation's distribution column to a value belonging to a
  * different shard.
  *
- * armShardMemo is a job-wide cache (shared across all tasks) of each arm's
+ * armShardHash is a job-wide cache (shared across all tasks) of each arm's
  * reachable shard set; see ReachableShardListForArm.
  */
 static void
 PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
-							   HTAB **armShardMemo)
+							   HTAB **armShardHash)
 {
 	Node *quals = taskQuery->jointree->quals;
 	if (quals == NULL)
@@ -3045,7 +3044,7 @@ PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
 		}
 
 		quals = PruneUnreachableOrArms(quals, relationId, fragment->rangeTableId,
-									   shardInterval->shardId, armShardMemo);
+									   shardInterval->shardId, armShardHash);
 	}
 
 	taskQuery->jointree->quals = quals;
@@ -3064,7 +3063,7 @@ PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
  */
 static Node *
 PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 shardId,
-					   HTAB **armShardMemo)
+					   HTAB **armShardHash)
 {
 	if (qual == NULL)
 	{
@@ -3079,7 +3078,7 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 		{
 			lfirst(conjunctCell) = PruneUnreachableOrArms((Node *) lfirst(conjunctCell),
 														  relationId, rangeTableId,
-														  shardId, armShardMemo);
+														  shardId, armShardHash);
 		}
 
 		return (Node *) conjuncts;
@@ -3096,7 +3095,7 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 			{
 				lfirst(argCell) = PruneUnreachableOrArms((Node *) lfirst(argCell),
 														 relationId, rangeTableId,
-														 shardId, armShardMemo);
+														 shardId, armShardHash);
 			}
 
 			return qual;
@@ -3110,7 +3109,7 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 				Node *arm = (Node *) lfirst(armCell);
 				List *armShardList = ReachableShardListForArm(arm, relationId,
 															  rangeTableId,
-															  armShardMemo);
+															  armShardHash);
 
 				if (ShardListContainsShardId(armShardList, shardId))
 				{
@@ -3147,11 +3146,11 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 /*
  * ReachableShardListForArm returns the list of ShardIntervals that the given OR
  * arm cannot be proven to exclude for (relationId, rangeTableId), i.e. the
- * shards on which the arm might match a row. Results are memoized in
- * *armShardMemo because reachability depends only on the arm expression and the
+ * shards on which the arm might match a row. Results are cached in
+ * *armShardHash because reachability depends only on the arm expression and the
  * relation, not on which task we are currently building.
  *
- * The memo is a hash table keyed on (relationId, rangeTableId, arm) so each
+ * The cache is a hash table keyed on (relationId, rangeTableId, arm) so each
  * lookup is O(1) in the number of distinct arms; this matters because a single
  * top-level OR can have very many arms (e.g. ORM-generated composite-key batch
  * reads), and SqlTaskList probes every arm once per shard. The table is created
@@ -3159,31 +3158,31 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
  */
 static List *
 ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
-						 HTAB **armShardMemo)
+						 HTAB **armShardHash)
 {
-	if (*armShardMemo == NULL)
+	if (*armShardHash == NULL)
 	{
 		HASHCTL info;
 		memset(&info, 0, sizeof(info));
-		info.keysize = sizeof(ArmShardMemoKey);
-		info.entrysize = sizeof(ArmShardMemoEntry);
-		info.hash = ArmShardMemoHash;
-		info.match = ArmShardMemoMatch;
+		info.keysize = sizeof(ArmShardHashKey);
+		info.entrysize = sizeof(ArmShardHashEntry);
+		info.hash = ArmShardHashFn;
+		info.match = ArmShardMatchFn;
 		info.hcxt = CurrentMemoryContext;
 
-		*armShardMemo = hash_create("Or arm shard memo", 32, &info,
+		*armShardHash = hash_create("Or arm shard cache", 32, &info,
 									HASH_ELEM | HASH_FUNCTION | HASH_COMPARE |
 									HASH_CONTEXT);
 	}
 
-	ArmShardMemoKey lookupKey;
+	ArmShardHashKey lookupKey;
 	memset(&lookupKey, 0, sizeof(lookupKey));
 	lookupKey.relationId = relationId;
 	lookupKey.rangeTableId = rangeTableId;
 	lookupKey.arm = arm;
 
 	bool found = false;
-	ArmShardMemoEntry *entry = hash_search(*armShardMemo, &lookupKey, HASH_FIND,
+	ArmShardHashEntry *entry = hash_search(*armShardHash, &lookupKey, HASH_FIND,
 										   &found);
 	if (found)
 	{
@@ -3191,14 +3190,14 @@ ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
 	}
 
 	/*
-	 * Compute the shard list before inserting the entry so the memo is never
+	 * Compute the shard list before inserting the entry so the cache is never
 	 * left holding an entry with an uninitialized value (e.g. if PruneShards
 	 * throws).
 	 */
 	List *armClauseList = make_ands_implicit((Expr *) arm);
 	List *shardIntervalList = PruneShards(relationId, rangeTableId, armClauseList, NULL);
 
-	entry = hash_search(*armShardMemo, &lookupKey, HASH_ENTER, &found);
+	entry = hash_search(*armShardHash, &lookupKey, HASH_ENTER, &found);
 	entry->shardIntervalList = shardIntervalList;
 
 	return shardIntervalList;
@@ -3206,41 +3205,41 @@ ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
 
 
 /*
- * ArmShardMemoHash hashes an ArmShardMemoKey. The arm expression is hashed via
+ * ArmShardHashFn hashes an ArmShardHashKey. The arm expression is hashed via
  * its canonical serialized form so that structurally identical arms (which
- * ArmShardMemoMatch treats as equal) land in the same bucket.
+ * ArmShardMatchFn treats as equal) land in the same bucket.
  */
 static uint32
-ArmShardMemoHash(const void *key, Size keysize)
+ArmShardHashFn(const void *key, Size keysize)
 {
-	const ArmShardMemoKey *memoKey = (const ArmShardMemoKey *) key;
+	const ArmShardHashKey *hashKey = (const ArmShardHashKey *) key;
 
-	char *armString = nodeToString(memoKey->arm);
+	char *armString = nodeToString(hashKey->arm);
 	uint32 hashValue = hash_bytes((const unsigned char *) armString,
 								  strlen(armString));
 	pfree(armString);
 
-	hashValue = hash_combine(hashValue, hash_uint32((uint32) memoKey->relationId));
-	hashValue = hash_combine(hashValue, hash_uint32((uint32) memoKey->rangeTableId));
+	hashValue = hash_combine(hashValue, hash_uint32((uint32) hashKey->relationId));
+	hashValue = hash_combine(hashValue, hash_uint32((uint32) hashKey->rangeTableId));
 
 	return hashValue;
 }
 
 
 /*
- * ArmShardMemoMatch compares two ArmShardMemoKeys, returning 0 when they are
+ * ArmShardMatchFn compares two ArmShardHashKeys, returning 0 when they are
  * equal. Arm equality uses node equal() so hash collisions never produce a
- * wrong memo hit.
+ * wrong cache hit.
  */
 static int
-ArmShardMemoMatch(const void *key1, const void *key2, Size keysize)
+ArmShardMatchFn(const void *key1, const void *key2, Size keysize)
 {
-	const ArmShardMemoKey *memoKey1 = (const ArmShardMemoKey *) key1;
-	const ArmShardMemoKey *memoKey2 = (const ArmShardMemoKey *) key2;
+	const ArmShardHashKey *hashKey1 = (const ArmShardHashKey *) key1;
+	const ArmShardHashKey *hashKey2 = (const ArmShardHashKey *) key2;
 
-	if (memoKey1->relationId == memoKey2->relationId &&
-		memoKey1->rangeTableId == memoKey2->rangeTableId &&
-		equal(memoKey1->arm, memoKey2->arm))
+	if (hashKey1->relationId == hashKey2->relationId &&
+		hashKey1->rangeTableId == hashKey2->rangeTableId &&
+		equal(hashKey1->arm, hashKey2->arm))
 	{
 		return 0;
 	}

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -92,6 +92,14 @@ int RepartitionJoinBucketCountPerNode = 4;
 int TaskAssignmentPolicy = TASK_ASSIGNMENT_GREEDY;
 bool EnableUniqueJobIds = true;
 
+/*
+ * EnableOrClauseArmPruning controls whether, when generating a per-shard task
+ * query, we drop the arms of top-level OR clauses that cannot match any row on
+ * the task's shard (because they constrain the distribution column to a value
+ * that prunes to a different shard).
+ */
+bool EnableOrClauseArmPruning = true;
+
 
 /*
  * OperatorCache is used for caching operator identifiers for given typeId,
@@ -180,6 +188,13 @@ static Task * QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
 									  bool updateQualsForOuterJoin,
 									  DeferredErrorMessage **planningError);
 static List * SqlTaskList(Job *job);
+static void PruneOrClausesForTaskFragments(Query *taskQuery,
+										   List *fragmentCombination,
+										   List **armShardMemo);
+static Node * PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId,
+									 uint64 shardId, List **armShardMemo);
+static List * ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
+									   List **armShardMemo);
 static bool DependsOnHashPartitionJob(Job *job);
 static uint32 AnchorRangeTableId(List *rangeTableList);
 static List * BaseRangeTableIdList(List *rangeTableList);
@@ -2885,6 +2900,16 @@ SqlTaskList(Job *job)
 	}
 
 	ListCell *fragmentCombinationCell = NULL;
+
+	/*
+	 * Memo of each OR arm's reachable shard set, shared across all tasks of this
+	 * job. An arm's reachability depends only on (relation, range table id, arm
+	 * expression), not on which task we are building, so we compute it once per
+	 * distinct arm here instead of once per shard. Only used when
+	 * EnableOrClauseArmPruning is set.
+	 */
+	List *armShardMemo = NIL;
+
 	foreach(fragmentCombinationCell, fragmentCombinationList)
 	{
 		List *fragmentCombination = (List *) lfirst(fragmentCombinationCell);
@@ -2898,6 +2923,19 @@ SqlTaskList(Job *job)
 		/* update range table entries with fragment aliases (in place) */
 		Query *taskQuery = copyObject(jobQuery);
 		List *fragmentRangeTableList = taskQuery->rtable;
+
+		/*
+		 * Drop the arms of top-level OR clauses that cannot match any row on
+		 * this task's shard. This turns a query that pushes the full N-way OR
+		 * to every shard into one that only carries the relevant disjunct(s)
+		 * per shard, which lets the worker pick a single, precise index scan.
+		 */
+		if (EnableOrClauseArmPruning)
+		{
+			PruneOrClausesForTaskFragments(taskQuery, fragmentCombination,
+										   &armShardMemo);
+		}
+
 		UpdateRangeTableAlias(fragmentRangeTableList, fragmentCombination);
 
 		/* transform the updated task query to a SQL query string */
@@ -2927,6 +2965,220 @@ SqlTaskList(Job *job)
 	}
 
 	return sqlTaskList;
+}
+
+
+/*
+ * ArmShardMemoEntry caches the shard set an OR arm can reach for a given
+ * (relation, range table id), so PruneShards is run once per distinct arm
+ * rather than once per shard. See PruneOrClausesForTaskFragments.
+ */
+typedef struct ArmShardMemoEntry
+{
+	Oid relationId;
+	Index rangeTableId;
+	Node *arm;
+	List *shardIntervalList;
+} ArmShardMemoEntry;
+
+
+/*
+ * PruneOrClausesForTaskFragments rewrites the task query's WHERE clause by
+ * removing the arms of top-level OR expressions that cannot match any row on
+ * the shard(s) targeted by this task. It iterates the fragments of the task
+ * and, for every base distributed relation fragment, prunes OR arms that
+ * constrain that relation's distribution column to a value belonging to a
+ * different shard.
+ *
+ * armShardMemo is a job-wide cache (shared across all tasks) of each arm's
+ * reachable shard set; see ReachableShardListForArm.
+ */
+static void
+PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
+							   List **armShardMemo)
+{
+	Node *quals = taskQuery->jointree->quals;
+	if (quals == NULL)
+	{
+		return;
+	}
+
+	RangeTableFragment *fragment = NULL;
+	foreach_declared_ptr(fragment, fragmentCombination)
+	{
+		if (fragment->fragmentType != CITUS_RTE_RELATION)
+		{
+			continue;
+		}
+
+		ShardInterval *shardInterval = (ShardInterval *) fragment->fragmentReference;
+		Oid relationId = shardInterval->relationId;
+
+		/*
+		 * Only hash-distributed tables with a distribution key are eligible:
+		 * for these the regular shard-pruning machinery can decide which shard
+		 * an OR arm targets.
+		 */
+		CitusTableCacheEntry *cacheEntry = GetCitusTableCacheEntry(relationId);
+		if (!IsCitusTableTypeCacheEntry(cacheEntry, HASH_DISTRIBUTED) ||
+			!HasDistributionKeyCacheEntry(cacheEntry))
+		{
+			continue;
+		}
+
+		quals = PruneUnreachableOrArms(quals, relationId, fragment->rangeTableId,
+									   shardInterval->shardId, armShardMemo);
+	}
+
+	taskQuery->jointree->quals = quals;
+}
+
+
+/*
+ * ReachableShardListForArm returns the list of ShardIntervals that the given OR
+ * arm cannot be proven to exclude for (relationId, rangeTableId), i.e. the
+ * shards on which the arm might match a row. Results are memoized in
+ * *armShardMemo because reachability depends only on the arm expression and the
+ * relation, not on which task we are currently building.
+ */
+static List *
+ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
+						 List **armShardMemo)
+{
+	ArmShardMemoEntry *memoEntry = NULL;
+	foreach_declared_ptr(memoEntry, *armShardMemo)
+	{
+		if (memoEntry->relationId == relationId &&
+			memoEntry->rangeTableId == rangeTableId &&
+			equal(memoEntry->arm, arm))
+		{
+			return memoEntry->shardIntervalList;
+		}
+	}
+
+	List *armClauseList = make_ands_implicit((Expr *) arm);
+	List *shardIntervalList = PruneShards(relationId, rangeTableId, armClauseList, NULL);
+
+	ArmShardMemoEntry *newEntry = palloc0(sizeof(ArmShardMemoEntry));
+	newEntry->relationId = relationId;
+	newEntry->rangeTableId = rangeTableId;
+	newEntry->arm = arm;
+	newEntry->shardIntervalList = shardIntervalList;
+	*armShardMemo = lappend(*armShardMemo, newEntry);
+
+	return shardIntervalList;
+}
+
+
+/*
+ * ShardListContainsShardId returns whether shardId appears in the given list
+ * of ShardIntervals.
+ */
+static bool
+ShardListContainsShardId(List *shardIntervalList, uint64 shardId)
+{
+	ShardInterval *shardInterval = NULL;
+	foreach_declared_ptr(shardInterval, shardIntervalList)
+	{
+		if (shardInterval->shardId == shardId)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
+ * PruneUnreachableOrArms walks a (sub)qualification and removes the arms of
+ * top-level OR expressions that cannot match any row on the given shard.
+ *
+ * For each arm of an OR, we run the regular shard-pruning machinery
+ * (PruneShards) on that arm alone. If the resulting shard set does not contain
+ * this task's shard, the arm provably matches no row here and is dropped. An
+ * arm that carries no constraint on the distribution column prunes to all
+ * shards and is therefore always kept, so this rewrite never changes results.
+ */
+static Node *
+PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 shardId,
+					   List **armShardMemo)
+{
+	if (qual == NULL)
+	{
+		return NULL;
+	}
+
+	if (IsA(qual, List))
+	{
+		List *conjuncts = (List *) qual;
+		ListCell *conjunctCell = NULL;
+		foreach(conjunctCell, conjuncts)
+		{
+			lfirst(conjunctCell) = PruneUnreachableOrArms((Node *) lfirst(conjunctCell),
+														  relationId, rangeTableId,
+														  shardId, armShardMemo);
+		}
+
+		return (Node *) conjuncts;
+	}
+
+	if (IsA(qual, BoolExpr))
+	{
+		BoolExpr *boolExpr = (BoolExpr *) qual;
+
+		if (boolExpr->boolop == AND_EXPR)
+		{
+			ListCell *argCell = NULL;
+			foreach(argCell, boolExpr->args)
+			{
+				lfirst(argCell) = PruneUnreachableOrArms((Node *) lfirst(argCell),
+														 relationId, rangeTableId,
+														 shardId, armShardMemo);
+			}
+
+			return qual;
+		}
+		else if (boolExpr->boolop == OR_EXPR)
+		{
+			List *keptArms = NIL;
+			ListCell *armCell = NULL;
+			foreach(armCell, boolExpr->args)
+			{
+				Node *arm = (Node *) lfirst(armCell);
+				List *armShardList = ReachableShardListForArm(arm, relationId,
+															  rangeTableId,
+															  armShardMemo);
+
+				if (ShardListContainsShardId(armShardList, shardId))
+				{
+					keptArms = lappend(keptArms, arm);
+				}
+			}
+
+			/*
+			 * Be a strict no-op unless we both kept at least one arm and
+			 * dropped at least one: keeping zero arms would only happen if our
+			 * pruning disagreed with the task's own shard selection.
+			 */
+			if (keptArms == NIL ||
+				list_length(keptArms) == list_length(boolExpr->args))
+			{
+				return qual;
+			}
+
+			if (list_length(keptArms) == 1)
+			{
+				/* a single-argument OR is not a valid expression */
+				return (Node *) linitial(keptArms);
+			}
+
+			boolExpr->args = keptArms;
+			return qual;
+		}
+	}
+
+	return qual;
 }
 
 

--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -2827,6 +2827,10 @@ CoPartitionedTables(Oid firstRelationId, Oid secondRelationId)
  * function then joins table fragments from different range tables, and creates
  * all fragment combinations. For each created combination, the function builds
  * a SQL task, and appends this task to a task list.
+ *
+ * When EnableOrClauseArmPruning is enabled, each per-task query is a private
+ * copy of the job query, and its WHERE clause is mutated in place to drop the
+ * arms of top-level OR clauses that cannot match any row on that task's shard.
  */
 static List *
 SqlTaskList(Job *job)
@@ -3060,6 +3064,10 @@ PruneOrClausesForTaskFragments(Query *taskQuery, List *fragmentCombination,
  * this task's shard, the arm provably matches no row here and is dropped. An
  * arm that carries no constraint on the distribution column prunes to all
  * shards and is therefore always kept, so this rewrite never changes results.
+ *
+ * Dropping an arm removes any volatile or side-effect-producing function it
+ * contains from the query on that shard, so the number of times such a function
+ * is invoked per row can change.
  */
 static Node *
 PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 shardId,
@@ -3103,32 +3111,55 @@ PruneUnreachableOrArms(Node *qual, Oid relationId, Index rangeTableId, uint64 sh
 		else if (boolExpr->boolop == OR_EXPR)
 		{
 			List *keptArms = NIL;
+			bool anyDropped = false;
+			int keptCount = 0;
+			int armIndex = 0;
 			ListCell *armCell = NULL;
+
 			foreach(armCell, boolExpr->args)
 			{
 				Node *arm = (Node *) lfirst(armCell);
 				List *armShardList = ReachableShardListForArm(arm, relationId,
 															  rangeTableId,
 															  armShardHash);
+				bool reachable = ShardListContainsShardId(armShardList, shardId);
 
-				if (ShardListContainsShardId(armShardList, shardId))
+				if (reachable)
+				{
+					keptCount++;
+				}
+
+				if (!reachable && !anyDropped)
+				{
+					/*
+					 * First arm we drop: only now do we materialize the kept
+					 * list, backfilling the earlier arms, which were all kept.
+					 */
+					anyDropped = true;
+					keptArms = list_copy_head(boolExpr->args, armIndex);
+				}
+				else if (reachable && anyDropped)
 				{
 					keptArms = lappend(keptArms, arm);
 				}
+
+				armIndex++;
 			}
 
 			/*
 			 * Be a strict no-op unless we both kept at least one arm and
-			 * dropped at least one: keeping zero arms would only happen if our
-			 * pruning disagreed with the task's own shard selection.
+			 * dropped at least one: nothing dropped needs no rewrite, and
+			 * keeping zero arms would only happen if our pruning disagreed with
+			 * the task's own shard selection. Not building the list until the
+			 * first arm is dropped also avoids allocating in the common case
+			 * where every arm is retained.
 			 */
-			if (keptArms == NIL ||
-				list_length(keptArms) == list_length(boolExpr->args))
+			if (!anyDropped || keptCount == 0)
 			{
 				return qual;
 			}
 
-			if (list_length(keptArms) == 1)
+			if (keptCount == 1)
 			{
 				/* a single-argument OR is not a valid expression */
 				return (Node *) linitial(keptArms);
@@ -3162,8 +3193,7 @@ ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
 {
 	if (*armShardHash == NULL)
 	{
-		HASHCTL info;
-		memset(&info, 0, sizeof(info));
+		HASHCTL info = { 0 };
 		info.keysize = sizeof(ArmShardHashKey);
 		info.entrysize = sizeof(ArmShardHashEntry);
 		info.hash = ArmShardHashFn;
@@ -3197,7 +3227,7 @@ ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
 	List *armClauseList = make_ands_implicit((Expr *) arm);
 	List *shardIntervalList = PruneShards(relationId, rangeTableId, armClauseList, NULL);
 
-	entry = hash_search(*armShardHash, &lookupKey, HASH_ENTER, &found);
+	entry = hash_search(*armShardHash, &lookupKey, HASH_ENTER, NULL);
 	entry->shardIntervalList = shardIntervalList;
 
 	return shardIntervalList;
@@ -3207,7 +3237,15 @@ ReachableShardListForArm(Node *arm, Oid relationId, Index rangeTableId,
 /*
  * ArmShardHashFn hashes an ArmShardHashKey. The arm expression is hashed via
  * its canonical serialized form so that structurally identical arms (which
- * ArmShardMatchFn treats as equal) land in the same bucket.
+ * ArmShardMatchFn treats as equal) land in the same bucket, even though they
+ * are distinct pointers in each per-task copy of the job query.
+ *
+ * Cost model: nodeToString() runs on every hash probe (both HASH_FIND and
+ * HASH_ENTER), i.e. O(arm size) per probe, with the probe count proportional to
+ * (OR arms x tasks). This serialization is the price of matching arms by value
+ * across copied query trees, and is dominated by the work the cache saves:
+ * PruneShards() runs only once per distinct arm (on a miss), not once per probe,
+ * and each task already pays a full copyObject() of the job query.
  */
 static uint32
 ArmShardHashFn(const void *key, Size keysize)

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1416,6 +1416,23 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_or_clause_arm_pruning",
+		gettext_noop("Enables removing the arms of a top-level OR clause that "
+					 "cannot match any row on a shard when generating the "
+					 "per-shard query."),
+		gettext_noop("When a query filters on the distribution column inside "
+					 "each arm of an OR (e.g. (dist=a AND ...) OR (dist=b AND "
+					 "...)), every shard otherwise receives the full OR. With "
+					 "this enabled, each shard's query only keeps the arms that "
+					 "can match on that shard, allowing a single precise index "
+					 "scan instead of an N-way bitmap OR."),
+		&EnableOrClauseArmPruning,
+		true,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.enable_local_execution",
 		gettext_noop("Enables queries on shards that are local to the current node "
 					 "to be planned and executed locally."),

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1416,23 +1416,6 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
-		"citus.enable_or_clause_arm_pruning",
-		gettext_noop("Enables removing the arms of a top-level OR clause that "
-					 "cannot match any row on a shard when generating the "
-					 "per-shard query."),
-		gettext_noop("When a query filters on the distribution column inside "
-					 "each arm of an OR (e.g. (dist=a AND ...) OR (dist=b AND "
-					 "...)), every shard otherwise receives the full OR. With "
-					 "this enabled, each shard's query only keeps the arms that "
-					 "can match on that shard, allowing a single precise index "
-					 "scan instead of an N-way bitmap OR."),
-		&EnableOrClauseArmPruning,
-		true,
-		PGC_USERSET,
-		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
-		NULL, NULL, NULL);
-
-	DefineCustomBoolVariable(
 		"citus.enable_local_execution",
 		gettext_noop("Enables queries on shards that are local to the current node "
 					 "to be planned and executed locally."),
@@ -1514,6 +1497,23 @@ RegisterCitusConfigVariables(void)
 					 "tables."),
 		&EnableNonColocatedRouterQueryPushdown,
 		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
+		"citus.enable_or_clause_arm_pruning",
+		gettext_noop("Enables removing the arms of a top-level OR clause that "
+					 "cannot match any row on a shard when generating the "
+					 "per-shard query."),
+		gettext_noop("When a query filters on the distribution column inside "
+					 "each arm of an OR (e.g. (dist=a AND ...) OR (dist=b AND "
+					 "...)), every shard otherwise receives the full OR. With "
+					 "this enabled, each shard's query only keeps the arms that "
+					 "can match on that shard, allowing a single precise index "
+					 "scan instead of an N-way bitmap OR."),
+		&EnableOrClauseArmPruning,
+		true,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);

--- a/src/include/distributed/multi_physical_planner.h
+++ b/src/include/distributed/multi_physical_planner.h
@@ -593,6 +593,7 @@ typedef List *(*ReorderFunction)(List *);
 /* Config variable managed via guc.c */
 extern int TaskAssignmentPolicy;
 extern bool EnableUniqueJobIds;
+extern bool EnableOrClauseArmPruning;
 
 
 /* Function declarations for building physical plans and constructing queries */

--- a/src/test/regress/expected/multi_hash_pruning.out
+++ b/src/test/regress/expected/multi_hash_pruning.out
@@ -513,6 +513,10 @@ DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -545,6 +549,10 @@ DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -665,6 +673,10 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -682,6 +694,14 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -703,6 +723,14 @@ DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -720,6 +748,12 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -737,6 +771,14 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -758,6 +800,12 @@ DEBUG:  constraint value: 2
 DEBUG:  constraint value: 2
 DEBUG:  constraint value: 3
 DEBUG:  shard count after pruning for orders_hash_partitioned: 3
+DEBUG:  constraint value: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 2
+DEBUG:  constraint value: 3
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -772,6 +820,11 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
@@ -795,6 +848,12 @@ DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  constraint value: 3
 DEBUG:  shard count after pruning for orders_hash_partitioned: 3
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 3
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -813,6 +872,10 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -830,6 +893,12 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -847,6 +916,10 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -860,6 +933,11 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
@@ -883,6 +961,11 @@ DEBUG:  constraint value: 3
 DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  shard count after pruning for orders_hash_partitioned: 3
+DEBUG:  constraint value: 1
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 3
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -899,6 +982,10 @@ DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -943,6 +1030,11 @@ DEBUG:  constraint value: 1
 DEBUG:  constraint value: 2
 DEBUG:  constraint value: 3
 DEBUG:  shard count after pruning for orders_hash_partitioned: 3
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 2
+DEBUG:  constraint value: 3
+DEBUG:  shard count after pruning for orders_hash_partitioned: 2
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -957,6 +1049,10 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
@@ -976,6 +1072,10 @@ DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -993,6 +1093,10 @@ DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
@@ -1008,6 +1112,10 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  constraint value: 1
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx
@@ -1055,6 +1163,10 @@ DEBUG:  Router planner cannot handle multi-shard select queries
 DEBUG:  constraint value: 2
 DEBUG:  constraint value: 3
 DEBUG:  shard count after pruning for orders_hash_partitioned: 2
+DEBUG:  constraint value: 2
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
+DEBUG:  constraint value: 3
+DEBUG:  shard count after pruning for orders_hash_partitioned: 1
 DEBUG:  assigned task to node localhost:xxxxx
 DEBUG:  assigned task to node localhost:xxxxx
  count
@@ -1068,6 +1180,10 @@ SELECT count(*) FROM orders_hash_partitioned
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  Router planner cannot handle multi-shard select queries
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
+DEBUG:  no shard pruning constraints on orders_hash_partitioned found
+DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  no shard pruning constraints on orders_hash_partitioned found
 DEBUG:  shard count after pruning for orders_hash_partitioned: 4
 DEBUG:  assigned task to node localhost:xxxxx

--- a/src/test/regress/expected/multi_or_arm_pruning.out
+++ b/src/test/regress/expected/multi_or_arm_pruning.out
@@ -351,6 +351,104 @@ SELECT count(*) AS prep_on_only FROM (TABLE prep_on EXCEPT ALL TABLE prep_off) z
 DROP TABLE prep_off, prep_on;
 DEALLOCATE or_prep;
 -- ===================================================================
+-- Partitioned distributed tables: the optimization must work when the
+-- distributed table is natively (declaratively) partitioned. The parent and
+-- every partition are hash-distributed on the same key, so they pass the
+-- eligibility guard and prune exactly like a plain table; partition expansion
+-- then happens on the worker under the already-pruned per-shard qual.
+-- ===================================================================
+SET citus.shard_count TO 4;
+CREATE TABLE pt (k int, v int, ts date) PARTITION BY RANGE (ts);
+CREATE TABLE pt_2020 PARTITION OF pt FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE pt_2021 PARTITION OF pt FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE pt_2022 PARTITION OF pt FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE pt_2023 PARTITION OF pt FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');
+SELECT create_distributed_table('pt', 'k');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE INDEX pt_k_v ON pt (k, v);
+INSERT INTO pt SELECT k, v, DATE '2020-06-01' FROM generate_series(1,8) k, generate_series(1,12) v;
+INSERT INTO pt SELECT k, v, DATE '2021-06-01' FROM generate_series(1,8) k, generate_series(13,25) v;
+INSERT INTO pt SELECT k, v, DATE '2022-06-01' FROM generate_series(1,8) k, generate_series(26,37) v;
+INSERT INTO pt SELECT k, v, DATE '2023-06-01' FROM generate_series(1,8) k, generate_series(38,50) v;
+ANALYZE pt;
+-- a second colocated partitioned distributed table for the join case
+CREATE TABLE pt2 (k int, w int, ts date) PARTITION BY RANGE (ts);
+CREATE TABLE pt2_a PARTITION OF pt2 FOR VALUES FROM ('2020-01-01') TO ('2022-01-01');
+CREATE TABLE pt2_b PARTITION OF pt2 FOR VALUES FROM ('2022-01-01') TO ('2024-01-01');
+SELECT create_distributed_table('pt2', 'k', colocate_with => 'pt');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO pt2 SELECT k, w, DATE '2020-06-01' FROM generate_series(1,8) k, generate_series(1,25) w;
+INSERT INTO pt2 SELECT k, w, DATE '2022-06-01' FROM generate_series(1,8) k, generate_series(26,50) w;
+ANALYZE pt2;
+-- EXPLAIN before vs after on the parent. Seq scans are forced, so each shard's
+-- task scans all 4 partitions and a per-shard filter appears once per partition;
+-- the count column is therefore (matching shards x 4 partitions).
+SET enable_indexscan TO off;
+SET enable_bitmapscan TO off;
+SET citus.explain_all_tasks TO on;
+-- BEFORE: every shard/partition scan carries the full 2-arm OR (2 shards x 4 = 8)
+SET citus.enable_or_clause_arm_pruning TO off;
+SELECT f, count(*) FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7)
+$$) f GROUP BY f ORDER BY f;
+                     f                      | count
+---------------------------------------------------------------------
+ Filter: ((v = 7) AND ((k = 1) OR (k = 2))) |     8
+(1 row)
+
+-- AFTER: each shard keeps only its own arm, across all 4 of its partition scans
+SET citus.enable_or_clause_arm_pruning TO on;
+SELECT f, count(*) FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7)
+$$) f GROUP BY f ORDER BY f;
+               f               | count
+---------------------------------------------------------------------
+ Filter: ((k = 1) AND (v = 7)) |     4
+ Filter: ((k = 2) AND (v = 7)) |     4
+(2 rows)
+
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+-- parity across partitioned shapes (off vs on must be identical)
+-- OR on the dist key, queried on the parent
+SELECT parity($$SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- arms constrain the dist key AND the partition key (partition + shard pruning)
+SELECT parity($$SELECT * FROM pt WHERE (k=1 AND ts=DATE '2020-06-01') OR (k=2 AND ts=DATE '2021-06-01')$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- OR queried directly on a child partition (itself a distributed table)
+SELECT parity($$SELECT * FROM pt_2020 WHERE (k=1 AND v=7) OR (k=2 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- colocated join between two partitioned distributed tables
+SELECT parity($$SELECT pt.v, pt2.w FROM pt JOIN pt2 USING (k) WHERE (pt.k=1 AND pt2.w=7) OR (pt.k=2 AND pt2.w=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- ===================================================================
 -- cleanup
 -- ===================================================================
 SET client_min_messages TO WARNING;

--- a/src/test/regress/expected/multi_or_arm_pruning.out
+++ b/src/test/regress/expected/multi_or_arm_pruning.out
@@ -176,6 +176,19 @@ SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AN
  parity ok
 (1 row)
 
+-- a large OR, modelling an ORM-generated batch read with many options: 100
+-- dist-key equality arms spread across the shards, so each shard's task keeps
+-- only its ~1/shard_count share and drops the rest. Exercises the per-arm memo
+-- at scale.
+SELECT parity(
+  'SELECT * FROM dt WHERE ' ||
+  string_agg(format('(k = %s AND v = 7)', g), ' OR ')
+) FROM generate_series(1, 100) g;
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
 -- two arms collide on the same shard (both must be kept on that shard)
 SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7)$$);
   parity

--- a/src/test/regress/expected/multi_or_arm_pruning.out
+++ b/src/test/regress/expected/multi_or_arm_pruning.out
@@ -147,6 +147,23 @@ $$) ORDER BY 1;
  Filter: ((v = 7) AND ((k <= 4) OR (k = 5)))
 (4 rows)
 
+-- Two EQUALITY arms whose dist-key values hash to the SAME shard must BOTH be
+-- kept there, while a third arm that lives on another shard collapses to a
+-- single arm on that shard. k=1 and k=5 collide on one shard; k=2 is on another;
+-- shards owning none of {1,2,5} are pruned away at the job level and get no task.
+-- This asserts the >=2-equality-arms-kept shape (not just the range mix above)
+-- and makes the k=1/k=5 collision self-checking: if they ever stopped colliding
+-- the "(k = 1) OR (k = 5)" grouping below would split into two separate filters.
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7) OR (k=2 AND v=7)
+$$) ORDER BY 1;
+               shard_filters
+---------------------------------------------------------------------
+ Filter: ((k = 2) AND (v = 7))
+ Filter: ((v = 7) AND ((k = 1) OR (k = 5)))
+(2 rows)
+
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 -- ===================================================================
@@ -240,6 +257,21 @@ SELECT parity($$SELECT * FROM dt WHERE (v=7 AND k=1) OR (v=8)$$);
  parity ok
 (1 row)
 
+-- no WHERE clause at all (the quals == NULL early return)
+SELECT parity($$SELECT * FROM dt$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- top-level NOT wrapping a prunable OR: the walker does not descend into NOT, so
+-- the OR is left intact and results are unchanged
+SELECT parity($$SELECT * FROM dt WHERE NOT ((k=1 AND v=7) OR (k=2 AND v=7))$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
 -- join with a reference table: the reference fragment is not hash-distributed,
 -- so it is skipped and all arms are kept; results must be unchanged.
 CREATE TABLE ref (k int, w int);
@@ -257,6 +289,45 @@ SELECT parity($$SELECT dt.v FROM dt JOIN ref ON dt.k = ref.k WHERE (dt.k=1 AND r
  parity ok
 (1 row)
 
+-- join with a single-shard (null distribution key) table: that fragment has no
+-- distribution column, so PruneOrClausesForTaskFragments skips it via the
+-- !HasDistributionKeyCacheEntry guard; the hash table's arms still prune and
+-- results must be unchanged.
+CREATE TABLE nk (k int, w int);
+SELECT create_distributed_table('nk', NULL, distribution_type => NULL);
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO nk SELECT g, g FROM generate_series(1, 8) g;
+ANALYZE nk;
+SET citus.enable_repartition_joins TO on;
+SELECT parity($$SELECT dt.v, nk.w FROM dt JOIN nk ON dt.k = nk.k WHERE (dt.k=1 AND nk.w=1) OR (dt.k=2 AND nk.w=2)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- repartition (non-colocated) join on a non-distribution column: the top job's
+-- fragments include non-relation (intermediate result) fragments, which the
+-- fragmentType != CITUS_RTE_RELATION guard skips; results must be unchanged.
+CREATE TABLE dt3 (k int, y int);
+SELECT create_distributed_table('dt3', 'k', colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dt3 SELECT k, y FROM generate_series(1, 8) k, generate_series(1, 50) y;
+ANALYZE dt3;
+SELECT parity($$SELECT dt.v, dt3.y FROM dt JOIN dt3 ON dt.v = dt3.y WHERE (dt.k=1 AND dt3.y=7) OR (dt.k=2 AND dt3.y=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+RESET citus.enable_repartition_joins;
 -- parameterized (prepared) query: a custom plan substitutes the params as
 -- constants, so pruning still applies and must not change the result.
 SET citus.enable_or_clause_arm_pruning TO off;

--- a/src/test/regress/expected/multi_or_arm_pruning.out
+++ b/src/test/regress/expected/multi_or_arm_pruning.out
@@ -1,0 +1,286 @@
+--
+-- MULTI_OR_ARM_PRUNING
+--
+-- Tests citus.enable_or_clause_arm_pruning: for a multi-shard SELECT whose
+-- WHERE clause is a top-level OR where each arm constrains the distribution
+-- column, each shard's task query should keep only the arms that can match on
+-- that shard, instead of pushing the full N-arm OR to every shard.
+--
+CREATE SCHEMA or_arm_pruning;
+SET search_path TO or_arm_pruning;
+SET citus.next_shard_id TO 1630000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+CREATE TABLE dt (k int, v int);
+SELECT create_distributed_table('dt', 'k');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE INDEX dt_k_v ON dt (k, v);
+INSERT INTO dt SELECT k, v FROM generate_series(1, 8) k, generate_series(1, 50) v;
+ANALYZE dt;
+-- a colocated table for the join cases
+CREATE TABLE dt2 (k int, y int);
+SELECT create_distributed_table('dt2', 'k');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO dt2 SELECT k, y FROM generate_series(1, 8) k, generate_series(1, 50) y;
+ANALYZE dt2;
+-- ===================================================================
+-- helpers (deterministic, port/shard-id independent)
+-- ===================================================================
+-- Returns the Filter lines of an EXPLAIN, with shard-id suffixes stripped and
+-- sorted, so the output does not depend on worker ports, shard ids, or task
+-- order. Forcing seq scans (see callers) keeps the plan node stable across PG
+-- versions, so only the per-shard WHERE clause (the thing this feature changes)
+-- shows up.
+CREATE OR REPLACE FUNCTION shard_filters(cmd text)
+RETURNS SETOF text LANGUAGE plpgsql AS $$
+DECLARE line text;
+BEGIN
+  FOR line IN EXECUTE cmd LOOP
+    IF position('Filter:' in line) > 0 THEN
+      RETURN NEXT trim(both ' ' from regexp_replace(line, '_[0-9]+', '', 'g'));
+    END IF;
+  END LOOP;
+  RETURN;
+END;
+$$;
+-- Runs a query with the optimization off and on and reports whether the result
+-- sets are identical (multiset equality). Independent of row order.
+CREATE OR REPLACE FUNCTION parity(q text)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE off_only bigint; on_only bigint;
+BEGIN
+  SET LOCAL citus.enable_or_clause_arm_pruning TO off;
+  EXECUTE 'CREATE TEMP TABLE _off AS ' || q;
+  SET LOCAL citus.enable_or_clause_arm_pruning TO on;
+  EXECUTE 'CREATE TEMP TABLE _on AS ' || q;
+  EXECUTE 'SELECT count(*) FROM (TABLE _off EXCEPT ALL TABLE _on) z' INTO off_only;
+  EXECUTE 'SELECT count(*) FROM (TABLE _on EXCEPT ALL TABLE _off) z' INTO on_only;
+  DROP TABLE _off, _on;
+  IF off_only = 0 AND on_only = 0 THEN
+    RETURN 'parity ok';
+  END IF;
+  RETURN format('MISMATCH off_only=%s on_only=%s', off_only, on_only);
+END;
+$$;
+-- ===================================================================
+-- GUC defaults to on
+-- ===================================================================
+SHOW citus.enable_or_clause_arm_pruning;
+ citus.enable_or_clause_arm_pruning
+---------------------------------------------------------------------
+ on
+(1 row)
+
+-- ===================================================================
+-- Per-shard WHERE clause: before vs after.
+-- k = 1, 2, 3, 6 each hash to a different one of the 4 shards.
+-- ===================================================================
+SET enable_indexscan TO off;
+SET enable_bitmapscan TO off;
+SET citus.explain_all_tasks TO on;
+-- BEFORE: every shard carries the full 4-arm OR
+SET citus.enable_or_clause_arm_pruning TO off;
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt
+  WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)
+$$) ORDER BY 1;
+                          shard_filters
+---------------------------------------------------------------------
+ Filter: ((v = 7) AND ((k = 1) OR (k = 2) OR (k = 3) OR (k = 6)))
+ Filter: ((v = 7) AND ((k = 1) OR (k = 2) OR (k = 3) OR (k = 6)))
+ Filter: ((v = 7) AND ((k = 1) OR (k = 2) OR (k = 3) OR (k = 6)))
+ Filter: ((v = 7) AND ((k = 1) OR (k = 2) OR (k = 3) OR (k = 6)))
+(4 rows)
+
+-- AFTER: each shard keeps only the single arm whose k lives on that shard
+SET citus.enable_or_clause_arm_pruning TO on;
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt
+  WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)
+$$) ORDER BY 1;
+         shard_filters
+---------------------------------------------------------------------
+ Filter: ((k = 1) AND (v = 7))
+ Filter: ((k = 2) AND (v = 7))
+ Filter: ((k = 3) AND (v = 7))
+ Filter: ((k = 6) AND (v = 7))
+(4 rows)
+
+-- Range/inequality on the dist column does NOT prune on a hash-distributed
+-- table (hashing is not order preserving), so a range arm is kept on every
+-- shard. An equality arm sharing the OR is still pruned. The optimization is
+-- on for both queries below.
+-- pure range OR: nothing is pruned, every shard keeps the full OR
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k <= 2 AND v=7) OR (k >= 7 AND v=7)
+$$) ORDER BY 1;
+                shard_filters
+---------------------------------------------------------------------
+ Filter: ((v = 7) AND ((k <= 2) OR (k >= 7)))
+ Filter: ((v = 7) AND ((k <= 2) OR (k >= 7)))
+ Filter: ((v = 7) AND ((k <= 2) OR (k >= 7)))
+ Filter: ((v = 7) AND ((k <= 2) OR (k >= 7)))
+(4 rows)
+
+-- mixed range + equality: the range arm is kept everywhere, while the equality
+-- arm (k=5) is dropped on the shards that do not own k=5
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k <= 4 AND v=7) OR (k=5 AND v=7)
+$$) ORDER BY 1;
+                shard_filters
+---------------------------------------------------------------------
+ Filter: ((k <= 4) AND (v = 7))
+ Filter: ((k <= 4) AND (v = 7))
+ Filter: ((k <= 4) AND (v = 7))
+ Filter: ((v = 7) AND ((k <= 4) OR (k = 5)))
+(4 rows)
+
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+-- ===================================================================
+-- Correctness: results are identical with the optimization off vs on
+-- ===================================================================
+-- basic: every arm pins the dist column
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- two arms collide on the same shard (both must be kept on that shard)
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- an arm with NO constraint on the dist column must be kept on all shards
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- mixed: top-level AND of a prunable OR with another predicate
+SELECT parity($$SELECT * FROM dt WHERE v < 10 AND ((k=1 AND v=7) OR (k=2 AND v=7))$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- nested OR inside an arm
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND (v=7 OR v=8)) OR (k=2 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- non-equality (range) and IN constraints on the dist column
+SELECT parity($$SELECT * FROM dt WHERE (k < 3 AND v=7) OR (k=5 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+SELECT parity($$SELECT * FROM dt WHERE (k IN (1,2) AND v=7) OR (k=5 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- pure range OR (no arm prunes on a hash table): exact no-op
+SELECT parity($$SELECT * FROM dt WHERE (k <= 2 AND v=7) OR (k >= 7 AND v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- colocated join, arms referencing both tables' dist keys
+SELECT parity($$SELECT dt.v, dt2.y FROM dt JOIN dt2 USING (k) WHERE (dt.k=1 AND dt2.y=7) OR (dt.k=2 AND dt2.y=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- colocated join, cross-table arms
+SELECT parity($$SELECT dt.v FROM dt JOIN dt2 USING (k) WHERE (dt.k=1 AND dt2.y=7) OR (dt2.k=2 AND dt.v=7)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- queries with nothing to prune are exact no-ops
+SELECT parity($$SELECT * FROM dt WHERE v=7$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+SELECT parity($$SELECT * FROM dt WHERE v=7 OR v=8$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+SELECT parity($$SELECT * FROM dt WHERE (v=7 AND k=1) OR (v=8)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- join with a reference table: the reference fragment is not hash-distributed,
+-- so it is skipped and all arms are kept; results must be unchanged.
+CREATE TABLE ref (k int, w int);
+SELECT create_reference_table('ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO ref SELECT g, g FROM generate_series(1, 8) g;
+ANALYZE ref;
+SELECT parity($$SELECT dt.v FROM dt JOIN ref ON dt.k = ref.k WHERE (dt.k=1 AND ref.w=1) OR (dt.k=2 AND ref.w=2)$$);
+  parity
+---------------------------------------------------------------------
+ parity ok
+(1 row)
+
+-- parameterized (prepared) query: a custom plan substitutes the params as
+-- constants, so pruning still applies and must not change the result.
+SET citus.enable_or_clause_arm_pruning TO off;
+PREPARE or_prep(int, int) AS
+  SELECT k, v FROM dt WHERE (k = $1 AND v = 7) OR (k = $2 AND v = 7);
+CREATE TEMP TABLE prep_off AS EXECUTE or_prep(1, 2);
+SET citus.enable_or_clause_arm_pruning TO on;
+CREATE TEMP TABLE prep_on AS EXECUTE or_prep(1, 2);
+SELECT count(*) AS prep_off_only FROM (TABLE prep_off EXCEPT ALL TABLE prep_on) z;
+ prep_off_only
+---------------------------------------------------------------------
+             0
+(1 row)
+
+SELECT count(*) AS prep_on_only FROM (TABLE prep_on EXCEPT ALL TABLE prep_off) z;
+ prep_on_only
+---------------------------------------------------------------------
+            0
+(1 row)
+
+DROP TABLE prep_off, prep_on;
+DEALLOCATE or_prep;
+-- ===================================================================
+-- cleanup
+-- ===================================================================
+SET client_min_messages TO WARNING;
+DROP SCHEMA or_arm_pruning CASCADE;

--- a/src/test/regress/expected/single_node_enterprise.out
+++ b/src/test/regress/expected/single_node_enterprise.out
@@ -158,8 +158,8 @@ SET client_min_messages TO DEBUG1;
 -- force multi-shard query to be able to
 -- have remote connections
 SELECT COUNT(*) FROM test WHERE x = 1 OR x = 2;
-NOTICE:  issuing SELECT count(*) AS count FROM single_node_ent.test_90730500 test WHERE ((x OPERATOR(pg_catalog.=) 1) OR (x OPERATOR(pg_catalog.=) 2))
-NOTICE:  issuing SELECT count(*) AS count FROM single_node_ent.test_90730503 test WHERE ((x OPERATOR(pg_catalog.=) 1) OR (x OPERATOR(pg_catalog.=) 2))
+NOTICE:  issuing SELECT count(*) AS count FROM single_node_ent.test_90730500 test WHERE (x OPERATOR(pg_catalog.=) 1)
+NOTICE:  issuing SELECT count(*) AS count FROM single_node_ent.test_90730503 test WHERE (x OPERATOR(pg_catalog.=) 2)
  count
 ---------------------------------------------------------------------
      1

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -197,6 +197,7 @@ test: multi_modifications
 test: multi_update_select
 test: multi_distribution_metadata
 test: multi_prune_shard_list
+test: multi_or_arm_pruning
 test: multi_upsert multi_simple_queries multi_data_types
 test: citus_copy_shard_placement
 # multi_utilities cannot be run in parallel with other tests because it checks

--- a/src/test/regress/sql/multi_or_arm_pruning.sql
+++ b/src/test/regress/sql/multi_or_arm_pruning.sql
@@ -216,6 +216,70 @@ DROP TABLE prep_off, prep_on;
 DEALLOCATE or_prep;
 
 -- ===================================================================
+-- Partitioned distributed tables: the optimization must work when the
+-- distributed table is natively (declaratively) partitioned. The parent and
+-- every partition are hash-distributed on the same key, so they pass the
+-- eligibility guard and prune exactly like a plain table; partition expansion
+-- then happens on the worker under the already-pruned per-shard qual.
+-- ===================================================================
+SET citus.shard_count TO 4;
+CREATE TABLE pt (k int, v int, ts date) PARTITION BY RANGE (ts);
+CREATE TABLE pt_2020 PARTITION OF pt FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE pt_2021 PARTITION OF pt FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE pt_2022 PARTITION OF pt FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE pt_2023 PARTITION OF pt FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');
+SELECT create_distributed_table('pt', 'k');
+CREATE INDEX pt_k_v ON pt (k, v);
+INSERT INTO pt SELECT k, v, DATE '2020-06-01' FROM generate_series(1,8) k, generate_series(1,12) v;
+INSERT INTO pt SELECT k, v, DATE '2021-06-01' FROM generate_series(1,8) k, generate_series(13,25) v;
+INSERT INTO pt SELECT k, v, DATE '2022-06-01' FROM generate_series(1,8) k, generate_series(26,37) v;
+INSERT INTO pt SELECT k, v, DATE '2023-06-01' FROM generate_series(1,8) k, generate_series(38,50) v;
+ANALYZE pt;
+
+-- a second colocated partitioned distributed table for the join case
+CREATE TABLE pt2 (k int, w int, ts date) PARTITION BY RANGE (ts);
+CREATE TABLE pt2_a PARTITION OF pt2 FOR VALUES FROM ('2020-01-01') TO ('2022-01-01');
+CREATE TABLE pt2_b PARTITION OF pt2 FOR VALUES FROM ('2022-01-01') TO ('2024-01-01');
+SELECT create_distributed_table('pt2', 'k', colocate_with => 'pt');
+INSERT INTO pt2 SELECT k, w, DATE '2020-06-01' FROM generate_series(1,8) k, generate_series(1,25) w;
+INSERT INTO pt2 SELECT k, w, DATE '2022-06-01' FROM generate_series(1,8) k, generate_series(26,50) w;
+ANALYZE pt2;
+
+-- EXPLAIN before vs after on the parent. Seq scans are forced, so each shard's
+-- task scans all 4 partitions and a per-shard filter appears once per partition;
+-- the count column is therefore (matching shards x 4 partitions).
+SET enable_indexscan TO off;
+SET enable_bitmapscan TO off;
+SET citus.explain_all_tasks TO on;
+
+-- BEFORE: every shard/partition scan carries the full 2-arm OR (2 shards x 4 = 8)
+SET citus.enable_or_clause_arm_pruning TO off;
+SELECT f, count(*) FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7)
+$$) f GROUP BY f ORDER BY f;
+
+-- AFTER: each shard keeps only its own arm, across all 4 of its partition scans
+SET citus.enable_or_clause_arm_pruning TO on;
+SELECT f, count(*) FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7)
+$$) f GROUP BY f ORDER BY f;
+
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
+-- parity across partitioned shapes (off vs on must be identical)
+-- OR on the dist key, queried on the parent
+SELECT parity($$SELECT * FROM pt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)$$);
+-- arms constrain the dist key AND the partition key (partition + shard pruning)
+SELECT parity($$SELECT * FROM pt WHERE (k=1 AND ts=DATE '2020-06-01') OR (k=2 AND ts=DATE '2021-06-01')$$);
+-- OR queried directly on a child partition (itself a distributed table)
+SELECT parity($$SELECT * FROM pt_2020 WHERE (k=1 AND v=7) OR (k=2 AND v=7)$$);
+-- colocated join between two partitioned distributed tables
+SELECT parity($$SELECT pt.v, pt2.w FROM pt JOIN pt2 USING (k) WHERE (pt.k=1 AND pt2.w=7) OR (pt.k=2 AND pt2.w=7)$$);
+
+-- ===================================================================
 -- cleanup
 -- ===================================================================
 SET client_min_messages TO WARNING;

--- a/src/test/regress/sql/multi_or_arm_pruning.sql
+++ b/src/test/regress/sql/multi_or_arm_pruning.sql
@@ -137,6 +137,15 @@ RESET enable_bitmapscan;
 -- basic: every arm pins the dist column
 SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)$$);
 
+-- a large OR, modelling an ORM-generated batch read with many options: 100
+-- dist-key equality arms spread across the shards, so each shard's task keeps
+-- only its ~1/shard_count share and drops the rest. Exercises the per-arm memo
+-- at scale.
+SELECT parity(
+  'SELECT * FROM dt WHERE ' ||
+  string_agg(format('(k = %s AND v = 7)', g), ' OR ')
+) FROM generate_series(1, 100) g;
+
 -- two arms collide on the same shard (both must be kept on that shard)
 SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7)$$);
 

--- a/src/test/regress/sql/multi_or_arm_pruning.sql
+++ b/src/test/regress/sql/multi_or_arm_pruning.sql
@@ -115,6 +115,18 @@ SELECT * FROM shard_filters($$
   SELECT * FROM dt WHERE (k <= 4 AND v=7) OR (k=5 AND v=7)
 $$) ORDER BY 1;
 
+-- Two EQUALITY arms whose dist-key values hash to the SAME shard must BOTH be
+-- kept there, while a third arm that lives on another shard collapses to a
+-- single arm on that shard. k=1 and k=5 collide on one shard; k=2 is on another;
+-- shards owning none of {1,2,5} are pruned away at the job level and get no task.
+-- This asserts the >=2-equality-arms-kept shape (not just the range mix above)
+-- and makes the k=1/k=5 collision self-checking: if they ever stopped colliding
+-- the "(k = 1) OR (k = 5)" grouping below would split into two separate filters.
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7) OR (k=2 AND v=7)
+$$) ORDER BY 1;
+
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
@@ -154,6 +166,13 @@ SELECT parity($$SELECT * FROM dt WHERE v=7$$);
 SELECT parity($$SELECT * FROM dt WHERE v=7 OR v=8$$);
 SELECT parity($$SELECT * FROM dt WHERE (v=7 AND k=1) OR (v=8)$$);
 
+-- no WHERE clause at all (the quals == NULL early return)
+SELECT parity($$SELECT * FROM dt$$);
+
+-- top-level NOT wrapping a prunable OR: the walker does not descend into NOT, so
+-- the OR is left intact and results are unchanged
+SELECT parity($$SELECT * FROM dt WHERE NOT ((k=1 AND v=7) OR (k=2 AND v=7))$$);
+
 -- join with a reference table: the reference fragment is not hash-distributed,
 -- so it is skipped and all arms are kept; results must be unchanged.
 CREATE TABLE ref (k int, w int);
@@ -161,6 +180,27 @@ SELECT create_reference_table('ref');
 INSERT INTO ref SELECT g, g FROM generate_series(1, 8) g;
 ANALYZE ref;
 SELECT parity($$SELECT dt.v FROM dt JOIN ref ON dt.k = ref.k WHERE (dt.k=1 AND ref.w=1) OR (dt.k=2 AND ref.w=2)$$);
+
+-- join with a single-shard (null distribution key) table: that fragment has no
+-- distribution column, so PruneOrClausesForTaskFragments skips it via the
+-- !HasDistributionKeyCacheEntry guard; the hash table's arms still prune and
+-- results must be unchanged.
+CREATE TABLE nk (k int, w int);
+SELECT create_distributed_table('nk', NULL, distribution_type => NULL);
+INSERT INTO nk SELECT g, g FROM generate_series(1, 8) g;
+ANALYZE nk;
+SET citus.enable_repartition_joins TO on;
+SELECT parity($$SELECT dt.v, nk.w FROM dt JOIN nk ON dt.k = nk.k WHERE (dt.k=1 AND nk.w=1) OR (dt.k=2 AND nk.w=2)$$);
+
+-- repartition (non-colocated) join on a non-distribution column: the top job's
+-- fragments include non-relation (intermediate result) fragments, which the
+-- fragmentType != CITUS_RTE_RELATION guard skips; results must be unchanged.
+CREATE TABLE dt3 (k int, y int);
+SELECT create_distributed_table('dt3', 'k', colocate_with => 'none');
+INSERT INTO dt3 SELECT k, y FROM generate_series(1, 8) k, generate_series(1, 50) y;
+ANALYZE dt3;
+SELECT parity($$SELECT dt.v, dt3.y FROM dt JOIN dt3 ON dt.v = dt3.y WHERE (dt.k=1 AND dt3.y=7) OR (dt.k=2 AND dt3.y=7)$$);
+RESET citus.enable_repartition_joins;
 
 -- parameterized (prepared) query: a custom plan substitutes the params as
 -- constants, so pruning still applies and must not change the result.

--- a/src/test/regress/sql/multi_or_arm_pruning.sql
+++ b/src/test/regress/sql/multi_or_arm_pruning.sql
@@ -1,0 +1,182 @@
+--
+-- MULTI_OR_ARM_PRUNING
+--
+-- Tests citus.enable_or_clause_arm_pruning: for a multi-shard SELECT whose
+-- WHERE clause is a top-level OR where each arm constrains the distribution
+-- column, each shard's task query should keep only the arms that can match on
+-- that shard, instead of pushing the full N-arm OR to every shard.
+--
+
+CREATE SCHEMA or_arm_pruning;
+SET search_path TO or_arm_pruning;
+
+SET citus.next_shard_id TO 1630000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+
+CREATE TABLE dt (k int, v int);
+SELECT create_distributed_table('dt', 'k');
+CREATE INDEX dt_k_v ON dt (k, v);
+INSERT INTO dt SELECT k, v FROM generate_series(1, 8) k, generate_series(1, 50) v;
+ANALYZE dt;
+
+-- a colocated table for the join cases
+CREATE TABLE dt2 (k int, y int);
+SELECT create_distributed_table('dt2', 'k');
+INSERT INTO dt2 SELECT k, y FROM generate_series(1, 8) k, generate_series(1, 50) y;
+ANALYZE dt2;
+
+-- ===================================================================
+-- helpers (deterministic, port/shard-id independent)
+-- ===================================================================
+
+-- Returns the Filter lines of an EXPLAIN, with shard-id suffixes stripped and
+-- sorted, so the output does not depend on worker ports, shard ids, or task
+-- order. Forcing seq scans (see callers) keeps the plan node stable across PG
+-- versions, so only the per-shard WHERE clause (the thing this feature changes)
+-- shows up.
+CREATE OR REPLACE FUNCTION shard_filters(cmd text)
+RETURNS SETOF text LANGUAGE plpgsql AS $$
+DECLARE line text;
+BEGIN
+  FOR line IN EXECUTE cmd LOOP
+    IF position('Filter:' in line) > 0 THEN
+      RETURN NEXT trim(both ' ' from regexp_replace(line, '_[0-9]+', '', 'g'));
+    END IF;
+  END LOOP;
+  RETURN;
+END;
+$$;
+
+-- Runs a query with the optimization off and on and reports whether the result
+-- sets are identical (multiset equality). Independent of row order.
+CREATE OR REPLACE FUNCTION parity(q text)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE off_only bigint; on_only bigint;
+BEGIN
+  SET LOCAL citus.enable_or_clause_arm_pruning TO off;
+  EXECUTE 'CREATE TEMP TABLE _off AS ' || q;
+  SET LOCAL citus.enable_or_clause_arm_pruning TO on;
+  EXECUTE 'CREATE TEMP TABLE _on AS ' || q;
+  EXECUTE 'SELECT count(*) FROM (TABLE _off EXCEPT ALL TABLE _on) z' INTO off_only;
+  EXECUTE 'SELECT count(*) FROM (TABLE _on EXCEPT ALL TABLE _off) z' INTO on_only;
+  DROP TABLE _off, _on;
+  IF off_only = 0 AND on_only = 0 THEN
+    RETURN 'parity ok';
+  END IF;
+  RETURN format('MISMATCH off_only=%s on_only=%s', off_only, on_only);
+END;
+$$;
+
+-- ===================================================================
+-- GUC defaults to on
+-- ===================================================================
+SHOW citus.enable_or_clause_arm_pruning;
+
+-- ===================================================================
+-- Per-shard WHERE clause: before vs after.
+-- k = 1, 2, 3, 6 each hash to a different one of the 4 shards.
+-- ===================================================================
+SET enable_indexscan TO off;
+SET enable_bitmapscan TO off;
+SET citus.explain_all_tasks TO on;
+
+-- BEFORE: every shard carries the full 4-arm OR
+SET citus.enable_or_clause_arm_pruning TO off;
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt
+  WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)
+$$) ORDER BY 1;
+
+-- AFTER: each shard keeps only the single arm whose k lives on that shard
+SET citus.enable_or_clause_arm_pruning TO on;
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt
+  WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)
+$$) ORDER BY 1;
+
+-- Range/inequality on the dist column does NOT prune on a hash-distributed
+-- table (hashing is not order preserving), so a range arm is kept on every
+-- shard. An equality arm sharing the OR is still pruned. The optimization is
+-- on for both queries below.
+
+-- pure range OR: nothing is pruned, every shard keeps the full OR
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k <= 2 AND v=7) OR (k >= 7 AND v=7)
+$$) ORDER BY 1;
+
+-- mixed range + equality: the range arm is kept everywhere, while the equality
+-- arm (k=5) is dropped on the shards that do not own k=5
+SELECT * FROM shard_filters($$
+  EXPLAIN (COSTS OFF)
+  SELECT * FROM dt WHERE (k <= 4 AND v=7) OR (k=5 AND v=7)
+$$) ORDER BY 1;
+
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
+-- ===================================================================
+-- Correctness: results are identical with the optimization off vs on
+-- ===================================================================
+
+-- basic: every arm pins the dist column
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=2 AND v=7) OR (k=3 AND v=7) OR (k=6 AND v=7)$$);
+
+-- two arms collide on the same shard (both must be kept on that shard)
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (k=5 AND v=7)$$);
+
+-- an arm with NO constraint on the dist column must be kept on all shards
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND v=7) OR (v=7)$$);
+
+-- mixed: top-level AND of a prunable OR with another predicate
+SELECT parity($$SELECT * FROM dt WHERE v < 10 AND ((k=1 AND v=7) OR (k=2 AND v=7))$$);
+
+-- nested OR inside an arm
+SELECT parity($$SELECT * FROM dt WHERE (k=1 AND (v=7 OR v=8)) OR (k=2 AND v=7)$$);
+
+-- non-equality (range) and IN constraints on the dist column
+SELECT parity($$SELECT * FROM dt WHERE (k < 3 AND v=7) OR (k=5 AND v=7)$$);
+SELECT parity($$SELECT * FROM dt WHERE (k IN (1,2) AND v=7) OR (k=5 AND v=7)$$);
+-- pure range OR (no arm prunes on a hash table): exact no-op
+SELECT parity($$SELECT * FROM dt WHERE (k <= 2 AND v=7) OR (k >= 7 AND v=7)$$);
+
+-- colocated join, arms referencing both tables' dist keys
+SELECT parity($$SELECT dt.v, dt2.y FROM dt JOIN dt2 USING (k) WHERE (dt.k=1 AND dt2.y=7) OR (dt.k=2 AND dt2.y=7)$$);
+
+-- colocated join, cross-table arms
+SELECT parity($$SELECT dt.v FROM dt JOIN dt2 USING (k) WHERE (dt.k=1 AND dt2.y=7) OR (dt2.k=2 AND dt.v=7)$$);
+
+-- queries with nothing to prune are exact no-ops
+SELECT parity($$SELECT * FROM dt WHERE v=7$$);
+SELECT parity($$SELECT * FROM dt WHERE v=7 OR v=8$$);
+SELECT parity($$SELECT * FROM dt WHERE (v=7 AND k=1) OR (v=8)$$);
+
+-- join with a reference table: the reference fragment is not hash-distributed,
+-- so it is skipped and all arms are kept; results must be unchanged.
+CREATE TABLE ref (k int, w int);
+SELECT create_reference_table('ref');
+INSERT INTO ref SELECT g, g FROM generate_series(1, 8) g;
+ANALYZE ref;
+SELECT parity($$SELECT dt.v FROM dt JOIN ref ON dt.k = ref.k WHERE (dt.k=1 AND ref.w=1) OR (dt.k=2 AND ref.w=2)$$);
+
+-- parameterized (prepared) query: a custom plan substitutes the params as
+-- constants, so pruning still applies and must not change the result.
+SET citus.enable_or_clause_arm_pruning TO off;
+PREPARE or_prep(int, int) AS
+  SELECT k, v FROM dt WHERE (k = $1 AND v = 7) OR (k = $2 AND v = 7);
+CREATE TEMP TABLE prep_off AS EXECUTE or_prep(1, 2);
+SET citus.enable_or_clause_arm_pruning TO on;
+CREATE TEMP TABLE prep_on AS EXECUTE or_prep(1, 2);
+SELECT count(*) AS prep_off_only FROM (TABLE prep_off EXCEPT ALL TABLE prep_on) z;
+SELECT count(*) AS prep_on_only FROM (TABLE prep_on EXCEPT ALL TABLE prep_off) z;
+DROP TABLE prep_off, prep_on;
+DEALLOCATE or_prep;
+
+-- ===================================================================
+-- cleanup
+-- ===================================================================
+SET client_min_messages TO WARNING;
+DROP SCHEMA or_arm_pruning CASCADE;


### PR DESCRIPTION
DESCRIPTION: Adds citus.enable_or_clause_arm_pruning to drop unreachable OR arms per shard

## Summary
Adds an optimization, GUC `citus.enable_or_clause_arm_pruning`
(**default on**), for multi-shard SELECTs whose `WHERE` clause is a top-level
`OR` where each arm constrains the distribution column, e.g.:

```sql
SELECT * FROM t WHERE (k = 1 AND v = 7) OR (k = 2 AND v = 7);
```

Today Citus pushes the **full N-arm OR to every shard**, so each shard runs an
N-way bitmap OR even though only the arm whose key hashes to that shard can
match. With this enabled, each shard's task query keeps only the arms that can
match on that shard, so the worker runs a single precise index scan.

## Before / After (2 shards, index on `(k, v)`)

Before (`citus.enable_or_clause_arm_pruning = off`, stock behavior):
```
->  Task (shard owning k=1)
      ->  Bitmap Heap Scan
            Recheck Cond: ((k=1 AND v=7) OR (k=2 AND v=7))
            ->  BitmapOr
                  ->  Bitmap Index Scan  Index Cond: (k=1 AND v=7)
                  ->  Bitmap Index Scan  Index Cond: (k=2 AND v=7)   <- dead on this shard
->  Task (shard owning k=2)   ... same full 2-way BitmapOr ...
```

After (`= on`):
```
->  Task (shard owning k=1):  Index Only Scan  Index Cond: (k=1 AND v=7)
->  Task (shard owning k=2):  Index Only Scan  Index Cond: (k=2 AND v=7)
```

## How it works
In `SqlTaskList()` (the logical/physical-planner path used by multi-shard
SELECTs — these are not router queries), while generating each per-shard task
query, drop the arms of top-level OR expressions that cannot match on that
task's shard.

- `PruneUnreachableOrArms()` recurses through top-level `List`/`AND`; for an
  `OR` it keeps only the arms whose pruned shard set (from the existing
  `PruneShards()`) contains the task's shard. An arm with no constraint on the
  distribution column prunes to all shards and is therefore always kept, so the
  rewrite is a guaranteed semantic no-op.
- Reachability depends only on `(relation, rangeTableId, arm)`, never on the
  task, so `ReachableShardListForArm()` caches results in a job-wide hash table
  (`HTAB`) keyed on `(relationId, rangeTableId, arm)`: `PruneShards()` runs once
  per distinct arm instead of once per (shard x arm). The hash uses the arm's
  serialized form and the comparator uses node `equal()`, so structurally
  identical arms from different per-task query copies share one entry and hash
  collisions never produce a wrong hit.

## Safety
- **On by default**; set `citus.enable_or_clause_arm_pruning = off` to restore
  the previous behavior byte-for-byte (the entire new code path is inside
  `if (EnableOrClauseArmPruning)`). The full `check-multi` schedule (193 tests)
  passes with the default on; the only expected-output change is additive
  `DEBUG` lines in `multi_hash_pruning` (the per-arm `PruneShards()` now runs
  during task generation) — no result/row changes.
- Correctness invariant: an arm is dropped on shard S only when it provably
  matches no row on S. Two independent code reviews found no correctness issues;
  joins, self-joins, params, NULLs, reference-table joins, ranges/IN, nested
  and mixed boolean, and value collisions were all validated.

## Tests
`src/test/regress/sql/multi_or_arm_pruning.sql` (wired into
`multi_1_schedule`):
- 5 before/after per-shard `Filter` comparisons (`shard_filters()` helper),
  including a hash-collision case that asserts the `>=2`-equality-arms-kept
  shape and is self-checking (if `k=1`/`k=5` ever stop colliding the grouped
  filter splits and the test fails rather than silently passing), plus pure-range
  and mixed range+equality shapes.
- 18 result-parity checks (off vs on, multiset equality via `EXCEPT ALL`):
  basic, shard collision, no-dist-constraint arm, mixed AND/OR, nested OR,
  range, `IN`, colocated join, cross-table-arm join, reference-table join,
  null-distribution-key (single-shard) join, repartition (non-colocated) join,
  prepared/parameterized query, no-WHERE, top-level `NOT`, and no-op cases.
- The `NULL`-key join exercises the `!HasDistributionKeyCacheEntry` eligibility
  guard; the repartition join exercises the `fragmentType != CITUS_RTE_RELATION`
  guard.
- Deterministic and environment-independent (helpers normalize shard ids; no
  ports/task-order dependence). The `Filter` outputs were verified against an
  independent ground-truth query formulation, not just off-vs-on parity. Passes
  the real pg_regress harness.

## Known considerations / follow-ups
- The "BEFORE" EXPLAIN line reflects the worker planner's boolean factoring of
  the OR, which is mildly PG-version-sensitive; may need a variant expected file
  for PG17/18. The "AFTER" lines (what the feature controls) are robust.
- CHANGELOG intentionally not touched (Citus generates it at release time).