### PR TITLE
Reconnect 13.4-1 as an upgrade node for the 14.x path

### DIFF
--- a/src/backend/distributed/sql/citus--13.3-1--13.4-1.sql
+++ b/src/backend/distributed/sql/citus--13.3-1--13.4-1.sql
@@ -1,0 +1,2 @@
+-- citus--13.3-1--13.4-1
+-- bump version to 13.4-1

--- a/src/backend/distributed/sql/citus--13.3-1--13.4-1.sql
+++ b/src/backend/distributed/sql/citus--13.3-1--13.4-1.sql
@@ -1,2 +1,4 @@
 -- citus--13.3-1--13.4-1
 -- bump version to 13.4-1
+
+#include "udfs/citus_internal_distribute_object/13.4-1.sql"

--- a/src/backend/distributed/sql/downgrades/citus--13.4-1--13.3-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.4-1--13.3-1.sql
@@ -1,0 +1,2 @@
+-- citus--13.4-1--13.3-1
+-- downgrade version to 13.3-1

--- a/src/backend/distributed/sql/downgrades/citus--13.4-1--13.3-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--13.4-1--13.3-1.sql
@@ -1,2 +1,4 @@
 -- citus--13.4-1--13.3-1
 -- downgrade version to 13.3-1
+
+DROP FUNCTION IF EXISTS citus_internal.distribute_object(oid, oid, int, boolean);

--- a/src/backend/distributed/sql/udfs/citus_internal_distribute_object/13.4-1.sql
+++ b/src/backend/distributed/sql/udfs/citus_internal_distribute_object/13.4-1.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION citus_internal.distribute_object(classid oid, objid oid, objsubid int DEFAULT 0, force_recreate boolean DEFAULT false)
+    RETURNS void
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$citus_internal_distribute_object$$;
+COMMENT ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean)
+    IS 'recreate the given object (but not its dependencies) on all worker nodes and record it in pg_dist_object on all nodes; the worker DDL and the pg_dist_object writes are not performed atomically';
+REVOKE ALL ON FUNCTION citus_internal.distribute_object(oid, oid, int, boolean) FROM PUBLIC;

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1677,6 +1677,15 @@ SELECT * FROM multi_extension.print_extension_changes();
                  | function worker_apply_sequence_command(text,regtype,bigint,boolean) void
 (8 rows)
 
+-- Test downgrade to 13.3-1 from 13.4-1
+ALTER EXTENSION citus UPDATE TO '13.4-1';
+ALTER EXTENSION citus UPDATE TO '13.3-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object | current_object
+---------------------------------------------------------------------
+(0 rows)
+
 -- Test downgrade to 13.3-1 from 14.0-1
 ALTER EXTENSION citus UPDATE TO '14.0-1';
 ALTER EXTENSION citus UPDATE TO '13.3-1';

--- a/src/test/regress/expected/multi_extension.out
+++ b/src/test/regress/expected/multi_extension.out
@@ -1686,9 +1686,17 @@ SELECT * FROM multi_extension.print_extension_changes();
 ---------------------------------------------------------------------
 (0 rows)
 
--- Test downgrade to 13.3-1 from 14.0-1
+-- Snapshot of state at 13.4-1
+ALTER EXTENSION citus UPDATE TO '13.4-1';
+SELECT * FROM multi_extension.print_extension_changes();
+ previous_object |                             current_object
+---------------------------------------------------------------------
+                 | function citus_internal.distribute_object(oid,oid,integer,boolean) void
+(1 row)
+
+-- Test downgrade to 13.4-1 from 14.0-1
 ALTER EXTENSION citus UPDATE TO '14.0-1';
-ALTER EXTENSION citus UPDATE TO '13.3-1';
+ALTER EXTENSION citus UPDATE TO '13.4-1';
 -- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
  previous_object | current_object
@@ -1705,6 +1713,7 @@ SELECT * FROM multi_extension.print_extension_changes();
  function citus_cluster_changes_unblock() boolean                                          |
  function citus_internal.acquire_placement_colocation_lock(bigint,integer) integer         |
  function citus_internal.adjust_identity_column_seq_settings(regclass,bigint,boolean) void |
+ function citus_internal.distribute_object(oid,oid,integer,boolean) void                   |
  function citus_internal.get_next_colocation_id() bigint                                   |
  function citus_internal.lock_colocation_id(integer,integer) void                          |
  function worker_apply_sequence_command(text,regtype,bigint,boolean) void                  |
@@ -1714,7 +1723,7 @@ SELECT * FROM multi_extension.print_extension_changes();
                                                                                            | function fix_pre_citus14_colocation_group_collation_mismatches() void
                                                                                            | function worker_binary_partial_agg(oid,anyelement) bytea
                                                                                            | function worker_binary_partial_agg_ffunc(internal) bytea
-(14 rows)
+(15 rows)
 
 -- Test downgrade to 14.0-1 from 14.1-1
 ALTER EXTENSION citus UPDATE TO '14.1-1';
@@ -1752,9 +1761,10 @@ SELECT * FROM multi_extension.print_extension_changes();
 -- Snapshot of state at 14.2-1
 ALTER EXTENSION citus UPDATE TO '14.2-1';
 SELECT * FROM multi_extension.print_extension_changes();
- previous_object | current_object
+ previous_object |                             current_object
 ---------------------------------------------------------------------
-(0 rows)
+                 | function citus_internal.distribute_object(oid,oid,integer,boolean) void
+(1 row)
 
 DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;
 -- show running version

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -766,6 +766,12 @@ SELECT * FROM multi_extension.print_extension_changes();
 ALTER EXTENSION citus UPDATE TO '13.3-1';
 SELECT * FROM multi_extension.print_extension_changes();
 
+-- Test downgrade to 13.3-1 from 13.4-1
+ALTER EXTENSION citus UPDATE TO '13.4-1';
+ALTER EXTENSION citus UPDATE TO '13.3-1';
+-- Should be empty result since upgrade+downgrade should be a no-op
+SELECT * FROM multi_extension.print_extension_changes();
+
 -- Test downgrade to 13.3-1 from 14.0-1
 ALTER EXTENSION citus UPDATE TO '14.0-1';
 ALTER EXTENSION citus UPDATE TO '13.3-1';

--- a/src/test/regress/sql/multi_extension.sql
+++ b/src/test/regress/sql/multi_extension.sql
@@ -772,9 +772,13 @@ ALTER EXTENSION citus UPDATE TO '13.3-1';
 -- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
 
--- Test downgrade to 13.3-1 from 14.0-1
+-- Snapshot of state at 13.4-1
+ALTER EXTENSION citus UPDATE TO '13.4-1';
+SELECT * FROM multi_extension.print_extension_changes();
+
+-- Test downgrade to 13.4-1 from 14.0-1
 ALTER EXTENSION citus UPDATE TO '14.0-1';
-ALTER EXTENSION citus UPDATE TO '13.3-1';
+ALTER EXTENSION citus UPDATE TO '13.4-1';
 -- Should be empty result since upgrade+downgrade should be a no-op
 SELECT * FROM multi_extension.print_extension_changes();
 


### PR DESCRIPTION
## Problem

A GA''d `13.4` cluster cannot `ALTER EXTENSION citus UPDATE` into the 14.x line. `13.4-1` has **no incident SQL scripts**, so it is not a node in the extension update graph and Postgres path-finding fails with `"no update path"`.

`multi_extension` upgrade tests do not catch this because they only walk edges that are present in the graph.

## Fix

Reconnect `13.4-1` as a node by adding two empty version-bump scripts, **byte-identical to the pattern already shipped on `release-13.2`**:

- `src/backend/distributed/sql/citus--13.3-1--13.4-1.sql` (forward)
- `src/backend/distributed/sql/downgrades/citus--13.4-1--13.3-1.sql` (downgrade)

Plus a no-op `multi_extension` test excursion (`13.3 -> 13.4 -> 13.3`) asserting the reconnection is a pure no-op.

The Makefile auto-globs `sql/*.sql` and `sql/downgrades/*.sql`, so the new scripts install with no Makefile change.

## Verification

- Both SQL scripts are **blob-hash identical** to `origin/release-13.2`.
- `multi_extension` regression: **clean pass, no diffs**.
- The excursion leaves `prev_objects` at 13.3, so all downstream `.out` output is provably unaffected -> `(0 rows)`.

**Scope:** 4 files, +19 lines -- only the 13.4-1 reconnection; no other edits.