### PR TITLE
Re-range clone sequences to new group id during promotion (Backport PR#8638)

### DIFF
--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -116,6 +116,7 @@ static bool SyncNodeMetadataSnapshotToNode(WorkerNode *workerNode, bool raiseOnE
 static void DropMetadataSnapshotOnNode(WorkerNode *workerNode);
 static List * IdentitySequenceDependencyCommandListLegacy(Oid targetRelationId);
 static void FetchSequenceState(Oid sequenceId, int64 *lastValue, bool *isCalled);
+static void AppendSequenceRangeAdjustCommand(Oid sequenceId, List **commandList);
 static char * CreateSequenceDependencyCommand(Oid relationId, Oid sequenceId,
 											  char *columnName);
 static GrantStmt * GenerateGrantStmtForRights(ObjectType objectType,
@@ -2081,23 +2082,7 @@ IdentitySequenceDependencyCommandList(Oid targetRelationId)
 			missingOk
 			);
 
-		char *qualifiedSequenceName = generate_qualified_relation_name(sequenceId);
-
-		/* prevent concurrent updates to the sequence until the end of the transaction */
-		LockRelationOid(sequenceId, RowExclusiveLock);
-
-		int64 lastValue = 0;
-		bool isCalled = false;
-		FetchSequenceState(sequenceId, &lastValue, &isCalled);
-
-		StringInfo stringInfo = makeStringInfo();
-		appendStringInfo(stringInfo,
-						 WORKER_ADJUST_IDENTITY_COLUMN_SEQ_SETTINGS,
-						 quote_literal_cstr(qualifiedSequenceName),
-						 lastValue, isCalled ? "true" : "false");
-
-		commandList = lappend(commandList,
-							  makeTableDDLCommandString(stringInfo->data));
+		AppendSequenceRangeAdjustCommand(sequenceId, &commandList);
 	}
 
 	relation_close(relation, NoLock);
@@ -2149,6 +2134,72 @@ IdentitySequenceDependencyCommandListLegacy(Oid targetRelationId)
 	}
 
 	return commandList;
+}
+
+
+/*
+ * SequenceRangeAdjustCommandList generates a list of commands to
+ * execute WORKER_ADJUST_IDENTITY_COLUMN_SEQ_SETTINGS for each nextval/serial
+ * sequence that the given relation depends on, so that those sequences' min/max
+ * values are re-ranged to the target node's local group-id window (producing
+ * globally-unique values across groups).
+ *
+ * This mirrors IdentitySequenceDependencyCommandList but covers sequence-backed
+ * default columns (serial, bigint DEFAULT nextval(...)) rather than identity
+ * columns. The worker side of the reused UDF runs AlterSequenceMinMax(), the
+ * same routine the classical activation path invokes via
+ * AdjustDependentSeqRangesOnLocalWorker(). It is used by the clone-promotion
+ * path to re-range the promoted clone's sequences to its newly-allocated group
+ * id, which the physical-replica clone would otherwise inherit from its source
+ * primary.
+ */
+List *
+SequenceRangeAdjustCommandList(Oid relationId)
+{
+	List *commandList = NIL;
+
+	List *seqInfoList = NIL;
+	GetDependentSequencesWithRelation(relationId, &seqInfoList, 0, DEPENDENCY_AUTO);
+
+	SequenceInfo *seqInfo = NULL;
+	foreach_declared_ptr(seqInfo, seqInfoList)
+	{
+		AppendSequenceRangeAdjustCommand(seqInfo->sequenceOid, &commandList);
+	}
+
+	return commandList;
+}
+
+
+/*
+ * AppendSequenceRangeAdjustCommand appends a WORKER_ADJUST_IDENTITY_COLUMN_SEQ_SETTINGS
+ * command for the given sequence to commandList. The command re-ranges the
+ * sequence's min/max values to the target node's local group-id window on
+ * workers (and sets last_value/is_called on the coordinator).
+ *
+ * It is shared by IdentitySequenceDependencyCommandList and
+ * SequenceRangeAdjustCommandList so the two stay in sync.
+ */
+static void
+AppendSequenceRangeAdjustCommand(Oid sequenceId, List **commandList)
+{
+	char *qualifiedSequenceName = generate_qualified_relation_name(sequenceId);
+
+	/* prevent concurrent updates to the sequence until the end of the transaction */
+	LockRelationOid(sequenceId, RowExclusiveLock);
+
+	int64 lastValue = 0;
+	bool isCalled = false;
+	FetchSequenceState(sequenceId, &lastValue, &isCalled);
+
+	StringInfo stringInfo = makeStringInfo();
+	appendStringInfo(stringInfo,
+					 WORKER_ADJUST_IDENTITY_COLUMN_SEQ_SETTINGS,
+					 quote_literal_cstr(qualifiedSequenceName),
+					 lastValue, isCalled ? "true" : "false");
+
+	*commandList = lappend(*commandList,
+						   makeTableDDLCommandString(stringInfo->data));
 }
 
 

--- a/src/backend/distributed/operations/node_promotion.c
+++ b/src/backend/distributed/operations/node_promotion.c
@@ -493,6 +493,23 @@ AdjustCloneSequenceRangesForNewGroup(WorkerNode *cloneNode)
 		commandList = lappend(commandList, GetTableDDLCommand(ddlCommand));
 	}
 
+	int reRangedSequenceCount = list_length(commandList);
+
+	/*
+	 * Disable DDL propagation on the clone before running these commands. The
+	 * identity-sequence re-range command uses the legacy
+	 * worker_adjust_identity_column_seq_ranges() UDF (returned by
+	 * IdentitySequenceDependencyCommandList() when called from the coordinator),
+	 * which runs an ALTER SEQUENCE without disabling DDL propagation itself.
+	 * Since the clone's sequences are already marked distributed by this point
+	 * (this runs after SyncNodeMetadataToNodes()), that ALTER would otherwise
+	 * trip the "Altering a distributed sequence is currently not supported"
+	 * guard in PreprocessAlterSequenceStmt. This mirrors how the classical
+	 * metadata-sync path (CreateTableMetadataOnRemoteNodes) disables propagation
+	 * on remote nodes before running such commands.
+	 */
+	commandList = lcons(pstrdup(DISABLE_DDL_PROPAGATION), commandList);
+
 	/*
 	 * Re-fetch the clone node so its hasMetadata/metadataSynced flags reflect
 	 * the post-activation, post-sync catalog state. The cloneNode passed in was
@@ -516,7 +533,7 @@ AdjustCloneSequenceRangesForNewGroup(WorkerNode *cloneNode)
 
 	ereport(NOTICE, (errmsg(
 						 "re-ranged %d sequence(s) on promoted clone %s:%d (ID %d) for new group %d",
-						 list_length(commandList), freshCloneNode->workerName,
+						 reRangedSequenceCount, freshCloneNode->workerName,
 						 freshCloneNode->workerPort, freshCloneNode->nodeId,
 						 freshCloneNode->groupId)));
 }

--- a/src/backend/distributed/operations/node_promotion.c
+++ b/src/backend/distributed/operations/node_promotion.c
@@ -5,17 +5,20 @@
 
 #include "distributed/argutils.h"
 #include "distributed/clonenode_utils.h"
+#include "distributed/coordinator_protocol.h"
 #include "distributed/listutils.h"
 #include "distributed/metadata_cache.h"
 #include "distributed/metadata_sync.h"
 #include "distributed/remote_commands.h"
 #include "distributed/shard_rebalancer.h"
+#include "distributed/worker_transaction.h"
 
 
 static void BlockAllWritesToWorkerNode(WorkerNode *workerNode);
 static bool GetNodeIsInRecoveryStatus(WorkerNode *workerNode);
 static void PromoteCloneNode(WorkerNode *cloneWorkerNode);
 static void EnsureSingleNodePromotion(WorkerNode *primaryNode);
+static void AdjustCloneSequenceRangesForNewGroup(WorkerNode *cloneNode);
 
 PG_FUNCTION_INFO_V1(citus_promote_clone_and_rebalance);
 
@@ -194,6 +197,16 @@ citus_promote_clone_and_rebalance(PG_FUNCTION_ARGS)
 	 * since the rebalancing algorithm depends on the latest metadata.
 	 */
 	SyncNodeMetadataToNodes();
+
+	/*
+	 * Re-range the promoted clone's distributed-table sequences to its new
+	 * group-id window. The clone is a physical replica, so its sequence objects
+	 * still carry the source primary's (groupId << 48) range; the classical
+	 * activation path does the equivalent re-ranging per group id. This must run
+	 * after SyncNodeMetadataToNodes() so the clone's local group id is already
+	 * corrected and visible over the reused metadata connection.
+	 */
+	AdjustCloneSequenceRangesForNewGroup(cloneNode);
 
 	/* Step 5: Split Shards Between Primary and Clone */
 	SplitShardsBetweenPrimaryAndClone(primaryNode, cloneNode, PG_GETARG_NAME_OR_NULL(1))
@@ -419,4 +432,91 @@ EnsureSingleNodePromotion(WorkerNode *primaryNode)
 		AcquirePlacementColocationLock(distributedTableId, ExclusiveLock, "promote clone")
 		;
 	}
+}
+
+
+/*
+ * AdjustCloneSequenceRangesForNewGroup re-ranges the promoted clone's
+ * sequence-backed columns for the same table surface that classical
+ * add/activate-node flow syncs to metadata workers (i.e. tables where
+ * ShouldSyncTableMetadata(relationId) is true).
+ *
+ * A clone is a physical streaming replica of its source primary, so its
+ * sequence objects are byte-for-byte copies that still carve out the source
+ * primary's (groupId << 48) value window. The classical activation path
+ * re-ranges sequences per group id (via AlterSequenceMinMax) so each group emits
+ * globally-unique values; the clone path must do the same once its group id is
+ * corrected.
+ *
+ * The command list is built on the coordinator (reusing the existing per-table
+ * sequence command builders) and sent to the clone over the metadata connection
+ * via SendMetadataCommandListToWorkerListInCoordinatedTransaction. That path
+ * reuses the same connection SyncNodeMetadataToNodes() used to update
+ * pg_dist_local_group, so the corrected local group id is visible when
+ * AlterSequenceMinMax() runs on the clone. Therefore this MUST be called after
+ * SyncNodeMetadataToNodes().
+ */
+static void
+AdjustCloneSequenceRangesForNewGroup(WorkerNode *cloneNode)
+{
+	List *ddlCommandList = NIL;
+
+	List *citusTableIdList = AllCitusTableIds();
+	Oid relationId = InvalidOid;
+	foreach_declared_oid(relationId, citusTableIdList)
+	{
+		if (!ShouldSyncTableMetadata(relationId))
+		{
+			continue;
+		}
+
+		ddlCommandList = list_concat(ddlCommandList,
+									 SequenceRangeAdjustCommandList(relationId));
+		ddlCommandList = list_concat(ddlCommandList,
+									 IdentitySequenceDependencyCommandList(relationId));
+	}
+
+	if (ddlCommandList == NIL)
+	{
+		/* no sequence-backed Citus-table columns to re-range */
+		return;
+	}
+
+	/*
+	 * SendMetadataCommandListToWorkerListInCoordinatedTransaction expects plain
+	 * command strings, so unwrap each TableDDLCommand.
+	 */
+	List *commandList = NIL;
+	TableDDLCommand *ddlCommand = NULL;
+	foreach_declared_ptr(ddlCommand, ddlCommandList)
+	{
+		commandList = lappend(commandList, GetTableDDLCommand(ddlCommand));
+	}
+
+	/*
+	 * Re-fetch the clone node so its hasMetadata/metadataSynced flags reflect
+	 * the post-activation, post-sync catalog state. The cloneNode passed in was
+	 * loaded at the start of promotion (before ActivateCloneNodeAsPrimary and
+	 * SyncNodeMetadataToNodes), so its in-memory metadata flags are still those
+	 * of an inactive clone and would trip the metadata-node sanity checks in the
+	 * send path.
+	 */
+	WorkerNode *freshCloneNode = FindNodeAnyClusterByNodeId(cloneNode->nodeId);
+	if (freshCloneNode == NULL)
+	{
+		ereport(ERROR, (errmsg("could not find promoted clone node with ID %d "
+							   "while re-ranging its sequences",
+							   cloneNode->nodeId)));
+	}
+
+	SendMetadataCommandListToWorkerListInCoordinatedTransaction(
+		list_make1(freshCloneNode),
+		CurrentUserName(),
+		commandList);
+
+	ereport(NOTICE, (errmsg(
+						 "re-ranged %d sequence(s) on promoted clone %s:%d (ID %d) for new group %d",
+						 list_length(commandList), freshCloneNode->workerName,
+						 freshCloneNode->workerPort, freshCloneNode->nodeId,
+						 freshCloneNode->groupId)));
 }

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -127,6 +127,7 @@ extern void SignalMetadataSyncDaemon(Oid database, int sig);
 extern bool ShouldInitiateMetadataSync(bool *lockFailure);
 extern List * SequenceDependencyCommandList(Oid relationId);
 extern List * IdentitySequenceDependencyCommandList(Oid targetRelationId);
+extern List * SequenceRangeAdjustCommandList(Oid relationId);
 
 extern List * DDLCommandsForSequence(Oid sequenceOid, char *ownerName);
 extern List * GetSequencesFromAttrDef(Oid attrdefOid);

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -120,6 +120,9 @@ DEPS = {
     "multi_add_node_from_backup_sync_replica": TestDeps(
         None, repeatable=False, worker_count=5
     ),
+    "multi_add_node_from_backup_sequences": TestDeps(
+        None, ["multi_add_node_from_backup_negative"], worker_count=5, repeatable=False
+    ),
     "single_node": TestDeps(None, ["multi_test_helpers"]),
     "single_node_truncate": TestDeps(None),
     "multi_explain": TestDeps(

--- a/src/test/regress/expected/multi_add_node_from_backup.out
+++ b/src/test/regress/expected/multi_add_node_from_backup.out
@@ -243,6 +243,7 @@ NOTICE:  Clone localhost:xxxxx is now caught up with primary localhost:xxxxx.
 NOTICE:  Attempting to promote clone localhost:xxxxx via pg_promote().
 NOTICE:  Clone node localhost:xxxxx (ID 3) has been successfully promoted.
 NOTICE:  Updating metadata for promoted clone localhost:xxxxx (ID 3)
+NOTICE:  re-ranged 6 sequence(s) on promoted clone localhost:xxxxx (ID 3) for new group 3
 NOTICE:  adjusting shard placements for primary localhost:xxxxx and clone localhost:xxxxx
 NOTICE:  processing 4 shards for primary node GroupID 1
 LOG:  inserting DELETE shard record for shard public.table1_colg2_102020 from clone node GroupID 3

--- a/src/test/regress/expected/multi_add_node_from_backup_negative.out
+++ b/src/test/regress/expected/multi_add_node_from_backup_negative.out
@@ -119,6 +119,7 @@ NOTICE:  Clone localhost:xxxxx is now caught up with primary localhost:xxxxx.
 NOTICE:  Attempting to promote clone localhost:xxxxx via pg_promote().
 NOTICE:  Clone node localhost:xxxxx (ID 4) has been successfully promoted.
 NOTICE:  Updating metadata for promoted clone localhost:xxxxx (ID 4)
+NOTICE:  re-ranged 6 sequence(s) on promoted clone localhost:xxxxx (ID 4) for new group 4
 ERROR:  could not find rebalance strategy with name invalid_strategy
 SELECT * from pg_dist_node ORDER by nodeid;
  nodeid | groupid | nodename  | nodeport | noderack | hasmetadata | isactive |  noderole   | nodecluster | metadatasynced | shouldhaveshards | nodeisclone | nodeprimarynodeid
@@ -228,6 +229,7 @@ NOTICE:  Clone localhost:xxxxx is now caught up with primary localhost:xxxxx.
 NOTICE:  Attempting to promote clone localhost:xxxxx via pg_promote().
 NOTICE:  Clone node localhost:xxxxx (ID 6) has been successfully promoted.
 NOTICE:  Updating metadata for promoted clone localhost:xxxxx (ID 6)
+NOTICE:  re-ranged 6 sequence(s) on promoted clone localhost:xxxxx (ID 6) for new group 6
 NOTICE:  adjusting shard placements for primary localhost:xxxxx and clone localhost:xxxxx
 NOTICE:  processing 13 shards for primary node GroupID 5
 LOG:  inserting DELETE shard record for shard public.backup_test2_102091 from clone node GroupID 6

--- a/src/test/regress/expected/multi_add_node_from_backup_sequences.out
+++ b/src/test/regress/expected/multi_add_node_from_backup_sequences.out
@@ -1,0 +1,330 @@
+--
+-- Test that promoting a clone re-ranges sequence-backed columns for the SAME
+-- table surface classical add/activate-node syncs to metadata workers, i.e.
+-- every table where ShouldSyncTableMetadata() is true: distributed tables,
+-- reference tables and Citus local tables.
+--
+-- Citus keeps bigint sequences globally unique by giving every node group a
+-- disjoint (groupId << 48) value window. A clone is a physical streaming
+-- replica, so its sequence objects start out carrying the SOURCE primary's
+-- window. After promotion the clone gets a brand-new group id, so its
+-- sequences must be re-ranged to the new window; otherwise the clone and its
+-- source primary emit values from the SAME window and collide.
+--
+-- CRITICAL: every table under test is created and seeded BEFORE the clone is
+-- promoted. That way the promotion-time re-range is the ONLY mechanism that can
+-- move the clone's sequence windows off the source primary's window. A table
+-- created AFTER promotion would be ranged by the normal creation path and would
+-- not exercise the promotion code at all.
+--
+-- Distributed / reference / Citus local tables: the sequence DEFAULT / IDENTITY
+-- value is evaluated on the node that runs the INSERT, so we generate values
+-- directly on the source primary and on the promoted clone (via MX worker
+-- connections) and compare their high-bit (>> 48) windows. Citus local tables
+-- keep their single shard on the coordinator but their shell table + sequences
+-- are synced to workers and support worker writes, so they follow the same
+-- per-group ranging rules (creating the coordinator metadata entry is required
+-- for them, hence citus_set_coordinator_host below).
+--
+-- Use a fresh worker/clone pair (worker_4 + follower_worker_4) that earlier
+-- tests in this schedule have not touched.
+SELECT 1 FROM master_add_node('localhost', :worker_4_port);
+ ?column?
+---------------------------------------------------------------------
+        1
+(1 row)
+
+-- Register the coordinator in the metadata so that Citus local tables can be
+-- created (their shell tables + sequences are then synced to workers, exactly
+-- like distributed / reference tables).
+SET client_min_messages TO WARNING;
+SELECT citus_set_coordinator_host('localhost', :master_port);
+ citus_set_coordinator_host
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEFAULT;
+-- A higher shard count guarantees the new worker (and, after promotion, its
+-- clone) own several shards, so the cluster is genuinely distributed.
+SET citus.shard_count TO 32;
+-- ---------------------------------------------------------------------------
+-- Create all three Citus table types BEFORE promotion, each exercising the
+-- three sequence-backed column kinds:
+--   * bigserial               (implicit OWNED-BY sequence)
+--   * bigint DEFAULT nextval  (explicit dependent sequence)
+--   * GENERATED AS IDENTITY   (identity sequence)
+-- ---------------------------------------------------------------------------
+-- Distributed table.
+CREATE SEQUENCE clone_seq_dist_manual AS bigint;
+CREATE TABLE clone_seq_dist (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_dist_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT create_distributed_table('clone_seq_dist', 'id', 'hash');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 60) g;
+-- Reference table.
+CREATE SEQUENCE clone_seq_ref_manual AS bigint;
+CREATE TABLE clone_seq_ref (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_ref_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT create_reference_table('clone_seq_ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+-- Citus local table.
+CREATE SEQUENCE clone_seq_local_manual AS bigint;
+CREATE TABLE clone_seq_local (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_local_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT citus_add_local_table_to_metadata('clone_seq_local');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+-- Quoted / mixed-case schema + sequence name coverage. The re-range command is
+-- built with generate_qualified_relation_name + quote_literal_cstr; the tables
+-- above all live in public with plain identifiers, so this case exercises the
+-- quoting/escaping path (which has historically been a source of deparse bugs).
+CREATE SCHEMA "Edge Schema";
+CREATE SEQUENCE "Edge Schema"."Weird Seq!" AS bigint;
+CREATE TABLE "Edge Schema"."Edge Tbl" (
+    id int,
+    nextval_col bigint DEFAULT nextval('"Edge Schema"."Weird Seq!"'),
+    payload text
+);
+SELECT create_distributed_table('"Edge Schema"."Edge Tbl"', 'id', 'hash');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+-- Register follower_worker_4 as a clone of worker_4, then promote it. The
+-- promotion path must re-range the clone's sequences (for all of the tables
+-- above) to its new group window.
+SET client_min_messages TO WARNING;
+SELECT citus_add_clone_node('localhost', :follower_worker_4_port, 'localhost', :worker_4_port) AS clone_node_id \gset
+SELECT citus_promote_clone_and_rebalance(:clone_node_id);
+ citus_promote_clone_and_rebalance
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEFAULT;
+-- ===========================================================================
+-- DISTRIBUTED table assertions
+-- ===========================================================================
+-- Generate values directly on the SOURCE PRIMARY (worker_4).
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'primary' FROM generate_series(1001, 1050) g;
+-- Generate values directly on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'clone' FROM generate_series(2001, 2050) g;
+\c - - - :master_port
+-- Uniqueness oracle: every generated value must be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS identity_unique
+FROM clone_seq_dist;
+ bigserial_unique | nextval_unique | identity_unique
+---------------------------------------------------------------------
+ t                | t              | t
+(1 row)
+
+-- Disjoint-window oracle: primary and clone values must fall in TWO buckets.
+SELECT
+    count(DISTINCT (bigserial_col >> 48)) AS bigserial_windows,
+    count(DISTINCT (nextval_col   >> 48)) AS nextval_windows,
+    count(DISTINCT (identity_col  >> 48)) AS identity_windows
+FROM clone_seq_dist
+WHERE payload IN ('primary', 'clone');
+ bigserial_windows | nextval_windows | identity_windows
+---------------------------------------------------------------------
+                 2 |               2 |                2
+(1 row)
+
+SELECT count(*) AS total_dist_rows FROM clone_seq_dist;
+ total_dist_rows
+---------------------------------------------------------------------
+             160
+(1 row)
+
+-- ===========================================================================
+-- REFERENCE table assertions
+-- ===========================================================================
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'ref_primary' FROM generate_series(3001, 3050) g;
+SELECT
+    max(bigserial_col >> 48) AS ref_primary_bigserial_window,
+    max(nextval_col   >> 48) AS ref_primary_nextval_window,
+    max(identity_col  >> 48) AS ref_primary_identity_window
+FROM clone_seq_ref
+WHERE payload = 'ref_primary' \gset
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'ref_clone' FROM generate_series(4001, 4050) g;
+SELECT
+    max(bigserial_col >> 48) AS ref_clone_bigserial_window,
+    max(nextval_col   >> 48) AS ref_clone_nextval_window,
+    max(identity_col  >> 48) AS ref_clone_identity_window
+FROM clone_seq_ref
+WHERE payload = 'ref_clone' \gset
+\c - - - :master_port
+-- The clone's window must differ from the source primary's for every kind.
+SELECT
+    :'ref_primary_bigserial_window'::bigint <> :'ref_clone_bigserial_window'::bigint AS ref_bigserial_windows_differ,
+    :'ref_primary_nextval_window'::bigint   <> :'ref_clone_nextval_window'::bigint   AS ref_nextval_windows_differ,
+    :'ref_primary_identity_window'::bigint  <> :'ref_clone_identity_window'::bigint  AS ref_identity_windows_differ;
+ ref_bigserial_windows_differ | ref_nextval_windows_differ | ref_identity_windows_differ
+---------------------------------------------------------------------
+ t                            | t                          | t
+(1 row)
+
+-- All generated values across the table must also be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS ref_bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS ref_nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS ref_identity_unique
+FROM clone_seq_ref;
+ ref_bigserial_unique | ref_nextval_unique | ref_identity_unique
+---------------------------------------------------------------------
+ t                    | t                  | t
+(1 row)
+
+-- ===========================================================================
+-- CITUS LOCAL table assertions
+-- ===========================================================================
+-- A Citus local table keeps its single shard on the coordinator, but its shell
+-- table and sequences are created on workers too and support writes from
+-- workers, so its sequences are re-ranged per group exactly like distributed /
+-- reference tables. The sequence DEFAULT / IDENTITY is evaluated on the node
+-- running the INSERT, so we generate values on the source primary and on the
+-- promoted clone and compare their windows.
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'local_primary' FROM generate_series(5001, 5050) g;
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'local_clone' FROM generate_series(6001, 6050) g;
+\c - - - :master_port
+-- The clone's window must differ from the source primary's for every kind.
+SELECT
+    (SELECT max(bigserial_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(bigserial_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_bigserial_windows_differ,
+    (SELECT max(nextval_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(nextval_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_nextval_windows_differ,
+    (SELECT max(identity_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(identity_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_identity_windows_differ;
+ local_bigserial_windows_differ | local_nextval_windows_differ | local_identity_windows_differ
+---------------------------------------------------------------------
+ t                              | t                            | t
+(1 row)
+
+-- All generated values across the table must also be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS local_bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS local_nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS local_identity_unique
+FROM clone_seq_local;
+ local_bigserial_unique | local_nextval_unique | local_identity_unique
+---------------------------------------------------------------------
+ t                      | t                    | t
+(1 row)
+
+-- ===========================================================================
+-- QUOTED / MIXED-CASE SCHEMA assertions
+-- ===========================================================================
+-- Same worker-vs-clone window check as the distributed section, but for a
+-- sequence whose qualified name needs quoting/escaping.
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'edge_primary' FROM generate_series(7001, 7050) g;
+SELECT max(nextval_col >> 48) AS edge_primary_window
+FROM "Edge Schema"."Edge Tbl"
+WHERE payload = 'edge_primary' \gset
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'edge_clone' FROM generate_series(8001, 8050) g;
+SELECT max(nextval_col >> 48) AS edge_clone_window
+FROM "Edge Schema"."Edge Tbl"
+WHERE payload = 'edge_clone' \gset
+\c - - - :master_port
+-- The clone's window must differ from the source primary's.
+SELECT :'edge_primary_window'::bigint <> :'edge_clone_window'::bigint AS edge_nextval_windows_differ;
+ edge_nextval_windows_differ
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- All generated values must be globally unique.
+SELECT count(*) = count(DISTINCT nextval_col) AS edge_nextval_unique
+FROM "Edge Schema"."Edge Tbl";
+ edge_nextval_unique
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- cleanup
+DROP TABLE clone_seq_dist;
+DROP TABLE clone_seq_ref;
+DROP TABLE clone_seq_local;
+DROP SEQUENCE clone_seq_dist_manual;
+DROP SEQUENCE clone_seq_ref_manual;
+DROP SEQUENCE clone_seq_local_manual;
+DROP SCHEMA "Edge Schema" CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to sequence "Edge Schema"."Weird Seq!"
+drop cascades to table "Edge Schema"."Edge Tbl"
+SET client_min_messages TO WARNING;
+SELECT citus_remove_node('localhost', :master_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEFAULT;
+SET citus.shard_count TO DEFAULT;

--- a/src/test/regress/multi_add_backup_node_schedule
+++ b/src/test/regress/multi_add_backup_node_schedule
@@ -1,2 +1,3 @@
 test: multi_add_node_from_backup
 test: multi_add_node_from_backup_negative
+test: multi_add_node_from_backup_sequences

--- a/src/test/regress/sql/multi_add_node_from_backup_sequences.sql
+++ b/src/test/regress/sql/multi_add_node_from_backup_sequences.sql
@@ -1,0 +1,273 @@
+--
+-- Test that promoting a clone re-ranges sequence-backed columns for the SAME
+-- table surface classical add/activate-node syncs to metadata workers, i.e.
+-- every table where ShouldSyncTableMetadata() is true: distributed tables,
+-- reference tables and Citus local tables.
+--
+-- Citus keeps bigint sequences globally unique by giving every node group a
+-- disjoint (groupId << 48) value window. A clone is a physical streaming
+-- replica, so its sequence objects start out carrying the SOURCE primary's
+-- window. After promotion the clone gets a brand-new group id, so its
+-- sequences must be re-ranged to the new window; otherwise the clone and its
+-- source primary emit values from the SAME window and collide.
+--
+-- CRITICAL: every table under test is created and seeded BEFORE the clone is
+-- promoted. That way the promotion-time re-range is the ONLY mechanism that can
+-- move the clone's sequence windows off the source primary's window. A table
+-- created AFTER promotion would be ranged by the normal creation path and would
+-- not exercise the promotion code at all.
+--
+-- Distributed / reference / Citus local tables: the sequence DEFAULT / IDENTITY
+-- value is evaluated on the node that runs the INSERT, so we generate values
+-- directly on the source primary and on the promoted clone (via MX worker
+-- connections) and compare their high-bit (>> 48) windows. Citus local tables
+-- keep their single shard on the coordinator but their shell table + sequences
+-- are synced to workers and support worker writes, so they follow the same
+-- per-group ranging rules (creating the coordinator metadata entry is required
+-- for them, hence citus_set_coordinator_host below).
+--
+
+-- Use a fresh worker/clone pair (worker_4 + follower_worker_4) that earlier
+-- tests in this schedule have not touched.
+SELECT 1 FROM master_add_node('localhost', :worker_4_port);
+
+-- Register the coordinator in the metadata so that Citus local tables can be
+-- created (their shell tables + sequences are then synced to workers, exactly
+-- like distributed / reference tables).
+SET client_min_messages TO WARNING;
+SELECT citus_set_coordinator_host('localhost', :master_port);
+SET client_min_messages TO DEFAULT;
+
+-- A higher shard count guarantees the new worker (and, after promotion, its
+-- clone) own several shards, so the cluster is genuinely distributed.
+SET citus.shard_count TO 32;
+
+-- ---------------------------------------------------------------------------
+-- Create all three Citus table types BEFORE promotion, each exercising the
+-- three sequence-backed column kinds:
+--   * bigserial               (implicit OWNED-BY sequence)
+--   * bigint DEFAULT nextval  (explicit dependent sequence)
+--   * GENERATED AS IDENTITY   (identity sequence)
+-- ---------------------------------------------------------------------------
+
+-- Distributed table.
+CREATE SEQUENCE clone_seq_dist_manual AS bigint;
+CREATE TABLE clone_seq_dist (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_dist_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT create_distributed_table('clone_seq_dist', 'id', 'hash');
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 60) g;
+
+-- Reference table.
+CREATE SEQUENCE clone_seq_ref_manual AS bigint;
+CREATE TABLE clone_seq_ref (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_ref_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT create_reference_table('clone_seq_ref');
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+
+-- Citus local table.
+CREATE SEQUENCE clone_seq_local_manual AS bigint;
+CREATE TABLE clone_seq_local (
+    id int,
+    bigserial_col bigserial,
+    nextval_col bigint DEFAULT nextval('clone_seq_local_manual'),
+    identity_col bigint GENERATED ALWAYS AS IDENTITY,
+    payload text
+);
+SELECT citus_add_local_table_to_metadata('clone_seq_local');
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+
+-- Quoted / mixed-case schema + sequence name coverage. The re-range command is
+-- built with generate_qualified_relation_name + quote_literal_cstr; the tables
+-- above all live in public with plain identifiers, so this case exercises the
+-- quoting/escaping path (which has historically been a source of deparse bugs).
+CREATE SCHEMA "Edge Schema";
+CREATE SEQUENCE "Edge Schema"."Weird Seq!" AS bigint;
+CREATE TABLE "Edge Schema"."Edge Tbl" (
+    id int,
+    nextval_col bigint DEFAULT nextval('"Edge Schema"."Weird Seq!"'),
+    payload text
+);
+SELECT create_distributed_table('"Edge Schema"."Edge Tbl"', 'id', 'hash');
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'seed' FROM generate_series(1, 20) g;
+
+-- Register follower_worker_4 as a clone of worker_4, then promote it. The
+-- promotion path must re-range the clone's sequences (for all of the tables
+-- above) to its new group window.
+SET client_min_messages TO WARNING;
+SELECT citus_add_clone_node('localhost', :follower_worker_4_port, 'localhost', :worker_4_port) AS clone_node_id \gset
+SELECT citus_promote_clone_and_rebalance(:clone_node_id);
+SET client_min_messages TO DEFAULT;
+
+-- ===========================================================================
+-- DISTRIBUTED table assertions
+-- ===========================================================================
+
+-- Generate values directly on the SOURCE PRIMARY (worker_4).
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'primary' FROM generate_series(1001, 1050) g;
+
+-- Generate values directly on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_dist (id, payload)
+    SELECT g, 'clone' FROM generate_series(2001, 2050) g;
+
+\c - - - :master_port
+-- Uniqueness oracle: every generated value must be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS identity_unique
+FROM clone_seq_dist;
+
+-- Disjoint-window oracle: primary and clone values must fall in TWO buckets.
+SELECT
+    count(DISTINCT (bigserial_col >> 48)) AS bigserial_windows,
+    count(DISTINCT (nextval_col   >> 48)) AS nextval_windows,
+    count(DISTINCT (identity_col  >> 48)) AS identity_windows
+FROM clone_seq_dist
+WHERE payload IN ('primary', 'clone');
+
+SELECT count(*) AS total_dist_rows FROM clone_seq_dist;
+
+-- ===========================================================================
+-- REFERENCE table assertions
+-- ===========================================================================
+
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'ref_primary' FROM generate_series(3001, 3050) g;
+SELECT
+    max(bigserial_col >> 48) AS ref_primary_bigserial_window,
+    max(nextval_col   >> 48) AS ref_primary_nextval_window,
+    max(identity_col  >> 48) AS ref_primary_identity_window
+FROM clone_seq_ref
+WHERE payload = 'ref_primary' \gset
+
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_ref (id, payload)
+    SELECT g, 'ref_clone' FROM generate_series(4001, 4050) g;
+SELECT
+    max(bigserial_col >> 48) AS ref_clone_bigserial_window,
+    max(nextval_col   >> 48) AS ref_clone_nextval_window,
+    max(identity_col  >> 48) AS ref_clone_identity_window
+FROM clone_seq_ref
+WHERE payload = 'ref_clone' \gset
+
+\c - - - :master_port
+-- The clone's window must differ from the source primary's for every kind.
+SELECT
+    :'ref_primary_bigserial_window'::bigint <> :'ref_clone_bigserial_window'::bigint AS ref_bigserial_windows_differ,
+    :'ref_primary_nextval_window'::bigint   <> :'ref_clone_nextval_window'::bigint   AS ref_nextval_windows_differ,
+    :'ref_primary_identity_window'::bigint  <> :'ref_clone_identity_window'::bigint  AS ref_identity_windows_differ;
+
+-- All generated values across the table must also be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS ref_bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS ref_nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS ref_identity_unique
+FROM clone_seq_ref;
+
+-- ===========================================================================
+-- CITUS LOCAL table assertions
+-- ===========================================================================
+-- A Citus local table keeps its single shard on the coordinator, but its shell
+-- table and sequences are created on workers too and support writes from
+-- workers, so its sequences are re-ranged per group exactly like distributed /
+-- reference tables. The sequence DEFAULT / IDENTITY is evaluated on the node
+-- running the INSERT, so we generate values on the source primary and on the
+-- promoted clone and compare their windows.
+
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'local_primary' FROM generate_series(5001, 5050) g;
+
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO clone_seq_local (id, payload)
+    SELECT g, 'local_clone' FROM generate_series(6001, 6050) g;
+
+\c - - - :master_port
+-- The clone's window must differ from the source primary's for every kind.
+SELECT
+    (SELECT max(bigserial_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(bigserial_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_bigserial_windows_differ,
+    (SELECT max(nextval_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(nextval_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_nextval_windows_differ,
+    (SELECT max(identity_col >> 48) FROM clone_seq_local WHERE payload = 'local_primary')
+      <> (SELECT max(identity_col >> 48) FROM clone_seq_local WHERE payload = 'local_clone') AS local_identity_windows_differ;
+
+-- All generated values across the table must also be globally unique.
+SELECT
+    count(*) = count(DISTINCT bigserial_col) AS local_bigserial_unique,
+    count(*) = count(DISTINCT nextval_col)   AS local_nextval_unique,
+    count(*) = count(DISTINCT identity_col)  AS local_identity_unique
+FROM clone_seq_local;
+
+-- ===========================================================================
+-- QUOTED / MIXED-CASE SCHEMA assertions
+-- ===========================================================================
+-- Same worker-vs-clone window check as the distributed section, but for a
+-- sequence whose qualified name needs quoting/escaping.
+
+-- Generate values on the SOURCE PRIMARY.
+\c - - - :worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'edge_primary' FROM generate_series(7001, 7050) g;
+SELECT max(nextval_col >> 48) AS edge_primary_window
+FROM "Edge Schema"."Edge Tbl"
+WHERE payload = 'edge_primary' \gset
+
+-- Generate values on the PROMOTED CLONE.
+\c - - - :follower_worker_4_port
+SET client_min_messages TO WARNING;
+INSERT INTO "Edge Schema"."Edge Tbl" (id, payload)
+    SELECT g, 'edge_clone' FROM generate_series(8001, 8050) g;
+SELECT max(nextval_col >> 48) AS edge_clone_window
+FROM "Edge Schema"."Edge Tbl"
+WHERE payload = 'edge_clone' \gset
+
+\c - - - :master_port
+-- The clone's window must differ from the source primary's.
+SELECT :'edge_primary_window'::bigint <> :'edge_clone_window'::bigint AS edge_nextval_windows_differ;
+
+-- All generated values must be globally unique.
+SELECT count(*) = count(DISTINCT nextval_col) AS edge_nextval_unique
+FROM "Edge Schema"."Edge Tbl";
+
+-- cleanup
+DROP TABLE clone_seq_dist;
+DROP TABLE clone_seq_ref;
+DROP TABLE clone_seq_local;
+DROP SEQUENCE clone_seq_dist_manual;
+DROP SEQUENCE clone_seq_ref_manual;
+DROP SEQUENCE clone_seq_local_manual;
+DROP SCHEMA "Edge Schema" CASCADE;
+SET client_min_messages TO WARNING;
+SELECT citus_remove_node('localhost', :master_port);
+SET client_min_messages TO DEFAULT;
+SET citus.shard_count TO DEFAULT;


### PR DESCRIPTION
DESCRIPTION: Re-range sequences to the new group id when promoting a clone node so distributed, reference and Citus local tables keep globally-unique sequence values

citus_promote_clone_and_rebalance promotes a physical streaming replica to a new primary with a freshly-allocated group id, but the clone's sequence objects are byte-for-byte copies of the source primary's and keep the old primary's (groupId << 48) value window. The classical add/activate-node path re-ranges sequences per group id via AlterSequenceMinMax, the clone path did not, so the promoted clone and the original primary emitted values from the same window, breaking the global-uniqueness invariant for bigserial / bigint nextval(...) defaults and GENERATED ... AS IDENTITY columns.

Add SequenceRangeAdjustCommandList() (mirrors
IdentitySequenceDependencyCommandList for nextval/serial sequences) and a promotion-path helper AdjustCloneSequenceRangesForNewGroup() that re-ranges the clone's sequences to its new group-id window. To stay in parity with the classical add/activate-node path, it selects tables via ShouldSyncTableMetadata(), so distributed, reference and Citus local tables are all covered. The helper runs after SyncNodeMetadataToNodes() over the reused metadata connection, so the clone's corrected local group id is visible when AlterSequenceMinMax executes.

Reuses the existing citus_internal.adjust_identity_column_seq_settings UDF so no SQL migration or catalog change.
