### PR TITLE
Clean up orphaned Citus local shard copies when cloning the coordinator (Backport PR#8651) 

### DIFF
--- a/src/backend/distributed/operations/shard_transfer.c
+++ b/src/backend/distributed/operations/shard_transfer.c
@@ -766,7 +766,7 @@ TransferShards(int64 shardId, char *sourceNodeName,
  * but the metadata is not aware of this replication, this function updates the
  * metadata to reflect the new shard distribution.
  *
- * The function handles three types of shards:
+ * The function handles four types of shards:
  *
  * 1. Shards moving to clone node (cloneShardList):
  *    - Updates shard placement metadata to move placements from primary to clone
@@ -780,6 +780,12 @@ TransferShards(int64 shardId, char *sourceNodeName,
  * 3. Reference tables:
  *    - Inserts new placement records on the clone node
  *    - Data is already present on clone, so only metadata update is needed
+ *
+ * 4. Citus local tables (only when the primary is the coordinator):
+ *    - Their single shard lives only on the coordinator, so its metadata
+ *      placement is left unchanged (still on the coordinator)
+ *    - A coordinator clone carries a byte-for-byte copy of that shard data, so
+ *      cleanup records are added to drop the orphaned copy from the clone node
  *
  * This function does not perform any actual data movement; it only updates the
  * shard placement metadata and schedules cleanup operations for later execution.
@@ -903,6 +909,36 @@ AdjustShardsForPrimaryCloneNodeSplit(WorkerNode *primaryNode,
 		 */
 		InsertCleanupRecordsForShardPlacementsOnNode(colocatedShardList,
 													 primaryGroupId);
+	}
+
+	/*
+	 * Citus local tables live only on the coordinator (group 0). When the
+	 * source primary is the coordinator, the physical clone carries byte-for-byte
+	 * copies of their shard data, yet their placement metadata correctly stays on
+	 * the coordinator -- the split above only relocates distributed shards, and
+	 * reference tables are handled below. Those physical copies on the clone are
+	 * therefore untracked, so schedule dropping them from the clone group. The
+	 * Citus local shell table (and its sequences) remain, exactly as on any other
+	 * worker.
+	 */
+	if (primaryGroupId == COORDINATOR_GROUP_ID)
+	{
+		List *citusLocalTableIdList = CitusTableTypeIdList(CITUS_LOCAL_TABLE);
+		Oid citusLocalTableId = InvalidOid;
+		foreach_declared_oid(citusLocalTableId, citusLocalTableIdList)
+		{
+			List *localShardIntervalList = LoadShardIntervalList(citusLocalTableId);
+			InsertCleanupRecordsForShardPlacementsOnNode(localShardIntervalList,
+														 cloneGroupId);
+		}
+
+		if (citusLocalTableIdList != NIL)
+		{
+			ereport(NOTICE, (errmsg(
+								 "scheduling cleanup of %d Citus local table shard copy(ies) "
+								 "orphaned on clone node GroupID %d",
+								 list_length(citusLocalTableIdList), cloneGroupId)));
+		}
 	}
 
 	/*

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -117,6 +117,9 @@ DEPS = {
     "multi_add_node_from_backup_negative": TestDeps(
         None, ["multi_add_node_from_backup"], worker_count=5, repeatable=False
     ),
+    "multi_add_node_from_backup_coordinator": TestDeps(
+        None, ["multi_add_node_from_backup_negative"], worker_count=5, repeatable=False
+    ),
     "multi_add_node_from_backup_sync_replica": TestDeps(
         None, repeatable=False, worker_count=5
     ),

--- a/src/test/regress/expected/multi_add_node_from_backup_coordinator.out
+++ b/src/test/regress/expected/multi_add_node_from_backup_coordinator.out
@@ -1,0 +1,135 @@
+--
+-- Test cloning the COORDINATOR node.
+--
+-- A clone of the coordinator is a byte-for-byte physical replica, so it also
+-- carries the coordinator's Citus local table shard data. Citus local tables
+-- live ONLY on the coordinator: the promotion shard-split relocates distributed
+-- shards and replicates reference tables, but it must leave Citus local tables'
+-- metadata placement on the coordinator and clean up the orphaned physical shard
+-- copy that the clone carries. This test locks that behavior in (plus the basic
+-- invariants: the clone becomes a worker, and the coordinator keeps serving the
+-- Citus local table).
+--
+-- Put the coordinator in the metadata and let it own shards, so it has
+-- distributed data to split to a clone and so Citus local tables can be created.
+SET client_min_messages TO WARNING;
+SELECT citus_set_coordinator_host('localhost', :master_port);
+ citus_set_coordinator_host
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT citus_set_node_property('localhost', :master_port, 'shouldhaveshards', true);
+ citus_set_node_property
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEFAULT;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+-- Distributed table: with the coordinator holding shards, some shards land on
+-- group 0 and are eligible to move to the clone.
+CREATE TABLE coord_clone_dist (id bigserial, payload text);
+SELECT create_distributed_table('coord_clone_dist', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO coord_clone_dist (payload) SELECT 'seed' FROM generate_series(1, 40);
+-- Reference table.
+CREATE TABLE coord_clone_ref (id bigserial, payload text);
+SELECT create_reference_table('coord_clone_ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO coord_clone_ref (payload) SELECT 'seed' FROM generate_series(1, 10);
+-- Citus local table: its single shard lives only on the coordinator.
+CREATE TABLE coord_clone_local (id bigserial, payload text);
+SELECT citus_add_local_table_to_metadata('coord_clone_local');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO coord_clone_local (payload) SELECT 'seed' FROM generate_series(1, 10);
+-- Remember the Citus local shard id so we can look for its physical copy later.
+SELECT shardid AS local_shardid
+FROM pg_dist_shard WHERE logicalrelid = 'coord_clone_local'::regclass \gset
+-- Clone the coordinator (master-follower streams from it) and promote it. Force
+-- the deferred cleanup so the orphaned-copy drop is observable deterministically.
+SET client_min_messages TO WARNING;
+SELECT citus_add_clone_node('localhost', :follower_master_port, 'localhost', :master_port) AS clone_node_id \gset
+SELECT citus_promote_clone_and_rebalance(:clone_node_id);
+ citus_promote_clone_and_rebalance
+---------------------------------------------------------------------
+
+(1 row)
+
+CALL citus_cleanup_orphaned_resources();
+SET client_min_messages TO DEFAULT;
+-- Metadata: the Citus local placement must still be on the coordinator (group 0),
+-- NOT moved to the clone.
+SELECT p.groupid AS local_placement_group
+FROM pg_dist_placement p
+WHERE p.shardid = :local_shardid;
+ local_placement_group
+---------------------------------------------------------------------
+                     0
+(1 row)
+
+-- On the promoted clone: the Citus local SHELL table remains (like any worker),
+-- but its orphaned shard-data copy must have been cleaned up.
+\c - - - :follower_master_port
+SELECT
+    to_regclass('coord_clone_local') IS NOT NULL AS shell_present,
+    to_regclass('coord_clone_local_' || :'local_shardid') IS NULL AS shard_copy_removed;
+ shell_present | shard_copy_removed
+---------------------------------------------------------------------
+ t             | t
+(1 row)
+
+-- The clone is a worker now, not the coordinator.
+SELECT citus_is_coordinator() AS clone_is_coordinator;
+ clone_is_coordinator
+---------------------------------------------------------------------
+ f
+(1 row)
+
+-- The Citus local table is still fully queryable from the promoted clone: the
+-- shell routes to the coordinator placement, so despite the orphaned shard copy
+-- being dropped, reads return the correct rows.
+SELECT count(*) AS local_rows_from_clone,
+       min(id)  AS min_id_from_clone,
+       max(id)  AS max_id_from_clone
+FROM coord_clone_local;
+ local_rows_from_clone | min_id_from_clone | max_id_from_clone
+---------------------------------------------------------------------
+                    10 |                 1 |                10
+(1 row)
+
+\c - - - :master_port
+-- The coordinator still serves the Citus local table correctly.
+SELECT count(*) AS local_rows FROM coord_clone_local;
+ local_rows
+---------------------------------------------------------------------
+         10
+(1 row)
+
+-- cleanup
+DROP TABLE coord_clone_dist;
+DROP TABLE coord_clone_ref;
+DROP TABLE coord_clone_local;
+SET client_min_messages TO WARNING;
+SELECT citus_remove_node('localhost', :master_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+SET client_min_messages TO DEFAULT;
+SET citus.shard_count TO DEFAULT;
+SET citus.shard_replication_factor TO DEFAULT;

--- a/src/test/regress/multi_add_backup_node_schedule
+++ b/src/test/regress/multi_add_backup_node_schedule
@@ -1,3 +1,4 @@
 test: multi_add_node_from_backup
 test: multi_add_node_from_backup_negative
 test: multi_add_node_from_backup_sequences
+test: multi_add_node_from_backup_coordinator

--- a/src/test/regress/sql/multi_add_node_from_backup_coordinator.sql
+++ b/src/test/regress/sql/multi_add_node_from_backup_coordinator.sql
@@ -1,0 +1,88 @@
+--
+-- Test cloning the COORDINATOR node.
+--
+-- A clone of the coordinator is a byte-for-byte physical replica, so it also
+-- carries the coordinator's Citus local table shard data. Citus local tables
+-- live ONLY on the coordinator: the promotion shard-split relocates distributed
+-- shards and replicates reference tables, but it must leave Citus local tables'
+-- metadata placement on the coordinator and clean up the orphaned physical shard
+-- copy that the clone carries. This test locks that behavior in (plus the basic
+-- invariants: the clone becomes a worker, and the coordinator keeps serving the
+-- Citus local table).
+--
+
+-- Put the coordinator in the metadata and let it own shards, so it has
+-- distributed data to split to a clone and so Citus local tables can be created.
+SET client_min_messages TO WARNING;
+SELECT citus_set_coordinator_host('localhost', :master_port);
+SELECT citus_set_node_property('localhost', :master_port, 'shouldhaveshards', true);
+SET client_min_messages TO DEFAULT;
+
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+
+-- Distributed table: with the coordinator holding shards, some shards land on
+-- group 0 and are eligible to move to the clone.
+CREATE TABLE coord_clone_dist (id bigserial, payload text);
+SELECT create_distributed_table('coord_clone_dist', 'id');
+INSERT INTO coord_clone_dist (payload) SELECT 'seed' FROM generate_series(1, 40);
+
+-- Reference table.
+CREATE TABLE coord_clone_ref (id bigserial, payload text);
+SELECT create_reference_table('coord_clone_ref');
+INSERT INTO coord_clone_ref (payload) SELECT 'seed' FROM generate_series(1, 10);
+
+-- Citus local table: its single shard lives only on the coordinator.
+CREATE TABLE coord_clone_local (id bigserial, payload text);
+SELECT citus_add_local_table_to_metadata('coord_clone_local');
+INSERT INTO coord_clone_local (payload) SELECT 'seed' FROM generate_series(1, 10);
+
+-- Remember the Citus local shard id so we can look for its physical copy later.
+SELECT shardid AS local_shardid
+FROM pg_dist_shard WHERE logicalrelid = 'coord_clone_local'::regclass \gset
+
+-- Clone the coordinator (master-follower streams from it) and promote it. Force
+-- the deferred cleanup so the orphaned-copy drop is observable deterministically.
+SET client_min_messages TO WARNING;
+SELECT citus_add_clone_node('localhost', :follower_master_port, 'localhost', :master_port) AS clone_node_id \gset
+SELECT citus_promote_clone_and_rebalance(:clone_node_id);
+CALL citus_cleanup_orphaned_resources();
+SET client_min_messages TO DEFAULT;
+
+-- Metadata: the Citus local placement must still be on the coordinator (group 0),
+-- NOT moved to the clone.
+SELECT p.groupid AS local_placement_group
+FROM pg_dist_placement p
+WHERE p.shardid = :local_shardid;
+
+-- On the promoted clone: the Citus local SHELL table remains (like any worker),
+-- but its orphaned shard-data copy must have been cleaned up.
+\c - - - :follower_master_port
+SELECT
+    to_regclass('coord_clone_local') IS NOT NULL AS shell_present,
+    to_regclass('coord_clone_local_' || :'local_shardid') IS NULL AS shard_copy_removed;
+
+-- The clone is a worker now, not the coordinator.
+SELECT citus_is_coordinator() AS clone_is_coordinator;
+
+-- The Citus local table is still fully queryable from the promoted clone: the
+-- shell routes to the coordinator placement, so despite the orphaned shard copy
+-- being dropped, reads return the correct rows.
+SELECT count(*) AS local_rows_from_clone,
+       min(id)  AS min_id_from_clone,
+       max(id)  AS max_id_from_clone
+FROM coord_clone_local;
+
+\c - - - :master_port
+-- The coordinator still serves the Citus local table correctly.
+SELECT count(*) AS local_rows FROM coord_clone_local;
+
+-- cleanup
+DROP TABLE coord_clone_dist;
+DROP TABLE coord_clone_ref;
+DROP TABLE coord_clone_local;
+SET client_min_messages TO WARNING;
+SELECT citus_remove_node('localhost', :master_port);
+SET client_min_messages TO DEFAULT;
+SET citus.shard_count TO DEFAULT;
+SET citus.shard_replication_factor TO DEFAULT;


### PR DESCRIPTION
DESCRIPTION: Drop orphaned Citus local table shard copies on a worker promoted from a clone of the coordinator

A clone node is a byte-for-byte physical replica, so a clone of the coordinator also carries the coordinator's Citus local table shard data. Citus local tables live only on the coordinator: the promotion shard-split (AdjustShardsForPrimaryCloneNodeSplit) relocates distributed shards and replicates reference tables, but it left the clone's physical copies of Citus local shards in place. Their metadata placement correctly stays on the coordinator, so the copies became untracked orphans on the new worker.

When the split source is the coordinator, schedule cleanup of the Citus local tables' shard copies from the clone group; the shell table and its sequences remain, exactly as on any other worker. The metadata needs no adjustment, since the single placement stays on the coordinator.

Add regression coverage (multi_add_node_from_backup_coordinator) that clones and promotes the coordinator with distributed, reference and Citus local tables present, asserting: the Citus local placement stays on group 0, the orphaned shard copy is cleaned up on the clone while the shell remains, the clone becomes a worker, and the coordinator keeps serving the Citus local table. Without the fix the orphaned copy lingers, so the test guards the change.

(cherry picked from commit c89af2b372206d3cb53a12fb479fea73e302d371)
