### PR TITLE
normalize.sed: add PG19 cosmetic-difference rules

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -388,3 +388,69 @@ s/^[[:space:]]*ERROR:[[:space:]]+could not connect to the publisher:[[:space:]]*
 # can be removed when dropping pg17 support
 s/(:varnullingrels \(b\) :varlevelsup 0) (:varnosyn 1)/\1 :varreturningtype 0 \2/g
 # end pg18 varreturningtype
+
+# PG19 EXPLAIN output uses named InitPlan/SubPlan references.
+# this rule can be removed when PG19 is the minimum supported version
+s/(InitPlan|SubPlan) ((exists|expr|hashed)_)?[0-9]+/\1 XXX/g
+
+# PG19 renamed implicit ANY subqueries.
+# this rule can be removed when PG19 is the minimum supported version
+s/"ANY_subquery"/unnamed_subquery/g
+
+# PG19 changed VACUUM PARALLEL option errors.
+# these rules can be removed when PG19 is the minimum supported version
+s/PARALLEL option must be between 0 and 1024/parallel workers for vacuum must be between 0 and 1024/g
+s/parallel requires an integer value/parallel option requires a value between 0 and 1024/g
+
+# PG19 reports partitioned-table primary-key errors more specifically.
+# this rule can be removed when PG19 is the minimum supported version
+s/PRIMARY KEY constraint on partitioned table must include all partitioning columns/unique constraint on partitioned table must include all partitioning columns/g
+
+# PG19 psql prints partition lists on separate, unpunctuated lines.
+# this rule can be removed when PG19 is the minimum supported version
+/^Partitions:$/ {
+	N
+	s/^Partitions:\n    /Partitions: /
+	:pg19_partition_list
+	N
+	/\n    [^ ]/ {
+		s/\n    ([^ ])/,\
+            \1/
+		b pg19_partition_list
+	}
+}
+
+# PG19 renders counts of known non-null columns as count(*).
+# this rule can be removed when PG19 is the minimum supported version
+s/count\(l_quantity\)/count(*)/g
+
+# PG19 adds numeric suffixes to inlined CTE names.
+# this rule can be removed when PG19 is the minimum supported version
+s/\<(cte[0-9]+)_[0-9]+\>/\1/g
+
+# PG19 changed tuple serialization sizes in EXPLAIN output.
+# this rule can be removed when PG19 is the minimum supported version
+s/(Tuple data received from nodes?: )[0-9]+ bytes/\1N bytes/g
+
+# PG19 no longer consistently relays function-resolution hints from workers.
+# these rules can be removed when PG19 is the minimum supported version
+/^HINT:  No function matches the given name and argument types\. You might need to add explicit type casts\.$/d
+/^DETAIL:  There is no function of that name\.$/d
+
+# PG19 adds context for DEBUG messages raised by function_delegation.
+# these rules can be removed when PG19 is the minimum supported version
+/^CONTEXT:  SQL statement "UPDATE test SET y = y \+ 1 WHERE x <  \$1"$/d
+/^PL\/pgSQL function function_delegation\(integer\) line (XX|[0-9]+) at SQL statement$/d
+
+# PG19 adds dependency detail when a view references a temporary sequence.
+# this rule can be removed when PG19 is the minimum supported version
+/^DETAIL:  It depends on temporary sequence temp_sequence_to_drop\.$/d
+
+# PG19 no longer adds a numeric suffix to this implicit foreign-key name.
+# this rule can be removed when PG19 is the minimum supported version
+s/local_table_5_col_1_fkey_([0-9]+)/local_table_5_col_1_fkey1_\1/g
+
+# PG19 uses one additional heap page for this append-partitioned shard.
+# these rules can be removed when PG19 is the minimum supported version
+/^([[:space:]]*)139264$/ s/139264$/131072/
+/^([[:space:]]*[0-9]+[[:space:]]+[|][[:space:]]+)139264$/ s/139264$/131072/

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -390,12 +390,17 @@ s/(:varnullingrels \(b\) :varlevelsup 0) (:varnosyn 1)/\1 :varreturningtype 0 \2
 # end pg18 varreturningtype
 
 # PG19 EXPLAIN output uses named InitPlan/SubPlan references.
-# this rule can be removed when PG19 is the minimum supported version
-s/(InitPlan|SubPlan) ((exists|expr|hashed)_)?[0-9]+/\1 XXX/g
+# PG19 also numbers nested EXISTS plans locally instead of globally.
+# these rules can be removed when PG19 is the minimum supported version
+s/^([ ]{8}One-Time Filter: \(InitPlan) exists_2/\1 4/
+s/^([ ]{8}InitPlan) exists_2/\1 4/
+s/^([ ]{16}InitPlan) exists_1/\1 2/
+s/^([ ]{22}One-Time Filter: \(InitPlan) exists_1/\1 2/
+s/(InitPlan|SubPlan) (exists|expr|hashed)_([0-9]+)/\1 \3/g
 
 # PG19 renamed implicit ANY subqueries.
 # this rule can be removed when PG19 is the minimum supported version
-s/"ANY_subquery"/unnamed_subquery/g
+s/\<unnamed_subquery\>/"ANY_subquery"/g
 
 # PG19 changed VACUUM PARALLEL option errors.
 # these rules can be removed when PG19 is the minimum supported version
@@ -422,20 +427,28 @@ s/PRIMARY KEY constraint on partitioned table must include all partitioning colu
 
 # PG19 renders counts of known non-null columns as count(*).
 # this rule can be removed when PG19 is the minimum supported version
-s/count\(l_quantity\)/count(*)/g
+/^[[:space:]]+Output: sum\(l_quantity\), sum\(l_quantity\), count\(\*\)/ s/count\(\*\)/count(l_quantity)/
 
 # PG19 adds numeric suffixes to inlined CTE names.
 # this rule can be removed when PG19 is the minimum supported version
-s/\<(cte[0-9]+)_[0-9]+\>/\1/g
+s/^([ ]{8}CTE cte1)_1$/\1/
 
 # PG19 changed tuple serialization sizes in EXPLAIN output.
-# this rule can be removed when PG19 is the minimum supported version
-s/(Tuple data received from nodes?: )[0-9]+ bytes/\1N bytes/g
-
-# PG19 no longer consistently relays function-resolution hints from workers.
 # these rules can be removed when PG19 is the minimum supported version
-/^HINT:  No function matches the given name and argument types\. You might need to add explicit type casts\.$/d
-/^DETAIL:  There is no function of that name\.$/d
+s/(Tuple data received from nodes: )280 bytes/\1290 bytes/g
+s/(Tuple data received from node: )112 bytes/\1118 bytes/g
+
+# PG19 changed or omitted function-resolution hints from workers.
+# these rules can be removed when PG19 is the minimum supported version
+s/^DETAIL:  There is no function of that name\.$/HINT:  No function matches the given name and argument types. You might need to add explicit type casts./
+/^DETAIL:  No function of that name accepts the given argument types\.$/ {
+	N
+	s/^DETAIL:  No function of that name accepts the given argument types\.\nHINT:  You might need to add explicit type casts\.$/HINT:  No function matches the given name and argument types. You might need to add explicit type casts./
+}
+/^ERROR:  function (aggregate_support\.square_func\(integer\)|replicate_ref_to_coordinator\.my_volatile_fn\(\)) does not exist$/ {
+	N
+	s/\n(CONTEXT:  while executing command on localhost:)[0-9]+/\nHINT:  No function matches the given name and argument types. You might need to add explicit type casts.\n\1xxxxx/
+}
 
 # PG19 adds context for DEBUG messages raised by function_delegation.
 # these rules can be removed when PG19 is the minimum supported version
@@ -446,7 +459,7 @@ s/(Tuple data received from nodes?: )[0-9]+ bytes/\1N bytes/g
 # this rule can be removed when PG19 is the minimum supported version
 /^DETAIL:  It depends on temporary sequence temp_sequence_to_drop\.$/d
 
-# PG19 no longer adds a numeric suffix to this implicit foreign-key name.
+# PG19 adds a numeric suffix to this implicit foreign-key name.
 # this rule can be removed when PG19 is the minimum supported version
 s/local_table_5_col_1_fkey_([0-9]+)/local_table_5_col_1_fkey1_\1/g
 


### PR DESCRIPTION
DESCRIPTION: Normalize PostgreSQL 19 cosmetic output differences without weakening existing regression or expected-output oracles.

Addresses #8659.

## Stack

This PR is stacked on #8622 and targets `ihalatci-pg19-regress-crashes`. The planner crash fixes must land before these output normalizations because they expose several normalized regression paths.

## Changes

Add narrowly scoped PG19 compatibility rules in `src/test/regress/bin/normalize.sed`. PG19 output is mapped back to canonical PG17/PG18 output; canonical expected files are left unchanged.

The final rules preserve plan numbers, deparsed worker queries, CTE identity outside the affected line, tuple byte counts outside the two observed deltas, and generic function-resolution diagnostics outside the exact PG19 forms.

## Rule provenance

| Added normalization rule | PG19 source commit | Attribution |
|---|---|---|
| Named `InitPlan`/`SubPlan` references and nested EXISTS numbering | `d3790f2af` | Inferred from "PG19 EXPLAIN cosmetic differences" |
| Implicit `_ANY_subquery` naming | `64c9585de` | Inferred from "EXPLAIN/error output differences" |
| `VACUUM ... PARALLEL` error wording | `64c9585de` | Inferred |
| Partitioned-table primary-key error wording | `64c9585de` | Inferred |
| Multiline `\d+` `Partitions:` lists | `0247b7ef1` | Directly documented |
| `count(non-null-column)` / `count(*)` plan output | `d3790f2af` | Inferred from EXPLAIN changes |
| Inlined CTE name suffix | `d3790f2af` | Inferred from EXPLAIN changes |
| Exact tuple-data byte deltas | `2119b6796` | Directly documented |
| Function-resolution `HINT`/`DETAIL` differences | `2119b6796` | Directly documented |
| Extra PL/pgSQL function context | `11b27a791` | Directly documented |
| Temporary-sequence dependency `DETAIL` | `11b27a791` | Directly documented |
| Implicit foreign-key name suffix | `11b27a791` | Directly documented |
| Append-partitioned shard length `139264` -> `131072` | `11b27a791` | Directly documented |

The original Git objects are unavailable on the current remotes and searched local/WSL repositories. The split between `64c9585de` and `d3790f2af` is therefore inferred from their documented subjects; the other mappings are explicitly supported by the local PG19 plan.

## Validation

- PostgreSQL 17.10, 18.4, and 19beta1 build cleanly with `CFLAGS=-Werror`.
- PG17/PG18 `check-multi`, `check-multi-1`, and `check-multi-mx` pass apart from the existing `multi_extension.out` MX baseline.
- PG19 `check-multi-1` passes. `check-multi` leaves only the four planned downstream files (`clock.out`, the two order-by files, and `multi_subquery_in_where_reference_clause.out`); `check-multi-mx` leaves only `multi_extension.out` and planned `multi_mx_explain.out`.
- Applying the final normalizer to all 835 canonical expected files changes zero files.
- Replaying PG19 CI artifacts resolves 21 intended result diffs: 12 in `check-multi`, 7 in `check-multi-1`, 1 in `check-multi-mx`, and 1 in `check-split`.