### PR TITLE
pg19 - Stabilize clock and pg17 regression tests

### DIFF
--- a/src/test/regress/expected/clock.out
+++ b/src/test/regress/expected/clock.out
@@ -187,11 +187,11 @@ CREATE INDEX cc_idx on cluster_clock_type(cc);
 -- Multiply rows to check index usage
 INSERT INTO cluster_clock_type SELECT a.cc FROM cluster_clock_type a, cluster_clock_type b;
 INSERT INTO cluster_clock_type SELECT a.cc FROM cluster_clock_type a, cluster_clock_type b;
-EXPLAIN SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
-                                            QUERY PLAN
+EXPLAIN (COSTS OFF) SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
+                         QUERY PLAN
 ---------------------------------------------------------------------
- Limit  (cost=0.28..0.92 rows=1 width=12)
-   ->  Index Only Scan using cc_idx on cluster_clock_type  (cost=0.28..667.95 rows=1045 width=12)
+ Limit
+   ->  Index Only Scan using cc_idx on cluster_clock_type
 (2 rows)
 
 SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
@@ -200,13 +200,13 @@ SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
  (0,100)
 (1 row)
 
-EXPLAIN SELECT cc FROM cluster_clock_type where cc = '(200, 20)' LIMIT 5;
-                                    QUERY PLAN
+EXPLAIN (COSTS OFF) SELECT cc FROM cluster_clock_type where cc = '(200, 20)' LIMIT 5;
+                       QUERY PLAN
 ---------------------------------------------------------------------
- Limit  (cost=4.32..20.94 rows=5 width=12)
-   ->  Bitmap Heap Scan on cluster_clock_type  (cost=4.32..20.94 rows=5 width=12)
+ Limit
+   ->  Bitmap Heap Scan on cluster_clock_type
          Recheck Cond: (cc = '(200,20)'::cluster_clock)
-         ->  Bitmap Index Scan on cc_idx  (cost=0.00..4.31 rows=5 width=0)
+         ->  Bitmap Index Scan on cc_idx
                Index Cond: (cc = '(200,20)'::cluster_clock)
 (5 rows)
 

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -750,7 +750,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
  partition_name |        partition_bound
 ---------------------------------------------------------------------
  pt_1           | FOR VALUES FROM (1) TO (50)
@@ -783,7 +784,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
  partition_name |         partition_bound
 ---------------------------------------------------------------------
  pt_1           | FOR VALUES FROM (1) TO (50)
@@ -814,7 +816,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
  partition_name |         partition_bound
 ---------------------------------------------------------------------
  pt_1           | FOR VALUES FROM (1) TO (50)
@@ -858,7 +861,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
  partition_name |        partition_bound
 ---------------------------------------------------------------------
  pt_1           | FOR VALUES FROM (1) TO (50)
@@ -880,7 +884,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
  partition_name |        partition_bound
 ---------------------------------------------------------------------
  pt_1           | FOR VALUES FROM (1) TO (50)
@@ -1089,7 +1094,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
  partition_name |         partition_bound
 ---------------------------------------------------------------------
  lpt_1          | FOR VALUES FROM (1) TO (50)
@@ -1128,7 +1134,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
  partition_name |         partition_bound
 ---------------------------------------------------------------------
  lpt_1          | FOR VALUES FROM (1) TO (50)
@@ -1169,7 +1176,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
  partition_name |        partition_bound
 ---------------------------------------------------------------------
  lpt_1          | FOR VALUES FROM (1) TO (50)
@@ -1190,7 +1198,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
  partition_name |        partition_bound
 ---------------------------------------------------------------------
  lpt_1          | FOR VALUES FROM (1) TO (50)

--- a/src/test/regress/sql/clock.sql
+++ b/src/test/regress/sql/clock.sql
@@ -65,10 +65,10 @@ CREATE INDEX cc_idx on cluster_clock_type(cc);
 INSERT INTO cluster_clock_type SELECT a.cc FROM cluster_clock_type a, cluster_clock_type b;
 INSERT INTO cluster_clock_type SELECT a.cc FROM cluster_clock_type a, cluster_clock_type b;
 
-EXPLAIN SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
+EXPLAIN (COSTS OFF) SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
 SELECT cc FROM cluster_clock_type ORDER BY 1 ASC LIMIT 1;
 
-EXPLAIN SELECT cc FROM cluster_clock_type where cc = '(200, 20)' LIMIT 5;
+EXPLAIN (COSTS OFF) SELECT cc FROM cluster_clock_type where cc = '(200, 20)' LIMIT 5;
 SELECT cc FROM cluster_clock_type where cc = '(200, 20)' LIMIT 5;
 
 -- Max limits

--- a/src/test/regress/sql/pg17.sql
+++ b/src/test/regress/sql/pg17.sql
@@ -454,7 +454,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
 
 -- (2) The partitions have the same identity column as the parent table;
 -- This is PG17 behavior for support for identity in partitioned tables.
@@ -470,7 +471,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
 \d pt_3;
 
 -- Partition pt_4 has its own identity column, which is not allowed in PG17
@@ -488,7 +490,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
 
 -- (2) The partititions have the same identity column as the parent table
 \d pt_1;
@@ -508,7 +511,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
 \d pt_3;
 
 -- Verify that the detach has propagated to the worker node
@@ -520,7 +524,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'partitioned_table';
+WHERE parent.relname = 'partitioned_table'
+ORDER BY partition_name;
 \d pt_3;
 
 \c - - - :master_port
@@ -631,7 +636,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
 \d lpt_1;
 \d lpt_2;
 \d lpt_3;
@@ -644,7 +650,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
 \d lpt_1;
 \d lpt_2;
 \d lpt_3;
@@ -660,7 +667,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
 \d lpt_3;
 
 \c - - - :worker_1_port
@@ -671,7 +679,8 @@ SELECT child.relname AS partition_name,
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
-WHERE parent.relname = 'local_partitioned_table';
+WHERE parent.relname = 'local_partitioned_table'
+ORDER BY partition_name;
 \d lpt_3;
 
 \c - - - :master_port


### PR DESCRIPTION
## Summary  - suppress planner cost estimates in the two `clock` EXPLAIN checks that assert `cc_idx` usage - order all nine previously unordered PG17 partition-listing queries by `partition_name` - update only the corresponding regression expected output  ## Validation  All validation used WSL and absolute PostgreSQL installation paths.  - PostgreSQL 17.10: `CFLAGS=-Werror` build/install; focused `clock` (7/7) and `pg17` (9/9) passed - PostgreSQL 18.4: `CFLAGS=-Werror` build/install; focused `clock` (7/7) and `pg17` (9/9) passed - PostgreSQL 19beta2: `CFLAGS=-Werror` build/install; focused `clock` (7/7) and `pg17` (9/9) passed - `citus_indent --quiet --check` - `git show --check`  Closes #8668. GitHub will only auto-close the issue once this change becomes reachable from the default branch.