### PR TITLE
Keep orphan cleanup snapshot active on PostgreSQL 18

### DIFF
--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1216,7 +1216,8 @@ CleanupRecordExists(uint64 recordId)
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
 	/* make sure we can always see deletion after acquiring the operation ID lock */
-	Snapshot snapshot = GetLatestSnapshot();
+	PushActiveSnapshot(GetLatestSnapshot());
+	Snapshot snapshot = GetActiveSnapshot();
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
@@ -1228,6 +1229,7 @@ CleanupRecordExists(uint64 recordId)
 	bool recordExists = HeapTupleIsValid(heapTuple);
 
 	systable_endscan(scanDescriptor);
+	PopActiveSnapshot();
 
 	CommandCounterIncrement();
 	table_close(pgDistCleanup, NoLock);

--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1215,9 +1215,16 @@ CleanupRecordExists(uint64 recordId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
-	/* make sure we can always see deletion after acquiring the operation ID lock */
-	PushActiveSnapshot(GetLatestSnapshot());
-	Snapshot snapshot = GetActiveSnapshot();
+	/*
+	 * Make sure we can always see deletion after acquiring the operation ID lock.
+	 *
+	 * PG18 requires the snapshot to be active or registered before it's used,
+	 * otherwise we hit
+	 * Assert(snapshot->regd_count > 0 || snapshot->active_count > 0);
+	 * Relevant PG18 commit:
+	 * 8076c00592e40e8dbd1fce7a98b20d4bf075e4ba
+	 */
+	Snapshot snapshot = RegisterSnapshot(GetLatestSnapshot());
 
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
@@ -1229,7 +1236,7 @@ CleanupRecordExists(uint64 recordId)
 	bool recordExists = HeapTupleIsValid(heapTuple);
 
 	systable_endscan(scanDescriptor);
-	PopActiveSnapshot();
+	UnregisterSnapshot(snapshot);
 
 	CommandCounterIncrement();
 	table_close(pgDistCleanup, NoLock);


### PR DESCRIPTION
## Summary

Keep the fresh snapshot used by `CleanupRecordExists()` active for the full system catalog scan.

`GetLatestSnapshot()` still provides the fresh secondary snapshot required by #8594. The function now pushes that snapshot, scans with the active copy returned by `GetActiveSnapshot()`, and pops it after `systable_endscan()`. This preserves visibility of cleanup-record deletions while satisfying PostgreSQL 18's requirement that MVCC snapshots used for tuple visibility are registered or active.

## Validation

Validated locally in WSL with PostgreSQL 18.4 built using `--enable-debug --enable-cassert`:

- Focused orphan-cleanup regression schedule: 5/5 passed, including `shard_move_deferred_delete`
- Focused failure schedule: 5/5 passed, including `failure_create_database`
- Focused isolation schedule: 2/2 passed, including `isolation_rebalancer_deferred_drop`

## Residual risk

The stale-snapshot/advisory-lock race addressed by #8594 still lacks a deterministic injection-point regression test. The focused tests cover cleanup behavior and the PostgreSQL 18 cassert snapshot lifecycle.

Fixes #8673
Related to #8665