### PR TITLE
Fix nightly pg-upgrade Python dependencies

### DIFF
--- a/.github/actions/setup_cassert_pg/action.yml
+++ b/.github/actions/setup_cassert_pg/action.yml
@@ -80,6 +80,7 @@ runs:
         echo "LD_LIBRARY_PATH=$("$PG_CONFIG" --libdir):${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
         # configure bakes bindir/libdir into Makefile.global, so `make check-*` auto-uses this PG.
         ./configure PG_CONFIG="$PG_CONFIG" --without-pg-version-check
+        make clean
         make -j"$(nproc)" all
         # Installs into the $HOME pgenv prefix for this version -> no sudo, no clobber across versions.
         make install

--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -112,6 +112,9 @@ jobs:
       - uses: ./.github/actions/setup_cassert_pg
         with:
           pg_full: ${{ matrix.new_full }}
+      - name: Install python env for upgrade harness
+        shell: bash
+        run: ( cd src/test/regress && pipenv install --deploy )
       - name: check-pg-upgrade (with and without columnar)
         shell: bash
         timeout-minutes: 90
@@ -119,10 +122,10 @@ jobs:
           set -euo pipefail
           OLD="$HOME/.pgenv/pgsql-${{ matrix.old_full }}/bin"
           NEW="$HOME/.pgenv/pgsql-${{ matrix.new_full }}/bin"
-          make -C src/test/regress check-pg-upgrade \
-            old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=false
-          make -C src/test/regress check-pg-upgrade \
-            old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=true
+          ( cd src/test/regress && pipenv run make -C . check-pg-upgrade \
+              old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=false )
+          ( cd src/test/regress && pipenv run make -C . check-pg-upgrade \
+              old-bindir="$OLD" new-bindir="$NEW" test-with-columnar=true )
       - name: Copy pg_upgrade logs for newData dir
         if: failure()
         shell: bash


### PR DESCRIPTION
## Summary

The nightly cassert pg-upgrade jobs had two setup gaps:

- The Python upgrade harness ran outside the locked `src/test/regress` Pipenv environment, so `docopt` was unavailable.
- The composite cassert setup action configured the same Citus build tree for two PostgreSQL majors without cleaning it, allowing the second invocation to reuse objects compiled against the first major.

Install the locked Python environment once per pg-upgrade job and run both columnar modes through `pipenv run`. After configuring Citus for each selected `PG_CONFIG`, clean the build tree before compiling so every action invocation performs a PG-specific rebuild while preserving the same Citus source and each PG prefix's installed files.

## Validation

- Parsed both changed YAML files successfully in WSL.
- `pipenv verify` and `pipenv install --deploy` succeeded; the locked `docopt` import and upgrade harness compilation passed.
- Ran consecutive Citus builds from one Linux-native source tree against pgenv PG16.14 and PG17.10. Each `make clean` left 0 objects; each subsequent build executed 363 compile commands and produced 292 objects.
- Full `make check-style` passed in WSL: Black, isort, Flake8, and `citus_indent`.
- Confirmed the workflow covers PG16->17 and PG17->18 with both columnar modes.

A branch-specific Nightly cassert dispatch validates the dual-PG upgrade jobs in GitHub Actions.

Fixes #8670
Related to #8665