### PR TITLE
Fix concurrent distribution relation lock assertion

### DIFF
--- a/src/backend/distributed/commands/alter_table.c
+++ b/src/backend/distributed/commands/alter_table.c
@@ -1358,7 +1358,7 @@ CreateTableConversion(TableConversionParameters *params)
 	relation_close(relation, NoLock);
 	con->distributionKey =
 		BuildDistributionKeyFromColumnName(con->relationId, con->distributionColumn,
-										   NoLock);
+										   NoLock, false);
 
 	con->originalAccessMethod = NULL;
 	if (!PartitionedTable(con->relationId) && !IsForeignTable(con->relationId))

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -704,7 +704,8 @@ EnsureColocateWithTableIsValid(Oid relationId, char distributionMethod,
 
 	Var *distributionColumn = BuildDistributionKeyFromColumnName(relationId,
 																 distributionColumnName,
-																 NoLock);
+																 AccessShareLock);
+	UnlockRelationOid(relationId, AccessShareLock);
 	EnsureTableCanBeColocatedWith(relationId, replicationModel,
 								  distributionColumn, colocateWithTableId);
 }

--- a/src/backend/distributed/commands/create_distributed_table.c
+++ b/src/backend/distributed/commands/create_distributed_table.c
@@ -535,7 +535,7 @@ CreateDistributedTableConcurrently(Oid relationId, char *distributionColumnName,
 	 */
 	Var *distributionColumn = BuildDistributionKeyFromColumnName(relationId,
 																 distributionColumnName,
-																 NoLock);
+																 NoLock, false);
 
 	/* get an advisory lock to serialize concurrent default group creations */
 	if (IsColocateWithDefault(colocateWithTableName))
@@ -704,8 +704,7 @@ EnsureColocateWithTableIsValid(Oid relationId, char distributionMethod,
 
 	Var *distributionColumn = BuildDistributionKeyFromColumnName(relationId,
 																 distributionColumnName,
-																 AccessShareLock);
-	UnlockRelationOid(relationId, AccessShareLock);
+																 AccessShareLock, true);
 	EnsureTableCanBeColocatedWith(relationId, replicationModel,
 								  distributionColumn, colocateWithTableId);
 }
@@ -1222,7 +1221,7 @@ CreateCitusTable(Oid relationId, CitusTableType tableType,
 		distributionColumn = BuildDistributionKeyFromColumnName(relationId,
 																distributedTableParams->
 																distributionColumnName,
-																NoLock);
+																NoLock, false);
 	}
 
 	CitusTableParams citusTableParams = DecideCitusTableParams(tableType,

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -3472,7 +3472,7 @@ citus_internal_add_partition_metadata(PG_FUNCTION_ARGS)
 
 		distributionColumnVar =
 			BuildDistributionKeyFromColumnName(relationId, distributionColumnString,
-											   AccessShareLock);
+											   AccessShareLock, false);
 		Assert(distributionColumnVar != NULL);
 	}
 

--- a/src/backend/distributed/operations/worker_split_copy_udf.c
+++ b/src/backend/distributed/operations/worker_split_copy_udf.c
@@ -317,7 +317,7 @@ CreatePartitionedSplitCopyDestReceiver(EState *estate,
 	Oid shardRelationId = LookupShardRelationFromCatalog(shardId, missingOK);
 	Var *partitionColumn = BuildDistributionKeyFromColumnName(shardRelationId,
 															  partitionColumnName,
-															  AccessShareLock);
+															  AccessShareLock, false);
 
 	CitusTableCacheEntry *shardSearchInfo =
 		QueryTupleShardSearchInfo(minValuesArray, maxValuesArray,

--- a/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
+++ b/src/backend/distributed/operations/worker_split_shard_replication_setup_udf.c
@@ -222,7 +222,7 @@ CreateShardSplitInfo(uint64 sourceShardIdToSplit,
 	/* determine the partition column in the tuple descriptor */
 	Var *partitionColumn = BuildDistributionKeyFromColumnName(sourceShardToSplitOid,
 															  partitionColumnName,
-															  AccessShareLock);
+															  AccessShareLock, false);
 	if (partitionColumn == NULL)
 	{
 		ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/backend/distributed/utils/distribution_column.c
+++ b/src/backend/distributed/utils/distribution_column.c
@@ -58,7 +58,7 @@ column_name_to_column(PG_FUNCTION_ARGS)
 	char *columnName = text_to_cstring(columnText);
 
 	Var *column = BuildDistributionKeyFromColumnName(relationId, columnName,
-													 AccessShareLock);
+													 AccessShareLock, false);
 	Assert(column != NULL);
 	char *columnNodeString = nodeToString(column);
 	text *columnNodeText = cstring_to_text(columnNodeString);
@@ -80,7 +80,7 @@ column_name_to_column_id(PG_FUNCTION_ARGS)
 	char *columnName = PG_GETARG_CSTRING(1);
 
 	Var *column = BuildDistributionKeyFromColumnName(distributedTableId, columnName,
-													 AccessExclusiveLock);
+													 AccessExclusiveLock, false);
 	Assert(column != NULL);
 
 	PG_RETURN_INT16((int16) column->varattno);
@@ -120,9 +120,12 @@ column_to_column_name(PG_FUNCTION_ARGS)
  *
  * The function returns NULL if the passed column name is NULL. That case only
  * corresponds to reference tables.
+ *
+ * If unlockRelation is true, the relation lock is released before returning.
  */
 Var *
-BuildDistributionKeyFromColumnName(Oid relationId, char *columnName, LOCKMODE lockMode)
+BuildDistributionKeyFromColumnName(Oid relationId, char *columnName, LOCKMODE lockMode,
+								   bool unlockRelation)
 {
 	Relation relation = try_relation_open(relationId, lockMode);
 
@@ -131,13 +134,13 @@ BuildDistributionKeyFromColumnName(Oid relationId, char *columnName, LOCKMODE lo
 		ereport(ERROR, (errmsg("relation does not exist")));
 	}
 
-	relation_close(relation, NoLock);
-
 	char *tableName = get_rel_name(relationId);
+	LOCKMODE closeLockMode = unlockRelation ? lockMode : NoLock;
 
 	/* short circuit for reference tables and single-shard tables */
 	if (columnName == NULL)
 	{
+		relation_close(relation, closeLockMode);
 		return NULL;
 	}
 
@@ -168,6 +171,7 @@ BuildDistributionKeyFromColumnName(Oid relationId, char *columnName, LOCKMODE lo
 									  columnForm->atttypmod, columnForm->attcollation, 0);
 
 	ReleaseSysCache(columnTuple);
+	relation_close(relation, closeLockMode);
 
 	return distributionColumn;
 }

--- a/src/backend/distributed/utils/distribution_column_map.c
+++ b/src/backend/distributed/utils/distribution_column_map.c
@@ -71,7 +71,8 @@ AddDistributionColumnForRelation(DistributionColumnMap *distributionColumnMap,
 	Assert(!entryFound);
 
 	entry->distributionColumn =
-		BuildDistributionKeyFromColumnName(relationId, distributionColumnName, NoLock);
+		BuildDistributionKeyFromColumnName(relationId, distributionColumnName, NoLock,
+										   false);
 
 	if (PartitionedTable(relationId))
 	{

--- a/src/include/distributed/distribution_column.h
+++ b/src/include/distributed/distribution_column.h
@@ -21,7 +21,8 @@
 /* Remaining metadata utility functions  */
 extern Var * BuildDistributionKeyFromColumnName(Oid relationId,
 												char *columnName,
-												LOCKMODE lockMode);
+												LOCKMODE lockMode,
+												bool unlockRelation);
 extern char * ColumnToColumnName(Oid relationId, Node *columnNode);
 extern Oid ColumnTypeIdForRelationColumnName(Oid relationId, char *columnName);
 extern void EnsureValidDistributionColumn(Oid relationId, char *columnName);


### PR DESCRIPTION
## Summary

`EnsureColocateWithTableIsValid` called `BuildDistributionKeyFromColumnName` with `NoLock` during concurrent-distribution preflight. On cassert builds, PostgreSQL's `try_relation_open` asserts that callers using `NoLock` already hold at least `AccessShareLock`, but this path held no relation lock.

The preflight now acquires `AccessShareLock` through `BuildDistributionKeyFromColumnName` and asks the helper to release that lock before returning. Existing callers retain their current lock lifetime. This keeps preflight lock retention short and preserves the later `ShareUpdateExclusiveLock` acquisition and distribution-column revalidation.

## Validation

- PG16.14 `--enable-cassert`: focused `create_distributed_table_concurrently` regression passed.
- PG17.10 `--enable-cassert`: focused `create_distributed_table_concurrently` regression passed.
- The exact `colocate_with := 'nocolo'` case returns the expected distribution-column type mismatch with no assertion or signal 6.
- `make check-style` passed.

The focused runs used `check-base EXTRA_TESTS=create_distributed_table_concurrently`; the target passed on both versions. The overall harness command remained nonzero because three unrelated out-of-tree fixture tests (`multi_cluster_management`, `multi_create_table_superuser`, and `tablespace`) failed due to the archived source layout.

Fixes #8671
Related to #8665