### PR TITLE
Stabilize PG19 ORDER BY pushdown regression plan

### DIFF
--- a/src/test/regress/expected/multi_orderby_pushdown.out
+++ b/src/test/regress/expected/multi_orderby_pushdown.out
@@ -1813,6 +1813,9 @@ LIMIT 10');
 (51 rows)
 
 -- H4 EXPLAIN
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+SET LOCAL enable_nestloop TO off;
 SELECT public.explain_filter('EXPLAIN (ANALYZE ON, VERBOSE ON, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) SELECT id, val FROM sorted_merge_test
 WHERE id IN (
     SELECT id FROM sorted_merge_events ORDER BY id LIMIT 10
@@ -1872,6 +1875,7 @@ LIMIT 5');
                                              Function Call: read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format)
 (50 rows)
 
+COMMIT;
 -- H5 EXPLAIN
 SELECT public.explain_filter('EXPLAIN (ANALYZE ON, VERBOSE ON, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) WITH small_cte AS (
     SELECT id, val FROM sorted_merge_test ORDER BY id LIMIT 20

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -608,6 +608,11 @@ if ($majorversion >= "14") {
     }
 }
 
+if ($majorversion >= "19" && !$vanillatest) {
+    # Eager aggregation is not yet supported by Citus.
+    push(@pgOptions, "enable_eager_aggregate=off");
+}
+
 # Citus options set for the tests
 push(@pgOptions, "citus.shard_count=4");
 push(@pgOptions, "citus.max_adaptive_executor_pool_size=4");

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -608,11 +608,6 @@ if ($majorversion >= "14") {
     }
 }
 
-if ($majorversion >= "19" && !$vanillatest) {
-    # Eager aggregation is not yet supported by Citus.
-    push(@pgOptions, "enable_eager_aggregate=off");
-}
-
 # Citus options set for the tests
 push(@pgOptions, "citus.shard_count=4");
 push(@pgOptions, "citus.max_adaptive_executor_pool_size=4");

--- a/src/test/regress/sql/multi_orderby_pushdown.sql
+++ b/src/test/regress/sql/multi_orderby_pushdown.sql
@@ -519,12 +519,16 @@ ORDER BY t.id
 LIMIT 10');
 
 -- H4 EXPLAIN
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+SET LOCAL enable_nestloop TO off;
 SELECT public.explain_filter('EXPLAIN (ANALYZE ON, VERBOSE ON, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) SELECT id, val FROM sorted_merge_test
 WHERE id IN (
     SELECT id FROM sorted_merge_events ORDER BY id LIMIT 10
 )
 ORDER BY id
 LIMIT 5');
+COMMIT;
 
 -- H5 EXPLAIN
 SELECT public.explain_filter('EXPLAIN (ANALYZE ON, VERBOSE ON, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF) WITH small_cte AS (


### PR DESCRIPTION
Stabilize PostgreSQL 19 ORDER BY pushdown plan assertions  ## Context  PostgreSQL BUG #19517 caused eager aggregation on semi/antijoin inner relations to return incorrect results on 19beta1 (`5|130`). Upstream commit `ffeda04259bb` fixes that bug, and the same reproducer returns the correct `5|26` on 19beta2. This PR therefore does not disable `enable_eager_aggregate` or `enable_hashagg` globally or in the regression harness.  The H4 case in `multi_orderby_pushdown` is independent of that correctness fix. On 19beta2, with eager aggregation at its default, it still chooses a worker `Nested Loop` plan instead of the asserted `Sort -> Hash Semi Join` shape. Both `Citus Sorted Merge Adaptive` nodes remain, so pushdown itself is intact.  This change stabilizes only the H4 EXPLAIN by wrapping it in a transaction and propagating transaction-local planner settings:  ```sql BEGIN; SET LOCAL citus.propagate_set_commands TO 'local'; SET LOCAL enable_nestloop TO off; -- existing H4 EXPLAIN COMMIT; ```  The expected plan is otherwise unchanged and continues to assert sorted-merge pushdown and the worker hash semi-join shape. There are no production-code or regression-harness changes.  ## Validation  - PostgreSQL 17.10: `-Werror` build and focused `multi_orderby_pushdown` path, 15/15 passed. - PostgreSQL 18.4: `-Werror` build and focused path, 15/15 passed. - PostgreSQL 19beta2: `-Werror` build and focused path, 15/15 passed with default `enable_eager_aggregate=on`. - PostgreSQL 19beta2 upstream regression suite: 245/245 passed, including `eager_aggregate`. - PostgreSQL 19beta2 Citus semi/antijoin path: `multi_subquery_in_where_reference_clause`, 15/15 passed with eager aggregation enabled. - Perl syntax, style, and diff whitespace checks passed.  Closes #8666  > This draft targets the non-default `pg19-support` branch. GitHub may defer automatic issue closure until the change reaches the default branch.