### PR TITLE
pg19 - Restore tdigest aggregate test plan intent

### DIFF
--- a/src/test/regress/expected/tdigest_aggregate_support.out
+++ b/src/test/regress/expected/tdigest_aggregate_support.out
@@ -4,6 +4,7 @@
 --   for push down parts of the aggregate to use parallelized execution and reduced data
 --   transfer sizes for aggregates not grouped by the distribution column
 --
+SET citus.allow_aggregate_worker_combine_on_internal_types TO off;
 SET citus.next_shard_id TO 20070000;
 CREATE SCHEMA tdigest_aggregate_support;
 SET search_path TO tdigest_aggregate_support, public;

--- a/src/test/regress/expected/tdigest_aggregate_support_0.out
+++ b/src/test/regress/expected/tdigest_aggregate_support_0.out
@@ -4,6 +4,7 @@
 --   for push down parts of the aggregate to use parallelized execution and reduced data
 --   transfer sizes for aggregates not grouped by the distribution column
 --
+SET citus.allow_aggregate_worker_combine_on_internal_types TO off;
 SET citus.next_shard_id TO 20070000;
 CREATE SCHEMA tdigest_aggregate_support;
 SET search_path TO tdigest_aggregate_support, public;

--- a/src/test/regress/expected/tdigest_aggregate_support_1.out
+++ b/src/test/regress/expected/tdigest_aggregate_support_1.out
@@ -4,6 +4,7 @@
 --   for push down parts of the aggregate to use parallelized execution and reduced data
 --   transfer sizes for aggregates not grouped by the distribution column
 --
+SET citus.allow_aggregate_worker_combine_on_internal_types TO off;
 SET citus.next_shard_id TO 20070000;
 CREATE SCHEMA tdigest_aggregate_support;
 SET search_path TO tdigest_aggregate_support, public;

--- a/src/test/regress/sql/tdigest_aggregate_support.sql
+++ b/src/test/regress/sql/tdigest_aggregate_support.sql
@@ -5,6 +5,7 @@
 --   transfer sizes for aggregates not grouped by the distribution column
 --
 
+SET citus.allow_aggregate_worker_combine_on_internal_types TO off;
 SET citus.next_shard_id TO 20070000;
 CREATE SCHEMA tdigest_aggregate_support;
 SET search_path TO tdigest_aggregate_support, public;


### PR DESCRIPTION
## Summary

- disable `citus.allow_aggregate_worker_combine_on_internal_types` in `tdigest_aggregate_support` so the regression test continues to assert tdigest-specific distributed plan shapes instead of the generic internal-state worker-combine path
- update the primary expected output and the existing `_0`/`_1` alternatives with the new `SET` echo
- keep the existing alternative semantics: `_0` covers extension-absent output and `_1` covers accepted tdigest result-value variation
- account for PostgreSQL 19 Beta 2's undefined-function `DETAIL` through the normalization already present on the refreshed `pg19-support` base (`ca86a5d95`); a separate `_2` alternative was validated during development but removed because that base normalization makes it redundant and unreachable

## Validation

- `-Werror` builds: PostgreSQL 17.10, 18.4, and 19 Beta 2
- focused `tdigest_aggregate_support` schedule with tdigest installed: passed on PostgreSQL 17.10, 18.4, and 19 Beta 2
- focused schedule without tdigest: PostgreSQL 17.10 and 18.4 matched `_0`; PostgreSQL 19 Beta 2's raw `DETAIL` normalized and matched `_0`
- `make check-style`
- `git diff --check`

Closes #8667

> This PR intentionally targets the non-default `pg19-support` branch. GitHub may not automatically close #8667 when this merges there; closure should be confirmed when the support branch is subsequently integrated into the default branch.