### PR TITLE
Redesign procedure 2PC skip: static analysis via PLpgSQL plugin (Backport PR#8566 to 14.2)

### DIFF
--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -293,6 +293,7 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 		 * stored procedures.
 		 */
 		StoredProcedureLevel += 1;
+		ProcedureNonCoordinatedExecutionCount = 0;
 
 		PG_TRY();
 		{
@@ -300,6 +301,7 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 							   params, queryEnv, dest, completionTag);
 
 			StoredProcedureLevel -= 1;
+			ProcedureNonCoordinatedExecutionCount = 0;
 
 			if (InDelegatedProcedureCall && StoredProcedureLevel == 0)
 			{
@@ -309,6 +311,7 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 		PG_CATCH();
 		{
 			StoredProcedureLevel -= 1;
+			ProcedureNonCoordinatedExecutionCount = 0;
 
 			if (InDelegatedProcedureCall && StoredProcedureLevel == 0)
 			{

--- a/src/backend/distributed/commands/utility_hook.c
+++ b/src/backend/distributed/commands/utility_hook.c
@@ -78,6 +78,7 @@
 #include "distributed/multi_logical_replication.h"
 #include "distributed/multi_partitioning_utils.h"
 #include "distributed/multi_physical_planner.h"
+#include "distributed/procedure_body_analysis.h"
 #include "distributed/reference_table_utils.h"
 #include "distributed/remote_commands.h"
 #include "distributed/resource_lock.h"
@@ -293,7 +294,6 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 		 * stored procedures.
 		 */
 		StoredProcedureLevel += 1;
-		ProcedureNonCoordinatedExecutionCount = 0;
 
 		PG_TRY();
 		{
@@ -301,7 +301,6 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 							   params, queryEnv, dest, completionTag);
 
 			StoredProcedureLevel -= 1;
-			ProcedureNonCoordinatedExecutionCount = 0;
 
 			if (InDelegatedProcedureCall && StoredProcedureLevel == 0)
 			{
@@ -311,7 +310,16 @@ citus_ProcessUtility(PlannedStmt *pstmt,
 		PG_CATCH();
 		{
 			StoredProcedureLevel -= 1;
-			ProcedureNonCoordinatedExecutionCount = 0;
+
+			/*
+			 * Defensively reset the single-statement flag on the error path.
+			 * The normal-path reset lives in the PLpgSQL plugin's
+			 * citus_func_end callback, which is not guaranteed to run when a
+			 * procedure errors mid-body. Clearing it here keeps the invariant
+			 * obvious: ProcedureBodyIsSingleStatement is never left true once
+			 * no procedure is executing, independent of func_end ordering.
+			 */
+			ProcedureBodyIsSingleStatement = false;
 
 			if (InDelegatedProcedureCall && StoredProcedureLevel == 0)
 			{

--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -15,6 +15,7 @@
 #include "distributed/executor_util.h"
 #include "distributed/listutils.h"
 #include "distributed/shardinterval_utils.h"
+#include "distributed/transaction_management.h"
 
 
 /*
@@ -42,6 +43,130 @@ TaskListModifiesDatabase(RowModifyLevel modLevel, List *taskList)
 	Task *firstTask = (Task *) linitial(taskList);
 
 	return !ReadOnlyTask(firstTask->taskType);
+}
+
+
+/*
+ * SkipProcedureTransactionBlock determines whether we can safely skip
+ * coordinated (2PC) transactions for the current procedure execution.
+ *
+ * This is safe only when ALL of the following are true:
+ *   1. The GUC citus.enable_procedure_transaction_skip is enabled
+ *   2. We are inside a stored procedure (StoredProcedureLevel == 1, not nested)
+ *   3. We are NOT inside an explicit BEGIN block or DO $$ block
+ *   4. There is exactly 1 task in the task list
+ *   5. That task has exactly 1 placement (no replication)
+ *   6. No coordinated transaction has been started yet (no prior distributed
+ *      work in this procedure call)
+ *   7. No prior non-coordinated execution has occurred in this procedure call
+ *
+ * When any check fails, we return false and the caller falls through to the
+ * normal coordinated transaction path.
+ *
+ * IMPORTANT: because the first statement executes without a coordinated
+ * transaction, it auto-commits on the worker (or locally).  If the procedure
+ * contains a second distributed statement, we raise an ERROR to prevent
+ * silent data inconsistency — but the first statement's effects have already
+ * been committed and cannot be rolled back.  This is acceptable because the
+ * GUC is explicitly documented for single-statement procedures only.
+ *
+ * NOTE: we are being conservative in the case of local execution.  When the
+ * first statement is executed locally (not on a remote worker), it still
+ * auto-commits and we still raise an ERROR on a second statement.  This is a
+ * deliberate limitation to keep the logic simple and consistent.
+ */
+static bool
+SkipProcedureTransactionBlock(List *taskList)
+{
+	/* GUC gate - must be explicitly opted in */
+	if (!EnableProcedureTransactionSkip)
+	{
+		return false;
+	}
+
+	/*
+	 * Only allow for non-nested stored procedure calls. StoredProcedureLevel > 1
+	 * means nested CALL where inner procedure may have multi-shard statements.
+	 */
+	if (StoredProcedureLevel != 1)
+	{
+		return false;
+	}
+
+	/* Do not allow inside explicit BEGIN block - user may add more statements */
+	if (IsTransactionBlock())
+	{
+		return false;
+	}
+
+	/* Do not allow inside DO $$ block - may contain multiple statements */
+	if (DoBlockLevel > 0)
+	{
+		return false;
+	}
+
+	/* Exactly one task */
+	if (list_length(taskList) != 1)
+	{
+		return false;
+	}
+
+	Task *task = (Task *) linitial(taskList);
+
+	/* Exactly one placement (no replication) */
+	if (list_length(task->taskPlacementList) != 1)
+	{
+		return false;
+	}
+
+	/* Additionally check for multi-query tasks */
+	if (task->queryCount > 1)
+	{
+		return false;
+	}
+
+	/*
+	 * If we already started a coordinated transaction (e.g., a prior statement
+	 * in the procedure touched a different shard), we cannot downgrade to
+	 * non-coordinated execution.
+	 */
+	if (InCoordinatedTransaction())
+	{
+		return false;
+	}
+
+	/*
+	 * Only single-statement procedures may skip coordination. If we already
+	 * executed one non-coordinated statement, a second would cause a partial
+	 * commit scenario: the first auto-committed on the worker (or locally)
+	 * and cannot be rolled back if the second fails.
+	 *
+	 * We raise an ERROR here to prevent silently continuing with an
+	 * inconsistent state.  Note that the first statement's effects are
+	 * already committed at this point (whether executed remotely or locally).
+	 *
+	 * NOTE: we are being conservative in the case of local execution — even
+	 * though a local statement does not go to a remote worker, we still
+	 * disallow a second statement.  This is a deliberate limitation to keep
+	 * the logic simple and consistent.
+	 */
+	if (ProcedureNonCoordinatedExecutionCount > 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("multi-statement procedures are not supported with "
+						"citus.enable_procedure_transaction_skip"),
+				 errdetail("The first statement has already been committed "
+						   "and cannot be rolled back. This applies to both "
+						   "remote and local execution."),
+				 errhint("Use this optimization only for single-statement "
+						 "procedures, or disable the GUC.")));
+	}
+
+	/* Track that we are about to execute without coordination */
+	ProcedureNonCoordinatedExecutionCount++;
+
+	return true;
 }
 
 
@@ -86,7 +211,23 @@ TaskListRequiresRollback(List *taskList)
 
 	if (IsMultiStatementTransaction())
 	{
-		return true;
+		/*
+		 * When the single-shard procedure optimization is enabled, we can
+		 * skip coordinated transactions for procedure calls that meet all
+		 * of the following conditions:
+		 *   - We are in a stored procedure (not nested)
+		 *   - Not inside an explicit BEGIN block or DO block
+		 *   - Exactly one task with one placement
+		 *   - No prior coordinated transaction started in this call
+		 *
+		 * This avoids the overhead of BEGIN + PREPARE TRANSACTION +
+		 * COMMIT PREPARED for single-shard single-placement writes
+		 * inside stored procedures.
+		 */
+		if (!SkipProcedureTransactionBlock(taskList))
+		{
+			return true;
+		}
 	}
 
 	if (list_length(taskList) > 1)

--- a/src/backend/distributed/executor/executor_util_tasks.c
+++ b/src/backend/distributed/executor/executor_util_tasks.c
@@ -14,6 +14,7 @@
 
 #include "distributed/executor_util.h"
 #include "distributed/listutils.h"
+#include "distributed/procedure_body_analysis.h"
 #include "distributed/shardinterval_utils.h"
 #include "distributed/transaction_management.h"
 
@@ -47,67 +48,81 @@ TaskListModifiesDatabase(RowModifyLevel modLevel, List *taskList)
 
 
 /*
- * SkipProcedureTransactionBlock determines whether we can safely skip
- * coordinated (2PC) transactions for the current procedure execution.
+ * CanSkipProcedureCoordination checks whether we can safely skip
+ * coordinated (2PC) transactions for the current procedure execution
+ * based on pre-execution static analysis of the procedure body.
  *
  * This is safe only when ALL of the following are true:
  *   1. The GUC citus.enable_procedure_transaction_skip is enabled
- *   2. We are inside a stored procedure (StoredProcedureLevel == 1, not nested)
- *   3. We are NOT inside an explicit BEGIN block or DO $$ block
- *   4. There is exactly 1 task in the task list
- *   5. That task has exactly 1 placement (no replication)
- *   6. No coordinated transaction has been started yet (no prior distributed
- *      work in this procedure call)
- *   7. No prior non-coordinated execution has occurred in this procedure call
+ *   2. The procedure body was analyzed and found to contain exactly one
+ *      SQL-producing statement (ProcedureBodyIsSingleStatement == true)
+ *   3. We are inside a stored procedure (StoredProcedureLevel == 1, not nested)
+ *   4. We are NOT inside an explicit BEGIN block or DO $$ block
+ *   5. There is exactly 1 task with exactly 1 placement
+ *   6. No coordinated transaction has been started yet
  *
- * When any check fails, we return false and the caller falls through to the
- * normal coordinated transaction path.
- *
- * IMPORTANT: because the first statement executes without a coordinated
- * transaction, it auto-commits on the worker (or locally).  If the procedure
- * contains a second distributed statement, we raise an ERROR to prevent
- * silent data inconsistency — but the first statement's effects have already
- * been committed and cannot be rolled back.  This is acceptable because the
- * GUC is explicitly documented for single-statement procedures only.
- *
- * NOTE: we are being conservative in the case of local execution.  When the
- * first statement is executed locally (not on a remote worker), it still
- * auto-commits and we still raise an ERROR on a second statement.  This is a
- * deliberate limitation to keep the logic simple and consistent.
+ * Unlike the previous runtime counter approach, this uses pre-execution
+ * static analysis: the PLpgSQL func_beg callback walks the procedure body
+ * and sets ProcedureBodyIsSingleStatement before any statement executes.
+ * Multi-statement procedures simply fall back to normal coordinated
+ * transactions — no ERROR is raised and no partial commits occur.
  */
 static bool
-SkipProcedureTransactionBlock(List *taskList)
+CanSkipProcedureCoordination(List *taskList)
 {
-	/* GUC gate - must be explicitly opted in */
+	/* GUC gate */
 	if (!EnableProcedureTransactionSkip)
 	{
 		return false;
 	}
 
-	/*
-	 * Only allow for non-nested stored procedure calls. StoredProcedureLevel > 1
-	 * means nested CALL where inner procedure may have multi-shard statements.
-	 */
+	/* Already in a coordinated transaction — no point evaluating further */
+	if (InCoordinatedTransaction())
+	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: already in "
+								"coordinated transaction")));
+		return false;
+	}
+
+	/* Body analysis must have determined single-statement */
+	if (!ProcedureBodyIsSingleStatement)
+	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: body is not "
+								"single-statement, using coordinated transaction")));
+		return false;
+	}
+
+	/* Only for non-nested stored procedure calls */
 	if (StoredProcedureLevel != 1)
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: nested procedure "
+								"call (level %d), using coordinated transaction",
+								StoredProcedureLevel)));
 		return false;
 	}
 
-	/* Do not allow inside explicit BEGIN block - user may add more statements */
+	/* Not inside explicit BEGIN block */
 	if (IsTransactionBlock())
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: inside explicit "
+								"transaction block, using coordinated transaction")));
 		return false;
 	}
 
-	/* Do not allow inside DO $$ block - may contain multiple statements */
+	/* Not inside DO $$ block */
 	if (DoBlockLevel > 0)
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: inside DO block, "
+								"using coordinated transaction")));
 		return false;
 	}
 
 	/* Exactly one task */
 	if (list_length(taskList) != 1)
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: %d tasks (need 1), "
+								"using coordinated transaction",
+								list_length(taskList))));
 		return false;
 	}
 
@@ -116,55 +131,22 @@ SkipProcedureTransactionBlock(List *taskList)
 	/* Exactly one placement (no replication) */
 	if (list_length(task->taskPlacementList) != 1)
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: %d placements "
+								"(need 1), using coordinated transaction",
+								list_length(task->taskPlacementList))));
 		return false;
 	}
 
-	/* Additionally check for multi-query tasks */
+	/* Multi-query tasks need a transaction */
 	if (task->queryCount > 1)
 	{
+		ereport(DEBUG2, (errmsg("procedure transaction skip: multi-query task, "
+								"using coordinated transaction")));
 		return false;
 	}
 
-	/*
-	 * If we already started a coordinated transaction (e.g., a prior statement
-	 * in the procedure touched a different shard), we cannot downgrade to
-	 * non-coordinated execution.
-	 */
-	if (InCoordinatedTransaction())
-	{
-		return false;
-	}
-
-	/*
-	 * Only single-statement procedures may skip coordination. If we already
-	 * executed one non-coordinated statement, a second would cause a partial
-	 * commit scenario: the first auto-committed on the worker (or locally)
-	 * and cannot be rolled back if the second fails.
-	 *
-	 * We raise an ERROR here to prevent silently continuing with an
-	 * inconsistent state.  Note that the first statement's effects are
-	 * already committed at this point (whether executed remotely or locally).
-	 *
-	 * NOTE: we are being conservative in the case of local execution — even
-	 * though a local statement does not go to a remote worker, we still
-	 * disallow a second statement.  This is a deliberate limitation to keep
-	 * the logic simple and consistent.
-	 */
-	if (ProcedureNonCoordinatedExecutionCount > 0)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("multi-statement procedures are not supported with "
-						"citus.enable_procedure_transaction_skip"),
-				 errdetail("The first statement has already been committed "
-						   "and cannot be rolled back. This applies to both "
-						   "remote and local execution."),
-				 errhint("Use this optimization only for single-statement "
-						 "procedures, or disable the GUC.")));
-	}
-
-	/* Track that we are about to execute without coordination */
-	ProcedureNonCoordinatedExecutionCount++;
+	ereport(DEBUG2, (errmsg("procedure transaction skip: all conditions met, "
+							"skipping coordinated transaction (2PC)")));
 
 	return true;
 }
@@ -212,19 +194,15 @@ TaskListRequiresRollback(List *taskList)
 	if (IsMultiStatementTransaction())
 	{
 		/*
-		 * When the single-shard procedure optimization is enabled, we can
-		 * skip coordinated transactions for procedure calls that meet all
-		 * of the following conditions:
-		 *   - We are in a stored procedure (not nested)
-		 *   - Not inside an explicit BEGIN block or DO block
-		 *   - Exactly one task with one placement
-		 *   - No prior coordinated transaction started in this call
+		 * When the single-shard procedure optimization is enabled and the
+		 * procedure body was determined to be a single SQL statement by
+		 * pre-execution analysis, we can skip coordinated transactions.
 		 *
 		 * This avoids the overhead of BEGIN + PREPARE TRANSACTION +
 		 * COMMIT PREPARED for single-shard single-placement writes
-		 * inside stored procedures.
+		 * inside single-statement stored procedures.
 		 */
-		if (!SkipProcedureTransactionBlock(taskList))
+		if (!CanSkipProcedureCoordination(taskList))
 		{
 			return true;
 		}

--- a/src/backend/distributed/executor/procedure_body_analysis.c
+++ b/src/backend/distributed/executor/procedure_body_analysis.c
@@ -1,0 +1,421 @@
+/*-------------------------------------------------------------------------
+ *
+ * procedure_body_analysis.c
+ *
+ * This file implements a PLpgSQL plugin that analyzes stored procedure
+ * bodies at execution time (in the func_beg callback) to determine
+ * whether the procedure contains a single distributed SQL statement.
+ *
+ * When citus.enable_procedure_transaction_skip is enabled, single-statement
+ * procedures that target a single shard can skip coordinated (2PC)
+ * transactions. Rather than using a fragile runtime counter that can lead
+ * to partial commits, we analyze the procedure body *before* any statement
+ * executes and set the ProcedureBodyIsSingleStatement flag.
+ *
+ * The analysis recursively walks the PLpgSQL statement tree counting
+ * SQL-producing statements (EXECSQL, PERFORM, DYNEXECUTE, and CALL) and
+ * detecting disqualifying statements (COMMIT, ROLLBACK, and every loop
+ * statement type — LOOP/WHILE/FOR variants — since a statement inside a
+ * loop may execute more than once). Container statements are recursed
+ * into: a BLOCK contributes the sum of its body and exception-handler
+ * actions (both may run), whereas an IF or CASE contributes the maximum
+ * SQL count across its branches (then/ELSIF/else, or WHEN/else) because
+ * only one branch executes at runtime. If the body contains exactly one
+ * SQL statement and no disqualifier, the flag is set to true, allowing the
+ * executor to skip 2PC.
+ *
+ * For multi-statement or disqualified procedures, the flag remains false
+ * and the normal coordinated transaction path is used — no ERROR is
+ * raised, no partial commits occur. The decision is made before any
+ * statement in the body executes.
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "plpgsql.h"
+
+#include "catalog/pg_proc.h"
+#include "utils/elog.h"
+
+#include "distributed/procedure_body_analysis.h"
+#include "distributed/transaction_management.h"
+
+
+/* flag set by func_beg to indicate whether the procedure body is a single statement */
+bool ProcedureBodyIsSingleStatement = false;
+
+/* saved previous plugin pointer for chaining */
+static PLpgSQL_plugin *prev_plpgsql_plugin = NULL;
+
+/* our plugin struct */
+static PLpgSQL_plugin citus_plpgsql_plugin;
+
+
+/*
+ * WalkStatementList recursively walks a list of PLpgSQL statements,
+ * counting SQL-producing statements and detecting disqualifiers.
+ *
+ * Returns the total count of SQL statements found so far. Sibling
+ * statements accumulate (sum), but the branches of an IF/CASE contribute
+ * only their maximum (one branch runs at runtime). Sets *disqualified to
+ * true if a COMMIT, ROLLBACK, or any loop statement (LOOP/WHILE/FOR
+ * variants) is found at any nesting level. Short-circuits as soon as the
+ * result is determined (count > 1 or disqualified).
+ */
+static int
+WalkStatementList(List *stmts, bool *disqualified)
+{
+	int count = 0;
+	ListCell *lc;
+
+	foreach(lc, stmts)
+	{
+		PLpgSQL_stmt *stmt = (PLpgSQL_stmt *) lfirst(lc);
+
+		/* short-circuit: already disqualified or enough statements counted */
+		if (*disqualified || count > 1)
+		{
+			return count;
+		}
+
+		switch (stmt->cmd_type)
+		{
+			/* SQL-producing statements: count them */
+			case PLPGSQL_STMT_EXECSQL:
+			case PLPGSQL_STMT_PERFORM:
+			case PLPGSQL_STMT_DYNEXECUTE:
+			{
+				count++;
+				break;
+			}
+
+			/* CALL may invoke another procedure with distributed statements */
+			case PLPGSQL_STMT_CALL:
+			{
+				count++;
+				break;
+			}
+
+			/* COMMIT / ROLLBACK: procedure manages its own transactions */
+			case PLPGSQL_STMT_COMMIT:
+			case PLPGSQL_STMT_ROLLBACK:
+			{
+				*disqualified = true;
+				return count;
+			}
+
+			/* Container statements: recurse into their bodies */
+			case PLPGSQL_STMT_BLOCK:
+			{
+				PLpgSQL_stmt_block *block = (PLpgSQL_stmt_block *) stmt;
+				count += WalkStatementList(block->body, disqualified);
+
+				/* Also walk exception handler bodies */
+				if (block->exceptions != NULL)
+				{
+					ListCell *exc_lc;
+					foreach(exc_lc, block->exceptions->exc_list)
+					{
+						PLpgSQL_exception *exc =
+							(PLpgSQL_exception *) lfirst(exc_lc);
+						count += WalkStatementList(exc->action, disqualified);
+						if (*disqualified || count > 1)
+						{
+							return count;
+						}
+					}
+				}
+				break;
+			}
+
+			case PLPGSQL_STMT_IF:
+			{
+				/*
+				 * Only one branch of an IF executes at runtime, so this IF
+				 * contributes the MAXIMUM SQL count across its then, ELSIF,
+				 * and else branches rather than their sum. Taking the max
+				 * keeps a procedure whose branches each hold a single SQL
+				 * statement eligible for the skip, while still rejecting a
+				 * branch that by itself holds two or more statements. A
+				 * disqualifier (loop/COMMIT/ROLLBACK) in ANY branch still
+				 * disqualifies the whole body via *disqualified, regardless
+				 * of the max count.
+				 */
+				PLpgSQL_stmt_if *if_stmt = (PLpgSQL_stmt_if *) stmt;
+				int branchMax = WalkStatementList(if_stmt->then_body, disqualified);
+				if (*disqualified)
+				{
+					return count;
+				}
+
+				/* Walk ELSIF branches, tracking the maximum */
+				ListCell *elsif_lc;
+				foreach(elsif_lc, if_stmt->elsif_list)
+				{
+					PLpgSQL_if_elsif *elsif =
+						(PLpgSQL_if_elsif *) lfirst(elsif_lc);
+					int elsifCount = WalkStatementList(elsif->stmts, disqualified);
+					if (*disqualified)
+					{
+						return count;
+					}
+					if (elsifCount > branchMax)
+					{
+						branchMax = elsifCount;
+					}
+				}
+
+				int elseCount = WalkStatementList(if_stmt->else_body, disqualified);
+				if (*disqualified)
+				{
+					return count;
+				}
+				if (elseCount > branchMax)
+				{
+					branchMax = elseCount;
+				}
+
+				count += branchMax;
+				break;
+			}
+
+			case PLPGSQL_STMT_CASE:
+			{
+				/*
+				 * As with IF, only one CASE branch executes, so contribute
+				 * the maximum across all WHEN branches and the else branch
+				 * rather than their sum. Disqualifiers in any branch still
+				 * propagate via *disqualified.
+				 */
+				PLpgSQL_stmt_case *case_stmt = (PLpgSQL_stmt_case *) stmt;
+				int branchMax = 0;
+				ListCell *when_lc;
+				foreach(when_lc, case_stmt->case_when_list)
+				{
+					PLpgSQL_case_when *when =
+						(PLpgSQL_case_when *) lfirst(when_lc);
+					int whenCount = WalkStatementList(when->stmts, disqualified);
+					if (*disqualified)
+					{
+						return count;
+					}
+					if (whenCount > branchMax)
+					{
+						branchMax = whenCount;
+					}
+				}
+
+				int elseCount = WalkStatementList(case_stmt->else_stmts, disqualified);
+				if (*disqualified)
+				{
+					return count;
+				}
+				if (elseCount > branchMax)
+				{
+					branchMax = elseCount;
+				}
+
+				count += branchMax;
+				break;
+			}
+
+			/*
+			 * Loop containers: disqualify unconditionally. A SQL statement
+			 * inside a loop may execute multiple times at runtime. Without
+			 * a coordinated transaction each iteration auto-commits, so a
+			 * failure mid-loop would leave prior iterations committed —
+			 * exactly the partial-commit scenario we want to prevent.
+			 *
+			 * We deliberately do NOT relax this for loops whose body happens
+			 * to contain zero SQL statements (e.g. a pure arithmetic
+			 * accumulator loop followed by a single write). Detecting that
+			 * safely would require proving a loop body is SQL-free at every
+			 * nesting depth, the pattern is rare, and the conservative
+			 * baseline only costs a missed optimization, never correctness.
+			 * Left as a possible future enhancement.
+			 */
+			case PLPGSQL_STMT_LOOP:
+			case PLPGSQL_STMT_WHILE:
+			case PLPGSQL_STMT_FORI:
+			case PLPGSQL_STMT_FORS:
+			case PLPGSQL_STMT_FORC:
+			case PLPGSQL_STMT_DYNFORS:
+			case PLPGSQL_STMT_FOREACH_A:
+			{
+				*disqualified = true;
+				return count;
+			}
+
+			/*
+			 * Non-SQL, non-container statements (ASSIGN, RETURN, RAISE,
+			 * GETDIAG, EXIT, OPEN, FETCH, CLOSE, ASSERT, RETURN_NEXT,
+			 * RETURN_QUERY): do not count, do not recurse.
+			 *
+			 * Some of these carry a SQL query (OPEN cursor, FETCH,
+			 * RETURN QUERY, RETURN NEXT), but they are intentionally left
+			 * uncounted here: a distributed *write* is always expressed as
+			 * EXECSQL/PERFORM/DYNEXECUTE/CALL, and any read that opens a
+			 * coordinated transaction is caught downstream by the
+			 * executor's InCoordinatedTransaction() gate before a skip is
+			 * allowed. Omitting them is therefore safe and deliberate, not
+			 * an oversight.
+			 */
+			default:
+			{
+				break;
+			}
+		}
+	}
+
+	return count;
+}
+
+
+/*
+ * citus_func_beg is our PLpgSQL plugin func_beg callback.
+ *
+ * Called after local variables are initialized, before any statement
+ * in the function body executes. We use this to analyze the procedure
+ * body and set ProcedureBodyIsSingleStatement.
+ */
+static void
+citus_func_beg(PLpgSQL_execstate *estate, PLpgSQL_function *func)
+{
+	/*
+	 * Only analyze for top-level procedure calls (not nested) when the
+	 * optimization GUC is enabled.
+	 */
+	if (EnableProcedureTransactionSkip &&
+		func->fn_prokind == PROKIND_PROCEDURE &&
+		StoredProcedureLevel == 1)
+	{
+		bool disqualified = false;
+		int sqlCount = WalkStatementList(func->action->body, &disqualified);
+
+		ProcedureBodyIsSingleStatement = (!disqualified && sqlCount == 1);
+
+		if (ProcedureBodyIsSingleStatement)
+		{
+			ereport(DEBUG2, (errmsg("procedure body analysis: single-statement "
+									"procedure detected, eligible for 2PC skip")));
+		}
+		else
+		{
+			ereport(DEBUG2, (errmsg("procedure body analysis: multi-statement "
+									"or disqualified procedure detected "
+									"(sql_count=%d, disqualified=%s), "
+									"using coordinated transaction",
+									sqlCount,
+									disqualified ? "true" : "false")));
+		}
+	}
+
+	/* chain to previous plugin if any */
+	if (prev_plpgsql_plugin && prev_plpgsql_plugin->func_beg)
+	{
+		prev_plpgsql_plugin->func_beg(estate, func);
+	}
+}
+
+
+/*
+ * citus_func_setup is our PLpgSQL plugin func_setup callback.
+ * Chains to the previous plugin.
+ */
+static void
+citus_func_setup(PLpgSQL_execstate *estate, PLpgSQL_function *func)
+{
+	if (prev_plpgsql_plugin && prev_plpgsql_plugin->func_setup)
+	{
+		prev_plpgsql_plugin->func_setup(estate, func);
+	}
+}
+
+
+/*
+ * citus_func_end is our PLpgSQL plugin func_end callback.
+ * Resets the flag and chains to the previous plugin.
+ */
+static void
+citus_func_end(PLpgSQL_execstate *estate, PLpgSQL_function *func)
+{
+	/*
+	 * Reset the flag when exiting a top-level procedure so it does
+	 * not leak into subsequent calls.
+	 */
+	if (func->fn_prokind == PROKIND_PROCEDURE &&
+		StoredProcedureLevel == 1)
+	{
+		ProcedureBodyIsSingleStatement = false;
+	}
+
+	if (prev_plpgsql_plugin && prev_plpgsql_plugin->func_end)
+	{
+		prev_plpgsql_plugin->func_end(estate, func);
+	}
+}
+
+
+/*
+ * citus_stmt_beg is our PLpgSQL plugin stmt_beg callback.
+ * Chains to the previous plugin.
+ */
+static void
+citus_stmt_beg(PLpgSQL_execstate *estate, PLpgSQL_stmt *stmt)
+{
+	if (prev_plpgsql_plugin && prev_plpgsql_plugin->stmt_beg)
+	{
+		prev_plpgsql_plugin->stmt_beg(estate, stmt);
+	}
+}
+
+
+/*
+ * citus_stmt_end is our PLpgSQL plugin stmt_end callback.
+ * Chains to the previous plugin.
+ */
+static void
+citus_stmt_end(PLpgSQL_execstate *estate, PLpgSQL_stmt *stmt)
+{
+	if (prev_plpgsql_plugin && prev_plpgsql_plugin->stmt_end)
+	{
+		prev_plpgsql_plugin->stmt_end(estate, stmt);
+	}
+}
+
+
+/*
+ * InstallProcedureBodyAnalysisPlugin registers our PLpgSQL plugin
+ * via the rendezvous variable mechanism. Must be called from _PG_init().
+ */
+void
+InstallProcedureBodyAnalysisPlugin(void)
+{
+	PLpgSQL_plugin **plugin_ptr =
+		(PLpgSQL_plugin **) find_rendezvous_variable("PLpgSQL_plugin");
+
+	/*
+	 * The PLpgSQL_plugin rendezvous variable holds a single slot. We chain
+	 * to whatever plugin was installed before Citus's _PG_init() ran, so a
+	 * plugin loaded earlier keeps working. Note the inherent limitation of
+	 * this single-slot mechanism: an extension whose _PG_init() runs *after*
+	 * Citus would overwrite this pointer and disable Citus's callbacks
+	 * (Citus would then no longer be chained). This is a standard PLpgSQL
+	 * plugin constraint, not specific to this optimization.
+	 */
+	prev_plpgsql_plugin = *plugin_ptr;
+
+	/* set up our plugin callbacks */
+	citus_plpgsql_plugin.func_setup = citus_func_setup;
+	citus_plpgsql_plugin.func_beg = citus_func_beg;
+	citus_plpgsql_plugin.func_end = citus_func_end;
+	citus_plpgsql_plugin.stmt_beg = citus_stmt_beg;
+	citus_plpgsql_plugin.stmt_end = citus_stmt_end;
+
+	/* install our plugin */
+	*plugin_ptr = &citus_plpgsql_plugin;
+}

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -89,6 +89,7 @@
 #include "distributed/pg_dist_partition.h"
 #include "distributed/placement_connection.h"
 #include "distributed/priority.h"
+#include "distributed/procedure_body_analysis.h"
 #include "distributed/query_pushdown_planning.h"
 #include "distributed/recursive_planning.h"
 #include "distributed/reference_table_utils.h"
@@ -517,6 +518,9 @@ _PG_init(void)
 
 	/* initialize coordinated transaction management */
 	InitializeTransactionManagement();
+
+	/* install PLpgSQL plugin for procedure body analysis */
+	InstallProcedureBodyAnalysisPlugin();
 	InitializeBackendManagement();
 	InitializeConnectionManagement();
 	InitPlacementConnectionManagement();
@@ -1540,15 +1544,15 @@ RegisterCitusConfigVariables(void)
 		"citus.enable_procedure_transaction_skip",
 		gettext_noop("Skip coordinated transactions for single-statement, "
 					 "single-shard procedure calls."),
-		gettext_noop("When enabled, CALL statements that execute exactly one "
-					 "distributed write targeting a single task on a single "
-					 "shard with a single placement skip coordinated (2PC) "
-					 "transactions. Only applies to non-nested procedure calls "
-					 "outside of explicit transaction blocks. "
-					 "WARNING: this is intended for single-statement procedures "
-					 "only. If a procedure issues a second distributed statement, "
-					 "it will raise an ERROR, but the first statement will have "
-					 "already been committed and cannot be rolled back."),
+		gettext_noop("When enabled, CALL statements whose procedure body "
+					 "contains exactly one SQL statement (determined by static "
+					 "analysis before execution) and that target a single task "
+					 "on a single shard skip coordinated (2PC) transactions. "
+					 "Multi-statement procedures gracefully fall back to the "
+					 "normal coordinated transaction path. The optimization "
+					 "applies to PLpgSQL procedures only; SQL-language and C "
+					 "procedures never set the single-statement flag and are "
+					 "never eligible."),
 		&EnableProcedureTransactionSkip,
 		false,
 		PGC_USERSET,

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1537,6 +1537,25 @@ RegisterCitusConfigVariables(void)
 		NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
+		"citus.enable_procedure_transaction_skip",
+		gettext_noop("Skip coordinated transactions for single-statement, "
+					 "single-shard procedure calls."),
+		gettext_noop("When enabled, CALL statements that execute exactly one "
+					 "distributed write targeting a single task on a single "
+					 "shard with a single placement skip coordinated (2PC) "
+					 "transactions. Only applies to non-nested procedure calls "
+					 "outside of explicit transaction blocks. "
+					 "WARNING: this is intended for single-statement procedures "
+					 "only. If a procedure issues a second distributed statement, "
+					 "it will raise an ERROR, but the first statement will have "
+					 "already been committed and cannot be rolled back."),
+		&EnableProcedureTransactionSkip,
+		false,
+		PGC_USERSET,
+		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
 		"citus.enable_recurring_outer_join_pushdown",
 		gettext_noop("Enables outer join pushdown for recurring relations."),
 		gettext_noop("When enabled, Citus will try to push down outer joins "

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -82,14 +82,6 @@ int StoredProcedureLevel = 0;
 /* number of nested DO block levels we are currently in */
 int DoBlockLevel = 0;
 
-/*
- * Tracks the number of statements that have been executed without
- * coordinated transaction in the current stored procedure call.
- * Used to ensure that at most one statement can skip coordination
- * per procedure invocation, preventing partial-commit scenarios.
- */
-int ProcedureNonCoordinatedExecutionCount = 0;
-
 /* state needed to keep track of operations used during a transaction */
 XactModificationType XactModificationLevel = XACT_MODIFICATION_NONE;
 
@@ -152,11 +144,11 @@ AllowedDistributionColumn AllowedDistributionColumnValue;
 bool FunctionOpensTransactionBlock = true;
 
 /*
- * When enabled, CALL statements that execute a single task on a single shard
- * with a single placement can skip coordinated (2PC) transactions. This avoids
- * the overhead of BEGIN + PREPARE TRANSACTION + COMMIT PREPARED when it is safe
- * to do so (i.e., there is only one participant and no cross-shard coordination
- * is needed).
+ * When enabled, CALL statements whose procedure body contains exactly one
+ * SQL statement (determined by static analysis at func_beg time) and that
+ * target a single task on a single shard skip coordinated (2PC) transactions.
+ * Multi-statement procedures gracefully fall back to the normal coordinated
+ * transaction path.
  */
 bool EnableProcedureTransactionSkip = false;
 

--- a/src/backend/distributed/transaction/transaction_management.c
+++ b/src/backend/distributed/transaction/transaction_management.c
@@ -82,6 +82,14 @@ int StoredProcedureLevel = 0;
 /* number of nested DO block levels we are currently in */
 int DoBlockLevel = 0;
 
+/*
+ * Tracks the number of statements that have been executed without
+ * coordinated transaction in the current stored procedure call.
+ * Used to ensure that at most one statement can skip coordination
+ * per procedure invocation, preventing partial-commit scenarios.
+ */
+int ProcedureNonCoordinatedExecutionCount = 0;
+
 /* state needed to keep track of operations used during a transaction */
 XactModificationType XactModificationLevel = XACT_MODIFICATION_NONE;
 
@@ -142,6 +150,15 @@ AllowedDistributionColumn AllowedDistributionColumnValue;
 
 /* if disabled, distributed statements in a function may run as separate transactions */
 bool FunctionOpensTransactionBlock = true;
+
+/*
+ * When enabled, CALL statements that execute a single task on a single shard
+ * with a single placement can skip coordinated (2PC) transactions. This avoids
+ * the overhead of BEGIN + PREPARE TRANSACTION + COMMIT PREPARED when it is safe
+ * to do so (i.e., there is only one participant and no cross-shard coordination
+ * is needed).
+ */
+bool EnableProcedureTransactionSkip = false;
 
 /* if true, we should trigger node metadata sync on commit */
 bool NodeMetadataSyncOnCommit = false;

--- a/src/include/distributed/procedure_body_analysis.h
+++ b/src/include/distributed/procedure_body_analysis.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ * procedure_body_analysis.h
+ *
+ * Declarations for PLpgSQL procedure body analysis used to determine
+ * whether a stored procedure is eligible for the single-statement
+ * transaction optimization (skip coordinated 2PC).
+ *
+ * Copyright (c) Citus Data, Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PROCEDURE_BODY_ANALYSIS_H
+#define PROCEDURE_BODY_ANALYSIS_H
+
+#include "postgres.h"
+
+extern bool ProcedureBodyIsSingleStatement;
+
+extern void InstallProcedureBodyAnalysisPlugin(void);
+
+#endif /* PROCEDURE_BODY_ANALYSIS_H */

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -117,6 +117,7 @@ extern bool SelectOpensTransactionBlock;
  * block.
  */
 extern bool FunctionOpensTransactionBlock;
+extern bool EnableProcedureTransactionSkip;
 
 /* state needed to prevent new connections during modifying transactions */
 extern XactModificationType XactModificationLevel;
@@ -137,6 +138,12 @@ extern int StoredProcedureLevel;
 
 /* number of nested DO block levels we are currently in */
 extern int DoBlockLevel;
+
+/*
+ * Tracks non-coordinated statement executions within the current stored
+ * procedure. At most one statement may skip coordination per CALL.
+ */
+extern int ProcedureNonCoordinatedExecutionCount;
 
 /* SET LOCAL statements active in the current (sub-)transaction. */
 extern StringInfo activeSetStmts;

--- a/src/include/distributed/transaction_management.h
+++ b/src/include/distributed/transaction_management.h
@@ -139,12 +139,6 @@ extern int StoredProcedureLevel;
 /* number of nested DO block levels we are currently in */
 extern int DoBlockLevel;
 
-/*
- * Tracks non-coordinated statement executions within the current stored
- * procedure. At most one statement may skip coordination per CALL.
- */
-extern int ProcedureNonCoordinatedExecutionCount;
-
 /* SET LOCAL statements active in the current (sub-)transaction. */
 extern StringInfo activeSetStmts;
 

--- a/src/test/regress/expected/sql_procedure_no_transaction_block.out
+++ b/src/test/regress/expected/sql_procedure_no_transaction_block.out
@@ -1,0 +1,597 @@
+--
+-- SQL_PROCEDURE_NO_TRANSACTION_BLOCK
+--
+-- Tests for citus.enable_procedure_transaction_skip GUC.
+-- This optimization allows single-statement procedures that execute
+-- a single task on a single shard to skip coordinated (2PC) transactions.
+--
+SET citus.next_shard_id TO 109000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+CREATE SCHEMA sql_proc_no_txn_block;
+SET search_path TO sql_proc_no_txn_block;
+CREATE TABLE test_dist (shard_key int PRIMARY KEY, other_key int);
+SELECT create_distributed_table('test_dist', 'shard_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- Disable local execution so all commands go through the distributed path.
+SET citus.enable_local_execution TO off;
+-- Create all procedures upfront (before enabling log_remote_commands)
+-- to avoid non-deterministic DDL propagation output.
+CREATE OR REPLACE PROCEDURE single_insert(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val, val * 10);
+END;
+$$;
+CREATE OR REPLACE PROCEDURE two_single_inserts(val1 int, val2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val1, val1 * 10);
+    INSERT INTO test_dist VALUES (val2, val2 * 10);
+END;
+$$;
+CREATE OR REPLACE PROCEDURE multi_then_single(input int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (input + 1, (input + 1) * 10), (input + 2, (input + 2) * 10);
+    INSERT INTO test_dist VALUES (input + 3, (input + 3) * 10);
+END;
+$$;
+CREATE OR REPLACE PROCEDURE outer_proc(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    CALL single_insert(val);
+END;
+$$;
+CREATE OR REPLACE PROCEDURE update_by_shard_key(key_val int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = new_other WHERE shard_key = key_val;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE update_by_other_key(other_val int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = new_other WHERE other_key = other_val;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE two_updates_by_shard_key(k1 int, v1 int, k2 int, v2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = v1 WHERE shard_key = k1;
+    UPDATE test_dist SET other_key = v2 WHERE shard_key = k2;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE insert_then_update(val int, upd_key int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val, val * 10);
+    UPDATE test_dist SET other_key = new_other WHERE shard_key = upd_key;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE update_shard_key_value(old_key int, new_key int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET shard_key = new_key WHERE shard_key = old_key;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE delete_by_shard_key(key_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE shard_key = key_val;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE two_deletes(k1 int, k2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE shard_key = k1;
+    DELETE FROM test_dist WHERE shard_key = k2;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE delete_by_other_key(other_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE other_key = other_val;
+END;
+$$;
+CREATE OR REPLACE PROCEDURE reads_then_write(val int)
+LANGUAGE plpgsql AS $$
+DECLARE cnt int;
+BEGIN
+    SELECT count(*) INTO cnt FROM test_dist WHERE shard_key = val;
+    INSERT INTO test_dist VALUES (val + 100, val * 10);
+END;
+$$;
+-- log_remote_commands is toggled ON only around single-shard CALL statements
+-- whose NOTICE output is deterministic (single connection, single shard).
+-- It is kept OFF for multi-shard operations (TRUNCATE, multi-shard CALL,
+-- SELECT ORDER BY, INSERT seeds) whose parallel NOTICE ordering is
+-- non-deterministic across connections.
+---------------------------------------------------------------------
+-- TEST 1: Single-statement INSERT with optimization ON
+-- Should succeed without error — note: no BEGIN/PREPARE/COMMIT
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL single_insert(1);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (1, 10)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 2: Single-statement INSERT with optimization OFF
+-- Should use coordinated transaction (BEGIN + COMMIT)
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO off;
+SET citus.log_remote_commands TO on;
+CALL single_insert(2);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109003 (shard_key, other_key) VALUES (2, 20)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         2 |        20
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 3: Two single-shard inserts in procedure
+-- Should ERROR on second statement with optimization ON
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_single_inserts(10, 20);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (10, 100)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val1, val1 * 10)"
+PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
+ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
+DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
+HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val2, val2 * 10)"
+PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        10 |       100
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 4: Multi-row insert + single insert in procedure
+-- First statement is multi-task, so coordination kicks in
+-- for both statements. No error expected.
+-- logging off: multi-shard output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL multi_then_single(100);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+       101 |      1010
+       102 |      1020
+       103 |      1030
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 5: Explicit BEGIN block should NOT use optimization
+-- (IsTransactionBlock() returns true, so optimization is skipped)
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+BEGIN;
+CALL single_insert(50);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (50, 500)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+COMMIT;
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        50 |       500
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 6: Nested CALL should NOT use optimization
+-- (StoredProcedureLevel > 1, so optimization is skipped)
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL outer_proc(60);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+SQL statement "CALL single_insert(val)"
+PL/pgSQL function outer_proc(integer) line XX at CALL
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (60, 600)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function single_insert(integer) line XX at SQL statement
+SQL statement "CALL single_insert(val)"
+PL/pgSQL function outer_proc(integer) line XX at CALL
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        60 |       600
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 7: Multi-row insert + single insert with optimization OFF
+-- Should work fine (normal coordinated transaction)
+-- logging off: multi-shard output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO off;
+CALL multi_then_single(200);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+       201 |      2010
+       202 |      2020
+       203 |      2030
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 8: Single UPDATE by shard_key with optimization ON
+-- WHERE clause targets a single shard, should skip 2PC
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL update_by_shard_key(2, 999);
+NOTICE:  issuing UPDATE sql_proc_no_txn_block.test_dist_109003 test_dist SET other_key = 999 WHERE (shard_key OPERATOR(pg_catalog.=) 2)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = new_other WHERE shard_key = key_val"
+PL/pgSQL function update_by_shard_key(integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |       999
+         3 |        30
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 9: Single UPDATE by other_key with optimization ON
+-- WHERE clause on non-distribution column => multi-shard query
+-- Coordination kicks in normally (optimization does not apply
+-- because the planner generates multiple tasks).
+-- logging off: multi-shard output is non-deterministic
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL update_by_other_key(20, 888);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |       888
+         3 |        30
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 10: Two UPDATEs by shard_key in one procedure
+-- Should ERROR on second statement with optimization ON
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_updates_by_shard_key(1, 111, 2, 222);
+NOTICE:  issuing UPDATE sql_proc_no_txn_block.test_dist_109000 test_dist SET other_key = 111 WHERE (shard_key OPERATOR(pg_catalog.=) 1)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = v1 WHERE shard_key = k1"
+PL/pgSQL function two_updates_by_shard_key(integer,integer,integer,integer) line XX at SQL statement
+ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
+DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
+HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = v2 WHERE shard_key = k2"
+PL/pgSQL function two_updates_by_shard_key(integer,integer,integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+-- Second UPDATE triggers ERROR; the first UPDATE (row 1 -> 111) was already
+-- committed on the worker and is NOT rolled back, so it remains visible.
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |       111
+         2 |        20
+         3 |        30
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 11: Single UPDATE by shard_key with optimization OFF
+-- Normal coordinated transaction path
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO off;
+SET citus.log_remote_commands TO on;
+CALL update_by_shard_key(3, 777);
+NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = new_other WHERE shard_key = key_val"
+PL/pgSQL function update_by_shard_key(integer,integer) line XX at SQL statement
+NOTICE:  issuing UPDATE sql_proc_no_txn_block.test_dist_109001 test_dist SET other_key = 777 WHERE (shard_key OPERATOR(pg_catalog.=) 3)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = new_other WHERE shard_key = key_val"
+PL/pgSQL function update_by_shard_key(integer,integer) line XX at SQL statement
+NOTICE:  issuing COMMIT
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |        20
+         3 |       777
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 12: INSERT + UPDATE in same procedure with optimization ON
+-- Should ERROR on the second statement (UPDATE)
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL insert_then_update(5, 5, 555);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (5, 50)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function insert_then_update(integer,integer,integer) line XX at SQL statement
+ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
+DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
+HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
+CONTEXT:  SQL statement "UPDATE test_dist SET other_key = new_other WHERE shard_key = upd_key"
+PL/pgSQL function insert_then_update(integer,integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         5 |        50
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 13: UPDATE modifying the shard_key itself with optimization ON
+-- Citus does not allow modifying the distribution column, so this
+-- should ERROR regardless of the optimization setting.
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL update_shard_key_value(2, 200);
+ERROR:  modifying the partition value of rows is not allowed
+CONTEXT:  SQL statement "UPDATE test_dist SET shard_key = new_key WHERE shard_key = old_key"
+PL/pgSQL function update_shard_key_value(integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |        20
+         3 |        30
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 14: Single-shard DELETE with optimization ON
+-- Should succeed without error (skip 2PC)
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL delete_by_shard_key(2);
+NOTICE:  issuing DELETE FROM sql_proc_no_txn_block.test_dist_109003 test_dist WHERE (shard_key OPERATOR(pg_catalog.=) 2)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "DELETE FROM test_dist WHERE shard_key = key_val"
+PL/pgSQL function delete_by_shard_key(integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         3 |        30
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 15: Two single-shard DELETEs in one procedure
+-- Should ERROR on second statement with optimization ON
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_deletes(1, 2);
+NOTICE:  issuing DELETE FROM sql_proc_no_txn_block.test_dist_109000 test_dist WHERE (shard_key OPERATOR(pg_catalog.=) 1)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "DELETE FROM test_dist WHERE shard_key = k1"
+PL/pgSQL function two_deletes(integer,integer) line XX at SQL statement
+ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
+DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
+HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
+CONTEXT:  SQL statement "DELETE FROM test_dist WHERE shard_key = k2"
+PL/pgSQL function two_deletes(integer,integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+-- Second DELETE triggers ERROR; first DELETE (row 1) was already committed
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         2 |        20
+         3 |        30
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 16: Multi-shard DELETE with optimization ON
+-- WHERE clause on non-distribution column => multi-shard query
+-- Coordination kicks in normally (optimization does not apply)
+-- logging off: multi-shard output is non-deterministic
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL delete_by_other_key(20);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         3 |        30
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 17: Read(s) then write should NOT error
+-- A SELECT (read-only task) does not count toward the
+-- non-coordinated execution counter, so a subsequent single-
+-- shard write should still be able to skip coordination.
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL reads_then_write(1);
+NOTICE:  issuing SELECT count(*) AS count FROM sql_proc_no_txn_block.test_dist_109000 test_dist WHERE (shard_key OPERATOR(pg_catalog.=) 1)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "SELECT count(*)          FROM test_dist WHERE shard_key = val"
+PL/pgSQL function reads_then_write(integer) line XX at SQL statement
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109001 (shard_key, other_key) VALUES (101, 10)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val + 100, val * 10)"
+PL/pgSQL function reads_then_write(integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |        20
+         3 |        30
+       101 |        10
+(4 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- Now switch to local execution for Tests 18-21
+-- (log_remote_commands is not relevant for local execution)
+---------------------------------------------------------------------
+SET citus.enable_local_execution TO on;
+---------------------------------------------------------------------
+-- TEST 18: Single-statement INSERT with local execution ON
+-- Verify the optimization works correctly with local execution
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL single_insert(1);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 19: Two single-shard inserts with local execution ON
+-- Should ERROR on second statement just like the remote case
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL two_single_inserts(10, 20);
+ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
+DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
+HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val2, val2 * 10)"
+PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        10 |       100
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 20: Single-shard DELETE with local execution ON
+-- Should succeed without error
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL delete_by_shard_key(2);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         3 |        30
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 21: Reads then write with local execution ON
+-- Should succeed without error
+---------------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL reads_then_write(1);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |        20
+         3 |        30
+       101 |        10
+(4 rows)
+
+TRUNCATE test_dist;
+-- Cleanup
+DROP TABLE test_dist;
+DROP PROCEDURE single_insert;
+DROP PROCEDURE two_single_inserts;
+DROP PROCEDURE multi_then_single;
+DROP PROCEDURE outer_proc;
+DROP PROCEDURE update_by_shard_key;
+DROP PROCEDURE update_by_other_key;
+DROP PROCEDURE two_updates_by_shard_key;
+DROP PROCEDURE insert_then_update;
+DROP PROCEDURE update_shard_key_value;
+DROP PROCEDURE delete_by_shard_key;
+DROP PROCEDURE two_deletes;
+DROP PROCEDURE delete_by_other_key;
+DROP PROCEDURE reads_then_write;
+DROP SCHEMA sql_proc_no_txn_block;
+RESET citus.enable_procedure_transaction_skip;
+RESET citus.enable_local_execution;
+RESET citus.log_remote_commands;
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;

--- a/src/test/regress/expected/sql_procedure_no_transaction_block.out
+++ b/src/test/regress/expected/sql_procedure_no_transaction_block.out
@@ -106,6 +106,101 @@ BEGIN
     INSERT INTO test_dist VALUES (val + 100, val * 10);
 END;
 $$;
+CREATE OR REPLACE PROCEDURE loop_insert(start_val int, end_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    FOR i IN start_val..end_val LOOP
+        INSERT INTO test_dist VALUES (i, i * 10);
+    END LOOP;
+END;
+$$;
+-- IF/ELSE with exactly one SQL statement per branch. Only one branch runs,
+-- so with max-based branch counting the body is single-statement and the
+-- executed single-shard write is eligible for the 2PC skip.
+CREATE OR REPLACE PROCEDURE if_one_per_branch(val int, flag boolean)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF flag THEN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    ELSE
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END IF;
+END;
+$$;
+-- IF branch containing two SQL statements: that single branch already holds
+-- two statements, so the body is multi-statement regardless of max counting
+-- and falls back to a coordinated transaction.
+CREATE OR REPLACE PROCEDURE if_two_in_branch(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF true THEN
+        INSERT INTO test_dist VALUES (val, val * 10);
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END IF;
+END;
+$$;
+-- Searched CASE with one SQL statement per branch: like IF, max-based
+-- counting keeps it single-statement and eligible for the skip.
+CREATE OR REPLACE PROCEDURE case_one_per_branch(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    CASE
+        WHEN val > 0 THEN
+            INSERT INTO test_dist VALUES (val, val * 10);
+        ELSE
+            INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END CASE;
+END;
+$$;
+-- Single SQL statement wrapped in a nested BEGIN ... END sub-block. The
+-- walker recurses into the block and counts the single write, so the
+-- procedure remains eligible for the skip.
+CREATE OR REPLACE PROCEDURE nested_block_single(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    END;
+END;
+$$;
+-- Two SQL statements inside a nested sub-block: recursion counts both, so
+-- the body is multi-statement and falls back to a coordinated transaction.
+CREATE OR REPLACE PROCEDURE nested_block_two(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END;
+END;
+$$;
+-- Nested block with an exception handler. The walker sums the block body and
+-- the exception-handler action (both are counted), so this two-statement
+-- body falls back to a coordinated transaction. Exercises the exception
+-- recursion path of the walker.
+CREATE OR REPLACE PROCEDURE exception_handler_proc(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    EXCEPTION WHEN others THEN
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END;
+END;
+$$;
+-- Loop nested inside an IF branch. The loop disqualifier must propagate out
+-- of the IF, disqualifying the whole procedure even though max-based branch
+-- counting is used. Guards the F6 short-circuit.
+CREATE OR REPLACE PROCEDURE loop_in_if(start_val int, end_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF true THEN
+        FOR i IN start_val..end_val LOOP
+            INSERT INTO test_dist VALUES (i, i * 10);
+        END LOOP;
+    END IF;
+END;
+$$;
 -- log_remote_commands is toggled ON only around single-shard CALL statements
 -- whose NOTICE output is deterministic (single connection, single shard).
 -- It is kept OFF for multi-shard operations (TRUNCATE, multi-shard CALL,
@@ -157,26 +252,20 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
 -- TEST 3: Two single-shard inserts in procedure
--- Should ERROR on second statement with optimization ON
+-- With static body analysis, this is detected as multi-statement
+-- before execution, so it falls back to coordinated transactions.
+-- No ERROR, both inserts succeed.
+-- logging off: multi-statement procedures use coordinated
+-- transactions with non-deterministic output.
 ---------------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_single_inserts(10, 20);
-NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (10, 100)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val1, val1 * 10)"
-PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
-ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
-DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
-HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
-CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val2, val2 * 10)"
-PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
         10 |       100
-(1 row)
+        20 |       200
+(2 rows)
 
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
@@ -311,29 +400,18 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
 -- TEST 10: Two UPDATEs by shard_key in one procedure
--- Should ERROR on second statement with optimization ON
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both updates succeed, no error.
+-- logging off: multi-shard coordinated output is non-deterministic
 ---------------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_updates_by_shard_key(1, 111, 2, 222);
-NOTICE:  issuing UPDATE sql_proc_no_txn_block.test_dist_109000 test_dist SET other_key = 111 WHERE (shard_key OPERATOR(pg_catalog.=) 1)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "UPDATE test_dist SET other_key = v1 WHERE shard_key = k1"
-PL/pgSQL function two_updates_by_shard_key(integer,integer,integer,integer) line XX at SQL statement
-ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
-DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
-HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
-CONTEXT:  SQL statement "UPDATE test_dist SET other_key = v2 WHERE shard_key = k2"
-PL/pgSQL function two_updates_by_shard_key(integer,integer,integer,integer) line XX at SQL statement
-SET citus.log_remote_commands TO off;
--- Second UPDATE triggers ERROR; the first UPDATE (row 1 -> 111) was already
--- committed on the worker and is NOT rolled back, so it remains visible.
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
          1 |       111
-         2 |        20
+         2 |       222
          3 |        30
 (3 rows)
 
@@ -368,25 +446,16 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
 -- TEST 12: INSERT + UPDATE in same procedure with optimization ON
--- Should ERROR on the second statement (UPDATE)
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both operations succeed, no error.
+-- logging off: coordinated output is non-deterministic
 ---------------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL insert_then_update(5, 5, 555);
-NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (5, 50)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
-PL/pgSQL function insert_then_update(integer,integer,integer) line XX at SQL statement
-ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
-DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
-HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
-CONTEXT:  SQL statement "UPDATE test_dist SET other_key = new_other WHERE shard_key = upd_key"
-PL/pgSQL function insert_then_update(integer,integer,integer) line XX at SQL statement
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
-         5 |        50
+         5 |       555
 (1 row)
 
 TRUNCATE test_dist;
@@ -435,29 +504,18 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
 -- TEST 15: Two single-shard DELETEs in one procedure
--- Should ERROR on second statement with optimization ON
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both deletes succeed, no error.
+-- logging off: multi-shard coordinated output is non-deterministic
 ---------------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_deletes(1, 2);
-NOTICE:  issuing DELETE FROM sql_proc_no_txn_block.test_dist_109000 test_dist WHERE (shard_key OPERATOR(pg_catalog.=) 1)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "DELETE FROM test_dist WHERE shard_key = k1"
-PL/pgSQL function two_deletes(integer,integer) line XX at SQL statement
-ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
-DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
-HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
-CONTEXT:  SQL statement "DELETE FROM test_dist WHERE shard_key = k2"
-PL/pgSQL function two_deletes(integer,integer) line XX at SQL statement
-SET citus.log_remote_commands TO off;
--- Second DELETE triggers ERROR; first DELETE (row 1) was already committed
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
-         2 |        20
          3 |        30
-(2 rows)
+(1 row)
 
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
@@ -478,24 +536,14 @@ SELECT * FROM test_dist ORDER BY shard_key;
 
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
--- TEST 17: Read(s) then write should NOT error
--- A SELECT (read-only task) does not count toward the
--- non-coordinated execution counter, so a subsequent single-
--- shard write should still be able to skip coordination.
+-- TEST 17: Read(s) then write
+-- Static analysis detects 2 SQL statements (SELECT + INSERT),
+-- so the procedure falls back to coordinated transactions.
+-- logging off: coordinated output is non-deterministic
 ---------------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL reads_then_write(1);
-NOTICE:  issuing SELECT count(*) AS count FROM sql_proc_no_txn_block.test_dist_109000 test_dist WHERE (shard_key OPERATOR(pg_catalog.=) 1)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "SELECT count(*)          FROM test_dist WHERE shard_key = val"
-PL/pgSQL function reads_then_write(integer) line XX at SQL statement
-NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109001 (shard_key, other_key) VALUES (101, 10)
-DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
-CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val + 100, val * 10)"
-PL/pgSQL function reads_then_write(integer) line XX at SQL statement
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
@@ -526,20 +574,17 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
 -- TEST 19: Two single-shard inserts with local execution ON
--- Should ERROR on second statement just like the remote case
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both inserts succeed, no error.
 ---------------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
 CALL two_single_inserts(10, 20);
-ERROR:  multi-statement procedures are not supported with citus.enable_procedure_transaction_skip
-DETAIL:  The first statement has already been committed and cannot be rolled back. This applies to both remote and local execution.
-HINT:  Use this optimization only for single-statement procedures, or disable the GUC.
-CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val2, val2 * 10)"
-PL/pgSQL function two_single_inserts(integer,integer) line XX at SQL statement
 SELECT * FROM test_dist ORDER BY shard_key;
  shard_key | other_key
 ---------------------------------------------------------------------
         10 |       100
-(1 row)
+        20 |       200
+(2 rows)
 
 TRUNCATE test_dist;
 ---------------------------------------------------------------------
@@ -574,6 +619,153 @@ SELECT * FROM test_dist ORDER BY shard_key;
 (4 rows)
 
 TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 22: Loop with single INSERT inside
+-- Static analysis detects the FOR loop and disqualifies the
+-- procedure to prevent partial commits if a mid-loop iteration
+-- fails. Uses coordinated transaction.
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.enable_local_execution TO off;
+CALL loop_insert(1, 3);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+         1 |        10
+         2 |        20
+         3 |        30
+(3 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 23: IF/ELSE with one SQL statement per branch
+-- Only one branch executes, so with max-based branch counting
+-- the body is single-statement and the single-shard write skips
+-- 2PC (no BEGIN/PREPARE/COMMIT in the remote command log).
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.enable_local_execution TO off;
+SET citus.log_remote_commands TO on;
+CALL if_one_per_branch(31, true);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (31, 310)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function if_one_per_branch(integer,boolean) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        31 |       310
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 24: IF branch containing two SQL statements
+-- The executed branch already holds two statements, so the body
+-- is multi-statement and falls back to a coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL if_two_in_branch(40);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        40 |       400
+        41 |       410
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 25: Searched CASE with one SQL statement per branch
+-- Like TEST 23, max-based counting makes this single-statement and
+-- the executed single-shard write skips 2PC.
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL case_one_per_branch(33);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (33, 330)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function case_one_per_branch(integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        33 |       330
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 26: Single SQL statement inside a nested BEGIN ... END block
+-- The walker recurses into the sub-block and counts the single write,
+-- so the procedure is single-statement and skips 2PC.
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL nested_block_single(35);
+NOTICE:  issuing INSERT INTO sql_proc_no_txn_block.test_dist_109000 (shard_key, other_key) VALUES (35, 350)
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  SQL statement "INSERT INTO test_dist VALUES (val, val * 10)"
+PL/pgSQL function nested_block_single(integer) line XX at SQL statement
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        35 |       350
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 27: Two SQL statements inside a nested sub-block
+-- Recursion counts both, so the body is multi-statement and falls
+-- back to a coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL nested_block_two(42);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        42 |       420
+        43 |       430
+(2 rows)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 28: Nested block with an exception handler
+-- The walker sums the block body and the exception-handler action,
+-- so this two-statement body falls back to a coordinated transaction.
+-- Exercises the exception-recursion path. No error is raised, so only
+-- the body INSERT takes effect.
+-- logging off: coordinated output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL exception_handler_proc(37);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        37 |       370
+(1 row)
+
+TRUNCATE test_dist;
+---------------------------------------------------------------------
+-- TEST 29: Loop nested inside an IF branch
+-- The loop disqualifier propagates out of the IF, disqualifying the
+-- whole procedure despite max-based branch counting. Falls back to a
+-- coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+---------------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL loop_in_if(44, 46);
+SELECT * FROM test_dist ORDER BY shard_key;
+ shard_key | other_key
+---------------------------------------------------------------------
+        44 |       440
+        45 |       450
+        46 |       460
+(3 rows)
+
+TRUNCATE test_dist;
 -- Cleanup
 DROP TABLE test_dist;
 DROP PROCEDURE single_insert;
@@ -589,6 +781,14 @@ DROP PROCEDURE delete_by_shard_key;
 DROP PROCEDURE two_deletes;
 DROP PROCEDURE delete_by_other_key;
 DROP PROCEDURE reads_then_write;
+DROP PROCEDURE loop_insert;
+DROP PROCEDURE if_one_per_branch;
+DROP PROCEDURE if_two_in_branch;
+DROP PROCEDURE case_one_per_branch;
+DROP PROCEDURE nested_block_single;
+DROP PROCEDURE nested_block_two;
+DROP PROCEDURE exception_handler_proc;
+DROP PROCEDURE loop_in_if;
 DROP SCHEMA sql_proc_no_txn_block;
 RESET citus.enable_procedure_transaction_skip;
 RESET citus.enable_local_execution;

--- a/src/test/regress/multi_schedule
+++ b/src/test/regress/multi_schedule
@@ -80,6 +80,7 @@ test: multi_basic_queries cross_join multi_complex_expressions multi_subquery mu
 test: issue_8468
 test: multi_subquery_complex_reference_clause multi_subquery_window_functions multi_view multi_sql_function multi_prepare_sql
 test: sql_procedure multi_function_in_join row_types materialized_view
+test: sql_procedure_no_transaction_block
 test: multi_subquery_in_where_reference_clause adaptive_executor propagate_set_commands geqo
 test: forcedelegation_functions system_queries
 # this should be run alone as it gets too many clients

--- a/src/test/regress/sql/sql_procedure_no_transaction_block.sql
+++ b/src/test/regress/sql/sql_procedure_no_transaction_block.sql
@@ -1,0 +1,399 @@
+--
+-- SQL_PROCEDURE_NO_TRANSACTION_BLOCK
+--
+-- Tests for citus.enable_procedure_transaction_skip GUC.
+-- This optimization allows single-statement procedures that execute
+-- a single task on a single shard to skip coordinated (2PC) transactions.
+--
+
+SET citus.next_shard_id TO 109000;
+SET citus.shard_count TO 4;
+SET citus.shard_replication_factor TO 1;
+
+CREATE SCHEMA sql_proc_no_txn_block;
+SET search_path TO sql_proc_no_txn_block;
+
+CREATE TABLE test_dist (shard_key int PRIMARY KEY, other_key int);
+SELECT create_distributed_table('test_dist', 'shard_key');
+
+-- Disable local execution so all commands go through the distributed path.
+SET citus.enable_local_execution TO off;
+
+-- Create all procedures upfront (before enabling log_remote_commands)
+-- to avoid non-deterministic DDL propagation output.
+CREATE OR REPLACE PROCEDURE single_insert(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val, val * 10);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE two_single_inserts(val1 int, val2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val1, val1 * 10);
+    INSERT INTO test_dist VALUES (val2, val2 * 10);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE multi_then_single(input int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (input + 1, (input + 1) * 10), (input + 2, (input + 2) * 10);
+    INSERT INTO test_dist VALUES (input + 3, (input + 3) * 10);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE outer_proc(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    CALL single_insert(val);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE update_by_shard_key(key_val int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = new_other WHERE shard_key = key_val;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE update_by_other_key(other_val int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = new_other WHERE other_key = other_val;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE two_updates_by_shard_key(k1 int, v1 int, k2 int, v2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET other_key = v1 WHERE shard_key = k1;
+    UPDATE test_dist SET other_key = v2 WHERE shard_key = k2;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE insert_then_update(val int, upd_key int, new_other int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO test_dist VALUES (val, val * 10);
+    UPDATE test_dist SET other_key = new_other WHERE shard_key = upd_key;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE update_shard_key_value(old_key int, new_key int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE test_dist SET shard_key = new_key WHERE shard_key = old_key;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE delete_by_shard_key(key_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE shard_key = key_val;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE two_deletes(k1 int, k2 int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE shard_key = k1;
+    DELETE FROM test_dist WHERE shard_key = k2;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE delete_by_other_key(other_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM test_dist WHERE other_key = other_val;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE reads_then_write(val int)
+LANGUAGE plpgsql AS $$
+DECLARE cnt int;
+BEGIN
+    SELECT count(*) INTO cnt FROM test_dist WHERE shard_key = val;
+    INSERT INTO test_dist VALUES (val + 100, val * 10);
+END;
+$$;
+
+-- log_remote_commands is toggled ON only around single-shard CALL statements
+-- whose NOTICE output is deterministic (single connection, single shard).
+-- It is kept OFF for multi-shard operations (TRUNCATE, multi-shard CALL,
+-- SELECT ORDER BY, INSERT seeds) whose parallel NOTICE ordering is
+-- non-deterministic across connections.
+
+------------------------------------------------------------
+-- TEST 1: Single-statement INSERT with optimization ON
+-- Should succeed without error — note: no BEGIN/PREPARE/COMMIT
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL single_insert(1);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 2: Single-statement INSERT with optimization OFF
+-- Should use coordinated transaction (BEGIN + COMMIT)
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO off;
+SET citus.log_remote_commands TO on;
+CALL single_insert(2);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 3: Two single-shard inserts in procedure
+-- Should ERROR on second statement with optimization ON
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_single_inserts(10, 20);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 4: Multi-row insert + single insert in procedure
+-- First statement is multi-task, so coordination kicks in
+-- for both statements. No error expected.
+-- logging off: multi-shard output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL multi_then_single(100);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 5: Explicit BEGIN block should NOT use optimization
+-- (IsTransactionBlock() returns true, so optimization is skipped)
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+BEGIN;
+CALL single_insert(50);
+COMMIT;
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 6: Nested CALL should NOT use optimization
+-- (StoredProcedureLevel > 1, so optimization is skipped)
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL outer_proc(60);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 7: Multi-row insert + single insert with optimization OFF
+-- Should work fine (normal coordinated transaction)
+-- logging off: multi-shard output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO off;
+CALL multi_then_single(200);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 8: Single UPDATE by shard_key with optimization ON
+-- WHERE clause targets a single shard, should skip 2PC
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL update_by_shard_key(2, 999);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 9: Single UPDATE by other_key with optimization ON
+-- WHERE clause on non-distribution column => multi-shard query
+-- Coordination kicks in normally (optimization does not apply
+-- because the planner generates multiple tasks).
+-- logging off: multi-shard output is non-deterministic
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL update_by_other_key(20, 888);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 10: Two UPDATEs by shard_key in one procedure
+-- Should ERROR on second statement with optimization ON
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_updates_by_shard_key(1, 111, 2, 222);
+SET citus.log_remote_commands TO off;
+-- Second UPDATE triggers ERROR; the first UPDATE (row 1 -> 111) was already
+-- committed on the worker and is NOT rolled back, so it remains visible.
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 11: Single UPDATE by shard_key with optimization OFF
+-- Normal coordinated transaction path
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO off;
+SET citus.log_remote_commands TO on;
+CALL update_by_shard_key(3, 777);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 12: INSERT + UPDATE in same procedure with optimization ON
+-- Should ERROR on the second statement (UPDATE)
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL insert_then_update(5, 5, 555);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 13: UPDATE modifying the shard_key itself with optimization ON
+-- Citus does not allow modifying the distribution column, so this
+-- should ERROR regardless of the optimization setting.
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL update_shard_key_value(2, 200);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 14: Single-shard DELETE with optimization ON
+-- Should succeed without error (skip 2PC)
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL delete_by_shard_key(2);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 15: Two single-shard DELETEs in one procedure
+-- Should ERROR on second statement with optimization ON
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL two_deletes(1, 2);
+SET citus.log_remote_commands TO off;
+-- Second DELETE triggers ERROR; first DELETE (row 1) was already committed
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 16: Multi-shard DELETE with optimization ON
+-- WHERE clause on non-distribution column => multi-shard query
+-- Coordination kicks in normally (optimization does not apply)
+-- logging off: multi-shard output is non-deterministic
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+CALL delete_by_other_key(20);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 17: Read(s) then write should NOT error
+-- A SELECT (read-only task) does not count toward the
+-- non-coordinated execution counter, so a subsequent single-
+-- shard write should still be able to skip coordination.
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL reads_then_write(1);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- Now switch to local execution for Tests 18-21
+-- (log_remote_commands is not relevant for local execution)
+------------------------------------------------------------
+SET citus.enable_local_execution TO on;
+
+------------------------------------------------------------
+-- TEST 18: Single-statement INSERT with local execution ON
+-- Verify the optimization works correctly with local execution
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL single_insert(1);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 19: Two single-shard inserts with local execution ON
+-- Should ERROR on second statement just like the remote case
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL two_single_inserts(10, 20);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 20: Single-shard DELETE with local execution ON
+-- Should succeed without error
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+
+SET citus.enable_procedure_transaction_skip TO on;
+CALL delete_by_shard_key(2);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 21: Reads then write with local execution ON
+-- Should succeed without error
+------------------------------------------------------------
+INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
+
+SET citus.enable_procedure_transaction_skip TO on;
+CALL reads_then_write(1);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+-- Cleanup
+DROP TABLE test_dist;
+DROP PROCEDURE single_insert;
+DROP PROCEDURE two_single_inserts;
+DROP PROCEDURE multi_then_single;
+DROP PROCEDURE outer_proc;
+DROP PROCEDURE update_by_shard_key;
+DROP PROCEDURE update_by_other_key;
+DROP PROCEDURE two_updates_by_shard_key;
+DROP PROCEDURE insert_then_update;
+DROP PROCEDURE update_shard_key_value;
+DROP PROCEDURE delete_by_shard_key;
+DROP PROCEDURE two_deletes;
+DROP PROCEDURE delete_by_other_key;
+DROP PROCEDURE reads_then_write;
+DROP SCHEMA sql_proc_no_txn_block;
+
+RESET citus.enable_procedure_transaction_skip;
+RESET citus.enable_local_execution;
+RESET citus.log_remote_commands;
+RESET citus.shard_count;
+RESET citus.shard_replication_factor;

--- a/src/test/regress/sql/sql_procedure_no_transaction_block.sql
+++ b/src/test/regress/sql/sql_procedure_no_transaction_block.sql
@@ -119,6 +119,109 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE PROCEDURE loop_insert(start_val int, end_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    FOR i IN start_val..end_val LOOP
+        INSERT INTO test_dist VALUES (i, i * 10);
+    END LOOP;
+END;
+$$;
+
+-- IF/ELSE with exactly one SQL statement per branch. Only one branch runs,
+-- so with max-based branch counting the body is single-statement and the
+-- executed single-shard write is eligible for the 2PC skip.
+CREATE OR REPLACE PROCEDURE if_one_per_branch(val int, flag boolean)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF flag THEN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    ELSE
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END IF;
+END;
+$$;
+
+-- IF branch containing two SQL statements: that single branch already holds
+-- two statements, so the body is multi-statement regardless of max counting
+-- and falls back to a coordinated transaction.
+CREATE OR REPLACE PROCEDURE if_two_in_branch(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF true THEN
+        INSERT INTO test_dist VALUES (val, val * 10);
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END IF;
+END;
+$$;
+
+-- Searched CASE with one SQL statement per branch: like IF, max-based
+-- counting keeps it single-statement and eligible for the skip.
+CREATE OR REPLACE PROCEDURE case_one_per_branch(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    CASE
+        WHEN val > 0 THEN
+            INSERT INTO test_dist VALUES (val, val * 10);
+        ELSE
+            INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END CASE;
+END;
+$$;
+
+-- Single SQL statement wrapped in a nested BEGIN ... END sub-block. The
+-- walker recurses into the block and counts the single write, so the
+-- procedure remains eligible for the skip.
+CREATE OR REPLACE PROCEDURE nested_block_single(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    END;
+END;
+$$;
+
+-- Two SQL statements inside a nested sub-block: recursion counts both, so
+-- the body is multi-statement and falls back to a coordinated transaction.
+CREATE OR REPLACE PROCEDURE nested_block_two(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END;
+END;
+$$;
+
+-- Nested block with an exception handler. The walker sums the block body and
+-- the exception-handler action (both are counted), so this two-statement
+-- body falls back to a coordinated transaction. Exercises the exception
+-- recursion path of the walker.
+CREATE OR REPLACE PROCEDURE exception_handler_proc(val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    BEGIN
+        INSERT INTO test_dist VALUES (val, val * 10);
+    EXCEPTION WHEN others THEN
+        INSERT INTO test_dist VALUES (val + 1, (val + 1) * 10);
+    END;
+END;
+$$;
+
+-- Loop nested inside an IF branch. The loop disqualifier must propagate out
+-- of the IF, disqualifying the whole procedure even though max-based branch
+-- counting is used. Guards the F6 short-circuit.
+CREATE OR REPLACE PROCEDURE loop_in_if(start_val int, end_val int)
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF true THEN
+        FOR i IN start_val..end_val LOOP
+            INSERT INTO test_dist VALUES (i, i * 10);
+        END LOOP;
+    END IF;
+END;
+$$;
+
 -- log_remote_commands is toggled ON only around single-shard CALL statements
 -- whose NOTICE output is deterministic (single connection, single shard).
 -- It is kept OFF for multi-shard operations (TRUNCATE, multi-shard CALL,
@@ -149,12 +252,14 @@ TRUNCATE test_dist;
 
 ------------------------------------------------------------
 -- TEST 3: Two single-shard inserts in procedure
--- Should ERROR on second statement with optimization ON
+-- With static body analysis, this is detected as multi-statement
+-- before execution, so it falls back to coordinated transactions.
+-- No ERROR, both inserts succeed.
+-- logging off: multi-statement procedures use coordinated
+-- transactions with non-deterministic output.
 ------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_single_inserts(10, 20);
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
@@ -230,15 +335,13 @@ TRUNCATE test_dist;
 
 ------------------------------------------------------------
 -- TEST 10: Two UPDATEs by shard_key in one procedure
--- Should ERROR on second statement with optimization ON
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both updates succeed, no error.
+-- logging off: multi-shard coordinated output is non-deterministic
 ------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_updates_by_shard_key(1, 111, 2, 222);
-SET citus.log_remote_commands TO off;
--- Second UPDATE triggers ERROR; the first UPDATE (row 1 -> 111) was already
--- committed on the worker and is NOT rolled back, so it remains visible.
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
@@ -256,12 +359,12 @@ TRUNCATE test_dist;
 
 ------------------------------------------------------------
 -- TEST 12: INSERT + UPDATE in same procedure with optimization ON
--- Should ERROR on the second statement (UPDATE)
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both operations succeed, no error.
+-- logging off: coordinated output is non-deterministic
 ------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL insert_then_update(5, 5, 555);
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
@@ -292,14 +395,13 @@ TRUNCATE test_dist;
 
 ------------------------------------------------------------
 -- TEST 15: Two single-shard DELETEs in one procedure
--- Should ERROR on second statement with optimization ON
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both deletes succeed, no error.
+-- logging off: multi-shard coordinated output is non-deterministic
 ------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL two_deletes(1, 2);
-SET citus.log_remote_commands TO off;
--- Second DELETE triggers ERROR; first DELETE (row 1) was already committed
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
@@ -316,16 +418,14 @@ SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
 ------------------------------------------------------------
--- TEST 17: Read(s) then write should NOT error
--- A SELECT (read-only task) does not count toward the
--- non-coordinated execution counter, so a subsequent single-
--- shard write should still be able to skip coordination.
+-- TEST 17: Read(s) then write
+-- Static analysis detects 2 SQL statements (SELECT + INSERT),
+-- so the procedure falls back to coordinated transactions.
+-- logging off: coordinated output is non-deterministic
 ------------------------------------------------------------
 INSERT INTO test_dist VALUES (1, 10), (2, 20), (3, 30);
 SET citus.enable_procedure_transaction_skip TO on;
-SET citus.log_remote_commands TO on;
 CALL reads_then_write(1);
-SET citus.log_remote_commands TO off;
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
@@ -346,7 +446,8 @@ TRUNCATE test_dist;
 
 ------------------------------------------------------------
 -- TEST 19: Two single-shard inserts with local execution ON
--- Should ERROR on second statement just like the remote case
+-- Detected as multi-statement, uses coordinated transaction.
+-- Both inserts succeed, no error.
 ------------------------------------------------------------
 SET citus.enable_procedure_transaction_skip TO on;
 CALL two_single_inserts(10, 20);
@@ -375,6 +476,103 @@ CALL reads_then_write(1);
 SELECT * FROM test_dist ORDER BY shard_key;
 TRUNCATE test_dist;
 
+------------------------------------------------------------
+-- TEST 22: Loop with single INSERT inside
+-- Static analysis detects the FOR loop and disqualifies the
+-- procedure to prevent partial commits if a mid-loop iteration
+-- fails. Uses coordinated transaction.
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.enable_local_execution TO off;
+CALL loop_insert(1, 3);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 23: IF/ELSE with one SQL statement per branch
+-- Only one branch executes, so with max-based branch counting
+-- the body is single-statement and the single-shard write skips
+-- 2PC (no BEGIN/PREPARE/COMMIT in the remote command log).
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.enable_local_execution TO off;
+SET citus.log_remote_commands TO on;
+CALL if_one_per_branch(31, true);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 24: IF branch containing two SQL statements
+-- The executed branch already holds two statements, so the body
+-- is multi-statement and falls back to a coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL if_two_in_branch(40);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 25: Searched CASE with one SQL statement per branch
+-- Like TEST 23, max-based counting makes this single-statement and
+-- the executed single-shard write skips 2PC.
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL case_one_per_branch(33);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 26: Single SQL statement inside a nested BEGIN ... END block
+-- The walker recurses into the sub-block and counts the single write,
+-- so the procedure is single-statement and skips 2PC.
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+SET citus.log_remote_commands TO on;
+CALL nested_block_single(35);
+SET citus.log_remote_commands TO off;
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 27: Two SQL statements inside a nested sub-block
+-- Recursion counts both, so the body is multi-statement and falls
+-- back to a coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL nested_block_two(42);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 28: Nested block with an exception handler
+-- The walker sums the block body and the exception-handler action,
+-- so this two-statement body falls back to a coordinated transaction.
+-- Exercises the exception-recursion path. No error is raised, so only
+-- the body INSERT takes effect.
+-- logging off: coordinated output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL exception_handler_proc(37);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
+------------------------------------------------------------
+-- TEST 29: Loop nested inside an IF branch
+-- The loop disqualifier propagates out of the IF, disqualifying the
+-- whole procedure despite max-based branch counting. Falls back to a
+-- coordinated transaction.
+-- logging off: multi-shard coordinated output is non-deterministic
+------------------------------------------------------------
+SET citus.enable_procedure_transaction_skip TO on;
+CALL loop_in_if(44, 46);
+SELECT * FROM test_dist ORDER BY shard_key;
+TRUNCATE test_dist;
+
 -- Cleanup
 DROP TABLE test_dist;
 DROP PROCEDURE single_insert;
@@ -390,6 +588,14 @@ DROP PROCEDURE delete_by_shard_key;
 DROP PROCEDURE two_deletes;
 DROP PROCEDURE delete_by_other_key;
 DROP PROCEDURE reads_then_write;
+DROP PROCEDURE loop_insert;
+DROP PROCEDURE if_one_per_branch;
+DROP PROCEDURE if_two_in_branch;
+DROP PROCEDURE case_one_per_branch;
+DROP PROCEDURE nested_block_single;
+DROP PROCEDURE nested_block_two;
+DROP PROCEDURE exception_handler_proc;
+DROP PROCEDURE loop_in_if;
 DROP SCHEMA sql_proc_no_txn_block;
 
 RESET citus.enable_procedure_transaction_skip;


### PR DESCRIPTION
DESCRIPTION: Avoid coordinated transactions for single-statement single-shard procedure calls

Replace the runtime-counter approach from PR#8524 with pre-execution static analysis of procedure bodies using the PLpgSQL plugin func_beg hook. The prior design detected multi-statement procedures only after the first statement had run, which could produce a partial commit followed by an ERROR. Analyzing the body before any statement executes lets multi-statement procedures fall back cleanly to a coordinated (2PC) transaction with no error and no partial commit.

How it works
A new PLpgSQL plugin walks the statement tree at func_beg time, before any statement runs and sets the ProcedureBodyIsSingleStatement flag. The executor gate (CanSkipProcedureCoordination) then treats a single-statement body as necessary but not sufficient: the existing single-task / single-placement / coordinated-transaction checks still apply before a skip is allowed.

The walker:

Counts SQL-producing statements: EXECSQL, PERFORM, DYNEXECUTE, and CALL (the motivating use case).
Disqualifies on COMMIT, ROLLBACK, and every loop type (LOOP, WHILE, FOR/FORI/FORS/FORC, DYNFORS, FOREACH), a statement inside a loop can run many times, which is exactly the partial-commit risk we avoid.
Recurses into container statements: a BLOCK contributes the sum of its body and its exception-handler actions (both may run), while an IF or CASE contributes the maximum SQL count across its branches (then/ELSIF/else, or WHEN/else) because only one branch executes at runtime. A disqualifier in any branch still disqualifies the whole body.

Key changes

New [procedure_body_analysis.c] PLpgSQL plugin performing the pre-execution walk.
Max-based IF/CASE branch counting, so a procedure with a single SQL statement per branch stays eligible for the skip.
Multi-statement or disqualified procedures fall back to normal coordinated (2PC) transactions instead of raising an ERROR.
Removed the ProcedureNonCoordinatedExecutionCount global counter and its reset sites in utility_hook.c; the single-statement flag is now also defensively reset on the procedure error path so it can never survive a failed procedure.
The optimization stays behind the off-by-default citus.enable_procedure_transaction_skip GUC (kept off here to keep the change backport-friendly for 14.2 & 13.4; enabling-by-default / GUC removal is deferred to a follow-up on main). Note the analysis only applies to PLpgSQL procedures.
Regression coverage for the IF, CASE, nested-block, and exception walker paths (plus the single-CALL and loop cases), asserting the 2PC skip via citus.log_remote_commands.