### PR TITLE
Fix bugs in UPDATE dist_table .. WHERE shard_key = X AND false (Backport PR8692)

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -178,6 +178,7 @@ static bool ModifiesLocalTableWithRemoteCitusLocalTable(List *rangeTableList);
 static DeferredErrorMessage * DeferErrorIfUnsupportedLocalTableJoin(List *rangeTableList);
 static bool IsLocallyAccessibleCitusLocalTable(Oid relationId);
 static bool ConvertToQueryOnShard(Query *query, Oid relationID, Oid shardRelationId);
+static void ReplaceModifyingCteWithEmptyResult(Query *outerQuery);
 
 /*
  * CreateRouterPlan attempts to create a router executor plan for the given
@@ -283,6 +284,16 @@ CreateSingleTaskRouterSelectPlan(DistributedPlan *distributedPlan, Query *origin
 		/* query cannot be handled by this planner */
 		return;
 	}
+
+	/*
+	 * RouterJob may rewrite a zero-shard modifying CTE inside a router SELECT
+	 * into a plain empty-result CTE (see ReplaceModifyingCteWithEmptyResult).
+	 * That clears originalQuery->hasModifyingCTE, so recompute modLevel from
+	 * the (possibly-transformed) job query -- otherwise the executor would
+	 * treat the plan as ROW_MODIFY_NONCOMMUTATIVE and attempt to acquire
+	 * shard-locks on the pruned-away shard.
+	 */
+	distributedPlan->modLevel = RowModifyLevelForQuery(job->jobQuery);
 
 	ereport(DEBUG2, (errmsg("Creating router plan")));
 
@@ -1984,6 +1995,39 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 			}
 		}
 	}
+	else if (shardId == INVALID_SHARD_ID && originalQuery->hasModifyingCTE)
+	{
+		/*
+		 * Router SELECT that wraps a modifying CTE whose pruning
+		 * yielded zero shards (e.g. WITH u AS (UPDATE t ... WHERE
+		 * dist_key = X AND FALSE RETURNING ...) SELECT ... FROM u).
+		 *
+		 * PlanRouterQuery returned INVALID_SHARD_ID with a dummy
+		 * placement, and UpdateRelationToShardNames has already
+		 * flipped the CTE's target relation RTE to an empty-result
+		 * RTE_SUBQUERY. The direct UPDATE/DELETE escape above only
+		 * inspects the OUTER query's resultRelation (which is 0 for
+		 * a SELECT), so absent this branch the query would fall
+		 * through to SingleShardTaskList and be promoted to a
+		 * MODIFY_TASK with anchorShardId = 0 -- which then fails at
+		 * execution time in AcquireMetadataLocks ->
+		 * LookupShardIdCacheEntry(0) with "could not find valid
+		 * entry for shard 0".
+		 *
+		 * We cannot use the taskList = NIL contract that the direct
+		 * UPDATE/DELETE escape above uses, because the outer SELECT
+		 * has a consumer (e.g. SELECT count(*) FROM u must return
+		 * one row containing 0, not the empty resultset that an empty
+		 * task list would yield). Instead, rewrite each modifying CTE
+		 * in-place to a plain SELECT that returns no rows but retains
+		 * the CTE's output column shape, and clear hasModifyingCTE.
+		 * The rewritten query then flows through the normal
+		 * zero-shard router-SELECT machinery (READ_TASK on the dummy
+		 * placement), producing the correct empty CTE and letting the
+		 * outer aggregate emit the required single row.
+		 */
+		ReplaceModifyingCteWithEmptyResult(originalQuery);
+	}
 
 	if (isMultiShardModifyQuery)
 	{
@@ -2108,6 +2152,27 @@ CheckAndBuildDelayedFastPathPlan(DistributedPlanningContext *planContext,
 	if (job->deferredPruning)
 	{
 		/* Execution time pruning => don't know which shard at this point */
+		planContext->plan = FastPathPlanner(planContext->originalQuery,
+											planContext->query,
+											planContext->boundParams);
+		return;
+	}
+
+	if (list_length(job->taskList) == 0)
+	{
+		/*
+		 * Planner-time shard pruning legitimately produced zero shards for a
+		 * delayed fast-path modification (e.g. WHERE dist_key = X AND FALSE,
+		 * or a fast-path fallback where the distribution-key type does not
+		 * match the literal type and PruneShards short-circuits on
+		 * ContainsFalseClause). GenerateSingleShardRouterTaskList already
+		 * established the terminal state job->taskList = NIL for this case
+		 * in the non-delayed fast-path route; mirror the deferred-pruning
+		 * branch above so we build a placeholder plan (no single-task local
+		 * shortcut, no deparse) and let the executor treat the empty task
+		 * list as a silent no-op, matching the non-fast-path direct
+		 * UPDATE/DELETE contract.
+		 */
 		planContext->plan = FastPathPlanner(planContext->originalQuery,
 											planContext->query,
 											planContext->boundParams);
@@ -2266,6 +2331,94 @@ ConvertToQueryOnShard(Query *query, Oid citusTableOid, Oid shardId)
 #endif
 
 	return true;
+}
+
+
+/*
+ * ReplaceModifyingCteWithEmptyResult rewrites each modifying (UPDATE/DELETE)
+ * CTE in outerQuery->cteList so that its body becomes a plain SELECT whose
+ * jointree quals are constant FALSE and whose target list is a matching-shape
+ * list of NULL constants. This preserves the outer query's structural reference
+ * to the CTE (name, output column names/types/typmods/collations) while
+ * guaranteeing the CTE produces zero rows and requires no shard metadata.
+ *
+ * hasModifyingCTE is cleared only if no other modifying CTE (e.g. CMD_INSERT,
+ * CMD_MERGE) remains in the cteList after the rewrite; otherwise the flag is
+ * preserved so downstream routing (READ_TASK vs MODIFY_TASK selection,
+ * modLevel computation, lock acquisition) still treats the query as
+ * modifying. When the flag does end up cleared, the outer SELECT flows
+ * through the standard zero-shard router-SELECT machinery (READ_TASK on the
+ * dummy placement, no shard-metadata lookups, no MODIFY_TASK promotion in
+ * SingleShardTaskList).
+ *
+ * This helper mutates outerQuery in place. Callers must have already
+ * established that pruning yielded zero shards (shardId == INVALID_SHARD_ID);
+ * pruning-relevant fields (placementList, relationShardList, prunedShardIntervalListList)
+ * are unaffected.
+ */
+static void
+ReplaceModifyingCteWithEmptyResult(Query *outerQuery)
+{
+	CommonTableExpr *cte = NULL;
+	bool anyModifyingCteLeft = false;
+
+	foreach_declared_ptr(cte, outerQuery->cteList)
+	{
+		Query *cteQuery = (Query *) cte->ctequery;
+
+		if (cteQuery->commandType != CMD_UPDATE &&
+			cteQuery->commandType != CMD_DELETE)
+		{
+			/*
+			 * Non-UPDATE/DELETE CTE: leave it alone. If it is still a
+			 * modification (e.g. CMD_INSERT, CMD_MERGE) note that so we do
+			 * not clear the outer query's hasModifyingCTE flag below.
+			 */
+			if (cteQuery->commandType != CMD_SELECT)
+			{
+				anyModifyingCteLeft = true;
+			}
+			continue;
+		}
+
+		int columnCount = list_length(cte->ctecoltypes);
+		List *targetList = NIL;
+
+		for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+		{
+			Oid coltype = list_nth_oid(cte->ctecoltypes, columnIndex);
+			int32 coltypmod = list_nth_int(cte->ctecoltypmods, columnIndex);
+			Oid colcoll = list_nth_oid(cte->ctecolcollations, columnIndex);
+			Node *colname = (Node *) list_nth(cte->ctecolnames, columnIndex);
+
+			Const *nullConst = makeNullConst(coltype, coltypmod, colcoll);
+
+			TargetEntry *targetEntry = makeNode(TargetEntry);
+			targetEntry->expr = (Expr *) nullConst;
+			targetEntry->resno = columnIndex + 1;
+			targetEntry->resname = pstrdup(strVal(colname));
+			targetEntry->resorigtbl = InvalidOid;
+			targetEntry->resorigcol = 0;
+			targetEntry->resjunk = false;
+
+			targetList = lappend(targetList, targetEntry);
+		}
+
+		FromExpr *joinTree = makeNode(FromExpr);
+		joinTree->fromlist = NIL;
+		joinTree->quals = (Node *) makeBoolConst(false, false);
+
+		Query *emptyCteQuery = makeNode(Query);
+		emptyCteQuery->commandType = CMD_SELECT;
+		emptyCteQuery->querySource = cteQuery->querySource;
+		emptyCteQuery->canSetTag = cteQuery->canSetTag;
+		emptyCteQuery->targetList = targetList;
+		emptyCteQuery->jointree = joinTree;
+
+		cte->ctequery = (Node *) emptyCteQuery;
+	}
+
+	outerQuery->hasModifyingCTE = anyModifyingCteLeft;
 }
 
 

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -112,6 +112,17 @@ DEPS = {
         "minimal_schedule", ["multi_test_helpers_superuser"], repeatable=False
     ),
     "create_role_propagation": TestDeps(None, ["multi_cluster_management"]),
+    # multi_copy uses test_user which requires CREATE on schema public;
+    # base_schedule's multi_cluster_management issues the compensating GRANT
+    # that PostgreSQL 15+ no longer grants by default. Using base_schedule
+    # (rather than an extra_tests=[multi_cluster_management] override) avoids
+    # duplicating multi_cluster_management in downstream tests' setup
+    # (e.g. multi_size_queries) whose DEPS pull multi_copy in as an extra_test.
+    "multi_copy": TestDeps("base_schedule"),
+    # fast_path_router_modify shares its schedule line with multi_copy, so
+    # --use-whole-schedule-line drags multi_copy along; mirror the same base
+    # for the same reason.
+    "fast_path_router_modify": TestDeps("base_schedule"),
     "single_node_enterprise": TestDeps(None),
     "multi_add_node_from_backup": TestDeps(None, repeatable=False, worker_count=5),
     "multi_add_node_from_backup_negative": TestDeps(

--- a/src/test/regress/expected/fast_path_router_modify.out
+++ b/src/test/regress/expected/fast_path_router_modify.out
@@ -29,6 +29,17 @@ SELECT create_reference_table('modify_fast_path_reference');
 
 (1 row)
 
+-- Pre-propagate the plpgsql extension to workers via Citus's function
+-- distribution machinery, before enabling DEBUG-level output. Otherwise the
+-- first distributed CREATE FUNCTION below would emit worker-side "extension
+-- plpgsql already exists" notices that only appear when this test runs against
+-- a setup where plpgsql wasn't registered in pg_dist_object by an earlier
+-- test in the schedule (e.g. the flakyness detector's minimal schedule).
+SET client_min_messages TO WARNING;
+CREATE OR REPLACE FUNCTION _propagate_plpgsql() RETURNS void
+    LANGUAGE plpgsql AS $$BEGIN END$$;
+DROP FUNCTION _propagate_plpgsql();
+RESET client_min_messages;
 -- show the output
 SET client_min_messages TO DEBUG;
 -- very simple queries goes through fast-path planning
@@ -488,10 +499,133 @@ EXECUTE prepared_zero_shard_update(7);
 RESET citus.enable_fast_path_router_planner;
 RESET client_min_messages;
 RESET citus.log_remote_commands;
+-- Regression coverage for the delayed-fast-path zero-shard modification
+-- case. When the WHERE clause combines a distribution-key equality with
+-- a statically-unsatisfiable sub-predicate (`AND false`, `AND 1 = 0`, or
+-- when the fast-path fallback triggers e.g. via bigint-key-vs-int-literal
+-- type mismatch) shard pruning legitimately yields zero shards. Prior to
+-- the fix, CheckAndBuildDelayedFastPathPlan tripped
+-- `Assert(list_length(tasks) == 1)`; the fix routes these queries through
+-- the same "empty task list is a silent no-op" contract already used by
+-- the non-fast-path UPDATE/DELETE route.
+CREATE TABLE modify_fast_path_bigint(dist_key bigint, val int);
+SELECT create_distributed_table('modify_fast_path_bigint', 'dist_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO modify_fast_path_bigint VALUES (7, 100), (8, 200);
+SET client_min_messages TO DEBUG2;
+-- bigint-key vs int-literal: DistKeyInSimpleOpExpression bails out on the
+-- type mismatch so fastPathContext->distributionKeyValue is NULL, then
+-- TargetShardIntervalForFastPathQuery falls back to PruneShards which
+-- short-circuits on ContainsFalseClause -> zero shards -> empty task list.
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND 1 = 0;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+-- Same shape but on an int-keyed table (matching type). Plan shape must
+-- remain the pre-fix fast-path single-shard dispatch that lets PG
+-- evaluate AND FALSE at the shard.
+UPDATE modify_fast_path SET value_1 = value_1 WHERE key = 1 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+UPDATE modify_fast_path SET value_1 = value_1 WHERE key = 1 AND 1 = 0;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+DELETE FROM modify_fast_path WHERE key = 1 AND (value_2 IS NULL AND false);
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+-- Standalone RETURNING variant: client sees an empty result set (no rows),
+-- distinct from the plain UPDATE/DELETE "UPDATE 0" client shape.
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+SELECT 1 AS still_alive;
+ still_alive
+---------------------------------------------------------------------
+           1
+(1 row)
+
+COMMIT;
+-- Sanity: the satisfiable happy-paths for both key types still resolve
+-- to fast-path single-shard dispatch (must show "query has a single
+-- distribution column value: N").
+UPDATE modify_fast_path_bigint SET val = val + 1 WHERE dist_key = 7;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+-- Sanity: the zero-shard rows returned zero rows affected.
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM modify_fast_path_bigint ORDER BY dist_key;
+ dist_key | val
+---------------------------------------------------------------------
+        7 | 101
+        8 | 200
+(2 rows)
+
+SET client_min_messages TO DEBUG2;
+-- Plain SELECT with AND false must still work (the Phase 2 gate must not
+-- fire here; only modifying-CTE SELECTs enter that transform).
+SELECT count(*) FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+SELECT count(*) FROM modify_fast_path WHERE key = 1 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 1
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+RESET client_min_messages;
 DROP SCHEMA fast_path_router_modify CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table modify_fast_path
 drop cascades to table modify_fast_path_replication_2
 drop cascades to table modify_fast_path_reference
 drop cascades to table modify_fast_path_reference_1840008
 drop cascades to function modify_fast_path_plpsql(integer,integer)
+drop cascades to table modify_fast_path_bigint

--- a/src/test/regress/expected/multi_copy.out
+++ b/src/test/regress/expected/multi_copy.out
@@ -7,6 +7,15 @@
 \set customer3datafile :abs_srcdir '/data/customer.3.data'
 \set lineitem1datafile :abs_srcdir '/data/lineitem.1.data'
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 560000;
+-- Make this test re-runnable within the same cluster (needed by the
+-- flakyness detector). customer_copy_hash is *not* dropped at the end of
+-- this file because multi_size_queries later in multi_1_schedule inherits
+-- it; drop-if-exists here handles the repeat-run case without breaking that
+-- downstream dependency. See the end-of-file cleanup block for the tables
+-- that can be safely dropped.
+SET client_min_messages TO WARNING;
+DROP TABLE IF EXISTS customer_copy_hash;
+RESET client_min_messages;
 -- Create a new hash-partitioned table into which to COPY
 CREATE TABLE customer_copy_hash (
         c_custkey integer,
@@ -1013,3 +1022,42 @@ DETAIL:  The input string ended unexpectedly.
 CONTEXT:  JSON data, line 1: {"r":255,"g":0,"b":0
 COPY copy_jsonb, line 1, column value: "{"r":255,"g":0,"b":0"
 DROP TABLE copy_jsonb;
+-- Drop the objects created earlier in this file that were not dropped inline,
+-- so that the test can be re-run within the same cluster without tripping on
+-- "relation already exists" / "type already exists" errors (e.g. from the
+-- flakyness detector or a repeated pg_regress invocation).
+--
+-- The BEGIN..master_create_empty_shard('customer_copy_append')..COPY-fails..END
+-- block near line 234 rolls back on the coordinator (removing the pg_dist_shard
+-- entry) but leaves the physical shard table customer_copy_append_560130 on the
+-- workers, because worker-side CREATE TABLE from master_create_empty_shard is
+-- not covered by the coordinator's rollback. A repeat run's ALTER SEQUENCE
+-- pg_dist_shardid_seq RESTART 560000 (line 11) cycles the shardid sequence and
+-- master_create_empty_shard re-issues 560130, colliding with the stranded
+-- worker-only table. Force-drop it via run_command_on_workers before the
+-- DROP TABLE below, since DROP TABLE only knows about shards recorded in
+-- pg_dist_shard.
+SET client_min_messages TO WARNING;
+SELECT success FROM run_command_on_workers($$DROP TABLE IF EXISTS customer_copy_append_560130$$);
+ success
+---------------------------------------------------------------------
+ t
+ t
+(2 rows)
+
+RESET client_min_messages;
+DROP TABLE customer_with_default;
+DROP TABLE customer_copy_range;
+DROP TABLE customer_copy_append;
+DROP TABLE lineitem_copy_append;
+DROP TABLE "customer_with_special_\\_character";
+DROP TABLE "1_customer";
+DROP TABLE packed_numbers_hash;
+DROP TABLE super_packed_numbers_hash;
+DROP TABLE packed_numbers_append;
+DROP TABLE super_packed_numbers_append;
+DROP TABLE composite_partition_column_table;
+DROP TYPE super_number_pack;
+DROP TYPE number_pack;
+DROP SCHEMA append CASCADE;
+NOTICE:  drop cascades to table append.customer_copy

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1730,5 +1730,269 @@ CREATE TABLE multi_modifications.local (a int default 1, b int);
 INSERT INTO multi_modifications.local VALUES (default, (SELECT min(id) FROM summary_table));
 ERROR:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+-- Regression coverage for zero-shard modifying CTE inside an outer SELECT.
+-- Prior to the fix, WITH u AS (UPDATE ... WHERE dist_key = X AND false
+-- RETURNING ...) SELECT ... FROM u; would fail at execution time in
+-- AcquireMetadataLocks -> LookupShardIdCacheEntry(0) with
+-- "could not find valid entry for shard xxxxx", because
+-- UpdateRelationToShardNames flipped every Citus-relation RTE to
+-- an empty-result RTE_SUBQUERY while the outer query's resultRelation
+-- (0 for a SELECT) did not trigger the direct UPDATE/DELETE escape in
+-- RouterJob. The fix rewrites each modifying CTE in-place to a plain
+-- SELECT returning matching-shape NULL columns under WHERE false and
+-- clears hasModifyingCTE, so the outer SELECT flows through the normal
+-- zero-shard router-SELECT machinery and emits the correct empty-CTE
+-- result set to its consumer.
+RESET client_min_messages;
+CREATE TABLE zero_shard_cte(dist_key int, val int, tag text);
+SELECT create_distributed_table('zero_shard_cte', 'dist_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO zero_shard_cte VALUES (7, 42, 'seven'), (8, 43, 'eight');
+CREATE TABLE zero_shard_cte_ref(k int, v int);
+SELECT create_reference_table('zero_shard_cte_ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO zero_shard_cte_ref VALUES (1, 100);
+SET client_min_messages TO DEBUG2;
+-- Literal false, folded (1 = 0), UPDATE and DELETE CTE variants -- all
+-- must return one row containing count = 0 from the outer SELECT.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND 1 = 0
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Multiple outer-consumer shapes: SELECT *, array_agg, max/count.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT * FROM u;
+DEBUG:  Creating router plan
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT array_agg(dist_key) FROM u;
+DEBUG:  Creating router plan
+ array_agg
+---------------------------------------------------------------------
+
+(1 row)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val)
+SELECT max(dist_key) AS mx, count(*) AS n FROM u;
+DEBUG:  Creating router plan
+ mx | n
+---------------------------------------------------------------------
+    | 0
+(1 row)
+
+-- RETURNING more than one column: the transform preserves output shape.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val, tag)
+SELECT count(*) AS n, count(tag) AS tag_n FROM u;
+DEBUG:  Creating router plan
+ n | tag_n
+---------------------------------------------------------------------
+ 0 |     0
+(1 row)
+
+-- Sanity: satisfiable modifying-CTE still performs the modification.
+WITH u AS (UPDATE zero_shard_cte SET val = val + 100 WHERE dist_key = 7
+           RETURNING dist_key, val)
+SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
 SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte WHERE dist_key = 7;
+ dist_key | val
+---------------------------------------------------------------------
+        7 | 142
+(1 row)
+
+SET client_min_messages TO DEBUG2;
+-- Sanity: satisfiable modifying-CTE that matches zero rows on a real
+-- shard still returns count = 0 (does not accidentally short-circuit
+-- through the Phase 2 gate).
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 999
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 999
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Standalone RETURNING at top level: client sees an empty result set,
+-- distinct from the CTE-wrapped `count = 0` shape.
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+              RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+              RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+SELECT 1 AS still_alive;
+ still_alive
+---------------------------------------------------------------------
+           1
+(1 row)
+
+COMMIT;
+-- Reference-table modifying-CTE: reference-table UPDATE/DELETE is
+-- multi-placement so this path is not fast-path; it goes through
+-- recursive planning, but should still succeed and return count = 0.
+WITH u AS (UPDATE zero_shard_cte_ref SET v = v WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+DEBUG:  cannot router plan modification of a non-distributed table
+DEBUG:  generating subplan XXX_1 for CTE u: UPDATE multi_modifications.zero_shard_cte_ref SET v = v WHERE ((k OPERATOR(pg_catalog.=) 1) AND false) RETURNING k
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.k FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(k integer)) u
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (DELETE FROM zero_shard_cte_ref WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+DEBUG:  cannot router plan modification of a non-distributed table
+DEBUG:  generating subplan XXX_1 for CTE u: DELETE FROM multi_modifications.zero_shard_cte_ref WHERE ((k OPERATOR(pg_catalog.=) 1) AND false) RETURNING k
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.k FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(k integer)) u
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Parameterised parameter that resolves to false at execution time.
+PREPARE cte_zero_prep(bool) AS
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND $1
+           RETURNING dist_key) SELECT count(*) FROM u;
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+DEALLOCATE cte_zero_prep;
+-- Two modifying CTEs where only one prunes to zero shards -- the
+-- satisfiable CTE must still update; overall the query executes and
+-- returns the correct aggregate.
+WITH u1 AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+              RETURNING dist_key),
+     u2 AS (UPDATE zero_shard_cte SET val = val + 1000 WHERE dist_key = 8
+              RETURNING dist_key, val)
+SELECT (SELECT count(*) FROM u1) AS n1, (SELECT count(*) FROM u2) AS n2;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 8
+ n1 | n2
+---------------------------------------------------------------------
+  0 |  1
+(1 row)
+
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte ORDER BY dist_key;
+ dist_key | val
+---------------------------------------------------------------------
+        7 |  142
+        8 | 1043
+(2 rows)
+
 DROP SCHEMA multi_modifications CASCADE;

--- a/src/test/regress/sql/fast_path_router_modify.sql
+++ b/src/test/regress/sql/fast_path_router_modify.sql
@@ -22,6 +22,18 @@ CREATE TABLE modify_fast_path_reference(key int, value_1 int, value_2 text);
 SELECT create_reference_table('modify_fast_path_reference');
 
 
+-- Pre-propagate the plpgsql extension to workers via Citus's function
+-- distribution machinery, before enabling DEBUG-level output. Otherwise the
+-- first distributed CREATE FUNCTION below would emit worker-side "extension
+-- plpgsql already exists" notices that only appear when this test runs against
+-- a setup where plpgsql wasn't registered in pg_dist_object by an earlier
+-- test in the schedule (e.g. the flakyness detector's minimal schedule).
+SET client_min_messages TO WARNING;
+CREATE OR REPLACE FUNCTION _propagate_plpgsql() RETURNS void
+    LANGUAGE plpgsql AS $$BEGIN END$$;
+DROP FUNCTION _propagate_plpgsql();
+RESET client_min_messages;
+
 -- show the output
 SET client_min_messages TO DEBUG;
 
@@ -173,4 +185,68 @@ RESET citus.enable_fast_path_router_planner;
 
 RESET client_min_messages;
 RESET citus.log_remote_commands;
+
+-- Regression coverage for the delayed-fast-path zero-shard modification
+-- case. When the WHERE clause combines a distribution-key equality with
+-- a statically-unsatisfiable sub-predicate (`AND false`, `AND 1 = 0`, or
+-- when the fast-path fallback triggers e.g. via bigint-key-vs-int-literal
+-- type mismatch) shard pruning legitimately yields zero shards. Prior to
+-- the fix, CheckAndBuildDelayedFastPathPlan tripped
+-- `Assert(list_length(tasks) == 1)`; the fix routes these queries through
+-- the same "empty task list is a silent no-op" contract already used by
+-- the non-fast-path UPDATE/DELETE route.
+CREATE TABLE modify_fast_path_bigint(dist_key bigint, val int);
+SELECT create_distributed_table('modify_fast_path_bigint', 'dist_key');
+INSERT INTO modify_fast_path_bigint VALUES (7, 100), (8, 200);
+
+SET client_min_messages TO DEBUG2;
+
+-- bigint-key vs int-literal: DistKeyInSimpleOpExpression bails out on the
+-- type mismatch so fastPathContext->distributionKeyValue is NULL, then
+-- TargetShardIntervalForFastPathQuery falls back to PruneShards which
+-- short-circuits on ContainsFalseClause -> zero shards -> empty task list.
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false;
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND 1 = 0;
+
+-- Same shape but on an int-keyed table (matching type). Plan shape must
+-- remain the pre-fix fast-path single-shard dispatch that lets PG
+-- evaluate AND FALSE at the shard.
+UPDATE modify_fast_path SET value_1 = value_1 WHERE key = 1 AND false;
+UPDATE modify_fast_path SET value_1 = value_1 WHERE key = 1 AND 1 = 0;
+DELETE FROM modify_fast_path WHERE key = 1 AND (value_2 IS NULL AND false);
+
+-- Standalone RETURNING variant: client sees an empty result set (no rows),
+-- distinct from the plain UPDATE/DELETE "UPDATE 0" client shape.
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+UPDATE modify_fast_path_bigint SET val = val WHERE dist_key = 7 AND false;
+DELETE FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+SELECT 1 AS still_alive;
+COMMIT;
+
+-- Sanity: the satisfiable happy-paths for both key types still resolve
+-- to fast-path single-shard dispatch (must show "query has a single
+-- distribution column value: N").
+UPDATE modify_fast_path_bigint SET val = val + 1 WHERE dist_key = 7;
+UPDATE modify_fast_path SET value_1 = value_1 + 1 WHERE key = 1;
+
+-- Sanity: the zero-shard rows returned zero rows affected.
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM modify_fast_path_bigint ORDER BY dist_key;
+SET client_min_messages TO DEBUG2;
+
+-- Plain SELECT with AND false must still work (the Phase 2 gate must not
+-- fire here; only modifying-CTE SELECTs enter that transform).
+SELECT count(*) FROM modify_fast_path_bigint WHERE dist_key = 7 AND false;
+SELECT count(*) FROM modify_fast_path WHERE key = 1 AND false;
+
+RESET client_min_messages;
+
 DROP SCHEMA fast_path_router_modify CASCADE;

--- a/src/test/regress/sql/multi_copy.sql
+++ b/src/test/regress/sql/multi_copy.sql
@@ -10,6 +10,16 @@
 
 ALTER SEQUENCE pg_catalog.pg_dist_shardid_seq RESTART 560000;
 
+-- Make this test re-runnable within the same cluster (needed by the
+-- flakyness detector). customer_copy_hash is *not* dropped at the end of
+-- this file because multi_size_queries later in multi_1_schedule inherits
+-- it; drop-if-exists here handles the repeat-run case without breaking that
+-- downstream dependency. See the end-of-file cleanup block for the tables
+-- that can be safely dropped.
+SET client_min_messages TO WARNING;
+DROP TABLE IF EXISTS customer_copy_hash;
+RESET client_min_messages;
+
 
 -- Create a new hash-partitioned table into which to COPY
 CREATE TABLE customer_copy_hash (
@@ -792,3 +802,35 @@ red	{"r":255,"g":0,"b":0
 \.
 
 DROP TABLE copy_jsonb;
+-- Drop the objects created earlier in this file that were not dropped inline,
+-- so that the test can be re-run within the same cluster without tripping on
+-- "relation already exists" / "type already exists" errors (e.g. from the
+-- flakyness detector or a repeated pg_regress invocation).
+--
+-- The BEGIN..master_create_empty_shard('customer_copy_append')..COPY-fails..END
+-- block near line 234 rolls back on the coordinator (removing the pg_dist_shard
+-- entry) but leaves the physical shard table customer_copy_append_560130 on the
+-- workers, because worker-side CREATE TABLE from master_create_empty_shard is
+-- not covered by the coordinator's rollback. A repeat run's ALTER SEQUENCE
+-- pg_dist_shardid_seq RESTART 560000 (line 11) cycles the shardid sequence and
+-- master_create_empty_shard re-issues 560130, colliding with the stranded
+-- worker-only table. Force-drop it via run_command_on_workers before the
+-- DROP TABLE below, since DROP TABLE only knows about shards recorded in
+-- pg_dist_shard.
+SET client_min_messages TO WARNING;
+SELECT success FROM run_command_on_workers($$DROP TABLE IF EXISTS customer_copy_append_560130$$);
+RESET client_min_messages;
+DROP TABLE customer_with_default;
+DROP TABLE customer_copy_range;
+DROP TABLE customer_copy_append;
+DROP TABLE lineitem_copy_append;
+DROP TABLE "customer_with_special_\\_character";
+DROP TABLE "1_customer";
+DROP TABLE packed_numbers_hash;
+DROP TABLE super_packed_numbers_hash;
+DROP TABLE packed_numbers_append;
+DROP TABLE super_packed_numbers_append;
+DROP TABLE composite_partition_column_table;
+DROP TYPE super_number_pack;
+DROP TYPE number_pack;
+DROP SCHEMA append CASCADE;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -1294,5 +1294,112 @@ DELETE FROM summary_table WHERE id < (
 CREATE TABLE multi_modifications.local (a int default 1, b int);
 INSERT INTO multi_modifications.local VALUES (default, (SELECT min(id) FROM summary_table));
 
+-- Regression coverage for zero-shard modifying CTE inside an outer SELECT.
+-- Prior to the fix, WITH u AS (UPDATE ... WHERE dist_key = X AND false
+-- RETURNING ...) SELECT ... FROM u; would fail at execution time in
+-- AcquireMetadataLocks -> LookupShardIdCacheEntry(0) with
+-- "could not find valid entry for shard 0", because
+-- UpdateRelationToShardNames flipped every Citus-relation RTE to
+-- an empty-result RTE_SUBQUERY while the outer query's resultRelation
+-- (0 for a SELECT) did not trigger the direct UPDATE/DELETE escape in
+-- RouterJob. The fix rewrites each modifying CTE in-place to a plain
+-- SELECT returning matching-shape NULL columns under WHERE false and
+-- clears hasModifyingCTE, so the outer SELECT flows through the normal
+-- zero-shard router-SELECT machinery and emits the correct empty-CTE
+-- result set to its consumer.
+RESET client_min_messages;
+CREATE TABLE zero_shard_cte(dist_key int, val int, tag text);
+SELECT create_distributed_table('zero_shard_cte', 'dist_key');
+INSERT INTO zero_shard_cte VALUES (7, 42, 'seven'), (8, 43, 'eight');
+
+CREATE TABLE zero_shard_cte_ref(k int, v int);
+SELECT create_reference_table('zero_shard_cte_ref');
+INSERT INTO zero_shard_cte_ref VALUES (1, 100);
+
+SET client_min_messages TO DEBUG2;
+
+-- Literal false, folded (1 = 0), UPDATE and DELETE CTE variants -- all
+-- must return one row containing count = 0 from the outer SELECT.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+WITH u AS (DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND 1 = 0
+           RETURNING dist_key) SELECT count(*) FROM u;
+
+-- Multiple outer-consumer shapes: SELECT *, array_agg, max/count.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT * FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT array_agg(dist_key) FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val)
+SELECT max(dist_key) AS mx, count(*) AS n FROM u;
+
+-- RETURNING more than one column: the transform preserves output shape.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val, tag)
+SELECT count(*) AS n, count(tag) AS tag_n FROM u;
+
+-- Sanity: satisfiable modifying-CTE still performs the modification.
+WITH u AS (UPDATE zero_shard_cte SET val = val + 100 WHERE dist_key = 7
+           RETURNING dist_key, val)
+SELECT count(*) FROM u;
 SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte WHERE dist_key = 7;
+SET client_min_messages TO DEBUG2;
+
+-- Sanity: satisfiable modifying-CTE that matches zero rows on a real
+-- shard still returns count = 0 (does not accidentally short-circuit
+-- through the Phase 2 gate).
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 999
+           RETURNING dist_key) SELECT count(*) FROM u;
+
+-- Standalone RETURNING at top level: client sees an empty result set,
+-- distinct from the CTE-wrapped `count = 0` shape.
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+              RETURNING dist_key;
+DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+              RETURNING dist_key;
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false;
+SELECT 1 AS still_alive;
+COMMIT;
+
+-- Reference-table modifying-CTE: reference-table UPDATE/DELETE is
+-- multi-placement so this path is not fast-path; it goes through
+-- recursive planning, but should still succeed and return count = 0.
+WITH u AS (UPDATE zero_shard_cte_ref SET v = v WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+WITH u AS (DELETE FROM zero_shard_cte_ref WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+
+-- Parameterised parameter that resolves to false at execution time.
+PREPARE cte_zero_prep(bool) AS
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND $1
+           RETURNING dist_key) SELECT count(*) FROM u;
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+DEALLOCATE cte_zero_prep;
+
+-- Two modifying CTEs where only one prunes to zero shards -- the
+-- satisfiable CTE must still update; overall the query executes and
+-- returns the correct aggregate.
+WITH u1 AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+              RETURNING dist_key),
+     u2 AS (UPDATE zero_shard_cte SET val = val + 1000 WHERE dist_key = 8
+              RETURNING dist_key, val)
+SELECT (SELECT count(*) FROM u1) AS n1, (SELECT count(*) FROM u2) AS n2;
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte ORDER BY dist_key;
+
 DROP SCHEMA multi_modifications CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fix malfunction in planning UPDATE of distributed table with shard key equality and FALSE predicate.

Fixes crash / "could not find valid entry for shard" error on UPDATE / DELETE against distributed tables whose WHERE clause combines a distribution-key equality with an always-false predicate (e.g. `dist_key = X AND false`), including when wrapped in a modifying CTE consumed by an outer SELECT.


(cherry picked from commit dd1c8769ab18a8c2aae6aa1dc12d71aa55002993)

DESCRIPTION: PR description that will go into the change log, up to 78 characters
