### PR TITLE
[release-12.1] Fix bugs in UPDATE dist_table .. WHERE shard_key = X AND false

### DIFF
--- a/src/backend/distributed/planner/multi_router_planner.c
+++ b/src/backend/distributed/planner/multi_router_planner.c
@@ -173,6 +173,7 @@ static void ReorderTaskPlacementsByTaskAssignmentPolicy(Job *job,
 static bool ModifiesLocalTableWithRemoteCitusLocalTable(List *rangeTableList);
 static DeferredErrorMessage * DeferErrorIfUnsupportedLocalTableJoin(List *rangeTableList);
 static bool IsLocallyAccessibleCitusLocalTable(Oid relationId);
+static void ReplaceModifyingCteWithEmptyResult(Query *outerQuery);
 
 
 /*
@@ -279,6 +280,16 @@ CreateSingleTaskRouterSelectPlan(DistributedPlan *distributedPlan, Query *origin
 		/* query cannot be handled by this planner */
 		return;
 	}
+
+	/*
+	 * RouterJob may rewrite a zero-shard modifying CTE inside a router SELECT
+	 * into a plain empty-result CTE (see ReplaceModifyingCteWithEmptyResult).
+	 * That clears originalQuery->hasModifyingCTE, so recompute modLevel from
+	 * the (possibly-transformed) job query -- otherwise the executor would
+	 * treat the plan as ROW_MODIFY_NONCOMMUTATIVE and attempt to acquire
+	 * shard-locks on the pruned-away shard.
+	 */
+	distributedPlan->modLevel = RowModifyLevelForQuery(job->jobQuery);
 
 	ereport(DEBUG2, (errmsg("Creating router plan")));
 
@@ -1959,6 +1970,39 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 			}
 		}
 	}
+	else if (shardId == INVALID_SHARD_ID && originalQuery->hasModifyingCTE)
+	{
+		/*
+		 * Router SELECT that wraps a modifying CTE whose pruning
+		 * yielded zero shards (e.g. WITH u AS (UPDATE t ... WHERE
+		 * dist_key = X AND FALSE RETURNING ...) SELECT ... FROM u).
+		 *
+		 * PlanRouterQuery returned INVALID_SHARD_ID with a dummy
+		 * placement, and UpdateRelationToShardNames has already
+		 * flipped the CTE's target relation RTE to an empty-result
+		 * RTE_SUBQUERY. The direct UPDATE/DELETE escape above only
+		 * inspects the OUTER query's resultRelation (which is 0 for
+		 * a SELECT), so absent this branch the query would fall
+		 * through to SingleShardTaskList and be promoted to a
+		 * MODIFY_TASK with anchorShardId = 0 -- which then fails at
+		 * execution time in AcquireMetadataLocks ->
+		 * LookupShardIdCacheEntry(0) with "could not find valid
+		 * entry for shard 0".
+		 *
+		 * We cannot use the taskList = NIL contract that the direct
+		 * UPDATE/DELETE escape above uses, because the outer SELECT
+		 * has a consumer (e.g. SELECT count(*) FROM u must return
+		 * one row containing 0, not the empty resultset that an empty
+		 * task list would yield). Instead, rewrite each modifying CTE
+		 * in-place to a plain SELECT that returns no rows but retains
+		 * the CTE's output column shape, and clear hasModifyingCTE.
+		 * The rewritten query then flows through the normal
+		 * zero-shard router-SELECT machinery (READ_TASK on the dummy
+		 * placement), producing the correct empty CTE and letting the
+		 * outer aggregate emit the required single row.
+		 */
+		ReplaceModifyingCteWithEmptyResult(originalQuery);
+	}
 
 	if (isMultiShardModifyQuery)
 	{
@@ -1983,6 +2027,94 @@ RouterJob(Query *originalQuery, PlannerRestrictionContext *plannerRestrictionCon
 
 	job->requiresCoordinatorEvaluation = requiresCoordinatorEvaluation;
 	return job;
+}
+
+
+/*
+ * ReplaceModifyingCteWithEmptyResult rewrites each modifying (UPDATE/DELETE)
+ * CTE in outerQuery->cteList so that its body becomes a plain SELECT whose
+ * jointree quals are constant FALSE and whose target list is a matching-shape
+ * list of NULL constants. This preserves the outer query's structural reference
+ * to the CTE (name, output column names/types/typmods/collations) while
+ * guaranteeing the CTE produces zero rows and requires no shard metadata.
+ *
+ * hasModifyingCTE is cleared only if no other modifying CTE (e.g. CMD_INSERT,
+ * CMD_MERGE) remains in the cteList after the rewrite; otherwise the flag is
+ * preserved so downstream routing (READ_TASK vs MODIFY_TASK selection,
+ * modLevel computation, lock acquisition) still treats the query as
+ * modifying. When the flag does end up cleared, the outer SELECT flows
+ * through the standard zero-shard router-SELECT machinery (READ_TASK on the
+ * dummy placement, no shard-metadata lookups, no MODIFY_TASK promotion in
+ * SingleShardTaskList).
+ *
+ * This helper mutates outerQuery in place. Callers must have already
+ * established that pruning yielded zero shards (shardId == INVALID_SHARD_ID);
+ * pruning-relevant fields (placementList, relationShardList, prunedShardIntervalListList)
+ * are unaffected.
+ */
+static void
+ReplaceModifyingCteWithEmptyResult(Query *outerQuery)
+{
+	CommonTableExpr *cte = NULL;
+	bool anyModifyingCteLeft = false;
+
+	foreach_ptr(cte, outerQuery->cteList)
+	{
+		Query *cteQuery = (Query *) cte->ctequery;
+
+		if (cteQuery->commandType != CMD_UPDATE &&
+			cteQuery->commandType != CMD_DELETE)
+		{
+			/*
+			 * Non-UPDATE/DELETE CTE: leave it alone. If it is still a
+			 * modification (e.g. CMD_INSERT, CMD_MERGE) note that so we do
+			 * not clear the outer query's hasModifyingCTE flag below.
+			 */
+			if (cteQuery->commandType != CMD_SELECT)
+			{
+				anyModifyingCteLeft = true;
+			}
+			continue;
+		}
+
+		int columnCount = list_length(cte->ctecoltypes);
+		List *targetList = NIL;
+
+		for (int columnIndex = 0; columnIndex < columnCount; columnIndex++)
+		{
+			Oid coltype = list_nth_oid(cte->ctecoltypes, columnIndex);
+			int32 coltypmod = list_nth_int(cte->ctecoltypmods, columnIndex);
+			Oid colcoll = list_nth_oid(cte->ctecolcollations, columnIndex);
+			Node *colname = (Node *) list_nth(cte->ctecolnames, columnIndex);
+
+			Const *nullConst = makeNullConst(coltype, coltypmod, colcoll);
+
+			TargetEntry *targetEntry = makeNode(TargetEntry);
+			targetEntry->expr = (Expr *) nullConst;
+			targetEntry->resno = columnIndex + 1;
+			targetEntry->resname = pstrdup(strVal(colname));
+			targetEntry->resorigtbl = InvalidOid;
+			targetEntry->resorigcol = 0;
+			targetEntry->resjunk = false;
+
+			targetList = lappend(targetList, targetEntry);
+		}
+
+		FromExpr *joinTree = makeNode(FromExpr);
+		joinTree->fromlist = NIL;
+		joinTree->quals = (Node *) makeBoolConst(false, false);
+
+		Query *emptyCteQuery = makeNode(Query);
+		emptyCteQuery->commandType = CMD_SELECT;
+		emptyCteQuery->querySource = cteQuery->querySource;
+		emptyCteQuery->canSetTag = cteQuery->canSetTag;
+		emptyCteQuery->targetList = targetList;
+		emptyCteQuery->jointree = joinTree;
+
+		cte->ctequery = (Node *) emptyCteQuery;
+	}
+
+	outerQuery->hasModifyingCTE = anyModifyingCteLeft;
 }
 
 

--- a/src/test/regress/expected/multi_modifications.out
+++ b/src/test/regress/expected/multi_modifications.out
@@ -1500,5 +1500,269 @@ CREATE TABLE multi_modifications.local (a int default 1, b int);
 INSERT INTO multi_modifications.local VALUES (default, (SELECT min(id) FROM summary_table));
 ERROR:  subqueries are not supported within INSERT queries
 HINT:  Try rewriting your queries with 'INSERT INTO ... SELECT' syntax.
+-- Regression coverage for zero-shard modifying CTE inside an outer SELECT.
+-- Prior to the fix, WITH u AS (UPDATE ... WHERE dist_key = X AND false
+-- RETURNING ...) SELECT ... FROM u; would fail at execution time in
+-- AcquireMetadataLocks -> LookupShardIdCacheEntry(0) with
+-- "could not find valid entry for shard xxxxx", because
+-- UpdateRelationToShardNames flipped every Citus-relation RTE to
+-- an empty-result RTE_SUBQUERY while the outer query's resultRelation
+-- (0 for a SELECT) did not trigger the direct UPDATE/DELETE escape in
+-- RouterJob. The fix rewrites each modifying CTE in-place to a plain
+-- SELECT returning matching-shape NULL columns under WHERE false and
+-- clears hasModifyingCTE, so the outer SELECT flows through the normal
+-- zero-shard router-SELECT machinery and emits the correct empty-CTE
+-- result set to its consumer.
+RESET client_min_messages;
+CREATE TABLE zero_shard_cte(dist_key int, val int, tag text);
+SELECT create_distributed_table('zero_shard_cte', 'dist_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO zero_shard_cte VALUES (7, 42, 'seven'), (8, 43, 'eight');
+CREATE TABLE zero_shard_cte_ref(k int, v int);
+SELECT create_reference_table('zero_shard_cte_ref');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO zero_shard_cte_ref VALUES (1, 100);
+SET client_min_messages TO DEBUG2;
+-- Literal false, folded (1 = 0), UPDATE and DELETE CTE variants -- all
+-- must return one row containing count = 0 from the outer SELECT.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND 1 = 0
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Multiple outer-consumer shapes: SELECT *, array_agg, max/count.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT * FROM u;
+DEBUG:  Creating router plan
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT array_agg(dist_key) FROM u;
+DEBUG:  Creating router plan
+ array_agg
+---------------------------------------------------------------------
+
+(1 row)
+
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val)
+SELECT max(dist_key) AS mx, count(*) AS n FROM u;
+DEBUG:  Creating router plan
+ mx | n
+---------------------------------------------------------------------
+    | 0
+(1 row)
+
+-- RETURNING more than one column: the transform preserves output shape.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val, tag)
+SELECT count(*) AS n, count(tag) AS tag_n FROM u;
+DEBUG:  Creating router plan
+ n | tag_n
+---------------------------------------------------------------------
+ 0 |     0
+(1 row)
+
+-- Sanity: satisfiable modifying-CTE still performs the modification.
+WITH u AS (UPDATE zero_shard_cte SET val = val + 100 WHERE dist_key = 7
+           RETURNING dist_key, val)
+SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
 SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte WHERE dist_key = 7;
+ dist_key | val
+---------------------------------------------------------------------
+        7 | 142
+(1 row)
+
+SET client_min_messages TO DEBUG2;
+-- Sanity: satisfiable modifying-CTE that matches zero rows on a real
+-- shard still returns count = 0 (does not accidentally short-circuit
+-- through the Phase 2 gate).
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 999
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 999
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Standalone RETURNING at top level: client sees an empty result set,
+-- distinct from the CTE-wrapped `count = 0` shape.
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ dist_key
+---------------------------------------------------------------------
+(0 rows)
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false;
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+SELECT 1 AS still_alive;
+ still_alive
+---------------------------------------------------------------------
+           1
+(1 row)
+
+COMMIT;
+-- Reference-table modifying-CTE: reference-table UPDATE/DELETE is
+-- multi-placement so this path is not fast-path; it goes through
+-- recursive planning, but should still succeed and return count = 0.
+WITH u AS (UPDATE zero_shard_cte_ref SET v = v WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+DEBUG:  cannot router plan modification of a non-distributed table
+DEBUG:  generating subplan XXX_1 for CTE u: UPDATE multi_modifications.zero_shard_cte_ref SET v = v WHERE ((k OPERATOR(pg_catalog.=) 1) AND false) RETURNING k
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.k FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(k integer)) u
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+WITH u AS (DELETE FROM zero_shard_cte_ref WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+DEBUG:  cannot router plan modification of a non-distributed table
+DEBUG:  generating subplan XXX_1 for CTE u: DELETE FROM multi_modifications.zero_shard_cte_ref WHERE ((k OPERATOR(pg_catalog.=) 1) AND false) RETURNING k
+DEBUG:  Distributed planning for a fast-path router query
+DEBUG:  Creating router plan
+DEBUG:  Plan XXX query after replacing subqueries and CTEs: SELECT count(*) AS count FROM (SELECT intermediate_result.k FROM read_intermediate_result('XXX_1'::text, 'binary'::citus_copy_format) intermediate_result(k integer)) u
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+-- Parameterised parameter that resolves to false at execution time.
+PREPARE cte_zero_prep(bool) AS
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND $1
+           RETURNING dist_key) SELECT count(*) FROM u;
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+EXECUTE cte_zero_prep(false);
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 7
+ count
+---------------------------------------------------------------------
+     0
+(1 row)
+
+DEALLOCATE cte_zero_prep;
+-- Two modifying CTEs where only one prunes to zero shards -- the
+-- satisfiable CTE must still update; overall the query executes and
+-- returns the correct aggregate.
+WITH u1 AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+            RETURNING dist_key),
+     u2 AS (UPDATE zero_shard_cte SET val = val + 1000 WHERE dist_key = 8
+            RETURNING dist_key, val)
+SELECT (SELECT count(*) FROM u1) AS n1, (SELECT count(*) FROM u2) AS n2;
+DEBUG:  Creating router plan
+DEBUG:  query has a single distribution column value: 8
+ n1 | n2
+---------------------------------------------------------------------
+  0 |  1
+(1 row)
+
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte ORDER BY dist_key;
+ dist_key | val
+---------------------------------------------------------------------
+        7 |  142
+        8 | 1043
+(2 rows)
+
 DROP SCHEMA multi_modifications CASCADE;

--- a/src/test/regress/sql/multi_modifications.sql
+++ b/src/test/regress/sql/multi_modifications.sql
@@ -1065,5 +1065,112 @@ DELETE FROM summary_table WHERE id < (
 CREATE TABLE multi_modifications.local (a int default 1, b int);
 INSERT INTO multi_modifications.local VALUES (default, (SELECT min(id) FROM summary_table));
 
+-- Regression coverage for zero-shard modifying CTE inside an outer SELECT.
+-- Prior to the fix, WITH u AS (UPDATE ... WHERE dist_key = X AND false
+-- RETURNING ...) SELECT ... FROM u; would fail at execution time in
+-- AcquireMetadataLocks -> LookupShardIdCacheEntry(0) with
+-- "could not find valid entry for shard 0", because
+-- UpdateRelationToShardNames flipped every Citus-relation RTE to
+-- an empty-result RTE_SUBQUERY while the outer query's resultRelation
+-- (0 for a SELECT) did not trigger the direct UPDATE/DELETE escape in
+-- RouterJob. The fix rewrites each modifying CTE in-place to a plain
+-- SELECT returning matching-shape NULL columns under WHERE false and
+-- clears hasModifyingCTE, so the outer SELECT flows through the normal
+-- zero-shard router-SELECT machinery and emits the correct empty-CTE
+-- result set to its consumer.
+RESET client_min_messages;
+CREATE TABLE zero_shard_cte(dist_key int, val int, tag text);
+SELECT create_distributed_table('zero_shard_cte', 'dist_key');
+INSERT INTO zero_shard_cte VALUES (7, 42, 'seven'), (8, 43, 'eight');
+
+CREATE TABLE zero_shard_cte_ref(k int, v int);
+SELECT create_reference_table('zero_shard_cte_ref');
+INSERT INTO zero_shard_cte_ref VALUES (1, 100);
+
+SET client_min_messages TO DEBUG2;
+
+-- Literal false, folded (1 = 0), UPDATE and DELETE CTE variants -- all
+-- must return one row containing count = 0 from the outer SELECT.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+WITH u AS (DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND 1 = 0
+           RETURNING dist_key) SELECT count(*) FROM u;
+
+-- Multiple outer-consumer shapes: SELECT *, array_agg, max/count.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT * FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT array_agg(dist_key) FROM u;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val)
+SELECT max(dist_key) AS mx, count(*) AS n FROM u;
+
+-- RETURNING more than one column: the transform preserves output shape.
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key, val, tag)
+SELECT count(*) AS n, count(tag) AS tag_n FROM u;
+
+-- Sanity: satisfiable modifying-CTE still performs the modification.
+WITH u AS (UPDATE zero_shard_cte SET val = val + 100 WHERE dist_key = 7
+           RETURNING dist_key, val)
+SELECT count(*) FROM u;
 SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte WHERE dist_key = 7;
+SET client_min_messages TO DEBUG2;
+
+-- Sanity: satisfiable modifying-CTE that matches zero rows on a real
+-- shard still returns count = 0 (does not accidentally short-circuit
+-- through the Phase 2 gate).
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 999
+           RETURNING dist_key) SELECT count(*) FROM u;
+
+-- Standalone RETURNING at top level: client sees an empty result set,
+-- distinct from the CTE-wrapped `count = 0` shape.
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+DELETE FROM zero_shard_cte WHERE dist_key = 7 AND false
+    RETURNING dist_key;
+
+-- Explicit transaction block: the no-op must not abort the surrounding
+-- transaction; subsequent statements proceed normally.
+BEGIN;
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+           RETURNING dist_key) SELECT count(*) FROM u;
+UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false;
+SELECT 1 AS still_alive;
+COMMIT;
+
+-- Reference-table modifying-CTE: reference-table UPDATE/DELETE is
+-- multi-placement so this path is not fast-path; it goes through
+-- recursive planning, but should still succeed and return count = 0.
+WITH u AS (UPDATE zero_shard_cte_ref SET v = v WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+WITH u AS (DELETE FROM zero_shard_cte_ref WHERE k = 1 AND false
+           RETURNING k) SELECT count(*) FROM u;
+
+-- Parameterised parameter that resolves to false at execution time.
+PREPARE cte_zero_prep(bool) AS
+WITH u AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND $1
+           RETURNING dist_key) SELECT count(*) FROM u;
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+EXECUTE cte_zero_prep(false);
+DEALLOCATE cte_zero_prep;
+
+-- Two modifying CTEs where only one prunes to zero shards -- the
+-- satisfiable CTE must still update; overall the query executes and
+-- returns the correct aggregate.
+WITH u1 AS (UPDATE zero_shard_cte SET val = val WHERE dist_key = 7 AND false
+            RETURNING dist_key),
+     u2 AS (UPDATE zero_shard_cte SET val = val + 1000 WHERE dist_key = 8
+            RETURNING dist_key, val)
+SELECT (SELECT count(*) FROM u1) AS n1, (SELECT count(*) FROM u2) AS n2;
+SET client_min_messages TO WARNING;
+SELECT dist_key, val FROM zero_shard_cte ORDER BY dist_key;
+
 DROP SCHEMA multi_modifications CASCADE;


### PR DESCRIPTION
Backport of #8692 to `release-12.1`.

Fixes the `could not find valid entry for shard 0` failure when a modifying CTE prunes to zero shards and is consumed by an outer SELECT, e.g.:

```sql
WITH u AS (UPDATE dist_table SET val = val WHERE dist_key = 7 AND false RETURNING dist_key)
SELECT count(*) FROM u;
```

Fixes #8693 on `release-12.1`.

## Scope vs. upstream

The upstream commit `e99ff05` has four logical parts. Three apply here; one does not.

| Part | Change | Backported |
|---|---|---|
| A | `CreateSingleTaskRouterSelectPlan`: recompute `distributedPlan->modLevel` from `job->jobQuery` after `RouterJob` | Yes |
| B | `RouterJob`: new `else if (shardId == INVALID_SHARD_ID && originalQuery->hasModifyingCTE)` branch | Yes |
| C | New static helper `ReplaceModifyingCteWithEmptyResult()` | Yes |
| D | `CheckAndBuildDelayedFastPathPlan()` zero-task-list guard | **No** |

Part D is not applicable: `CheckAndBuildDelayedFastPathPlan()` does not exist on `release-12.1` (delayed fast-path planning is a 13.x feature). Verified empirically that the standalone case it guards already behaves correctly here:

```sql
UPDATE dist_table SET val = val WHERE dist_key = 7 AND false RETURNING dist_key;
-- returns 0 rows on pristine release-12.1
```

It terminates via the pre-existing `originalQuery->resultRelation > 0` / `RTE_SUBQUERY` escape in `RouterJob`, which leaves `job->taskList = NIL`.

Because D is dropped, the test changes that only covered D are dropped too:
- `fast_path_router_modify.sql` / `.out` — exercises D exclusively.
- `multi_copy.sql` / `.out` and the `run_test.py` `DEPS` entries — pure flakiness-detector re-runnability plumbing that exists only because the new `fast_path_router_modify` cases share a schedule line with `multi_copy`.

## Porting adjustment

`foreach_declared_ptr()` does not exist on `release-12.1`; `foreach_ptr()` is used instead (this file already uses `foreach_ptr` in 8 other places on this branch).

No other changes. Diffing the added C lines against upstream confirms hunk D is the *only* delta.

No SQL schema changes, so no migration / upgrade-downgrade ladder / `multi_extension` work is needed.

## Verification (PG 16.14)

- **Bug reproduced on pristine `release-12.1`**: `ERROR: could not find valid entry for shard 0` at ~16 sites in the new test block (plain, `PREPARE`/`EXECUTE`, and in-transaction variants).
- **Fixed after the patch**: `multi_modifications` green.
- **`expected/multi_modifications.out` regenerated** via `run_test.py` (not hand-edited). The new section is byte-identical to upstream's expected output, *including every DEBUG line*.
- **Neighbouring tests green**: `fast_path_router_modify`, `multi_router_planner`, `multi_shard_update_delete`.
- `with_modifying` fails to run standalone under `run_test.py`, but **fails identically on the unpatched baseline** — it has no `DEPS` entry on this branch, so `public.users_table` (created by `multi_behavioral_analytics_create_table`) is missing. Pre-existing harness gap, unrelated to this change.
- `configure` untouched.
