### PR TITLE
Use GetLatestSnapshot in CleanupRecordExists (#8594)

### DIFF
--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1109,6 +1109,29 @@ TupleToCleanupRecord(HeapTuple heapTuple, TupleDesc tupleDescriptor)
 /*
  * CleanupRecordExists returns whether a cleanup record with the given
  * record ID exists in pg_dist_cleanup.
+ *
+ * The scan deliberately uses a freshly acquired GetLatestSnapshot()
+ * rather than the caller's transaction snapshot. This is required so
+ * that the cleanup worker, after a successful TryLockOperationId(),
+ * can observe a deletion of the cleanup record committed by the
+ * operation owner immediately before it released the operation-ID
+ * advisory lock. Reading under the older outer-transaction snapshot
+ * (the default when NULL is passed to systable_beginscan) would still
+ * see the row as live and trigger a redundant drop of the underlying
+ * resource. Callers that need to read pg_dist_cleanup under their
+ * own (possibly older) snapshot semantics should NOT use this helper.
+ *
+ * Note: there is no automated regression test for this race today.
+ * TryLockOperationId() uses dontWait = true (cleanup never blocks),
+ * so pg_isolationtester cannot orchestrate the required interleave
+ * because it schedules sessions by detecting *blocked* steps. A
+ * deterministic test will require Citus to adopt PostgreSQL's
+ * INJECTION_POINT() infrastructure (or an equivalent test-only
+ * delay GUC inserted between TryLockOperationId() success and this
+ * scan) so a competing op-completing session can be raced into the
+ * gap. Until that test infrastructure exists, the GetLatestSnapshot()
+ * call below is load-bearing: replacing it with NULL silently
+ * reintroduces the double-drop race.
  */
 static bool
 CleanupRecordExists(uint64 recordId)
@@ -1123,10 +1146,14 @@ CleanupRecordExists(uint64 recordId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
+	/* make sure we can always see deletion after acquiring the operation ID lock */
+	Snapshot snapshot = GetLatestSnapshot();
+
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
 													indexOK,
-													NULL, scanKeyCount, scanKey);
+													snapshot,
+													scanKeyCount, scanKey);
 
 	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	bool recordExists = HeapTupleIsValid(heapTuple);


### PR DESCRIPTION
Backport of #8594 to `release-12.1`.

**DESCRIPTION: Prevent a possible race condition in shard cleanup**

`systable_beginscan` without a snapshot calls `GetCatalogSnapshot`, which may be cached from a previous call. If a shard move succeeded and the cleanup record was deleted just before the cleaner acquired the operation-ID lock, `CleanupRecordExists` could still see the record in its stale snapshot and incorrectly proceed to drop the underlying resource.

Cherry-picked from `c41586cc8fa6e96a677b921c01be6f585f27d819` — **clean apply, no adaptation**.

### Behavior-change analysis
- `CleanupRecordExists` is `static` with exactly **one** call site (`shard_cleaner.c:289`), inside the cleanup loop immediately after a successful `TryLockOperationId()`. Nothing outside deferred/orphaned-resource cleanup is reachable.
- The fresher snapshot can only make the function return `true -> false` (a record committed-deleted after `ListCleanupRecords`). It can never turn `false` into `true`, so the change can only *prevent* an erroneous drop, never cause one.
- `GetLatestSnapshot()` returns the static `SecondarySnapshotData`; it is not refcounted and needs no `UnregisterSnapshot`. The scan is opened and closed before any other snapshot call.

### Testing (PG 16.14)
- Builds clean, zero new warnings.
- `check-operations` — 15/16; the single `multi_move_mx` failure reproduces **byte-identically on unmodified `release-12.1` (659338fa6)** and is an IPv4/IPv6 `localhost` resolution artifact of the local environment.
- Full `check-multi` A/B (baseline vs. all four 12.1.14 backports applied): **100% pass, results identical**.

No automated regression test exists upstream for this race — `TryLockOperationId()` uses `dontWait = true`, so `pg_isolationtester` cannot orchestrate the interleave (it schedules on *blocked* steps). This is documented in the code comment.