### PR TITLE
Fix segfault in EXPLAIN with LEFT JOIN and correlated subqueries (#8556)

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -94,7 +94,7 @@ int PlannerLevel = 0;
 
 static bool ListContainsDistributedTableRTE(List *rangeTableList,
 											bool *maybeHasForeignDistributedTable);
-static bool PlanContainsDistributedSubPlanRTE(List *subPlanList);
+static bool PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext);
 static PlannedStmt * CreateDistributedPlannedStmt(DistributedPlanningContext *
 												  planContext);
 static PlannedStmt * InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
@@ -424,8 +424,9 @@ ListContainsDistributedTableRTE(List *rangeTableList,
 
 
 /*
- * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the given
- * subPlanList is a Read Intermediate Result function scan.
+ * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the
+ * plan context's PlannedStmt->subplans list is a Read Intermediate Result
+ * function scan.
  *
  * It is used by the check after standard_planner() to determine whether the plan
  * still requires distributed planning; in addition to checking the range table for
@@ -434,13 +435,25 @@ ListContainsDistributedTableRTE(List *rangeTableList,
  * that distributed planning is required.
  */
 static bool
-PlanContainsDistributedSubPlanRTE(List *subPlanList)
+PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext)
 {
+	/*
+	 * We iterate over planContext->plan->subplans, which is PostgreSQL's
+	 * PlannedStmt->subplans list. PostgreSQL's setrefs.c (set_plan_references)
+	 * resolves AlternativeSubPlan nodes by picking one alternative and setting
+	 * the discarded subplan entries to NULL. We must therefore skip NULL entries.
+	 */
+	List *subPlanList = planContext->plan->subplans;
 	ListCell *subPlanCell = NULL;
 
 	foreach(subPlanCell, subPlanList)
 	{
 		Node *planRoot = (Node *) lfirst(subPlanCell);
+
+		if (planRoot == NULL)
+		{
+			continue;
+		}
 
 		if (!IsA(planRoot, FunctionScan))
 		{
@@ -2818,7 +2831,7 @@ CheckPostPlanDistribution(DistributedPlanningContext *planContext, bool
 			/* ..or a distributed subplan */
 			planHasDistribution = planHasDistribution ||
 								  PlanContainsDistributedSubPlanRTE(
-				planContext->plan->subplans);
+				planContext);
 
 			/*
 			 * The plan has a distributed relation, so we know for sure that

--- a/src/test/regress/expected/subquery_in_where.out
+++ b/src/test/regress/expected/subquery_in_where.out
@@ -1405,6 +1405,70 @@ WHERE true OR NOT EXISTS (SELECT 1 FROM t1);
                1
 (1 row)
 
+-- Test crash fix for issue #8548
+-- A query with LEFT JOIN to a distributed table and correlated subqueries
+-- could crash because PostgreSQL's setrefs.c sets subplan list entries to
+-- NULL when AlternativeSubPlan resolution discards unused alternatives.
+-- PlanContainsDistributedSubPlanRTE must skip NULL entries.
+CREATE TABLE t4 (vkey integer, pkey integer, c30 integer, c31 integer, c32 text);
+CREATE TABLE t5 (vkey integer, pkey integer, c33 text, c34 integer, c35 integer,
+                 c36 timestamp without time zone);
+CREATE TABLE t2 (vkey integer, pkey integer, c15 numeric, c16 timestamp without time zone,
+                 c17 text, c18 text, c19 timestamp without time zone,
+                 c20 timestamp without time zone, c21 integer);
+CREATE TABLE t22 (vkey integer, pkey integer, c37 numeric, c38 text, c39 numeric,
+                  c40 numeric, c41 numeric, c42 integer,
+                  c43 timestamp without time zone, c44 numeric,
+                  colocated_key numeric);
+SELECT create_distributed_table('t22', 'colocated_key');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+-- This query should not crash (issue #8548)
+SELECT
+  70 AS c_0
+FROM
+  (
+    SELECT
+      (
+        EXISTS (
+          SELECT ref_5.c33 AS c_0
+          FROM t5 AS ref_5
+          WHERE (make_timestamp(2001, 7, 13, 17, 53, 31)) = (ref_1.c43)
+        )
+      ) AS c_0
+    FROM
+      (
+        t4 AS ref_0
+        LEFT OUTER JOIN t22 AS ref_1
+          ON (ref_0.vkey = ref_1.vkey)
+      )
+    WHERE
+      (
+        (ref_0.c31) >= (
+          SELECT ref_1.pkey AS c_0
+          FROM t2 AS ref_2
+          WHERE (true) < ((ref_2.c17) ^@ (ref_0.c32))
+          ORDER BY c_0 DESC
+          LIMIT 1
+        )
+      ) IN (
+        SELECT (ref_1.c40) <= (ref_1.c37) AS c_0
+        FROM t7 AS ref_4
+        WHERE NOT ((ref_1.c40) <> (ref_1.c41))
+      )
+  ) AS subq_0
+WHERE
+  (TRUE) < (TRUE);
+ERROR:  Distributed queries with outer joins and pseudoconstant quals are not supported in PG14, PG15 and PG16.
+DETAIL:  PG14, PG15 and PG16 disallow replacing joins with scans when the query has pseudoconstant quals
+HINT:  Consider upgrading your PG version to PG17+
+DROP TABLE t4;
+DROP TABLE t5;
+DROP TABLE t2;
+DROP TABLE t22;
 DROP TABLE local_table;
 DROP TABLE t0;
 DROP TABLE t1;

--- a/src/test/regress/sql/subquery_in_where.sql
+++ b/src/test/regress/sql/subquery_in_where.sql
@@ -1047,6 +1047,65 @@ SELECT CASE WHEN EXISTS (
 FROM   a
 WHERE true OR NOT EXISTS (SELECT 1 FROM t1);
 
+-- Test crash fix for issue #8548
+-- A query with LEFT JOIN to a distributed table and correlated subqueries
+-- could crash because PostgreSQL's setrefs.c sets subplan list entries to
+-- NULL when AlternativeSubPlan resolution discards unused alternatives.
+-- PlanContainsDistributedSubPlanRTE must skip NULL entries.
+CREATE TABLE t4 (vkey integer, pkey integer, c30 integer, c31 integer, c32 text);
+CREATE TABLE t5 (vkey integer, pkey integer, c33 text, c34 integer, c35 integer,
+                 c36 timestamp without time zone);
+CREATE TABLE t2 (vkey integer, pkey integer, c15 numeric, c16 timestamp without time zone,
+                 c17 text, c18 text, c19 timestamp without time zone,
+                 c20 timestamp without time zone, c21 integer);
+CREATE TABLE t22 (vkey integer, pkey integer, c37 numeric, c38 text, c39 numeric,
+                  c40 numeric, c41 numeric, c42 integer,
+                  c43 timestamp without time zone, c44 numeric,
+                  colocated_key numeric);
+SELECT create_distributed_table('t22', 'colocated_key');
+
+-- This query should not crash (issue #8548)
+SELECT
+  70 AS c_0
+FROM
+  (
+    SELECT
+      (
+        EXISTS (
+          SELECT ref_5.c33 AS c_0
+          FROM t5 AS ref_5
+          WHERE (make_timestamp(2001, 7, 13, 17, 53, 31)) = (ref_1.c43)
+        )
+      ) AS c_0
+    FROM
+      (
+        t4 AS ref_0
+        LEFT OUTER JOIN t22 AS ref_1
+          ON (ref_0.vkey = ref_1.vkey)
+      )
+    WHERE
+      (
+        (ref_0.c31) >= (
+          SELECT ref_1.pkey AS c_0
+          FROM t2 AS ref_2
+          WHERE (true) < ((ref_2.c17) ^@ (ref_0.c32))
+          ORDER BY c_0 DESC
+          LIMIT 1
+        )
+      ) IN (
+        SELECT (ref_1.c40) <= (ref_1.c37) AS c_0
+        FROM t7 AS ref_4
+        WHERE NOT ((ref_1.c40) <> (ref_1.c41))
+      )
+  ) AS subq_0
+WHERE
+  (TRUE) < (TRUE);
+
+DROP TABLE t4;
+DROP TABLE t5;
+DROP TABLE t2;
+DROP TABLE t22;
+
 DROP TABLE local_table;
 DROP TABLE t0;
 DROP TABLE t1;


### PR DESCRIPTION
Backport of #8556 to `release-12.1`. Fixes #8548.

**DESCRIPTION: Fix segfault in EXPLAIN with LEFT JOIN and correlated subqueries**

PostgreSQL's `setrefs.c` (`set_plan_references`) resolves `AlternativeSubPlan` nodes by picking one alternative and setting the **discarded** entries in `PlannedStmt->subplans` to `NULL`. `PlanContainsDistributedSubPlanRTE()` iterated that list without a NULL check and segfaulted.

Cherry-picked from `a3d5708a6ae8bc8ed7129f8256b4585c01b917f3`.

### Adaptation from main
The upstream commit also added `src/test/regress/expected/subquery_in_where_0.out`. That variant exists on `main` **solely** to cover PG17, where the new regression query returns `0 rows`; on PG16 and below it errors with the pseudoconstant-quals message. Since `release-12.1` supports only PG14/15/16, the variant is unreachable here — and worse, it is main-shaped (it contains tests 12.1's `.sql` file does not have), so it could never match.

Therefore on this branch:
- `subquery_in_where_0.out` is **not** added.
- The expected output in `subquery_in_where.out` carries the PG14/15/16 error text taken verbatim from this branch's `recursive_planning.c:505-515` (`"... not supported in PG14, PG15 and PG16."`), rather than main's PG16-only wording.

This reduces the diff from 1631 to **141 insertions**. The expected output was **validated by an actual test run**, not by hand.

> Note: on 12.1's supported PG versions the added query hits the pseudoconstant-quals `ERROR` before reaching the crash site, so the new test does not itself exercise the fix on this branch. The code fix is still warranted — PG14's `setrefs.c` (commit `41efb8340`) already NULLs discarded `AlternativeSubPlan` entries, so the crash is reachable through other query shapes.

### Behavior-change analysis
- `PlanContainsDistributedSubPlanRTE` is `static` with exactly **one** call site (`distributed_planner.c:2833`).
- The signature refactor is mechanical: the old call site passed `planContext->plan->subplans`; the function now reads `planContext->plan->subplans` itself. Identical value, zero functional delta.
- The only semantic change is `if (planRoot == NULL) continue;`. For any list without NULL entries — every case that did not previously crash — behavior is bit-for-bit unchanged.

### Testing (PG 16.14)
- Builds clean, zero new warnings.
- `subquery_in_where` — **pass**, confirming the adapted expected output.
- Full `check-multi` A/B (baseline vs. all four 12.1.14 backports applied): **100% pass, results identical**.