### PR TITLE
Use GetLatestSnapshot in CleanupRecordExists (#8594)

### DIFF
--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1178,6 +1178,29 @@ TupleToCleanupRecord(HeapTuple heapTuple, TupleDesc tupleDescriptor)
 /*
  * CleanupRecordExists returns whether a cleanup record with the given
  * record ID exists in pg_dist_cleanup.
+ *
+ * The scan deliberately uses a freshly acquired GetLatestSnapshot()
+ * rather than the caller's transaction snapshot. This is required so
+ * that the cleanup worker, after a successful TryLockOperationId(),
+ * can observe a deletion of the cleanup record committed by the
+ * operation owner immediately before it released the operation-ID
+ * advisory lock. Reading under the older outer-transaction snapshot
+ * (the default when NULL is passed to systable_beginscan) would still
+ * see the row as live and trigger a redundant drop of the underlying
+ * resource. Callers that need to read pg_dist_cleanup under their
+ * own (possibly older) snapshot semantics should NOT use this helper.
+ *
+ * Note: there is no automated regression test for this race today.
+ * TryLockOperationId() uses dontWait = true (cleanup never blocks),
+ * so pg_isolationtester cannot orchestrate the required interleave
+ * because it schedules sessions by detecting *blocked* steps. A
+ * deterministic test will require Citus to adopt PostgreSQL's
+ * INJECTION_POINT() infrastructure (or an equivalent test-only
+ * delay GUC inserted between TryLockOperationId() success and this
+ * scan) so a competing op-completing session can be raced into the
+ * gap. Until that test infrastructure exists, the GetLatestSnapshot()
+ * call below is load-bearing: replacing it with NULL silently
+ * reintroduces the double-drop race.
  */
 static bool
 CleanupRecordExists(uint64 recordId)
@@ -1192,10 +1215,14 @@ CleanupRecordExists(uint64 recordId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
+	/* make sure we can always see deletion after acquiring the operation ID lock */
+	Snapshot snapshot = GetLatestSnapshot();
+
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
 													indexOK,
-													NULL, scanKeyCount, scanKey);
+													snapshot,
+													scanKeyCount, scanKey);
 
 	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	bool recordExists = HeapTupleIsValid(heapTuple);


### PR DESCRIPTION
DESCRIPTION: Prevent a possible race condition in shard cleanup

Backport of #8594 to `release-13.2`.
Tracks #8707.

`systable_beginscan` without an explicit snapshot may use a cached catalog
snapshot. If an operation deletes its cleanup record just before the cleaner
acquires the operation-ID lock, `CleanupRecordExists` could still see the stale
row and incorrectly proceed to drop the underlying resource.

Cherry-picked from `c41586cc8fa6e96a677b921c01be6f585f27d819`.

### Adaptation

Clean apply, no adaptation. The stable patch ID is identical to upstream.

### Behavior-change analysis

- `CleanupRecordExists` is `static` and has exactly one call site, in
  `DropOrphanedResourcesForCleanup`, immediately after a successful
  `TryLockOperationId()`.
- `TryLockOperationId()` acquires the operation-ID exclusive lock with
  `dontWait = true`; an active operation owner therefore causes the cleaner to
  skip the record.
- The fresher snapshot can only expose a cleanup-record deletion committed
  after the original list was read. It can only prevent the stale-row drop
  race; no other caller inherits the changed snapshot semantics.

### Verification (PostgreSQL 17.10)

- Clean build with `./configure --without-libcurl`.
- `check-operations`: all 17 tests passed.
- Full `check-multi` A/B against pristine `release-13.2`: all 190 test statuses
  were identical. Both runs had the same pre-existing local-environment failure,
  `custom_aggregate_support`, because TopN was installed while the selected
  expected variant assumes it is absent. The normalized status files have the
  same SHA-256, and the failing result files are byte-identical.
