### PR TITLE
Fix type mismatch when COLLATE is used with type cast in distributed queries (#8498)

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -242,7 +242,7 @@ static bool QueryTreeHasImproperForDeparseNodes(Node *inputNode, void *context);
 static Node * AdjustImproperForDeparseNodes(Node *inputNode, void *context);
 static bool IsImproperForDeparseRelabelTypeNode(Node *inputNode);
 static bool IsImproperForDeparseCoerceViaIONode(Node *inputNode);
-static CollateExpr * RelabelTypeToCollateExpr(RelabelType *relabelType);
+static Node * RelabelTypeToCollateExpr(RelabelType *relabelType);
 
 
 /*
@@ -2870,10 +2870,14 @@ SqlTaskList(Job *job)
 
 
 /*
- * RelabelTypeToCollateExpr converts RelabelType's into CollationExpr's.
- * With that, we will be able to pushdown COLLATE's.
+ * RelabelTypeToCollateExpr converts RelabelType nodes for deparsing.
+ * When the RelabelType only changes collation, it produces a CollateExpr.
+ * When it also changes the type (resulttype != argType), the CollateExpr
+ * is wrapped in a new RelabelType with DEFAULT_COLLATION_OID to preserve
+ * the type cast while avoiding re-detection by
+ * IsImproperForDeparseRelabelTypeNode.
  */
-static CollateExpr *
+static Node *
 RelabelTypeToCollateExpr(RelabelType *relabelType)
 {
 	Assert(OidIsValid(relabelType->resultcollid));
@@ -2883,7 +2887,23 @@ RelabelTypeToCollateExpr(RelabelType *relabelType)
 	collateExpr->collOid = relabelType->resultcollid;
 	collateExpr->location = relabelType->location;
 
-	return collateExpr;
+	Oid argType = exprType((Node *) relabelType->arg);
+	if (relabelType->resulttype != argType)
+	{
+		RelabelType *castRelabel = makeNode(RelabelType);
+		castRelabel->arg = (Expr *) collateExpr;
+		castRelabel->resulttype = relabelType->resulttype;
+		castRelabel->resulttypmod = relabelType->resulttypmod;
+
+		/* DEFAULT_COLLATION_OID prevents re-detection by IsImproperForDeparseRelabelTypeNode */
+		castRelabel->resultcollid = DEFAULT_COLLATION_OID;
+		castRelabel->relabelformat = relabelType->relabelformat;
+		castRelabel->location = relabelType->location;
+
+		return (Node *) castRelabel;
+	}
+
+	return (Node *) collateExpr;
 }
 
 

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -85,6 +85,46 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 (1 row)
 
 RESET citus.log_remote_commands;
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+ sum
+---------------------------------------------------------------------
+ 1.5
+(1 row)
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+      c1
+---------------------------------------------------------------------
+ 14.25.58.22
+ 144.150.228.243
+ 22.171.214.19
+(3 rows)
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');

--- a/src/test/regress/sql/distributed_collations.sql
+++ b/src/test/regress/sql/distributed_collations.sql
@@ -45,6 +45,32 @@ SELECT ALL MIN((lower(CAST(test_collate_pushed_down_aggregate.a AS VARCHAR)) COL
     FROM ONLY test_collate_pushed_down_aggregate;
 RESET citus.log_remote_commands;
 
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');


### PR DESCRIPTION
DESCRIPTION: Fixes type mismatch when COLLATE is used with type cast in distributed queries

Backport of #8498 to `release-13.2`. Fixes #8469.
Tracks #8707.

`RelabelTypeToCollateExpr` dropped the type cast when converting a
`RelabelType` back to a `CollateExpr` for deparsing. Workers could consequently
receive an expression with the wrong result type.

Cherry-picked from `810e7fbb91c8cb51097484da8f695aff62fcecac`.

### Adaptation

Clean apply, no adaptation. The stable patch ID is identical to upstream.

### Behavior-change analysis

- `RelabelTypeToCollateExpr` is `static` with exactly one call site.
- The existing gate accepts only `RelabelType` nodes with a valid,
  non-default result collation.
- The new branch runs only when `resulttype != exprType(arg)`, preserving the
  cast by wrapping the same `CollateExpr` in a `RelabelType`.
- When the types are equal, the function returns the same `CollateExpr` built
  from the same argument, collation, and location; only the C return type changes
  from `CollateExpr *` to `Node *`.
- The wrapper uses `DEFAULT_COLLATION_OID`, so it cannot be re-detected by the
  existing improper-node gate.
- `release-13.2` has no numbered alternate expected files for
  `distributed_collations.out`, so there is no hidden PG15/16 output variant.

### Verification (PostgreSQL 17.10)

- Clean build with `./configure --without-libcurl`.
- `check-multi-1`: all 207 tests passed, including
  `distributed_collations`.
- Full `check-multi` A/B against pristine `release-13.2`: all 190 test statuses
  were identical. Both runs had the same pre-existing local-environment failure,
  `custom_aggregate_support`, because TopN was installed while the selected
  expected variant assumes it is absent. The normalized status files have the
  same SHA-256, and the failing result files are byte-identical.
