### PR TITLE
Fix segfault in EXPLAIN with LEFT JOIN and correlated subqueries (#8556)

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -85,7 +85,7 @@ int PlannerLevel = 0;
 
 static bool ListContainsDistributedTableRTE(List *rangeTableList,
 											bool *maybeHasForeignDistributedTable);
-static bool PlanContainsDistributedSubPlanRTE(List *subPlanList);
+static bool PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext);
 static PlannedStmt * CreateDistributedPlannedStmt(DistributedPlanningContext *
 												  planContext);
 static PlannedStmt * InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
@@ -416,8 +416,9 @@ ListContainsDistributedTableRTE(List *rangeTableList,
 
 
 /*
- * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the given
- * subPlanList is a Read Intermediate Result function scan.
+ * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the
+ * plan context's PlannedStmt->subplans list is a Read Intermediate Result
+ * function scan.
  *
  * It is used by the check after standard_planner() to determine whether the plan
  * still requires distributed planning; in addition to checking the range table for
@@ -426,13 +427,25 @@ ListContainsDistributedTableRTE(List *rangeTableList,
  * that distributed planning is required.
  */
 static bool
-PlanContainsDistributedSubPlanRTE(List *subPlanList)
+PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext)
 {
+	/*
+	 * We iterate over planContext->plan->subplans, which is PostgreSQL's
+	 * PlannedStmt->subplans list. PostgreSQL's setrefs.c (set_plan_references)
+	 * resolves AlternativeSubPlan nodes by picking one alternative and setting
+	 * the discarded subplan entries to NULL. We must therefore skip NULL entries.
+	 */
+	List *subPlanList = planContext->plan->subplans;
 	ListCell *subPlanCell = NULL;
 
 	foreach(subPlanCell, subPlanList)
 	{
 		Node *planRoot = (Node *) lfirst(subPlanCell);
+
+		if (planRoot == NULL)
+		{
+			continue;
+		}
 
 		if (!IsA(planRoot, FunctionScan))
 		{
@@ -2874,7 +2887,7 @@ CheckPostPlanDistribution(DistributedPlanningContext *planContext, bool
 			/* ..or a distributed subplan */
 			planHasDistribution = planHasDistribution ||
 								  PlanContainsDistributedSubPlanRTE(
-				planContext->plan->subplans);
+				planContext);
 
 			/*
 			 * The plan has a distributed relation, so we know for sure that

--- a/src/test/regress/expected/subquery_in_where_0.out
+++ b/src/test/regress/expected/subquery_in_where_0.out
@@ -1470,10 +1470,9 @@ FROM
   ) AS subq_0
 WHERE
   (TRUE) < (TRUE);
- c_0
----------------------------------------------------------------------
-(0 rows)
-
+ERROR:  Distributed queries with outer joins and pseudoconstant quals are not supported in PG15 and PG16.
+DETAIL:  PG15 and PG16 disallow replacing joins with scans when the query has pseudoconstant quals
+HINT:  Consider upgrading your PG version to PG17+
 DROP TABLE t4;
 DROP TABLE t5;
 DROP TABLE t2;

--- a/src/test/regress/sql/subquery_in_where.sql
+++ b/src/test/regress/sql/subquery_in_where.sql
@@ -1052,6 +1052,65 @@ SELECT CASE WHEN EXISTS (
 FROM   a
 WHERE true OR NOT EXISTS (SELECT 1 FROM t1);
 
+-- Test crash fix for issue #8548
+-- A query with LEFT JOIN to a distributed table and correlated subqueries
+-- could crash because PostgreSQL's setrefs.c sets subplan list entries to
+-- NULL when AlternativeSubPlan resolution discards unused alternatives.
+-- PlanContainsDistributedSubPlanRTE must skip NULL entries.
+CREATE TABLE t4 (vkey integer, pkey integer, c30 integer, c31 integer, c32 text);
+CREATE TABLE t5 (vkey integer, pkey integer, c33 text, c34 integer, c35 integer,
+                 c36 timestamp without time zone);
+CREATE TABLE t2 (vkey integer, pkey integer, c15 numeric, c16 timestamp without time zone,
+                 c17 text, c18 text, c19 timestamp without time zone,
+                 c20 timestamp without time zone, c21 integer);
+CREATE TABLE t22 (vkey integer, pkey integer, c37 numeric, c38 text, c39 numeric,
+                  c40 numeric, c41 numeric, c42 integer,
+                  c43 timestamp without time zone, c44 numeric,
+                  colocated_key numeric);
+SELECT create_distributed_table('t22', 'colocated_key');
+
+-- This query should not crash (issue #8548)
+SELECT
+  70 AS c_0
+FROM
+  (
+    SELECT
+      (
+        EXISTS (
+          SELECT ref_5.c33 AS c_0
+          FROM t5 AS ref_5
+          WHERE (make_timestamp(2001, 7, 13, 17, 53, 31)) = (ref_1.c43)
+        )
+      ) AS c_0
+    FROM
+      (
+        t4 AS ref_0
+        LEFT OUTER JOIN t22 AS ref_1
+          ON (ref_0.vkey = ref_1.vkey)
+      )
+    WHERE
+      (
+        (ref_0.c31) >= (
+          SELECT ref_1.pkey AS c_0
+          FROM t2 AS ref_2
+          WHERE (true) < ((ref_2.c17) ^@ (ref_0.c32))
+          ORDER BY c_0 DESC
+          LIMIT 1
+        )
+      ) IN (
+        SELECT (ref_1.c40) <= (ref_1.c37) AS c_0
+        FROM t7 AS ref_4
+        WHERE NOT ((ref_1.c40) <> (ref_1.c41))
+      )
+  ) AS subq_0
+WHERE
+  (TRUE) < (TRUE);
+
+DROP TABLE t4;
+DROP TABLE t5;
+DROP TABLE t2;
+DROP TABLE t22;
+
 DROP TABLE local_table;
 DROP TABLE t0;
 DROP TABLE t1;


### PR DESCRIPTION
DESCRIPTION: Fix segfault in EXPLAIN with LEFT JOIN and correlated subqueries (#8548)

Backport of #8556 to `release-13.2`. Fixes #8548.
Tracks #8707.

PostgreSQL's `set_plan_references` resolves `AlternativeSubPlan` nodes by
selecting one alternative and setting discarded entries in
`PlannedStmt->subplans` to `NULL`. `PlanContainsDistributedSubPlanRTE` iterated
that list without a NULL check and could segfault.

Cherry-picked from `a3d5708a6ae8bc8ed7129f8256b4585c01b917f3`.

### Adaptation

The code and SQL applied cleanly. The new alternate expected file
`subquery_in_where_0.out` was regenerated on PostgreSQL 16 for the release
branch:

- main says pseudoconstant quals are unsupported in PG16; release-13.2 supports
  PG15/16/17 and emits "PG15 and PG16";
- main's test shape includes an `ORDER BY` and corresponding DEBUG plan suffix
  that are absent from release-13.2.

The generated release variant differs from upstream by exactly those five
lines. No production code was adapted.

On the final branch, `subquery_in_where.out` and
`subquery_in_where_0.out` are byte-identical except for the single
version-dependent block: PG17 returns `(0 rows)`, while PG15/16 emit the
three-line error/detail/hint. This proves the regenerated variant matches the
branch's SQL shape and contains no unrelated local-output differences. The base
`subquery_in_where.out` was not changed during the adaptation.

### Behavior-change analysis

- `PlanContainsDistributedSubPlanRTE` is `static` with exactly one call site.
- The parameter refactor is mechanical: the old caller passed
  `planContext->plan->subplans`; the function now reads that same list from
  `planContext`.
- The only semantic change is skipping `NULL` entries. Lists without discarded
  alternatives follow the unchanged FunctionScan/intermediate-result checks.

### Verification

- Clean builds with PostgreSQL 16.14 and 17.10 using
  `./configure --without-libcurl`.
- PostgreSQL 16.14: the verbatim main variant failed as expected; after
  regenerating `_0.out`, `multi_behavioral_analytics_create_table` and
  `subquery_in_where` passed 8/8 in `check-minimal`.
- The PostgreSQL 17 pass uses `subquery_in_where.out` and is not evidence for
  the alternate-file adaptation.
- Full `check-multi` A/B against pristine `release-13.2`: all 190 test statuses
  were identical. Both runs had the same pre-existing local-environment failure,
  `custom_aggregate_support`, because TopN was installed while the selected
  expected variant assumes it is absent. The normalized status files have the
  same SHA-256, and the failing result files are byte-identical.
