### PR TITLE
[release-14.0] Use GetLatestSnapshot in CleanupRecordExists (#8594)

### DIFF
--- a/src/backend/distributed/operations/shard_cleaner.c
+++ b/src/backend/distributed/operations/shard_cleaner.c
@@ -1178,6 +1178,29 @@ TupleToCleanupRecord(HeapTuple heapTuple, TupleDesc tupleDescriptor)
 /*
  * CleanupRecordExists returns whether a cleanup record with the given
  * record ID exists in pg_dist_cleanup.
+ *
+ * The scan deliberately uses a freshly acquired GetLatestSnapshot()
+ * rather than the caller's transaction snapshot. This is required so
+ * that the cleanup worker, after a successful TryLockOperationId(),
+ * can observe a deletion of the cleanup record committed by the
+ * operation owner immediately before it released the operation-ID
+ * advisory lock. Reading under the older outer-transaction snapshot
+ * (the default when NULL is passed to systable_beginscan) would still
+ * see the row as live and trigger a redundant drop of the underlying
+ * resource. Callers that need to read pg_dist_cleanup under their
+ * own (possibly older) snapshot semantics should NOT use this helper.
+ *
+ * Note: there is no automated regression test for this race today.
+ * TryLockOperationId() uses dontWait = true (cleanup never blocks),
+ * so pg_isolationtester cannot orchestrate the required interleave
+ * because it schedules sessions by detecting *blocked* steps. A
+ * deterministic test will require Citus to adopt PostgreSQL's
+ * INJECTION_POINT() infrastructure (or an equivalent test-only
+ * delay GUC inserted between TryLockOperationId() success and this
+ * scan) so a competing op-completing session can be raced into the
+ * gap. Until that test infrastructure exists, the GetLatestSnapshot()
+ * call below is load-bearing: replacing it with NULL silently
+ * reintroduces the double-drop race.
  */
 static bool
 CleanupRecordExists(uint64 recordId)
@@ -1192,10 +1215,14 @@ CleanupRecordExists(uint64 recordId)
 	ScanKeyInit(&scanKey[0], Anum_pg_dist_cleanup_record_id,
 				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(recordId));
 
+	/* make sure we can always see deletion after acquiring the operation ID lock */
+	Snapshot snapshot = GetLatestSnapshot();
+
 	SysScanDesc scanDescriptor = systable_beginscan(pgDistCleanup,
 													DistCleanupPrimaryKeyIndexId(),
 													indexOK,
-													NULL, scanKeyCount, scanKey);
+													snapshot,
+													scanKeyCount, scanKey);
 
 	HeapTuple heapTuple = systable_getnext(scanDescriptor);
 	bool recordExists = HeapTupleIsValid(heapTuple);


### PR DESCRIPTION
Backport of #8594 to `release-14.0`. Tracking issue: #8713.

**Verbatim cherry-pick** — `git cherry-pick -x c41586cc8`, zero conflicts, **zero adaptation**. `git patch-id --stable` is identical to the upstream commit.

### The bug
`CleanupRecordExists` ran its catalog lookup under whatever snapshot the caller happened to hold. In the shard-cleanup path that snapshot can predate the deletion of a cleanup record, so an already-deleted record still looks present — and cleanup then proceeds to drop a shard that is actually live.

### The fix
Take a fresh snapshot for the lookup:

```c
Snapshot snapshot = GetLatestSnapshot();
```

### Why this cannot change behavior on 14.0
`CleanupRecordExists` is `static` with exactly **one** call site, and that site is reached only after a successful `TryLockOperationId()`. A fresher snapshot can only ever flip the result `true → false` — i.e. it can only *prevent* an erroneous drop. It cannot cause a drop that the old code would have skipped.

### Applicability to release-14.0
Vulnerable code confirmed present before the pick: `shard_cleaner.c:1183 CleanupRecordExists(uint64 recordId)` — the old signature with no snapshot argument. `git diff c41586cc8^ release-14.0` over the touched file was empty, i.e. the branch was in the exact pre-fix state.

### Validation
Branch is 1 ahead / 0 behind `8cdb17e25`.

Full A/B on PG16.14 (WSL), unmodified `release-14.0` vs a stack of all five backports, **with `make install` before each leg and an assertion that the installed `citus.so` md5 matches the worktree build**:

| leg | `check-multi` | `check-multi-1` |
|---|---|---|
| baseline `8cdb17e25` | 190 ok, 0 failed | 207 ok, 0 failed |
| all five stacked | 190 ok, 0 failed | 207 ok, 0 failed |

Normalized status sets are **byte-identical** between the two legs (`check-multi` SHA256 `d94f42d7…`, `check-multi-1` SHA256 `f47f18bf…`), with zero `not ok` lines on either side.

Also swept: `release-14.0` has **no** `_N` numbered expected-output variants anywhere, so there is no PG-version-variant exposure of the kind that required a five-line adaptation when #8556 was backported to `release-13.2`.

Same fix shipped in **12.1.14** via #8703 and proposed for `release-13.2` in #8709.