### PR TITLE
[release-14.0] Fix type mismatch when COLLATE is used with type cast (#8498)

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -242,7 +242,7 @@ static bool QueryTreeHasImproperForDeparseNodes(Node *inputNode, void *context);
 static Node * AdjustImproperForDeparseNodes(Node *inputNode, void *context);
 static bool IsImproperForDeparseRelabelTypeNode(Node *inputNode);
 static bool IsImproperForDeparseCoerceViaIONode(Node *inputNode);
-static CollateExpr * RelabelTypeToCollateExpr(RelabelType *relabelType);
+static Node * RelabelTypeToCollateExpr(RelabelType *relabelType);
 
 
 /*
@@ -2875,10 +2875,14 @@ SqlTaskList(Job *job)
 
 
 /*
- * RelabelTypeToCollateExpr converts RelabelType's into CollationExpr's.
- * With that, we will be able to pushdown COLLATE's.
+ * RelabelTypeToCollateExpr converts RelabelType nodes for deparsing.
+ * When the RelabelType only changes collation, it produces a CollateExpr.
+ * When it also changes the type (resulttype != argType), the CollateExpr
+ * is wrapped in a new RelabelType with DEFAULT_COLLATION_OID to preserve
+ * the type cast while avoiding re-detection by
+ * IsImproperForDeparseRelabelTypeNode.
  */
-static CollateExpr *
+static Node *
 RelabelTypeToCollateExpr(RelabelType *relabelType)
 {
 	Assert(OidIsValid(relabelType->resultcollid));
@@ -2888,7 +2892,23 @@ RelabelTypeToCollateExpr(RelabelType *relabelType)
 	collateExpr->collOid = relabelType->resultcollid;
 	collateExpr->location = relabelType->location;
 
-	return collateExpr;
+	Oid argType = exprType((Node *) relabelType->arg);
+	if (relabelType->resulttype != argType)
+	{
+		RelabelType *castRelabel = makeNode(RelabelType);
+		castRelabel->arg = (Expr *) collateExpr;
+		castRelabel->resulttype = relabelType->resulttype;
+		castRelabel->resulttypmod = relabelType->resulttypmod;
+
+		/* DEFAULT_COLLATION_OID prevents re-detection by IsImproperForDeparseRelabelTypeNode */
+		castRelabel->resultcollid = DEFAULT_COLLATION_OID;
+		castRelabel->relabelformat = relabelType->relabelformat;
+		castRelabel->location = relabelType->location;
+
+		return (Node *) castRelabel;
+	}
+
+	return (Node *) collateExpr;
 }
 
 

--- a/src/test/regress/expected/distributed_collations.out
+++ b/src/test/regress/expected/distributed_collations.out
@@ -85,6 +85,46 @@ DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
 (1 row)
 
 RESET citus.log_remote_commands;
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+ sum
+---------------------------------------------------------------------
+ 1.5
+(1 row)
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+      c1
+---------------------------------------------------------------------
+ 14.25.58.22
+ 144.150.228.243
+ 22.171.214.19
+(3 rows)
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');

--- a/src/test/regress/sql/distributed_collations.sql
+++ b/src/test/regress/sql/distributed_collations.sql
@@ -45,6 +45,32 @@ SELECT ALL MIN((lower(CAST(test_collate_pushed_down_aggregate.a AS VARCHAR)) COL
     FROM ONLY test_collate_pushed_down_aggregate;
 RESET citus.log_remote_commands;
 
+-- Test COLLATE with type cast does not cause type mismatch (issue #8469)
+-- When a GROUP BY expression uses both ::VARCHAR and COLLATE, the type cast
+-- must be preserved in the query sent to workers.
+SET citus.next_shard_id TO 20070000;
+CREATE TABLE test_collate_cast (c0 inet, c1 inet);
+SELECT create_distributed_table('test_collate_cast', 'c0');
+INSERT INTO test_collate_cast(c1, c0) VALUES
+    ('144.150.228.243', '230.194.119.117'),
+    ('22.171.214.19', '138.53.199.60'),
+    ('14.25.58.22', '103.167.89.59');
+
+-- This used to fail with: "attribute 2 of type record has wrong type"
+-- "Table has type text, but query expects character varying"
+SELECT SUM(agg0)
+FROM (
+    SELECT ALL SUM(0.5) as agg0
+    FROM ONLY test_collate_cast
+    GROUP BY
+        (((('fooText')||(test_collate_cast.c1)))::VARCHAR COLLATE "C")
+) as asdf;
+
+-- Also verify ORDER BY with type cast + COLLATE works
+SELECT test_collate_cast.c1
+FROM test_collate_cast
+ORDER BY (test_collate_cast.c1::VARCHAR COLLATE "C");
+
 -- Test range table with collated distribution column
 CREATE TABLE test_range(key text COLLATE german_phonebook, val int);
 SELECT create_distributed_table('test_range', 'key', 'range');


### PR DESCRIPTION
Backport of #8498 to `release-14.0` (fixes #8469). Tracking issue: #8713.

**Verbatim cherry-pick** — `git cherry-pick -x 810e7fbb9`, zero conflicts, **zero adaptation**. `git patch-id --stable` is identical to the upstream commit.

### The bug
When `COLLATE` was combined with a type cast, `RelabelTypeToCollateExpr` discarded the cast and returned a bare `CollateExpr`. The deparsed query then lost the type information, and otherwise-valid queries failed with:

```
ERROR:  attribute 2 of type record has wrong type
```

### The fix
Preserve the cast when the relabel actually changes the type, and wrap with the default collation where needed (`multi_physical_planner.c`).

### Why this cannot change behavior on 14.0
`RelabelTypeToCollateExpr` is `static` with one call site, already gated behind `IsImproperForDeparseRelabelTypeNode`. The new code path fires only when `relabelType->resulttype != argType`. When the types are equal — every case that works correctly today — the function returns a byte-identical `CollateExpr`.

### Applicability to release-14.0
Vulnerable code confirmed present before the pick: `multi_physical_planner.c:2882` still returned a bare `CollateExpr`. The only pre-existing drift versus main-at-parent-of-fix was a 56-line offset caused by the Sorted Merge feature (`UseSortedMerge`, ~L162/271/2039), which is absent on 14.0 and **does not overlap** the fix hunks (L243/2931/2944).

### Validation
Branch is 1 ahead / 0 behind `8cdb17e25`.

Full A/B on PG16.14 (WSL), unmodified `release-14.0` vs a stack of all five backports, **with `make install` before each leg and an assertion that the installed `citus.so` md5 matches the worktree build**:

| leg | `check-multi` | `check-multi-1` |
|---|---|---|
| baseline `8cdb17e25` | 190 ok, 0 failed | 207 ok, 0 failed |
| all five stacked | 190 ok, 0 failed | 207 ok, 0 failed |

Normalized status sets are **byte-identical** between the two legs, with zero `not ok` lines on either side. `distributed_collations` — which this PR extends — passes on both.

This PR touches `src/test/regress/expected/distributed_collations.out`. `release-14.0` has **no** `_N` numbered variant of that file (nor of any other expected file on the branch), so there is no second variant that could silently go unchecked.

Same fix shipped in **12.1.14** via #8704 and proposed for `release-13.2` in #8710.