### PR TITLE
[release-14.0] Fix segfault in EXPLAIN with LEFT JOIN and correlated subqueries (#8556)

### DIFF
--- a/src/backend/distributed/planner/distributed_planner.c
+++ b/src/backend/distributed/planner/distributed_planner.c
@@ -83,7 +83,7 @@ int PlannerLevel = 0;
 
 static bool ListContainsDistributedTableRTE(List *rangeTableList,
 											bool *maybeHasForeignDistributedTable);
-static bool PlanContainsDistributedSubPlanRTE(List *subPlanList);
+static bool PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext);
 static PlannedStmt * CreateDistributedPlannedStmt(DistributedPlanningContext *
 												  planContext);
 static PlannedStmt * InlineCtesAndCreateDistributedPlannedStmt(uint64 planId,
@@ -436,8 +436,9 @@ ListContainsDistributedTableRTE(List *rangeTableList,
 
 
 /*
- * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the given
- * subPlanList is a Read Intermediate Result function scan.
+ * PlanContainsDistributedSubPlanRTE checks whether any of the subplans in the
+ * plan context's PlannedStmt->subplans list is a Read Intermediate Result
+ * function scan.
  *
  * It is used by the check after standard_planner() to determine whether the plan
  * still requires distributed planning; in addition to checking the range table for
@@ -446,13 +447,25 @@ ListContainsDistributedTableRTE(List *rangeTableList,
  * that distributed planning is required.
  */
 static bool
-PlanContainsDistributedSubPlanRTE(List *subPlanList)
+PlanContainsDistributedSubPlanRTE(DistributedPlanningContext *planContext)
 {
+	/*
+	 * We iterate over planContext->plan->subplans, which is PostgreSQL's
+	 * PlannedStmt->subplans list. PostgreSQL's setrefs.c (set_plan_references)
+	 * resolves AlternativeSubPlan nodes by picking one alternative and setting
+	 * the discarded subplan entries to NULL. We must therefore skip NULL entries.
+	 */
+	List *subPlanList = planContext->plan->subplans;
 	ListCell *subPlanCell = NULL;
 
 	foreach(subPlanCell, subPlanList)
 	{
 		Node *planRoot = (Node *) lfirst(subPlanCell);
+
+		if (planRoot == NULL)
+		{
+			continue;
+		}
 
 		if (!IsA(planRoot, FunctionScan))
 		{
@@ -2975,7 +2988,7 @@ CheckPostPlanDistribution(DistributedPlanningContext *planContext, bool
 			/* ..or a distributed subplan */
 			planHasDistribution = planHasDistribution ||
 								  PlanContainsDistributedSubPlanRTE(
-				planContext->plan->subplans);
+				planContext);
 
 			/*
 			 * The plan has a distributed relation, so we know for sure that

--- a/src/test/regress/expected/subquery_in_where_0.out
+++ b/src/test/regress/expected/subquery_in_where_0.out
@@ -1471,10 +1471,9 @@ FROM
   ) AS subq_0
 WHERE
   (TRUE) < (TRUE);
- c_0
----------------------------------------------------------------------
-(0 rows)
-
+ERROR:  Distributed queries with outer joins and pseudoconstant quals are not supported in PG16.
+DETAIL:  PG16 disallows replacing joins with scans when the query has pseudoconstant quals
+HINT:  Consider upgrading your PG version to PG17+
 DROP TABLE t4;
 DROP TABLE t5;
 DROP TABLE t2;

--- a/src/test/regress/sql/subquery_in_where.sql
+++ b/src/test/regress/sql/subquery_in_where.sql
@@ -1053,6 +1053,65 @@ SELECT CASE WHEN EXISTS (
 FROM   a
 WHERE true OR NOT EXISTS (SELECT 1 FROM t1);
 
+-- Test crash fix for issue #8548
+-- A query with LEFT JOIN to a distributed table and correlated subqueries
+-- could crash because PostgreSQL's setrefs.c sets subplan list entries to
+-- NULL when AlternativeSubPlan resolution discards unused alternatives.
+-- PlanContainsDistributedSubPlanRTE must skip NULL entries.
+CREATE TABLE t4 (vkey integer, pkey integer, c30 integer, c31 integer, c32 text);
+CREATE TABLE t5 (vkey integer, pkey integer, c33 text, c34 integer, c35 integer,
+                 c36 timestamp without time zone);
+CREATE TABLE t2 (vkey integer, pkey integer, c15 numeric, c16 timestamp without time zone,
+                 c17 text, c18 text, c19 timestamp without time zone,
+                 c20 timestamp without time zone, c21 integer);
+CREATE TABLE t22 (vkey integer, pkey integer, c37 numeric, c38 text, c39 numeric,
+                  c40 numeric, c41 numeric, c42 integer,
+                  c43 timestamp without time zone, c44 numeric,
+                  colocated_key numeric);
+SELECT create_distributed_table('t22', 'colocated_key');
+
+-- This query should not crash (issue #8548)
+SELECT
+  70 AS c_0
+FROM
+  (
+    SELECT
+      (
+        EXISTS (
+          SELECT ref_5.c33 AS c_0
+          FROM t5 AS ref_5
+          WHERE (make_timestamp(2001, 7, 13, 17, 53, 31)) = (ref_1.c43)
+        )
+      ) AS c_0
+    FROM
+      (
+        t4 AS ref_0
+        LEFT OUTER JOIN t22 AS ref_1
+          ON (ref_0.vkey = ref_1.vkey)
+      )
+    WHERE
+      (
+        (ref_0.c31) >= (
+          SELECT ref_1.pkey AS c_0
+          FROM t2 AS ref_2
+          WHERE (true) < ((ref_2.c17) ^@ (ref_0.c32))
+          ORDER BY c_0 DESC
+          LIMIT 1
+        )
+      ) IN (
+        SELECT (ref_1.c40) <= (ref_1.c37) AS c_0
+        FROM t7 AS ref_4
+        WHERE NOT ((ref_1.c40) <> (ref_1.c41))
+      )
+  ) AS subq_0
+WHERE
+  (TRUE) < (TRUE);
+
+DROP TABLE t4;
+DROP TABLE t5;
+DROP TABLE t2;
+DROP TABLE t22;
+
 DROP TABLE local_table;
 DROP TABLE t0;
 DROP TABLE t1;


### PR DESCRIPTION
Backport of #8556 to `release-14.0` (fixes #8548). Tracking issue: #8713.

**Verbatim cherry-pick** — `git cherry-pick -x a3d5708a6`, zero conflicts, **zero adaptation**. `git patch-id --stable` is identical to the upstream commit.

### The bug
`EXPLAIN` on a query with a `LEFT JOIN` plus correlated subqueries could segfault. AlternativeSubPlan resolution leaves NULL entries in `PlannedStmt->subplans`, and `PlanContainsDistributedSubPlanRTE` dereferenced them unconditionally.

Worth noting: **#8548 was reported against a released Citus 14.0.0 on PG18.1**, and was closed with the `cherry-pick-14` label — but the fix never reached this branch.

### The fix
A NULL skip in the subplan walk, plus a small parameter refactor:

```c
if (planRoot == NULL)
    continue;
```

### Why this cannot change behavior on 14.0
Lists containing no NULL entries — every case that does not currently crash — walk exactly as before. The guard only short-circuits entries that would have caused a NULL dereference.

### Applicability to release-14.0
Vulnerable code confirmed present before the pick: `distributed_planner.c:449 PlanContainsDistributedSubPlanRTE(List *)`, the old signature with no NULL check. `git diff a3d5708a6^ release-14.0` over `.sql`, `.out` and `distributed_planner.c` was empty — the branch was in the exact pre-fix state.

### No expected-output adaptation needed here (unlike release-13.2)
This commit introduces `src/test/regress/expected/subquery_in_where_0.out`, the variant read by PG versions that reject pseudoconstant quals. That file embeds a **static string enumerating the branch's pre-PG17 versions**, so it is branch-specific:

```
release-12.1 : "...not supported in PG14, PG15 and PG16."
release-13.2 : "...not supported in PG15 and PG16."
release-14.0 : "...not supported in PG16."
main         : "...not supported in PG16."
```

`release-14.0` shares main's PG16/17/18 range and its error string byte-for-byte (`recursive_planning.c:531-534`), so the file transfers verbatim. Backporting the same commit to `release-13.2` required a five-line adaptation; **none of that applies here**, and this was verified by direct string comparison rather than assumed.

### Validation
Branch is 1 ahead / 0 behind `8cdb17e25`.

Full A/B on PG16.14 (WSL), unmodified `release-14.0` vs a stack of all five backports, **with `make install` before each leg and an assertion that the installed `citus.so` md5 matches the worktree build**:

| leg | `check-multi` | `check-multi-1` |
|---|---|---|
| baseline `8cdb17e25` | 190 ok, 0 failed | 207 ok, 0 failed |
| all five stacked | 190 ok, 0 failed | 207 ok, 0 failed |

`subquery_in_where` lives in `multi_schedule` (`check-multi`) and passes on both legs. Normalized status sets are **byte-identical**, with zero `not ok` lines on either side. PG16 is the version that actually reads `_0.out` on this branch, so this run exercises the new file rather than skipping past it.

Same fix shipped in **12.1.14** via #8705 and proposed for `release-13.2` in #8711.