### PR TITLE
[release-14.0] Fix CREATE EXTENSION IF NOT EXISTS for non-owner users (#8465)

### DIFF
--- a/src/backend/distributed/commands/extension.c
+++ b/src/backend/distributed/commands/extension.c
@@ -199,6 +199,18 @@ PostprocessCreateExtensionStmt(Node *node, const char *queryString)
 	/*  the code-path only supports a single object */
 	Assert(list_length(extensionAddresses) == 1);
 
+	/*
+	 * If the extension is already distributed, don't do anything to avoid
+	 * ownership checks on workers. This is important when a non-owner user runs
+	 * CREATE EXTENSION IF NOT EXISTS for an existing extension - PostgreSQL's
+	 * standard_ProcessUtility succeeds (extension exists, no-op), but metadata
+	 * propagation would fail the ownership check.
+	 */
+	if (IsAnyObjectDistributed(extensionAddresses))
+	{
+		return NIL;
+	}
+
 	EnsureAllObjectDependenciesExistOnAllNodes(extensionAddresses);
 
 	return NodeDDLTaskList(NON_COORDINATOR_NODES, commands);

--- a/src/test/regress/expected/propagate_extension_commands.out
+++ b/src/test/regress/expected/propagate_extension_commands.out
@@ -629,5 +629,31 @@ ROLLBACK;
 DROP EXTENSION isn CASCADE;
 CREATE EXTENSION isn WITH SCHEMA pg_temp;
 ERROR:  schema "pg_temp" does not exist
+-- Test that CREATE EXTENSION IF NOT EXISTS works for non-owner users
+-- when extension already exists
+RESET search_path;
+CREATE USER non_owner_user;
+-- Create extension as superuser
+CREATE EXTENSION seg SCHEMA public;
+-- Verify it's distributed
+SELECT count(*) FROM pg_catalog.pg_dist_object WHERE objid = (SELECT oid FROM pg_extension WHERE extname = 'seg');
+ count
+---------------------------------------------------------------------
+     1
+(1 row)
+
+-- Switch to non-owner user and try CREATE EXTENSION IF NOT EXISTS
+-- This should succeed without "must be owner of extension" error
+SET ROLE non_owner_user;
+SET client_min_messages TO NOTICE;
+CREATE EXTENSION IF NOT EXISTS seg SCHEMA public;
+NOTICE:  extension "seg" already exists, skipping
+SET client_min_messages TO WARNING;
+-- Clean up
+RESET ROLE;
+DROP EXTENSION seg;
+DROP USER non_owner_user;
 -- drop the schema and all the objects
 DROP SCHEMA "extension'test" CASCADE;
+DROP TEXT SEARCH TEMPLATE intdict_template CASCADE;
+DROP FUNCTION dintdict_init(internal), dintdict_lexize(internal, internal, internal, internal) CASCADE;


### PR DESCRIPTION
Backport of #8465 to `release-14.0` (fixes #7091). Tracking issue: #8713.

**Verbatim cherry-pick** — `git cherry-pick -x fde8ceace`, zero conflicts, **zero adaptation**. `git patch-id --stable` is identical to the upstream commit.

### The bug
`CREATE EXTENSION IF NOT EXISTS <ext>` failed for a non-owner user even when the extension was already installed. Citus propagated the statement without preserving `if_not_exists`, so the remote side attempted a real create and rejected it:

```
ERROR:  must be owner of extension seg
```

`IF NOT EXISTS` is supposed to be a no-op in exactly this situation.

### The fix
Set `if_not_exists` on the propagated statement at the three sites that construct it (`extension.c`).

### Why this cannot change behavior on 14.0
The change only makes the propagated statement carry the same `IF NOT EXISTS` semantics the user actually wrote. When the extension is absent the statement still creates it; when it is present the remote side now no-ops instead of erroring. No path that succeeds today changes outcome.

### Applicability to release-14.0
Vulnerable code confirmed present before the pick: `extension.c:185,1146,1318` never set `if_not_exists`. `git diff fde8ceace^ release-14.0` over the touched files was empty — the branch was in the exact pre-fix state.

Note this fix is missing from **all three** maintained release lines, not just 14.0; it is included here because `release-14.0` is the active 14.x line.

### Validation
Branch is 1 ahead / 0 behind `8cdb17e25`.

Full A/B on PG16.14 (WSL), unmodified `release-14.0` vs a stack of all five backports, **with `make install` before each leg and an assertion that the installed `citus.so` md5 matches the worktree build**:

| leg | `check-multi` | `check-multi-1` |
|---|---|---|
| baseline `8cdb17e25` | 190 ok, 0 failed | 207 ok, 0 failed |
| all five stacked | 190 ok, 0 failed | 207 ok, 0 failed |

`propagate_extension_commands` — which this PR extends — is in `multi_1_schedule` (`check-multi-1`) and passes on both legs. Normalized status sets are **byte-identical**, with zero `not ok` lines on either side.

`release-14.0` has **no** `_N` numbered expected-output variants anywhere on the branch, so there is no PG-version-specific variant of the touched expected file that could go unchecked.