### PR TITLE
Release 13.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+### citus v13.4.0 (August 6, 2026) ###
+
+* Adds `citus_internal.distribute_object()`, a superuser-only repair UDF
+  that manually propagates an existing object to the worker nodes as a
+  distributed object (#8621)
+
+* Adds `citus.allow_unsafe_insert_select_pushdown` to allow shard-local
+  batched `INSERT ... SELECT` pushdown for colocated tables, for workloads
+  that call expensive batch-oriented UDFs (#8625)
+
+* Avoids coordinated transactions for single-statement single-shard
+  procedure calls by determining 2PC requirements through PL/pgSQL static
+  analysis instead of a runtime counter (#8566)
+
+* Enforces object ownership for more citus-internal UDFs (#8587)
+
+* Re-ranges sequences to the new group id when promoting a clone node so
+  that distributed, reference and Citus local tables keep globally-unique
+  sequence values (#8638)
+
+* Drops orphaned Citus local table shard copies on a worker promoted from
+  a clone of the coordinator (#8651)
+
+* Fixes wrong query results when recursive planning projects
+  restriction-referenced columns as NULL, such as for
+  `NOT (x IS DISTINCT FROM y)` (#8497)
+
+* Fixes a crash and `could not find valid entry for shard` errors when
+  planning `UPDATE` or `DELETE` on a distributed table whose `WHERE`
+  clause combines distribution key equality with an always-false
+  predicate (#8692)
+
+* Fixes a race condition in shard cleanup where a stale catalog snapshot
+  could cause an in-use shard to be dropped (#8594)
+
+* Fixes a type mismatch when `COLLATE` is used together with a type cast
+  in distributed queries (#8498)
+
+* Fixes a segfault in `EXPLAIN` for queries with a `LEFT JOIN` and
+  correlated subqueries (#8556)
+
+* Fixes a crash on a writable standby coordinator when writing to a
+  coordinator-local shard (#8561)
+
 ### citus v13.3.0 (May 15, 2026) ###
 
 * Adds support for running several DDLs for schema-based sharding from any


### PR DESCRIPTION
Adds the CHANGELOG entry for **v13.4.0**.

## This is a CHANGELOG-only release

The version bump was already landed by `0aa073fe4` ("Set 13.4.0 as upcoming version; run N-1 tests against 13.3.0", #8632). Re-verified on this branch, all already at 13.4.0 / 13.4-1:

| artifact | state |
|---|---|
| `configure.ac` | `AC_INIT([Citus], [13.4.0])` |
| `configure` | 9 version strings at `13.4.0` |
| `src/backend/distributed/citus.control` | `default_version = '13.4-1'` |
| `src/backend/columnar/citus_columnar.control` | `default_version = '13.4-1'` |
| `sql/citus--13.3-1--13.4-1.sql` + downgrade | present |
| `sql/citus_columnar--13.3-1--13.4-1.sql` + downgrade | present |
| `expected/multi_extension.out` | contains the 13.4-1 tests |

So this PR touches **one file**: `CHANGELOG.md`, 44 insertions, 0 deletions.

This mirrors the shape of the v13.3.0 release commit `e5b5a3c45` (#8588), which was likewise CHANGELOG-only because its bump had landed in `e8a841d46`.

I also checked the one-off cleanup that `e5b5a3c45` carried: it removed 4 accidentally duplicated `DROP FUNCTION` lines from `citus--13.3-1--13.2-1.sql`. The 13.4 counterpart `citus--13.4-1--13.3-1.sql` has no duplicates, so no SQL cleanup is needed here.

## Contents

`v13.3.0..release-13.2` contains 14 non-merge commits; 12 are changelogged. The two excluded:

- `0aa073fe4` - version housekeeping (referenced in the commit message instead)
- `f5b93d328` - PG-version/N-1 expected-output fixup that folds into #8625

Citations use **origin PR numbers**, with `(via #backportPR)` noted in the commit message only where they differ - matching the v13.3.0 convention (its bullet for #8466 reads just `(#8466)` even though the commit body says "via #8579").

| origin PR | via | entry |
|---|---|---|
| #8621 | - | `citus_internal.distribute_object()` repair UDF |
| #8625 | - | `citus.allow_unsafe_insert_select_pushdown` GUC |
| #8566 | #8695 | skip 2PC for single-statement single-shard procedures |
| #8587 | - | object ownership for more citus-internal UDFs |
| #8638 | #8654 | re-range sequences when promoting a clone node |
| #8651 | #8657 | drop orphaned Citus local table shard copies |
| #8497 | - | wrong results when recursive planning projects columns as NULL |
| #8692 | - | `UPDATE`/`DELETE` with shard key equality + always-false predicate |
| #8594 | #8709 | race condition in shard cleanup |
| #8498 | #8710 | type mismatch with `COLLATE` + type cast |
| #8556 | #8711 | segfault in `EXPLAIN` with `LEFT JOIN` + correlated subqueries |
| #8561 | #8712 | crash on writable standby coordinator |

The last four are the 12.1/13.2/14.0 P1 backport set tracked in #8707.

## Formatting

Verified against the existing sections: header `### citus v13.4.0 (August 4, 2026) ###`, all lines <= 76 columns, 2-space continuation indent, blank line between every bullet, `Adds` entries before `Fixes`.

Note this repo has `core.autocrlf=true`, so the worktree is CRLF while the blob is LF. The section was written with CRLF and the committed blob verified LF-only (`git ls-files --eol` -> `i/lf w/crlf`), which is why the diff is a clean 44-line insertion rather than a whole-file rewrite.