### PR TITLE
Add changelog for Citus v14.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+### citus v14.2.0 (August 6, 2026) ###
+
+* Adds `citus_internal.distribute_object()`, a superuser-only repair UDF
+  that manually propagates an existing object to the worker nodes as a
+  distributed object (#8621)
+
+* Adds `citus.allow_unsafe_insert_select_pushdown` to allow shard-local
+  batched `INSERT ... SELECT` pushdown for colocated tables, for workloads
+  that call expensive batch-oriented UDFs (#8625)
+
+* Avoids coordinated transactions for single-statement single-shard
+  procedure calls by determining 2PC requirements through PL/pgSQL static
+  analysis instead of a runtime counter (#8566)
+
+* Enforces object ownership for more citus-internal UDFs (#8587)
+
+* Re-ranges sequences to the new group id when promoting a clone node so
+  that distributed, reference and Citus local tables keep globally-unique
+  sequence values (#8638)
+
+* Drops orphaned Citus local table shard copies on a worker promoted from
+  a clone of the coordinator (#8651)
+
+* Fixes wrong query results when recursive planning projects
+  restriction-referenced columns as NULL, such as for
+  `NOT (x IS DISTINCT FROM y)` (#8497)
+
+* Fixes a crash and `could not find valid entry for shard` errors when
+  planning `UPDATE` or `DELETE` on a distributed table whose `WHERE`
+  clause combines distribution key equality with an always-false
+  predicate (#8692)
+
+* Fixes a race condition in shard cleanup where a stale catalog snapshot
+  could cause an in-use shard to be dropped (#8594)
+
+* Fixes a type mismatch when `COLLATE` is used together with a type cast
+  in distributed queries (#8498)
+
+* Fixes a segfault in `EXPLAIN` for queries with a `LEFT JOIN` and
+  correlated subqueries (#8556)
+
+* Fixes an unexpected "must be owner of extension" error on
+  `CREATE EXTENSION IF NOT EXISTS` for an already-distributed extension
+  by skipping the ownership check in that case (#8465)
+
+* Fixes a crash on a writable standby coordinator when writing to a
+  coordinator-local shard (#8561)
+
 ### citus v14.1.0 (May 14, 2026) ###
 
 * Adds support for running several DDLs for schema-based sharding from any


### PR DESCRIPTION
Release prep for **citus v14.2.0** from `release-14.0`.

This is a **CHANGELOG-only** change. All version-bearing artifacts were already
bumped in 152fdf425 (#8635):

| artifact | state on `release-14.0` |
| --- | --- |
| `configure.ac` / `configure` | `14.2.0` |
| `citus.control` / `citus_columnar.control` | `14.2-1` |
| `expected/multi_extension.out` | references `14.2` |
| `14.1-1` -> `14.2-1` migration + downgrade scripts | present |

So the diff here is a single file: `CHANGELOG.md | 48 +`.

### Changelog entries (user-visible only)

| origin PR | backport PR | entry |
| --- | --- | --- |
| #8621 | - | `citus_internal.distribute_object()` repair UDF |
| #8625 | - | `citus.allow_unsafe_insert_select_pushdown` GUC |
| #8566 | #8694 | skip 2PC for single-statement single-shard procedures |
| #8587 | - | object ownership for more citus-internal UDFs |
| #8638 | #8653 | re-range sequences when promoting a clone node |
| #8651 | #8656 | drop orphaned Citus local table shard copies |
| #8497 | - | wrong results when recursive planning projects columns as NULL |
| #8692 | #8700 | `UPDATE`/`DELETE` with dist-key equality + always-false predicate |
| #8594 | #8714 | race condition in shard cleanup (stale catalog snapshot) |
| #8498 | #8715 | type mismatch with `COLLATE` + type cast |
| #8556 | #8716 | segfault in `EXPLAIN` with `LEFT JOIN` + correlated subqueries |
| #8465 | #8718 | `CREATE EXTENSION IF NOT EXISTS` ownership error |
| #8561 | #8717 | crash on a writable standby coordinator |

Bullets cite **origin** PR numbers only, per the existing convention in the file.

### Commits intentionally excluded

Four of the 17 commits in `v14.1.0..release-14.0` carry no `DESCRIPTION:` line
and are not user-visible:

- `f70aeb54f` - move a GUC test into the N-1-excluded schedule (folds into #8625)
- `3383b2463` - `multi_extension` version-ladder test
- `65d0a7ece` - `13.3-1--13.4-1` upgrade path plumbing (folds into #8621)
- `152fdf425` - the version bump itself (#8635), cited above

### Relationship to #8719

12 of the 13 entries are shared with the 13.4.0 changelog (#8719) and the text is
byte-identical between the two, deliberately, so the same fix reads the same way on
both lines. The one 14.0-only entry is #8465, which was not backported to 13.2.