### PR TITLE
Install downgrade scripts in cassert setup

### DIFF
--- a/.github/actions/setup_cassert_pg/action.yml
+++ b/.github/actions/setup_cassert_pg/action.yml
@@ -83,4 +83,4 @@ runs:
         make clean
         make -j"$(nproc)" all
         # Installs into the $HOME pgenv prefix for this version -> no sudo, no clobber across versions.
-        make install
+        make install-all


### PR DESCRIPTION
## Summary

Use `make install-all` in `setup_cassert_pg` so `multi_extension` receives historical Citus and columnar downgrade scripts.

## Validation

- WSL cassert PostgreSQL 16.13, 17.9, and 18.3: `multi_extension` passed
- Verified all distributed and columnar downgrade scripts were installed for each version
- YAML parsing/lint, `git diff --check`, and `make check-style` passed

Fixes #8726
Related to #8724