### PR TITLE
Exclude unsupported PostgreSQL 19 packaging jobs

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -54,6 +54,11 @@ jobs:
           - almalinux-8
           - almalinux-9
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
+        exclude:
+          - packaging_docker_image: oraclelinux-8
+            POSTGRES_VERSION: 19
+          - packaging_docker_image: almalinux-8
+            POSTGRES_VERSION: 19
 
     container:
       image: citus/packaging:${{ matrix.packaging_docker_image }}-pg${{ matrix.POSTGRES_VERSION }}
@@ -126,9 +131,11 @@ jobs:
 
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
         exclude:
-          # PG18 is not supported on Ubuntu focal
+          # PG18 and PG19 are not supported on Ubuntu focal
           - packaging_docker_image: ubuntu-focal-all
             POSTGRES_VERSION: 18
+          - packaging_docker_image: ubuntu-focal-all
+            POSTGRES_VERSION: 19
 
     container:
       image: citus/packaging:${{ matrix.packaging_docker_image }}


### PR DESCRIPTION
## Summary
- exclude PostgreSQL 19 packaging tests for Oracle Linux 8 and AlmaLinux 8, where PGDG packages are unavailable
- exclude PostgreSQL 19 packaging tests for Ubuntu focal, while preserving the existing PostgreSQL 18 exclusion
- keep PostgreSQL 19 coverage for AlmaLinux 9, Debian bullseye/bookworm, and Ubuntu jammy

## Validation
- parsed the workflow YAML
- verified the expanded PostgreSQL 19 matrix retains only supported packaging images
- verified the branch is exactly one commit ahead of `pg19-support` with a one-file diff

Tracks #8731.