### PR TITLE
PG19: handle property graph dependency object classes

### DIFF
--- a/src/include/pg_version_compat.h
+++ b/src/include/pg_version_compat.h
@@ -352,6 +352,10 @@ LWLockNewTrancheIdCompat(const char *name)
 #include "catalog/pg_parameter_acl.h"
 #include "catalog/pg_policy.h"
 #include "catalog/pg_proc.h"
+#if PG_VERSION_NUM >= PG_VERSION_19
+#include "catalog/pg_propgraph_label.h"
+#include "catalog/pg_propgraph_property.h"
+#endif
 #include "catalog/pg_publication.h"
 #include "catalog/pg_publication_namespace.h"
 #include "catalog/pg_publication_rel.h"
@@ -410,6 +414,10 @@ typedef enum ObjectClass
 	OCLASS_EVENT_TRIGGER,       /* pg_event_trigger */
 	OCLASS_PARAMETER_ACL,       /* pg_parameter_acl */
 	OCLASS_POLICY,              /* pg_policy */
+#if PG_VERSION_NUM >= PG_VERSION_19
+	OCLASS_PROPGRAPH_LABEL,     /* pg_propgraph_label */
+	OCLASS_PROPGRAPH_PROPERTY,  /* pg_propgraph_property */
+#endif
 	OCLASS_PUBLICATION,         /* pg_publication */
 	OCLASS_PUBLICATION_NAMESPACE,   /* pg_publication_namespace */
 	OCLASS_PUBLICATION_REL,     /* pg_publication_rel */
@@ -618,6 +626,18 @@ getObjectClass(const ObjectAddress *object)
 		{
 			return OCLASS_POLICY;
 		}
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+		case PropgraphLabelRelationId:
+		{
+			return OCLASS_PROPGRAPH_LABEL;
+		}
+
+		case PropgraphPropertyRelationId:
+		{
+			return OCLASS_PROPGRAPH_PROPERTY;
+		}
+#endif
 
 		case PublicationNamespaceRelationId:
 		{


### PR DESCRIPTION
## Summary
- recognize PostgreSQL 19 property-graph label and property object classes in the compatibility mapper
- keep property-graph objects on Citus's safe unsupported-dependency path
- gate the new catalogs and mappings to PostgreSQL 19+

## Validation
- PostgreSQL 19beta2: clean build and targeted `privileges` regression pass; original object-class 6470/6473 errors no longer reproduce
- PostgreSQL 17.10: all 225 vanilla tests pass
- PostgreSQL 18.4: all 231 vanilla tests pass

Fixes #8729

Fixes #8729.
## Upstream provenance

The property-graph catalogs and relation OIDs 6470/6473 predate PG19 Beta1. Beta2-range PostgreSQL commit `9d8cdcbe0c8a` began recording graph-label/property dependencies, which exposed those pre-existing `ObjectAddress.classId` values to Citus and triggered the stale compatibility mapper. Thus the omission was latent in Beta1 and directly exposed by Beta2 dependency behavior.