### PR TITLE
PG19: stabilize columnar regression outputs

### DIFF
--- a/src/test/regress/expected/columnar_insert.out
+++ b/src/test/regress/expected/columnar_insert.out
@@ -127,8 +127,10 @@ ALTER TABLE test_toast_row ALTER COLUMN plain SET STORAGE plain; -- inline, unco
 ALTER TABLE test_toast_row ALTER COLUMN main SET STORAGE main; -- inline, compressed
 ALTER TABLE test_toast_row ALTER COLUMN external SET STORAGE external; -- out-of-line, uncompressed
 ALTER TABLE test_toast_row ALTER COLUMN extended SET STORAGE extended; -- out-of-line, compressed
+SET default_toast_compression TO 'pglz';
 INSERT INTO test_toast_row VALUES(
        repeat('w', 5000), repeat('x', 5000), repeat('y', 5000), repeat('z', 5000));
+RESET default_toast_compression;
 SELECT
   pg_column_size(plain), pg_column_size(main),
   pg_column_size(external), pg_column_size(extended)

--- a/src/test/regress/expected/columnar_test_helpers.out
+++ b/src/test/regress/expected/columnar_test_helpers.out
@@ -139,8 +139,9 @@ BEGIN
   pgversion = substring(version(), '\d+')::int ;
   FOR query_plan IN execute explain_command LOOP
     IF pgversion >= 17 THEN
-      IF query_plan ~ 'SubPlan \d+\).col' THEN
-    	  query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (\d+)\).col1\)\)', '(SubPlan \1)', 'g');
+      IF query_plan ~ 'SubPlan (any_)?\d+' THEN
+        query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (any_)?(\d+)\).col1\)\)', '(SubPlan \2)', 'g');
+        query_plan = regexp_replace(query_plan, 'SubPlan any_(\d+)', 'SubPlan \1', 'g');
       END IF;
     END IF;
     RETURN NEXT;

--- a/src/test/regress/expected/columnar_vacuum_vs_insert_0.out
+++ b/src/test/regress/expected/columnar_vacuum_vs_insert_0.out
@@ -1,0 +1,73 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1-insert s1-begin s1-insert s2-vacuum s1-commit s2-select
+step s1-insert:
+    INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
+
+step s1-begin:
+    BEGIN;
+
+step s1-insert:
+    INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
+
+s2: INFO:  statistics for "test_vacuum_vs_insert":
+storage id: xxxxx
+total file size: 24576, total data size: 26
+compression rate: 1.00x
+total row count: 3, stripe count: 1, average rows per stripe: 3
+chunk count: 2, containing data for dropped columns: 0, none compressed: 2
+
+s2: INFO:  "test_vacuum_vs_insert": stopping truncate due to conflicting lock request
+step s2-vacuum:
+    VACUUM VERBOSE test_vacuum_vs_insert;
+
+step s1-commit:
+    COMMIT;
+
+step s2-select:
+    SELECT * FROM test_vacuum_vs_insert;
+
+a|b
+---------------------------------------------------------------------
+1|2
+2|4
+3|6
+1|2
+2|4
+3|6
+(6 rows)
+
+
+starting permutation: s1-insert s1-begin s1-insert s2-vacuum-full s1-commit s2-select
+step s1-insert:
+    INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
+
+step s1-begin:
+    BEGIN;
+
+step s1-insert:
+    INSERT INTO test_vacuum_vs_insert SELECT i, 2 * i FROM generate_series(1, 3) i;
+
+step s2-vacuum-full:
+    VACUUM FULL VERBOSE test_vacuum_vs_insert;
+ <waiting ...>
+step s1-commit: 
+    COMMIT;
+
+s2: INFO:  repacking "public.test_vacuum_vs_insert" in physical order
+s2: INFO:  "public.test_vacuum_vs_insert": found 0 removable, 6 nonremovable row versions in 4 pages
+DETAIL:  0 dead row versions cannot be removed yet.
+step s2-vacuum-full: <... completed>
+step s2-select:
+    SELECT * FROM test_vacuum_vs_insert;
+
+a|b
+---------------------------------------------------------------------
+1|2
+2|4
+3|6
+1|2
+2|4
+3|6
+(6 rows)
+

--- a/src/test/regress/sql/columnar_insert.sql
+++ b/src/test/regress/sql/columnar_insert.sql
@@ -89,8 +89,10 @@ ALTER TABLE test_toast_row ALTER COLUMN main SET STORAGE main; -- inline, compre
 ALTER TABLE test_toast_row ALTER COLUMN external SET STORAGE external; -- out-of-line, uncompressed
 ALTER TABLE test_toast_row ALTER COLUMN extended SET STORAGE extended; -- out-of-line, compressed
 
+SET default_toast_compression TO 'pglz';
 INSERT INTO test_toast_row VALUES(
        repeat('w', 5000), repeat('x', 5000), repeat('y', 5000), repeat('z', 5000));
+RESET default_toast_compression;
 
 SELECT
   pg_column_size(plain), pg_column_size(main),

--- a/src/test/regress/sql/columnar_test_helpers.sql
+++ b/src/test/regress/sql/columnar_test_helpers.sql
@@ -151,8 +151,9 @@ BEGIN
   pgversion = substring(version(), '\d+')::int ;
   FOR query_plan IN execute explain_command LOOP
     IF pgversion >= 17 THEN
-      IF query_plan ~ 'SubPlan \d+\).col' THEN
-    	  query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (\d+)\).col1\)\)', '(SubPlan \1)', 'g');
+      IF query_plan ~ 'SubPlan (any_)?\d+' THEN
+        query_plan = regexp_replace(query_plan, '\(ANY \(\w+ = \(SubPlan (any_)?(\d+)\).col1\)\)', '(SubPlan \2)', 'g');
+        query_plan = regexp_replace(query_plan, 'SubPlan any_(\d+)', 'SubPlan \1', 'g');
       END IF;
     END IF;
     RETURN NEXT;


### PR DESCRIPTION
Closes #8732.

## Summary

- pin `pglz` only around the heap TOAST-size assertion in `columnar_insert`
- extend the existing EXPLAIN normalizer for PG19 `SubPlan any_N` names
- add the PG19 alternate `VACUUM FULL` status output for `columnar_vacuum_vs_insert`

All three failures are PostgreSQL output/configuration drift that predates `REL_19_BETA1`, not Beta2 regressions or columnar compatibility defects:

- PostgreSQL `34dfca293432` made LZ4 the default TOAST compression when available
- PostgreSQL `8c49a484e8eb` introduced textual subplan names such as `any_1`
- PostgreSQL `ac58465e0618` introduced REPACK and the `repacking ... in physical order` wording

Direct Beta1 and Beta2 runs reproduce the same behavior for all three cases.

## Tests

- PG17.10: `check-columnar-minimal EXTRA_TESTS="columnar_insert columnar_chunk_filtering"`; `check-columnar-isolation`
- PG18.4: `check-columnar-minimal EXTRA_TESTS="columnar_insert columnar_chunk_filtering"`; `check-columnar-isolation`
- PG19beta2: `check-columnar-minimal EXTRA_TESTS="columnar_insert columnar_chunk_filtering"`; `check-columnar-isolation`