### PR TITLE
PG19: fix follower cluster status replies

### DIFF
--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -586,7 +586,7 @@ push(@pgOptions, "wal_level='logical'");
 
 # Faster logical replication status update so tests with logical replication
 # run faster
-push(@pgOptions, "wal_receiver_status_interval=0");
+push(@pgOptions, "wal_receiver_status_interval=1");
 
 # Faster logical replication apply worker launch so tests with logical
 # replication run faster. This is used in ApplyLauncherMain in


### PR DESCRIPTION
## Summary

- send WAL receiver apply-status replies once per second in the Perl follower-cluster test harness
- match the existing Python test harness behavior
- preserve PostgreSQL and Citus production defaults

## Provenance

- published from the explicitly approved commit `5e4ddc836a95df6cea9cceef33cb44d48559b736`
- based directly on `pg19-support` at `ff8f1f8c46de4c3ed094c99796c9805529d1a328`
- contains only the one-line `wal_receiver_status_interval=0` to `1` test-harness change

## Testing

- PG19beta2 before fix: `make -C src/test/regress check-follower-cluster` timed out after 180 seconds while creating the follower topology
- PG17.10 after fix: 8/8 follower-cluster tests passed
- PG18.4 after fix: 8/8 follower-cluster tests passed
- PG19beta2 after fix: 8/8 follower-cluster tests passed

Closes #8736