### PR TITLE
PG19: stabilize remaining planner and shard-size outputs

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -178,6 +178,7 @@ DEPS = {
     "multi_mx_modifying_xacts": TestDeps(None, ["multi_mx_create_table"]),
     "multi_mx_router_planner": TestDeps(None, ["multi_mx_create_table"]),
     "multi_mx_copy_data": TestDeps(None, ["multi_mx_create_table"]),
+    "multi_mx_explain": TestDeps(None, ["multi_mx_copy_data"]),
     "multi_mx_modifications": TestDeps(None, ["multi_mx_create_table"]),
     "multi_mx_schema_support": TestDeps(None, ["multi_mx_copy_data"]),
     "multi_simple_queries": TestDeps("base_schedule"),

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -182,6 +182,10 @@ DEPS = {
     "multi_mx_modifications": TestDeps(None, ["multi_mx_create_table"]),
     "multi_mx_schema_support": TestDeps(None, ["multi_mx_copy_data"]),
     "multi_simple_queries": TestDeps("base_schedule"),
+    # These share a schedule line that needs both TPC-H and behavioral data.
+    "multi_array_agg": TestDeps("base_schedule"),
+    "multi_limit_clause": TestDeps("base_schedule"),
+    "multi_orderby_limit_pushdown": TestDeps("base_schedule"),
     "create_single_shard_table": TestDeps("minimal_schedule"),
     "isolation_schema_based_sharding_from_any_node": TestDeps(
         None, ["isolation_setup"]

--- a/src/test/regress/expected/isolation_shard_rebalancer_progress.out
+++ b/src/test/regress/expected/isolation_shard_rebalancer_progress.out
@@ -19,7 +19,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -41,7 +41,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
 colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
@@ -63,7 +63,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -102,7 +102,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -124,7 +124,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       2|move          |t               |t                   |f                   |Completed
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       2|move          |t               |t                   |f                   |Completed
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       2|move          |t               |t                   |f                   |Completed
 colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       1|move          |t               |t                   |f                   |Setting Up
 (4 rows)
@@ -141,7 +141,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -184,7 +184,7 @@ step s1-rebalance-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -206,7 +206,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|move          |t               |t                   |f                   |Copying Data
 colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
@@ -228,7 +228,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -271,7 +271,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -293,7 +293,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
 colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
@@ -315,7 +315,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -358,7 +358,7 @@ step s1-rebalance-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -380,7 +380,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|move          |t               |t                   |t                   |Final Catchup
 colocated1|1500002|    200000|localhost |     57637|           200000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 colocated2|1500006|      8000|localhost |     57637|             8000|localhost |     57638|                0|       0|move          |t               |t                   |f                   |Not Started Yet
 (4 rows)
@@ -402,7 +402,7 @@ rebalance_table_shards
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -445,7 +445,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -467,7 +467,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -487,7 +487,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -530,7 +530,7 @@ step s1-shard-move-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -552,7 +552,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|move          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -572,7 +572,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -616,7 +616,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -638,7 +638,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -658,7 +658,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -702,7 +702,7 @@ step s1-shard-copy-c1-block-writes:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -724,7 +724,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|copy          |t               |t                   |f                   |Copying Data
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|copy          |t               |t                   |f                   |Copying Data
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|copy          |t               |t                   |f                   |Copying Data
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -744,7 +744,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -787,7 +787,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -809,7 +809,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|move          |t               |t                   |f                   |Setting Up
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -829,7 +829,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -872,7 +872,7 @@ step s1-shard-move-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -894,7 +894,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|move          |t               |t                   |t                   |Final Catchup
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -914,7 +914,7 @@ citus_move_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -958,7 +958,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -980,7 +980,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|copy          |t               |t                   |f                   |Setting Up
 (2 rows)
 
 step s5-release-advisory-lock:
@@ -1000,7 +1000,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1044,7 +1044,7 @@ step s1-shard-copy-c1-online:
  <waiting ...>
 step s7-get-progress: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1066,7 +1066,7 @@ step s7-get-progress:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available|status
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|copy          |t               |t                   |t                   |Final Catchup
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|copy          |t               |t                   |t                   |Final Catchup
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|copy          |t               |t                   |t                   |Final Catchup
 (2 rows)
 
 step s6-release-advisory-lock:
@@ -1086,7 +1086,7 @@ citus_copy_shard_placement
 step s1-wait:
 step s7-get-progress:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1132,7 +1132,7 @@ step s4-shard-move-sep-block-writes:
  <waiting ...>
 step s7-get-progress-ordered: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1154,7 +1154,7 @@ step s7-get-progress-ordered:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|             8000|       1|move          |t               |t                   |f
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|             8000|       1|move          |t               |t                   |f
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|             8000|       1|move          |t               |t                   |f
 separate  |1500009|    200000|localhost |     57637|           200000|localhost |     57638|             8000|       1|move          |t               |t                   |f
 (3 rows)
 
@@ -1182,7 +1182,7 @@ step s1-wait:
 step s4-wait:
 step s7-get-progress-ordered:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1228,7 +1228,7 @@ step s4-shard-move-sep-block-writes:
  <waiting ...>
 step s7-get-progress-ordered: 
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,
@@ -1250,7 +1250,7 @@ step s7-get-progress-ordered:
 table_name|shardid|shard_size|sourcename|sourceport|source_shard_size|targetname|targetport|target_shard_size|progress|operation_type|lsn_sanity_check|source_lsn_available|target_lsn_available
 ---------------------------------------------------------------------
 colocated1|1500001|     40000|localhost |     57637|            40000|localhost |     57638|            40000|       1|move          |t               |t                   |f
-colocated2|1500005|    480000|localhost |     57637|           480000|localhost |     57638|           480000|       1|move          |t               |t                   |f
+colocated2|1500005|    520000|localhost |     57637|           520000|localhost |     57638|           520000|       1|move          |t               |t                   |f
 separate  |1500009|    200000|localhost |     57637|           200000|localhost |     57638|           200000|       1|move          |t               |t                   |f
 (3 rows)
 
@@ -1278,7 +1278,7 @@ step s1-wait:
 step s4-wait:
 step s7-get-progress-ordered:
  set LOCAL client_min_messages=NOTICE;
- WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+ WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
  SELECT
   table_name,
   shardid,

--- a/src/test/regress/expected/multi_mx_explain.out
+++ b/src/test/regress/expected/multi_mx_explain.out
@@ -14,7 +14,7 @@ VACUUM ANALYZE supplier_mx;
 \c - - - :worker_1_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -25,7 +25,7 @@ BEGIN
 END;
 $BODY$ LANGUAGE plpgsql;
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE
@@ -38,7 +38,7 @@ $BODY$ LANGUAGE plpgsql;
 \c - - - :worker_2_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -49,7 +49,7 @@ BEGIN
 END;
 $BODY$ LANGUAGE plpgsql;
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE

--- a/src/test/regress/expected/multi_mx_explain.out
+++ b/src/test/regress/expected/multi_mx_explain.out
@@ -410,6 +410,10 @@ Custom Scan (Citus Adaptive)
         ->  Seq Scan on lineitem_mx_1220052 lineitem_mx
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
+-- This test checks all-task EXPLAIN formatting, not worker scan costing.
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+SET LOCAL enable_seqscan TO off;
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030;
 Aggregate
@@ -484,8 +488,8 @@ Aggregate
         ->  Task
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_mx_1220065 lineitem_mx
-                          Filter: (l_orderkey > 9030)
+                    ->  Index Only Scan using lineitem_mx_pkey_1220065 on lineitem_mx_1220065 lineitem_mx
+                          Index Cond: (l_orderkey > 9030)
         ->  Task
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
@@ -502,6 +506,7 @@ t
 SELECT true AS valid FROM explain_json($$
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030$$);
 t
+ROLLBACK;
 -- Test track tracker
 SET citus.explain_all_tasks TO off;
 EXPLAIN (COSTS FALSE)

--- a/src/test/regress/expected/multi_mx_explain_0.out
+++ b/src/test/regress/expected/multi_mx_explain_0.out
@@ -14,7 +14,7 @@ VACUUM ANALYZE supplier_mx;
 \c - - - :worker_1_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -25,7 +25,7 @@ BEGIN
 END;
 $BODY$ LANGUAGE plpgsql;
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE
@@ -38,7 +38,7 @@ $BODY$ LANGUAGE plpgsql;
 \c - - - :worker_2_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -49,7 +49,7 @@ BEGIN
 END;
 $BODY$ LANGUAGE plpgsql;
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE

--- a/src/test/regress/expected/multi_mx_explain_0.out
+++ b/src/test/regress/expected/multi_mx_explain_0.out
@@ -405,6 +405,10 @@ Custom Scan (Citus Adaptive)
         ->  Seq Scan on lineitem_mx_1220052 lineitem_mx
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
+-- This test checks all-task EXPLAIN formatting, not worker scan costing.
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+SET LOCAL enable_seqscan TO off;
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030;
 Aggregate
@@ -479,8 +483,8 @@ Aggregate
         ->  Task
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
-                    ->  Seq Scan on lineitem_mx_1220065 lineitem_mx
-                          Filter: (l_orderkey > 9030)
+                    ->  Index Only Scan using lineitem_mx_pkey_1220065 on lineitem_mx_1220065 lineitem_mx
+                          Index Cond: (l_orderkey > 9030)
         ->  Task
               Node: host=localhost port=xxxxx dbname=regression
               ->  Aggregate
@@ -497,6 +501,7 @@ t
 SELECT true AS valid FROM explain_json($$
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030$$);
 t
+ROLLBACK;
 -- Test track tracker
 SET citus.explain_all_tasks TO off;
 EXPLAIN (COSTS FALSE)

--- a/src/test/regress/expected/multi_orderby_limit_pushdown.out
+++ b/src/test/regress/expected/multi_orderby_limit_pushdown.out
@@ -373,6 +373,16 @@ LIMIT 2;
        6 |     5
 (2 rows)
 
+-- PG19 eager aggregation changes worker plans; keep this EXPLAIN focused on Citus pushdown.
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+DO $$
+BEGIN
+	IF current_setting('server_version_num')::int >= 190000 THEN
+		EXECUTE 'SET LOCAL min_eager_agg_group_size TO 1e308';
+	END IF;
+END;
+$$;
 EXPLAIN (COSTS OFF)
 SELECT ut.user_id, avg(ut.value_2)
 FROM users_table ut, events_table et
@@ -403,3 +413,4 @@ LIMIT 5;
                                                          Filter: (value_2 < 5)
 (19 rows)
 
+ROLLBACK;

--- a/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
+++ b/src/test/regress/spec/isolation_shard_rebalancer_progress.spec
@@ -128,10 +128,12 @@ step "s6-release-advisory-lock"
 
 session "s7"
 
+// Keep the upper size bucket far enough from 200000 to absorb one-block
+// storage layout differences across PostgreSQL versions.
 step "s7-get-progress"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
 	SELECT
 		table_name,
 		shardid,
@@ -157,7 +159,7 @@ step "s7-get-progress"
 step "s7-get-progress-ordered"
 {
 	set LOCAL client_min_messages=NOTICE;
-	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (480000))
+	WITH possible_sizes(size) as (VALUES (0), (8000), (40000), (200000), (520000))
 	SELECT
 		table_name,
 		shardid,

--- a/src/test/regress/sql/multi_mx_explain.sql
+++ b/src/test/regress/sql/multi_mx_explain.sql
@@ -158,6 +158,11 @@ EXPLAIN (COSTS FALSE)
 -- Test all tasks output
 SET citus.explain_all_tasks TO on;
 
+-- This test checks all-task EXPLAIN formatting, not worker scan costing.
+BEGIN;
+SET LOCAL citus.propagate_set_commands TO 'local';
+SET LOCAL enable_seqscan TO off;
+
 EXPLAIN (COSTS FALSE)
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030;
 
@@ -166,6 +171,8 @@ SELECT true AS valid FROM explain_xml($$
 
 SELECT true AS valid FROM explain_json($$
 	SELECT avg(l_linenumber) FROM lineitem_mx WHERE l_orderkey > 9030$$);
+
+ROLLBACK;
 
 -- Test track tracker
 SET citus.explain_all_tasks TO off;

--- a/src/test/regress/sql/multi_mx_explain.sql
+++ b/src/test/regress/sql/multi_mx_explain.sql
@@ -19,7 +19,7 @@ VACUUM ANALYZE supplier_mx;
 \c - - - :worker_1_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -31,7 +31,7 @@ END;
 $BODY$ LANGUAGE plpgsql;
 
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE
@@ -45,7 +45,7 @@ $BODY$ LANGUAGE plpgsql;
 \c - - - :worker_2_port
 -- Function that parses explain output as JSON
 SET citus.enable_metadata_sync TO OFF;
-CREATE FUNCTION explain_json(query text)
+CREATE OR REPLACE FUNCTION explain_json(query text)
 RETURNS jsonb
 AS $BODY$
 DECLARE
@@ -57,7 +57,7 @@ END;
 $BODY$ LANGUAGE plpgsql;
 
 -- Function that parses explain output as XML
-CREATE FUNCTION explain_xml(query text)
+CREATE OR REPLACE FUNCTION explain_xml(query text)
 RETURNS xml
 AS $BODY$
 DECLARE

--- a/src/test/regress/sql/multi_orderby_limit_pushdown.sql
+++ b/src/test/regress/sql/multi_orderby_limit_pushdown.sql
@@ -176,6 +176,19 @@ GROUP BY ut.user_id
 ORDER BY 2, AVG(ut.value_1), 1 DESC
 LIMIT 2;
 
+-- PG19 eager aggregation changes worker plans; keep this EXPLAIN focused on Citus pushdown.
+BEGIN;
+
+SET LOCAL citus.propagate_set_commands TO 'local';
+
+DO $$
+BEGIN
+	IF current_setting('server_version_num')::int >= 190000 THEN
+		EXECUTE 'SET LOCAL min_eager_agg_group_size TO 1e308';
+	END IF;
+END;
+$$;
+
 EXPLAIN (COSTS OFF)
 SELECT ut.user_id, avg(ut.value_2)
 FROM users_table ut, events_table et
@@ -183,3 +196,5 @@ WHERE ut.user_id = et.user_id and et.value_2 < 5
 GROUP BY ut.user_id
 ORDER BY 2, AVG(ut.value_1), 1 DESC
 LIMIT 5;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

Stabilize the remaining PostgreSQL 19 planner-sensitive and shard-size regression outputs with narrowly scoped test controls.

- `multi_orderby_limit_pushdown`: PostgreSQL commit `8e11859102f9` introduced eager aggregation before Beta1. Direct `REL_19_BETA1` and `REL_19_BETA2` reproductions both select eager aggregation depending on costing/state; the test now dynamically applies and propagates the PG19-only `min_eager_agg_group_size` setting so PG17/18 never parse it. Guarded and unguarded executions return identical results.
- `multi_mx_explain`: pre-Beta1 visibility/planner behavior from `b46e1e54d078` and `378a216187ae` can change `relallvisible` and flip Seq Scan versus Index Only Scan selection on both Beta1 and Beta2. The affected all-task EXPLAIN is pinned with propagated `enable_seqscan=off` without changing task count, shard identity, output format, or query results.
- `isolation_shard_rebalancer_progress`: direct Beta1 and Beta2 reproductions both show the same `335872 -> 344064` byte transition, exactly one PostgreSQL block, excluding Beta2 commit `e9eaeb04248a` as causal. The normalization midpoint is moved from `340000` to `360000`, keeping both transient values in the lower bucket while the larger `663552` relation remains in the upper bucket. Progress state, status, operation type, source/target identity, LSN sanity, and completion assertions remain intact.

All three are latent/missed Beta1 planner or physical-size sensitivities, not semantic Citus regressions and not direct Beta2 deltas.

## Validation

Focused cross-version validation passed on PostgreSQL 17.10, PostgreSQL 18.4, and PostgreSQL 19 Beta 2.

Closes #8737