### PR TITLE
Fix PG19 CDC catalog access

### DIFF
--- a/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
+++ b/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
@@ -1,7 +1,9 @@
 -- citus--14.0-1--15.0-1
 -- bump version to 15.0-1
 
--- Citus CDC scans these catalogs while logical decoding uses a historic snapshot.
+-- CDC decoder helpers in src/backend/distributed/cdc/cdc_decoder_utils.c scan
+-- these three catalogs under historic snapshots. Future decoder catalog scans
+-- must also update this migration and catalog accessibility.
 ALTER TABLE pg_catalog.pg_dist_partition SET (user_catalog_table = true);
 ALTER TABLE pg_catalog.pg_dist_shard SET (user_catalog_table = true);
 ALTER TABLE pg_catalog.pg_dist_local_group SET (user_catalog_table = true);

--- a/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
+++ b/src/backend/distributed/sql/citus--14.0-1--15.0-1.sql
@@ -1,6 +1,11 @@
 -- citus--14.0-1--15.0-1
 -- bump version to 15.0-1
 
+-- Citus CDC scans these catalogs while logical decoding uses a historic snapshot.
+ALTER TABLE pg_catalog.pg_dist_partition SET (user_catalog_table = true);
+ALTER TABLE pg_catalog.pg_dist_shard SET (user_catalog_table = true);
+ALTER TABLE pg_catalog.pg_dist_local_group SET (user_catalog_table = true);
+
 #include "udfs/citus_internal_get_next_colocation_id/15.0-1.sql"
 
 -- drop the legacy version that we kept for backward compatibility at Citus 13 and 14

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -1,6 +1,10 @@
 -- citus--15.0-1--14.0-1
 -- downgrade version to 14.0-1
 
+ALTER TABLE pg_catalog.pg_dist_partition RESET (user_catalog_table);
+ALTER TABLE pg_catalog.pg_dist_shard RESET (user_catalog_table);
+ALTER TABLE pg_catalog.pg_dist_local_group RESET (user_catalog_table);
+
 DROP FUNCTION IF EXISTS citus_internal.get_next_colocation_id();
 
 -- re-create the legacy version that we kept for backward compatibility at Citus 13 and 14

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -1,7 +1,9 @@
 -- citus--15.0-1--14.0-1
 -- downgrade version to 14.0-1
 
--- Retain user_catalog_table so logical decoding remains compatible with PostgreSQL 19.
+-- The user_catalog_table reloptions set by 15.0-1 are intentionally retained
+-- for PostgreSQL 19 logical decoding; this downgrade requires no SQL for them.
+
 DROP FUNCTION IF EXISTS citus_internal.get_next_colocation_id();
 
 -- re-create the legacy version that we kept for backward compatibility at Citus 13 and 14

--- a/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
+++ b/src/backend/distributed/sql/downgrades/citus--15.0-1--14.0-1.sql
@@ -1,10 +1,7 @@
 -- citus--15.0-1--14.0-1
 -- downgrade version to 14.0-1
 
-ALTER TABLE pg_catalog.pg_dist_partition RESET (user_catalog_table);
-ALTER TABLE pg_catalog.pg_dist_shard RESET (user_catalog_table);
-ALTER TABLE pg_catalog.pg_dist_local_group RESET (user_catalog_table);
-
+-- Retain user_catalog_table so logical decoding remains compatible with PostgreSQL 19.
 DROP FUNCTION IF EXISTS citus_internal.get_next_colocation_id();
 
 -- re-create the legacy version that we kept for backward compatibility at Citus 13 and 14


### PR DESCRIPTION
## Summary
- mark only `pg_dist_partition`, `pg_dist_shard`, and `pg_dist_local_group` as `user_catalog_table=true` for PostgreSQL 19 logical decoding
- preserve those reloptions across downgrade so Citus CDC remains usable while PostgreSQL stays on 19
- document the paired downgrade as an intentional no-op; no unrelated metadata is marked

## Validation
- PostgreSQL 19 focused CDC 001/002/003/005/006: 16 tests passed
- PostgreSQL 19 14.x -> 15 -> 14.x cycle retained all three reloptions; CDC insert/update/delete/truncate passed after downgrade; re-upgrade and subsequent decoding passed
- PostgreSQL 17.10 focused CDC 001/002/003/005/006: 16 tests passed
- PostgreSQL 18.4 focused CDC 001/002/003/005/006: 16 tests passed
- `multi_extension`: passed
- migration pairing and generated-artifact audits: passed

Closes #8735