### PR TITLE
PG19: fix backend crash on ALTER PUBLICATION ... SET ALL TABLES EXCEPT and restore EXCEPT membership across Citus conversions

### DIFF
--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -176,10 +176,18 @@ BuildCreatePublicationStmt(Oid publicationId)
 	if (publicationForm->puballtables)
 	{
 		excluded = true;
+
+		/*
+		 * An EXCEPT list names relations explicitly, and those exact relations
+		 * are what pg_publication_rel stores. Always ask for the listed relation
+		 * itself, regardless of pubviaroot: expanding an excluded partitioned
+		 * root to its leaves would drop the exclusion entirely when the root has
+		 * no partitions, and would freeze it to the partitions that happen to
+		 * exist now, so partitions added later would be published on the worker
+		 * but not on the coordinator.
+		 */
 		relationIds = GetExcludedPublicationTables(publicationId,
-												   publicationForm->pubviaroot ?
-												   PUBLICATION_PART_ROOT :
-												   PUBLICATION_PART_LEAF);
+												   PUBLICATION_PART_ROOT);
 	}
 	else
 #endif

--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -136,9 +136,13 @@ CreatePublicationDDLCommand(Oid publicationId)
  * so we always have to resend the whole list. This is needed when a table that
  * was excluded while it was still a local table becomes a Citus table, since
  * such a table is filtered out when the publication is first propagated.
+ *
+ * Callers that restore the publication on the local node pass includeLocalTables
+ * as true, since the local publication has to keep excluding local tables too.
  */
 char *
-GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId)
+GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId,
+											bool includeLocalTables)
 {
 	CreatePublicationStmt *createPubStmt = BuildCreatePublicationStmt(publicationId);
 
@@ -151,9 +155,6 @@ GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId)
 
 	/* we took the WHERE clause from the catalog where it is already transformed */
 	bool whereClauseRequiresTransform = false;
-
-	/* only propagate Citus tables in publication */
-	bool includeLocalTables = false;
 
 	return DeparseAlterPublicationStmtExtended((Node *) alterPubStmt,
 											   whereClauseRequiresTransform,
@@ -498,6 +499,39 @@ GetAlterPublicationDDLCommandsForTable(Oid relationId, bool isAdd)
 
 		commands = lappend(commands, command);
 	}
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+	/*
+	 * A table that is excluded from a FOR ALL TABLES publication cannot be
+	 * restored with ALTER PUBLICATION .. ADD TABLE, so we regenerate the
+	 * complete membership instead.
+	 *
+	 * Callers capture these commands before a conversion that gives the table
+	 * a new OID, and replay them once the replacement table exists under the
+	 * same name. Since the commands name the excluded tables, replaying them
+	 * moves the exclusion onto the replacement table. Replacing the whole list
+	 * at once also drops the exclusion that stayed behind on the relation that
+	 * the conversion turned into a shard.
+	 *
+	 * The DROP side needs nothing here, because the exclusions we would drop
+	 * are the ones the commands above restore.
+	 */
+	if (isAdd)
+	{
+		List *excludedPublicationIds = GetRelationExcludedPublications(relationId);
+
+		foreach_declared_oid(publicationId, excludedPublicationIds)
+		{
+			/* the publication on this node also excludes local tables */
+			bool includeLocalTables = true;
+
+			commands = lappend(commands,
+							   GetAlterPublicationExcludedTablesDDLCommand(
+								   publicationId, includeLocalTables));
+		}
+	}
+#endif
 
 	return commands;
 }

--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -35,7 +35,8 @@
 static CreatePublicationStmt * BuildCreatePublicationStmt(Oid publicationId);
 static PublicationObjSpec * BuildPublicationRelationObjSpec(Oid relationId,
 															Oid publicationId,
-															bool tableOnly);
+															bool tableOnly,
+															bool excluded);
 static void AppendPublishOptionList(StringInfo str, List *strings);
 static char * AlterPublicationOwnerCommand(Oid publicationId);
 static bool ShouldPropagateCreatePublication(CreatePublicationStmt *stmt);
@@ -149,8 +150,9 @@ BuildCreatePublicationStmt(Oid publicationId)
 
 	/* FOR ALL TABLES */
 	createPubStmt->for_all_tables = publicationForm->puballtables;
-
-	ReleaseSysCache(publicationTuple);
+#if PG_VERSION_NUM >= PG_VERSION_19
+	createPubStmt->for_all_sequences = publicationForm->puballsequences;
+#endif
 
 	List *schemaIds = GetPublicationSchemas(publicationId);
 	Oid schemaId = InvalidOid;
@@ -168,10 +170,25 @@ BuildCreatePublicationStmt(Oid publicationId)
 		createPubStmt->pubobjects = lappend(createPubStmt->pubobjects, publicationObject);
 	}
 
-	List *relationIds = GetPublicationRelations(publicationId,
-												publicationForm->pubviaroot ?
-												PUBLICATION_PART_ROOT :
-												PUBLICATION_PART_LEAF);
+	bool excluded = false;
+	List *relationIds = NIL;
+#if PG_VERSION_NUM >= PG_VERSION_19
+	if (publicationForm->puballtables)
+	{
+		excluded = true;
+		relationIds = GetExcludedPublicationTables(publicationId,
+												   publicationForm->pubviaroot ?
+												   PUBLICATION_PART_ROOT :
+												   PUBLICATION_PART_LEAF);
+	}
+	else
+#endif
+	{
+		relationIds = GetPublicationRelations(publicationId,
+											  publicationForm->pubviaroot ?
+											  PUBLICATION_PART_ROOT :
+											  PUBLICATION_PART_LEAF);
+	}
 	Oid relationId = InvalidOid;
 
 	/* mainly for consistent ordering in test output */
@@ -179,11 +196,12 @@ BuildCreatePublicationStmt(Oid publicationId)
 
 	foreach_declared_oid(relationId, relationIds)
 	{
-		bool tableOnly = false;
+		bool tableOnly = excluded;
 
 		/* since postgres 15, tables can have a column list and filter */
 		PublicationObjSpec *publicationObject =
-			BuildPublicationRelationObjSpec(relationId, publicationId, tableOnly);
+			BuildPublicationRelationObjSpec(relationId, publicationId, tableOnly,
+											excluded);
 
 		createPubStmt->pubobjects = lappend(createPubStmt->pubobjects, publicationObject);
 	}
@@ -250,6 +268,7 @@ BuildCreatePublicationStmt(Oid publicationId)
 		createPubStmt->options = lappend(createPubStmt->options, publishOption);
 	}
 
+	ReleaseSysCache(publicationTuple);
 
 	return createPubStmt;
 }
@@ -283,7 +302,7 @@ AppendPublishOptionList(StringInfo str, List *options)
  */
 static PublicationObjSpec *
 BuildPublicationRelationObjSpec(Oid relationId, Oid publicationId,
-								bool tableOnly)
+								bool tableOnly, bool excluded)
 {
 	HeapTuple pubRelationTuple = SearchSysCache2(PUBLICATIONRELMAP,
 												 ObjectIdGetDatum(relationId),
@@ -348,6 +367,15 @@ BuildPublicationRelationObjSpec(Oid relationId, Oid publicationId,
 
 	PublicationObjSpec *publicationObject = makeNode(PublicationObjSpec);
 	publicationObject->pubobjtype = PUBLICATIONOBJ_TABLE;
+#if PG_VERSION_NUM >= PG_VERSION_19
+	if (excluded)
+	{
+		publicationObject->pubobjtype = PUBLICATIONOBJ_EXCEPT_TABLE;
+		publicationTable->except = true;
+	}
+#else
+	Assert(!excluded);
+#endif
 	publicationObject->pubtable = publicationTable;
 	publicationObject->name = NULL;
 	publicationObject->location = -1;
@@ -458,7 +486,7 @@ GetAlterPublicationTableDDLCommand(Oid publicationId, Oid relationId,
 
 	/* since postgres 15, tables can have a column list and filter */
 	PublicationObjSpec *publicationObject =
-		BuildPublicationRelationObjSpec(relationId, publicationId, tableOnly);
+		BuildPublicationRelationObjSpec(relationId, publicationId, tableOnly, false);
 
 	alterPubStmt->pubobjects = lappend(alterPubStmt->pubobjects, publicationObject);
 	alterPubStmt->action = isAdd ? AP_AddObjects : AP_DropObjects;

--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -125,6 +125,45 @@ CreatePublicationDDLCommand(Oid publicationId)
 }
 
 
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+/*
+ * GetAlterPublicationExcludedTablesDDLCommand returns an
+ * "ALTER PUBLICATION .. SET ALL TABLES EXCEPT (..)" string that restores the
+ * complete membership of a FOR ALL TABLES publication.
+ *
+ * EXCEPT membership cannot be amended with ALTER PUBLICATION .. ADD/DROP TABLE,
+ * so we always have to resend the whole list. This is needed when a table that
+ * was excluded while it was still a local table becomes a Citus table, since
+ * such a table is filtered out when the publication is first propagated.
+ */
+char *
+GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId)
+{
+	CreatePublicationStmt *createPubStmt = BuildCreatePublicationStmt(publicationId);
+
+	AlterPublicationStmt *alterPubStmt = makeNode(AlterPublicationStmt);
+	alterPubStmt->pubname = createPubStmt->pubname;
+	alterPubStmt->action = AP_SetObjects;
+	alterPubStmt->pubobjects = createPubStmt->pubobjects;
+	alterPubStmt->for_all_tables = createPubStmt->for_all_tables;
+	alterPubStmt->for_all_sequences = createPubStmt->for_all_sequences;
+
+	/* we took the WHERE clause from the catalog where it is already transformed */
+	bool whereClauseRequiresTransform = false;
+
+	/* only propagate Citus tables in publication */
+	bool includeLocalTables = false;
+
+	return DeparseAlterPublicationStmtExtended((Node *) alterPubStmt,
+											   whereClauseRequiresTransform,
+											   includeLocalTables);
+}
+
+
+#endif
+
+
 /*
  * BuildCreatePublicationStmt constructs a CreatePublicationStmt struct for the
  * given publication.

--- a/src/backend/distributed/deparser/deparse_publication_stmts.c
+++ b/src/backend/distributed/deparser/deparse_publication_stmts.c
@@ -273,6 +273,7 @@ AppendPublicationObjects(StringInfo buf, List *publicationObjects,
 
 
 #if PG_VERSION_NUM >= PG_VERSION_19
+
 /*
  * AppendPublicationAllObjects appends the object list for a PG19
  * ALL TABLES/ALL SEQUENCES publication.
@@ -306,12 +307,14 @@ AppendPublicationAllObjects(StringInfo buf, bool forAllTables,
 	if (forAllSequences)
 	{
 		appendStringInfoString(buf, appendedObject ? ", ALL SEQUENCES" :
-							  " ALL SEQUENCES");
+							   " ALL SEQUENCES");
 		appendedObject = true;
 	}
 
 	return appendedObject;
 }
+
+
 #endif
 
 

--- a/src/backend/distributed/deparser/deparse_publication_stmts.c
+++ b/src/backend/distributed/deparser/deparse_publication_stmts.c
@@ -35,6 +35,13 @@ static void AppendCreatePublicationStmt(StringInfo buf, CreatePublicationStmt *s
 static bool AppendPublicationObjects(StringInfo buf, List *publicationObjects,
 									 bool whereClauseNeedsTransform,
 									 bool includeLocalTables);
+#if PG_VERSION_NUM >= PG_VERSION_19
+static bool AppendPublicationAllObjects(StringInfo buf, bool forAllTables,
+										bool forAllSequences,
+										List *publicationObjects,
+										bool whereClauseNeedsTransform,
+										bool includeLocalTables);
+#endif
 static void AppendWhereClauseExpression(StringInfo buf, RangeVar *tableName,
 										Node *whereClause,
 										bool whereClauseNeedsTransform);
@@ -99,9 +106,27 @@ AppendCreatePublicationStmt(StringInfo buf, CreatePublicationStmt *stmt,
 	appendStringInfo(buf, "CREATE PUBLICATION %s",
 					 quote_identifier(stmt->pubname));
 
-	if (stmt->for_all_tables)
+	if (stmt->for_all_tables
+#if PG_VERSION_NUM >= PG_VERSION_19
+		|| stmt->for_all_sequences
+#endif
+		)
 	{
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+		/*
+		 * PG19 keeps ALL TABLES and ALL SEQUENCES in separate flags, and stores
+		 * the ALL TABLES EXCEPT relations in pubobjects.
+		 */
+		appendStringInfoString(buf, " FOR");
+		AppendPublicationAllObjects(buf, stmt->for_all_tables,
+									stmt->for_all_sequences,
+									stmt->pubobjects,
+									whereClauseNeedsTransform,
+									includeLocalTables);
+#else
 		appendStringInfoString(buf, " FOR ALL TABLES");
+#endif
 	}
 	else if (stmt->pubobjects != NIL)
 	{
@@ -166,7 +191,11 @@ AppendPublicationObjects(StringInfo buf, List *publicationObjects,
 
 	foreach_declared_ptr(publicationObject, publicationObjects)
 	{
-		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE)
+		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE
+#if PG_VERSION_NUM >= PG_VERSION_19
+			|| publicationObject->pubobjtype == PUBLICATIONOBJ_EXCEPT_TABLE
+#endif
+			)
 		{
 			/* FOR TABLE ... */
 			PublicationTable *publicationTable = publicationObject->pubtable;
@@ -241,6 +270,49 @@ AppendPublicationObjects(StringInfo buf, List *publicationObjects,
 
 	return appendedObject;
 }
+
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+/*
+ * AppendPublicationAllObjects appends the object list for a PG19
+ * ALL TABLES/ALL SEQUENCES publication.
+ */
+static bool
+AppendPublicationAllObjects(StringInfo buf, bool forAllTables,
+							bool forAllSequences, List *publicationObjects,
+							bool whereClauseNeedsTransform,
+							bool includeLocalTables)
+{
+	bool appendedObject = false;
+
+	if (forAllTables)
+	{
+		appendStringInfoString(buf, " ALL TABLES");
+		appendedObject = true;
+
+		StringInfoData exceptObjects = { 0 };
+		initStringInfo(&exceptObjects);
+
+		if (AppendPublicationObjects(&exceptObjects, publicationObjects,
+									 whereClauseNeedsTransform,
+									 includeLocalTables))
+		{
+			appendStringInfo(buf, " EXCEPT (%s)", exceptObjects.data + 1);
+		}
+
+		pfree(exceptObjects.data);
+	}
+
+	if (forAllSequences)
+	{
+		appendStringInfoString(buf, appendedObject ? ", ALL SEQUENCES" :
+							  " ALL SEQUENCES");
+		appendedObject = true;
+	}
+
+	return appendedObject;
+}
+#endif
 
 
 /*
@@ -355,6 +427,16 @@ AppendAlterPublicationStmt(StringInfo buf, AlterPublicationStmt *stmt,
 	}
 
 	AppendAlterPublicationAction(buf, stmt->action);
+#if PG_VERSION_NUM >= PG_VERSION_19
+	if (stmt->for_all_tables || stmt->for_all_sequences)
+	{
+		return AppendPublicationAllObjects(buf, stmt->for_all_tables,
+										   stmt->for_all_sequences,
+										   stmt->pubobjects,
+										   whereClauseNeedsTransform,
+										   includeLocalTables);
+	}
+#endif
 	return AppendPublicationObjects(buf, stmt->pubobjects, whereClauseNeedsTransform,
 									includeLocalTables);
 }

--- a/src/backend/distributed/deparser/qualify_publication_stmt.c
+++ b/src/backend/distributed/deparser/qualify_publication_stmt.c
@@ -47,7 +47,11 @@ QualifyPublicationObjects(List *publicationObjects)
 
 	foreach_declared_ptr(publicationObject, publicationObjects)
 	{
-		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE)
+		if (publicationObject->pubobjtype == PUBLICATIONOBJ_TABLE
+#if PG_VERSION_NUM >= PG_VERSION_19
+			|| publicationObject->pubobjtype == PUBLICATIONOBJ_EXCEPT_TABLE
+#endif
+			)
 		{
 			/* FOR TABLE ... */
 			PublicationTable *publicationTable = publicationObject->pubtable;

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -2090,7 +2090,7 @@ GetPublicationRelationsDependencyList(Oid publicationId)
 		 * depends on.
 		 */
 		allRelationIds = GetExcludedPublicationTables(publicationId,
-													 PUBLICATION_PART_ROOT);
+													  PUBLICATION_PART_ROOT);
 	}
 	else
 #endif

--- a/src/backend/distributed/metadata/dependency.c
+++ b/src/backend/distributed/metadata/dependency.c
@@ -2076,8 +2076,28 @@ GetRelationTriggerFunctionDependencyList(Oid relationId)
 static List *
 GetPublicationRelationsDependencyList(Oid publicationId)
 {
-	List *allRelationIds = GetPublicationRelations(publicationId, PUBLICATION_PART_ROOT);
+	List *allRelationIds = NIL;
 	List *citusRelationIds = NIL;
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+	if (GetPublication(publicationId)->alltables)
+	{
+		/*
+		 * A FOR ALL TABLES publication records only its EXCEPT tables in
+		 * pg_publication_rel, and GetIncludedPublicationRelations() asserts that
+		 * the publication is not FOR ALL TABLES. The DDL we reconstruct for such
+		 * a publication names the excluded tables, so those are the relations it
+		 * depends on.
+		 */
+		allRelationIds = GetExcludedPublicationTables(publicationId,
+													 PUBLICATION_PART_ROOT);
+	}
+	else
+#endif
+	{
+		allRelationIds = GetPublicationRelations(publicationId,
+												 PUBLICATION_PART_ROOT);
+	}
 
 	Oid relationId = InvalidOid;
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -111,6 +111,7 @@ static void CreateShellTableOnRemoteNodes(Oid relationId);
 static void CreateTableMetadataOnRemoteNodes(Oid relationId);
 static void CreateDependingViewsOnRemoteNodes(Oid relationId);
 static void AddTableToPublications(Oid relationId);
+static bool EnsurePublicationPropagatable(Oid publicationId);
 static NodeMetadataSyncResult SyncNodeMetadataToNodesOptional(void);
 static bool ShouldSyncTableMetadataInternal(bool hashDistributed,
 											bool citusTableWithNoDistKey);
@@ -367,18 +368,11 @@ AddTableToPublications(Oid relationId)
 
 	foreach_declared_oid(publicationId, publicationIds)
 	{
-		ObjectAddress *publicationAddress = palloc0(sizeof(ObjectAddress));
-		ObjectAddressSet(*publicationAddress, PublicationRelationId, publicationId);
-		List *addresses = list_make1(publicationAddress);
-
-		if (!ShouldPropagateAnyObject(addresses))
+		if (!EnsurePublicationPropagatable(publicationId))
 		{
 			/* skip non-distributed publications */
 			continue;
 		}
-
-		/* ensure schemas exist */
-		EnsureAllObjectDependenciesExistOnAllNodes(addresses);
 
 		bool isAdd = true;
 		char *alterPublicationCommand =
@@ -391,18 +385,11 @@ AddTableToPublications(Oid relationId)
 #if PG_VERSION_NUM >= PG_VERSION_19
 	foreach_declared_oid(publicationId, excludedPublicationIds)
 	{
-		ObjectAddress *publicationAddress = palloc0(sizeof(ObjectAddress));
-		ObjectAddressSet(*publicationAddress, PublicationRelationId, publicationId);
-		List *addresses = list_make1(publicationAddress);
-
-		if (!ShouldPropagateAnyObject(addresses))
+		if (!EnsurePublicationPropagatable(publicationId))
 		{
 			/* skip non-distributed publications */
 			continue;
 		}
-
-		/* ensure schemas exist */
-		EnsureAllObjectDependenciesExistOnAllNodes(addresses);
 
 		/*
 		 * The table was filtered out of the EXCEPT list when the publication was
@@ -418,6 +405,28 @@ AddTableToPublications(Oid relationId)
 #endif
 
 	SendCommandToRemoteNodesWithMetadata(ENABLE_DDL_PROPAGATION);
+}
+
+
+/*
+ * EnsurePublicationPropagatable returns whether the publication should be
+ * propagated and ensures its dependencies exist on all metadata nodes if so.
+ */
+static bool
+EnsurePublicationPropagatable(Oid publicationId)
+{
+	ObjectAddress *publicationAddress = palloc0(sizeof(ObjectAddress));
+	ObjectAddressSet(*publicationAddress, PublicationRelationId, publicationId);
+	List *addresses = list_make1(publicationAddress);
+
+	if (!ShouldPropagateAnyObject(addresses))
+	{
+		return false;
+	}
+
+	EnsureAllObjectDependenciesExistOnAllNodes(addresses);
+
+	return true;
 }
 
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -409,8 +409,11 @@ AddTableToPublications(Oid relationId)
 		 * propagated, because it was not a Citus table back then. Resend the full
 		 * membership, since an EXCEPT list can only be replaced as a whole.
 		 */
+		bool includeLocalTables = false;
+
 		SendCommandToRemoteNodesWithMetadata(
-			GetAlterPublicationExcludedTablesDDLCommand(publicationId));
+			GetAlterPublicationExcludedTablesDDLCommand(publicationId,
+														includeLocalTables));
 	}
 #endif
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -56,6 +56,8 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
+#include "pg_version_constants.h"
+
 #include "distributed/argutils.h"
 #include "distributed/backend_data.h"
 #include "distributed/background_worker_utils.h"
@@ -342,7 +344,19 @@ static void
 AddTableToPublications(Oid relationId)
 {
 	List *publicationIds = GetRelationPublications(relationId);
-	if (publicationIds == NIL)
+	List *excludedPublicationIds = NIL;
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+
+	/*
+	 * A table can also be a member of a FOR ALL TABLES publication through its
+	 * EXCEPT list. GetRelationPublications() only reports the publications that
+	 * include the table, so look up the ones that exclude it separately.
+	 */
+	excludedPublicationIds = GetRelationExcludedPublications(relationId);
+#endif
+
+	if (publicationIds == NIL && excludedPublicationIds == NIL)
 	{
 		return;
 	}
@@ -373,6 +387,32 @@ AddTableToPublications(Oid relationId)
 		/* send ALTER PUBLICATION .. ADD to workers with metadata */
 		SendCommandToRemoteNodesWithMetadata(alterPublicationCommand);
 	}
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+	foreach_declared_oid(publicationId, excludedPublicationIds)
+	{
+		ObjectAddress *publicationAddress = palloc0(sizeof(ObjectAddress));
+		ObjectAddressSet(*publicationAddress, PublicationRelationId, publicationId);
+		List *addresses = list_make1(publicationAddress);
+
+		if (!ShouldPropagateAnyObject(addresses))
+		{
+			/* skip non-distributed publications */
+			continue;
+		}
+
+		/* ensure schemas exist */
+		EnsureAllObjectDependenciesExistOnAllNodes(addresses);
+
+		/*
+		 * The table was filtered out of the EXCEPT list when the publication was
+		 * propagated, because it was not a Citus table back then. Resend the full
+		 * membership, since an EXCEPT list can only be replaced as a whole.
+		 */
+		SendCommandToRemoteNodesWithMetadata(
+			GetAlterPublicationExcludedTablesDDLCommand(publicationId));
+	}
+#endif
 
 	SendCommandToRemoteNodesWithMetadata(ENABLE_DDL_PROPAGATION);
 }

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -21,6 +21,8 @@
 #include "utils/acl.h"
 #include "utils/rel.h"
 
+#include "pg_version_constants.h"
+
 #include "distributed/metadata_utility.h"
 
 
@@ -490,6 +492,9 @@ extern List * PreprocessAlterPublicationStmt(Node *stmt, const char *queryString
 extern List * GetAlterPublicationDDLCommandsForTable(Oid relationId, bool isAdd);
 extern char * GetAlterPublicationTableDDLCommand(Oid publicationId, Oid relationId,
 												 bool isAdd);
+#if PG_VERSION_NUM >= PG_VERSION_19
+extern char * GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId);
+#endif
 extern List * AlterPublicationOwnerStmtObjectAddress(Node *node, bool missingOk,
 													 bool isPostProcess);
 extern List * AlterPublicationStmtObjectAddress(Node *node, bool missingOk,

--- a/src/include/distributed/commands.h
+++ b/src/include/distributed/commands.h
@@ -493,7 +493,8 @@ extern List * GetAlterPublicationDDLCommandsForTable(Oid relationId, bool isAdd)
 extern char * GetAlterPublicationTableDDLCommand(Oid publicationId, Oid relationId,
 												 bool isAdd);
 #if PG_VERSION_NUM >= PG_VERSION_19
-extern char * GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId);
+extern char * GetAlterPublicationExcludedTablesDDLCommand(Oid publicationId,
+														  bool includeLocalTables);
 #endif
 extern List * AlterPublicationOwnerStmtObjectAddress(Node *node, bool missingOk,
 													 bool isPostProcess);

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -414,22 +414,76 @@ $$);
 (1 row)
 
 DROP PUBLICATION publication_all_except;
+-- A table that is excluded while it is still a local table cannot be named on
+-- the workers, so it is filtered out when the publication is propagated.
+-- Distributing it later has to restore the exclusion on the workers, otherwise
+-- the workers would publish a table that the coordinator excludes.
+CREATE TABLE publication_late_excluded (id int);
+CREATE PUBLICATION publication_all_except_late
+    FOR ALL TABLES EXCEPT (TABLE publication_late_excluded);
+SELECT bool_and(result::boolean) AS exclusion_deferred_while_local
+FROM run_command_on_workers($$
+    SELECT count(*) = 0
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    WHERE p.pubname = 'publication_all_except_late'
+$$);
+ exclusion_deferred_while_local
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT create_distributed_table('publication_late_excluded', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::boolean) AS exclusion_restored_after_distribution
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_late'
+      AND c.relname = 'publication_late_excluded'
+$$);
+ exclusion_restored_after_distribution
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*) = 1 AS exclusion_retained_on_coordinator
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_late'
+  AND c.relname = 'publication_late_excluded';
+ exclusion_retained_on_coordinator
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except_late;
 -- The activation path rebuilds publication DDL from catalogs rather than
 -- deparsing the original statement, so exercise it directly. An excluded
 -- partitioned root must survive as the root (not be expanded to its leaves),
 -- and excluded Citus tables must be ordered before the publication itself.
+-- The publication is created while the excluded root is still a local table so
+-- that it is registered as a distributed object before the table is; only the
+-- publication -> excluded relation dependency can order the table first.
 CREATE TABLE publication_part_excluded (id int, ts timestamptz)
     PARTITION BY RANGE (ts);
 CREATE TABLE publication_part_excluded_2020 PARTITION OF publication_part_excluded
     FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE PUBLICATION publication_all_except_part
+    FOR ALL TABLES EXCEPT (TABLE publication_part_excluded);
 SELECT create_distributed_table('publication_part_excluded', 'id');
  create_distributed_table
 ---------------------------------------------------------------------
 
 (1 row)
 
-CREATE PUBLICATION publication_all_except_part
-    FOR ALL TABLES EXCEPT (TABLE publication_part_excluded);
 CREATE OR REPLACE FUNCTION activate_node_snapshot()
     RETURNS text[]
     LANGUAGE C STRICT
@@ -445,6 +499,7 @@ WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%'
 (1 row)
 
 SELECT min(ord) FILTER (WHERE c LIKE '%publication_part_excluded%'
+                          AND c NOT LIKE '%publication_part_excluded_2020%'
                           AND c NOT LIKE '%CREATE PUBLICATION%')
      < min(ord) FILTER (WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%')
        AS excluded_table_precedes_publication

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -414,6 +414,47 @@ $$);
 (1 row)
 
 DROP PUBLICATION publication_all_except;
+-- The activation path rebuilds publication DDL from catalogs rather than
+-- deparsing the original statement, so exercise it directly. An excluded
+-- partitioned root must survive as the root (not be expanded to its leaves),
+-- and excluded Citus tables must be ordered before the publication itself.
+CREATE TABLE publication_part_excluded (id int, ts timestamptz)
+    PARTITION BY RANGE (ts);
+CREATE TABLE publication_part_excluded_2020 PARTITION OF publication_part_excluded
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('publication_part_excluded', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE PUBLICATION publication_all_except_part
+    FOR ALL TABLES EXCEPT (TABLE publication_part_excluded);
+CREATE OR REPLACE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+SELECT count(*) = 1 AS part_root_preserved
+FROM unnest(activate_node_snapshot()) c
+WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%'
+  AND c LIKE '%publication_part_excluded%'
+  AND c NOT LIKE '%publication_part_excluded_2020%';
+ part_root_preserved
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT min(ord) FILTER (WHERE c LIKE '%publication_part_excluded%'
+                          AND c NOT LIKE '%CREATE PUBLICATION%')
+     < min(ord) FILTER (WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%')
+       AS excluded_table_precedes_publication
+FROM unnest(activate_node_snapshot()) WITH ORDINALITY AS s(c, ord);
+ excluded_table_precedes_publication
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except_part;
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -510,6 +510,102 @@ FROM unnest(activate_node_snapshot()) WITH ORDINALITY AS s(c, ord);
 (1 row)
 
 DROP PUBLICATION publication_all_except_part;
+-- Conversions that give a table a new OID must not lose its exclusion, because
+-- the exclusion is tied to the old OID and cannot be restored with
+-- ALTER PUBLICATION .. ADD TABLE.
+SET client_min_messages TO WARNING;
+-- undistribute_table() drops the table and recreates it under the same name.
+CREATE TABLE publication_undist_excluded (id int);
+CREATE PUBLICATION publication_all_except_undist
+    FOR ALL TABLES EXCEPT (TABLE publication_undist_excluded);
+SELECT create_distributed_table('publication_undist_excluded', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT undistribute_table('publication_undist_excluded');
+ undistribute_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) = 1 AS exclusion_retained_after_undistribute
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_undist'
+  AND c.relname = 'publication_undist_excluded';
+ exclusion_retained_after_undistribute
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except_undist;
+DROP TABLE publication_undist_excluded;
+-- citus_add_local_table_to_metadata() renames the original table into a shard
+-- and creates a new shell table under the original name, so the exclusion has
+-- to move to the shell table instead of staying behind on the shard.
+SELECT citus_set_coordinator_host('localhost', :master_port);
+ citus_set_coordinator_host
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE publication_conv_excluded (id int);
+CREATE PUBLICATION publication_all_except_conv
+    FOR ALL TABLES EXCEPT (TABLE publication_conv_excluded);
+SELECT citus_add_local_table_to_metadata('publication_conv_excluded');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT count(*) = 1 AS exclusion_moved_to_shell_table
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_conv'
+  AND c.relname = 'publication_conv_excluded';
+ exclusion_moved_to_shell_table
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT count(*) = 0 AS no_exclusion_left_behind_on_shard
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_conv'
+  AND c.relname <> 'publication_conv_excluded';
+ no_exclusion_left_behind_on_shard
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::boolean) AS exclusion_present_on_workers
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_conv'
+      AND c.relname = 'publication_conv_excluded'
+$$);
+ exclusion_present_on_workers
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except_conv;
+DROP TABLE publication_conv_excluded;
+SELECT citus_remove_node('localhost', :master_port);
+ citus_remove_node
+---------------------------------------------------------------------
+
+(1 row)
+
+RESET client_min_messages;
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -465,6 +465,33 @@ WHERE p.pubname = 'publication_all_except_late'
 (1 row)
 
 DROP PUBLICATION publication_all_except_late;
+-- Reference-table creation follows the same metadata-sync path and must restore
+-- an exclusion that could not be propagated while the table was still local.
+CREATE TABLE publication_ref_excluded (id int PRIMARY KEY);
+CREATE PUBLICATION publication_all_except_ref
+    FOR ALL TABLES EXCEPT (TABLE publication_ref_excluded);
+SELECT create_reference_table('publication_ref_excluded');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT bool_and(result::boolean) AS exclusion_restored_after_reference_table
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_ref'
+      AND c.relname = 'publication_ref_excluded'
+$$);
+ exclusion_restored_after_reference_table
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except_ref;
+DROP TABLE publication_ref_excluded;
 -- The activation path rebuilds publication DDL from catalogs rather than
 -- deparsing the original statement, so exercise it directly. An excluded
 -- partitioned root must survive as the root (not be expanded to its leaves),

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -355,6 +355,65 @@ SELECT create_distributed_table('repack_part', 'id');
 REPACK repack_part USING INDEX repack_part_pk;
 WARNING:  not propagating REPACK command for partitioned table to worker nodes
 HINT:  Provide a child partition table names in order to REPACK distributed partitioned tables.
+-- PG19 represents ALL TABLES EXCEPT relations as PUBLICATIONOBJ_EXCEPT_TABLE,
+-- and stores ALL TABLES/ALL SEQUENCES as independent flags. Verify both
+-- catalog-backed CREATE reconstruction and direct ALTER propagation.
+CREATE TABLE publication_excluded_1 (id int);
+CREATE TABLE publication_excluded_2 (id int);
+CREATE TABLE publication_local_excluded (id int);
+SELECT create_distributed_table('publication_excluded_1', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT create_distributed_table('publication_excluded_2', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE PUBLICATION publication_all_except
+    FOR ALL TABLES EXCEPT (TABLE publication_excluded_1,
+                           TABLE publication_local_excluded),
+        ALL SEQUENCES;
+SELECT bool_and(result::boolean) AS create_propagated
+FROM run_command_on_workers($$
+    SELECT p.puballtables AND p.puballsequences
+           AND count(*) FILTER (WHERE r.prexcept) = 1
+           AND bool_and(c.relname = 'publication_excluded_1')
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except'
+    GROUP BY p.puballtables, p.puballsequences
+$$);
+ create_propagated
+---------------------------------------------------------------------
+ t
+(1 row)
+
+ALTER PUBLICATION publication_all_except
+    SET ALL TABLES EXCEPT (TABLE publication_excluded_2,
+                           TABLE publication_local_excluded),
+        ALL SEQUENCES;
+SELECT bool_and(result::boolean) AS alter_propagated
+FROM run_command_on_workers($$
+    SELECT p.puballtables AND p.puballsequences
+           AND count(*) FILTER (WHERE r.prexcept) = 1
+           AND bool_and(c.relname = 'publication_excluded_2')
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except'
+    GROUP BY p.puballtables, p.puballsequences
+$$);
+ alter_propagated
+---------------------------------------------------------------------
+ t
+(1 row)
+
+DROP PUBLICATION publication_all_except;
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -392,6 +392,72 @@ FROM unnest(activate_node_snapshot()) WITH ORDINALITY AS s(c, ord);
 
 DROP PUBLICATION publication_all_except_part;
 
+-- Conversions that give a table a new OID must not lose its exclusion, because
+-- the exclusion is tied to the old OID and cannot be restored with
+-- ALTER PUBLICATION .. ADD TABLE.
+SET client_min_messages TO WARNING;
+
+-- undistribute_table() drops the table and recreates it under the same name.
+CREATE TABLE publication_undist_excluded (id int);
+
+CREATE PUBLICATION publication_all_except_undist
+    FOR ALL TABLES EXCEPT (TABLE publication_undist_excluded);
+
+SELECT create_distributed_table('publication_undist_excluded', 'id');
+SELECT undistribute_table('publication_undist_excluded');
+
+SELECT count(*) = 1 AS exclusion_retained_after_undistribute
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_undist'
+  AND c.relname = 'publication_undist_excluded';
+
+DROP PUBLICATION publication_all_except_undist;
+DROP TABLE publication_undist_excluded;
+
+-- citus_add_local_table_to_metadata() renames the original table into a shard
+-- and creates a new shell table under the original name, so the exclusion has
+-- to move to the shell table instead of staying behind on the shard.
+SELECT citus_set_coordinator_host('localhost', :master_port);
+
+CREATE TABLE publication_conv_excluded (id int);
+
+CREATE PUBLICATION publication_all_except_conv
+    FOR ALL TABLES EXCEPT (TABLE publication_conv_excluded);
+
+SELECT citus_add_local_table_to_metadata('publication_conv_excluded');
+
+SELECT count(*) = 1 AS exclusion_moved_to_shell_table
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_conv'
+  AND c.relname = 'publication_conv_excluded';
+
+SELECT count(*) = 0 AS no_exclusion_left_behind_on_shard
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_conv'
+  AND c.relname <> 'publication_conv_excluded';
+
+SELECT bool_and(result::boolean) AS exclusion_present_on_workers
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_conv'
+      AND c.relname = 'publication_conv_excluded'
+$$);
+
+DROP PUBLICATION publication_all_except_conv;
+DROP TABLE publication_conv_excluded;
+
+SELECT citus_remove_node('localhost', :master_port);
+RESET client_min_messages;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -273,6 +273,51 @@ CREATE TABLE repack_part_2021 PARTITION OF repack_part
 SELECT create_distributed_table('repack_part', 'id');
 REPACK repack_part USING INDEX repack_part_pk;
 
+-- PG19 represents ALL TABLES EXCEPT relations as PUBLICATIONOBJ_EXCEPT_TABLE,
+-- and stores ALL TABLES/ALL SEQUENCES as independent flags. Verify both
+-- catalog-backed CREATE reconstruction and direct ALTER propagation.
+CREATE TABLE publication_excluded_1 (id int);
+CREATE TABLE publication_excluded_2 (id int);
+CREATE TABLE publication_local_excluded (id int);
+SELECT create_distributed_table('publication_excluded_1', 'id');
+SELECT create_distributed_table('publication_excluded_2', 'id');
+
+CREATE PUBLICATION publication_all_except
+    FOR ALL TABLES EXCEPT (TABLE publication_excluded_1,
+                           TABLE publication_local_excluded),
+        ALL SEQUENCES;
+
+SELECT bool_and(result::boolean) AS create_propagated
+FROM run_command_on_workers($$
+    SELECT p.puballtables AND p.puballsequences
+           AND count(*) FILTER (WHERE r.prexcept) = 1
+           AND bool_and(c.relname = 'publication_excluded_1')
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except'
+    GROUP BY p.puballtables, p.puballsequences
+$$);
+
+ALTER PUBLICATION publication_all_except
+    SET ALL TABLES EXCEPT (TABLE publication_excluded_2,
+                           TABLE publication_local_excluded),
+        ALL SEQUENCES;
+
+SELECT bool_and(result::boolean) AS alter_propagated
+FROM run_command_on_workers($$
+    SELECT p.puballtables AND p.puballsequences
+           AND count(*) FILTER (WHERE r.prexcept) = 1
+           AND bool_and(c.relname = 'publication_excluded_2')
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except'
+    GROUP BY p.puballtables, p.puballsequences
+$$);
+
+DROP PUBLICATION publication_all_except;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -318,6 +318,38 @@ $$);
 
 DROP PUBLICATION publication_all_except;
 
+-- The activation path rebuilds publication DDL from catalogs rather than
+-- deparsing the original statement, so exercise it directly. An excluded
+-- partitioned root must survive as the root (not be expanded to its leaves),
+-- and excluded Citus tables must be ordered before the publication itself.
+CREATE TABLE publication_part_excluded (id int, ts timestamptz)
+    PARTITION BY RANGE (ts);
+CREATE TABLE publication_part_excluded_2020 PARTITION OF publication_part_excluded
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+SELECT create_distributed_table('publication_part_excluded', 'id');
+
+CREATE PUBLICATION publication_all_except_part
+    FOR ALL TABLES EXCEPT (TABLE publication_part_excluded);
+
+CREATE OR REPLACE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+
+SELECT count(*) = 1 AS part_root_preserved
+FROM unnest(activate_node_snapshot()) c
+WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%'
+  AND c LIKE '%publication_part_excluded%'
+  AND c NOT LIKE '%publication_part_excluded_2020%';
+
+SELECT min(ord) FILTER (WHERE c LIKE '%publication_part_excluded%'
+                          AND c NOT LIKE '%CREATE PUBLICATION%')
+     < min(ord) FILTER (WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%')
+       AS excluded_table_precedes_publication
+FROM unnest(activate_node_snapshot()) WITH ORDINALITY AS s(c, ord);
+
+DROP PUBLICATION publication_all_except_part;
+
 SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -356,6 +356,27 @@ WHERE p.pubname = 'publication_all_except_late'
 
 DROP PUBLICATION publication_all_except_late;
 
+-- Reference-table creation follows the same metadata-sync path and must restore
+-- an exclusion that could not be propagated while the table was still local.
+CREATE TABLE publication_ref_excluded (id int PRIMARY KEY);
+CREATE PUBLICATION publication_all_except_ref
+    FOR ALL TABLES EXCEPT (TABLE publication_ref_excluded);
+
+SELECT create_reference_table('publication_ref_excluded');
+
+SELECT bool_and(result::boolean) AS exclusion_restored_after_reference_table
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_ref'
+      AND c.relname = 'publication_ref_excluded'
+$$);
+
+DROP PUBLICATION publication_all_except_ref;
+DROP TABLE publication_ref_excluded;
+
 -- The activation path rebuilds publication DDL from catalogs rather than
 -- deparsing the original statement, so exercise it directly. An excluded
 -- partitioned root must survive as the root (not be expanded to its leaves),

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -318,18 +318,59 @@ $$);
 
 DROP PUBLICATION publication_all_except;
 
+-- A table that is excluded while it is still a local table cannot be named on
+-- the workers, so it is filtered out when the publication is propagated.
+-- Distributing it later has to restore the exclusion on the workers, otherwise
+-- the workers would publish a table that the coordinator excludes.
+CREATE TABLE publication_late_excluded (id int);
+
+CREATE PUBLICATION publication_all_except_late
+    FOR ALL TABLES EXCEPT (TABLE publication_late_excluded);
+
+SELECT bool_and(result::boolean) AS exclusion_deferred_while_local
+FROM run_command_on_workers($$
+    SELECT count(*) = 0
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    WHERE p.pubname = 'publication_all_except_late'
+$$);
+
+SELECT create_distributed_table('publication_late_excluded', 'id');
+
+SELECT bool_and(result::boolean) AS exclusion_restored_after_distribution
+FROM run_command_on_workers($$
+    SELECT count(*) = 1
+    FROM pg_publication p
+    JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+    JOIN pg_class c ON c.oid = r.prrelid
+    WHERE p.pubname = 'publication_all_except_late'
+      AND c.relname = 'publication_late_excluded'
+$$);
+
+SELECT count(*) = 1 AS exclusion_retained_on_coordinator
+FROM pg_publication p
+JOIN pg_publication_rel r ON r.prpubid = p.oid AND r.prexcept
+JOIN pg_class c ON c.oid = r.prrelid
+WHERE p.pubname = 'publication_all_except_late'
+  AND c.relname = 'publication_late_excluded';
+
+DROP PUBLICATION publication_all_except_late;
+
 -- The activation path rebuilds publication DDL from catalogs rather than
 -- deparsing the original statement, so exercise it directly. An excluded
 -- partitioned root must survive as the root (not be expanded to its leaves),
 -- and excluded Citus tables must be ordered before the publication itself.
+-- The publication is created while the excluded root is still a local table so
+-- that it is registered as a distributed object before the table is; only the
+-- publication -> excluded relation dependency can order the table first.
 CREATE TABLE publication_part_excluded (id int, ts timestamptz)
     PARTITION BY RANGE (ts);
 CREATE TABLE publication_part_excluded_2020 PARTITION OF publication_part_excluded
     FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
-SELECT create_distributed_table('publication_part_excluded', 'id');
-
 CREATE PUBLICATION publication_all_except_part
     FOR ALL TABLES EXCEPT (TABLE publication_part_excluded);
+
+SELECT create_distributed_table('publication_part_excluded', 'id');
 
 CREATE OR REPLACE FUNCTION activate_node_snapshot()
     RETURNS text[]
@@ -343,6 +384,7 @@ WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%'
   AND c NOT LIKE '%publication_part_excluded_2020%';
 
 SELECT min(ord) FILTER (WHERE c LIKE '%publication_part_excluded%'
+                          AND c NOT LIKE '%publication_part_excluded_2020%'
                           AND c NOT LIKE '%CREATE PUBLICATION%')
      < min(ord) FILTER (WHERE c LIKE '%CREATE PUBLICATION%publication_all_except_part%')
        AS excluded_table_precedes_publication


### PR DESCRIPTION
Closes #8730

## Problem

On PostgreSQL 19, the backend **SEGFAULTs** when Citus is installed and a user runs:

```sql
ALTER PUBLICATION testpub_foralltables_excepttable SET ALL TABLES EXCEPT (TABLE testpub_tbl2);
```

This is reproducible in `check-vanilla` (`publication` test), where the crash also cascades into a long tail of unrelated vanilla failures. `postmaster.log` shows the backend terminated by signal 11.

Symbolized stack:

```
quote_identifier (rdi = 0x0)
  AppendPublicationObjects
  DeparseAlterPublicationStmtExtended
  QualifyPublicationObjects
  PreprocessAlterPublicationStmt
  citus_ProcessUtility
```

### Root cause

`AppendPublicationObjects()` in `deparse_publication_stmts.c` special-cased only `PUBLICATIONOBJ_TABLE`. Every other object kind fell through into the `TABLES IN SCHEMA` branch, which does:

```c
appendStringInfo(buf, "%s", quote_identifier(publicationObject->name));
```

PG19 adds `PUBLICATIONOBJ_EXCEPT_TABLE`, which carries its relation in `publicationObject->pubtable` and leaves `publicationObject->name == NULL`. Citus therefore passed `NULL` to `quote_identifier()` — a straight NULL dereference.

The crash is only the most visible symptom. Once EXCEPT tables are deparsed correctly, three further layers of Citus publication handling turn out to be unaware of exclusions.

## Provenance — this is a pre-Beta1 PG19 feature, not a Beta2 regression

| Upstream commit | Date | Change |
| --- | --- | --- |
| `fd366065` | 2026-03-04 | Allow table exclusions in publications via `EXCEPT TABLE` |
| `493f8c64` | 2026-03-20 | Add support for `EXCEPT TABLE` in `ALTER PUBLICATION` (the exact crashing path) |
| `96b37849` | 2025-10-09 | Add `ALL SEQUENCES` support to publications (`for_all_tables` / `for_all_sequences`) |

All three are present in both `REL_19_BETA1` (2026-06-01) and `REL_19_BETA2` (2026-07-13). **This is not Beta2-introduced** — it is a PG19 feature that predates Beta1 and was missed by the original PG19 compatibility sweep. It surfaced now only because the crash became visible in a fresh `check-vanilla` run.

## The four correctness layers

### 1. Deparse and qualify EXCEPT-table objects (the crash)

`deparse_publication_stmts.c` — `AppendPublicationObjects()` now handles `PUBLICATIONOBJ_EXCEPT_TABLE` explicitly, reading the relation from `pubtable` and emitting proper `ALL TABLES EXCEPT (TABLE ...)` syntax. Local (non-distributed) tables continue to be filtered out of worker-bound commands, and `AppendPublicationAllObjects()` accounts for PG19's `for_all_tables` / `for_all_sequences` reconstruction semantics.

`qualify_publication_stmt.c` — `QualifyPublicationObjects()` schema-qualifies `PUBLICATIONOBJ_EXCEPT_TABLE` relations so the deparsed command is unambiguous on workers.

This is a real semantic fix, not a NULL guard: the object kind is deparsed and qualified through its own path.

### 2. Metadata-activation dependency traversal

`metadata/dependency.c` — for a `FOR ALL TABLES` publication, `GetPublicationRelationsDependencyList()` was calling the included-relations APIs. On PG19 those assert `!alltables`, and even without asserts they miss the EXCEPT tables entirely, so an excluded table could be absent from the node snapshot when the publication is created on a worker.

It now collects explicit exclusions with `GetExcludedPublicationTables(pubid, PUBLICATION_PART_ROOT)` and orders them correctly, so `activate_node_snapshot()` emits the excluded relation before the publication that references it.

### 3. Partition-root preservation, and lifecycle when an excluded table is later distributed

`commands/publication.c` — EXCEPT reconstruction now always requests `PUBLICATION_PART_ROOT`. Under `publish_via_partition_root = false` the previous `PUBLICATION_PART_LEAF` choice dropped the partitioned root OID, but `EXCEPT` syntax must preserve the explicitly listed root.

`metadata/metadata_sync.c` — `AddTableToPublications()` previously consulted only *included* publications. A local table excluded via `ALL TABLES EXCEPT (t)` and later distributed would begin being published on workers while the coordinator still excluded it. It now also detects excluded publications and rebuilds a complete `SET ALL TABLES EXCEPT (...)` on workers, preserving local-table filtering.

Note: EXCEPT membership cannot be amended with `ALTER PUBLICATION ADD/DROP TABLE` — the whole object list must be re-`SET`, which is why these paths reconstruct rather than patch.

### 4. OID-rewriting conversions

`commands/publication.c` — `GetAlterPublicationDDLCommandsForTable()` also queried only included publications, so any conversion that changes a relation's OID silently lost EXCEPT membership:

- **`citus_add_local_table_to_metadata()`** renames the original OID to `<name>_<shardid>` and creates a new shell relation. The surviving `pg_publication_rel` exclusion row follows the OID, so the publication ended up excluding the **shard** while the new shell table was published.
- **`ReplaceTable()` / drop-CASCADE** (e.g. `undistribute_table()`) deletes the exclusion row outright; the post-load replay restored only included memberships.

The function now, under `#if PG_VERSION_NUM >= PG_VERSION_19` and only for the add direction, emits one complete `SET ALL TABLES EXCEPT (...)` per publication returned by `GetRelationExcludedPublications(relationId)`.

This works because deparsed commands name tables **by name, not by OID**: capturing the command before the rewrite and replaying it after the replacement exists re-points the exclusion at the new relation, and because `SET` replaces the whole object list wholesale it simultaneously evicts the stale shard-named exclusion — no extra DROP is required.

`GetAlterPublicationExcludedTablesDDLCommand()` gained an `includeLocalTables` parameter: worker propagation must filter local tables (workers cannot name them), while the coordinator-local restore must keep them, or restoring would silently drop local excluded tables from the coordinator's EXCEPT list.

## Negative controls

Each layer was validated by surgically disabling only that fix, rebuilding, and confirming that exactly the corresponding assertions flip — no more, no less.

The layer-4 control is the clearest. Same binary, same test; only difference is the restore loop present vs. replaced with `NIL`:

```
############ WITH FIX ############
 FLOW1 | t_undist
 FLOW2 | t_local

############ WITHOUT FIX ############
 FLOW2 | t_local_9600002
 flow | excluded_relname
---------------------------------------------------------------------
(0 rows)
```

| Flow | Mechanism | Without fix | With fix |
| --- | --- | --- | --- |
| `undistribute_table` | ReplaceTable / drop-CASCADE | **0 rows** — exclusion deleted | `t_undist` |
| `citus_add_local_table_to_metadata` | OID renamed to shard | **`t_local_9600002`** — stale shard OID | `t_local` |

## Tests

New coverage lives in a dedicated `pg19` regression test (with a `_0.out` skip stub so it is a no-op on PG < 19). `publication.sql` / `publication.out` are left **byte-identical** to upstream, and no expected output anywhere was altered to mask the crash.

Scenarios covered:

- `ALTER PUBLICATION ... SET ALL TABLES EXCEPT (...)` deparse/qualify (the original crash)
- metadata activation / node-snapshot ordering, asserting the publication is emitted after its excluded root — with the partitioned child excluded explicitly so the assertion cannot pass by accident
- excluding a partitioned **root** under default `publish_via_partition_root` settings
- an excluded local table that is subsequently distributed, verified against the **worker** catalogs
- both OID-rewrite conversions, asserting `exclusion_retained_after_undistribute`, `exclusion_moved_to_shell_table`, `no_exclusion_left_behind_on_shard`, and `exclusion_present_on_workers`

## Validation

| Environment | `publication` | `pg19` |
| --- | --- | --- |
| PG19 Beta2 | pass, no diffs | pass, no diffs |
| PG18.4 | pass, no diffs | pass (skip stub) |
| PG17.10 | pass, no diffs | pass (skip stub) |

All builds complete with 0 warnings and 0 errors. Expected-output files were md5-verified before and after each run to prove the harness never regenerated them.

## Diff

8 files changed, 716 insertions(+), 16 deletions(-) — 4 source files, 2 header/metadata files, 2 test files.

```
 src/backend/distributed/commands/publication.c              | 131 ++++++++++-
 src/backend/distributed/deparser/deparse_publication_stmts.c |  86 ++++++-
 src/backend/distributed/deparser/qualify_publication_stmt.c  |   6 +-
 src/backend/distributed/metadata/dependency.c                |  22 +-
 src/backend/distributed/metadata/metadata_sync.c             |  45 +++-
 src/include/distributed/commands.h                           |   6 +
 src/test/regress/expected/pg19.out                           | 251 +++++++++++
 src/test/regress/sql/pg19.sql                                | 185 +++++++++
```

All PG19-specific behavior is version-gated behind `PG_VERSION_NUM >= PG_VERSION_19`; PG17 and PG18 code paths are unchanged.
