### PR TITLE
Fix partition publication reconstruction

### DIFF
--- a/src/backend/distributed/commands/publication.c
+++ b/src/backend/distributed/commands/publication.c
@@ -232,10 +232,8 @@ BuildCreatePublicationStmt(Oid publicationId)
 	else
 #endif
 	{
-		relationIds = GetPublicationRelations(publicationId,
-											  publicationForm->pubviaroot ?
-											  PUBLICATION_PART_ROOT :
-											  PUBLICATION_PART_LEAF);
+		/* reconstruct explicit catalog entries, not runtime-expanded partitions */
+		relationIds = GetPublicationRelations(publicationId, PUBLICATION_PART_ROOT);
 	}
 	Oid relationId = InvalidOid;
 

--- a/src/test/regress/enterprise_schedule
+++ b/src/test/regress/enterprise_schedule
@@ -18,6 +18,7 @@ test: citus_local_tables_ent
 
 # --------
 
+test: publication_partition_root
 test: publication
 test: logical_replication
 test: check_cluster_state

--- a/src/test/regress/expected/publication_partition_root.out
+++ b/src/test/regress/expected/publication_partition_root.out
@@ -1,0 +1,86 @@
+CREATE SCHEMA publication_partition_root;
+SET search_path TO publication_partition_root;
+SET citus.shard_replication_factor TO 1;
+CREATE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+CREATE TABLE parent_with_children (id int) PARTITION BY RANGE (id);
+CREATE TABLE child_1 PARTITION OF parent_with_children
+    FOR VALUES FROM (0) TO (10);
+CREATE TABLE child_2 PARTITION OF parent_with_children
+    FOR VALUES FROM (10) TO (20);
+SELECT create_distributed_table('parent_with_children', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE TABLE parent_without_children (id int) PARTITION BY RANGE (id);
+SELECT create_distributed_table('parent_without_children', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE PUBLICATION pub_partition_root_with_children
+    FOR TABLE parent_with_children
+    WITH (publish_via_partition_root = false);
+CREATE PUBLICATION pub_partition_root_without_children
+    FOR TABLE parent_without_children
+    WITH (publish_via_partition_root = false);
+-- Worker catalogs should contain the explicitly published roots.
+SELECT DISTINCT result
+FROM run_command_on_workers($$
+    SELECT array_agg(p.pubname || ':' || c.relname || ':' || p.pubviaroot
+                     ORDER BY p.pubname)::text
+    FROM pg_publication p
+    JOIN pg_publication_rel pr ON pr.prpubid = p.oid
+    JOIN pg_class c ON c.oid = pr.prrelid
+    WHERE p.pubname LIKE 'pub_partition_root_%'
+$$)
+ORDER BY result;
+                                                             result
+---------------------------------------------------------------------
+ {pub_partition_root_with_children:parent_with_children:false,pub_partition_root_without_children:parent_without_children:false}
+(1 row)
+
+-- PostgreSQL should retain its runtime leaf expansion semantics.
+SELECT p.pubname,
+       COALESCE(string_agg(t.tablename, ', ' ORDER BY t.tablename), '<none>') AS tables
+FROM pg_publication p
+LEFT JOIN pg_publication_tables t USING (pubname)
+WHERE p.pubname LIKE 'pub_partition_root_%'
+GROUP BY p.pubname
+ORDER BY p.pubname;
+               pubname               |      tables
+---------------------------------------------------------------------
+ pub_partition_root_with_children    | child_1, child_2
+ pub_partition_root_without_children | <none>
+(2 rows)
+
+-- Node activation should reconstruct the roots, not expanded leaves.
+SELECT c
+FROM unnest(activate_node_snapshot()) c
+WHERE c LIKE '%CREATE PUBLICATION%'
+  AND c LIKE '%pub_partition_root_%'
+ORDER BY c;
+                                                                                                                              c
+---------------------------------------------------------------------
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_with_children FOR TABLE publication_partition_root.parent_with_children WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_without_children FOR TABLE publication_partition_root.parent_without_children WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
+(2 rows)
+
+DROP PUBLICATION pub_partition_root_with_children;
+DROP PUBLICATION pub_partition_root_without_children;
+DROP SCHEMA publication_partition_root CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to function activate_node_snapshot()
+drop cascades to table parent_with_children
+drop cascades to table parent_without_children
+SELECT public.wait_for_resource_cleanup();
+ wait_for_resource_cleanup
+---------------------------------------------------------------------
+
+(1 row)
+

--- a/src/test/regress/expected/publication_partition_root.out
+++ b/src/test/regress/expected/publication_partition_root.out
@@ -23,41 +23,74 @@ SELECT create_distributed_table('parent_without_children', 'id');
 
 (1 row)
 
+CREATE TABLE standalone (id int);
+SELECT create_distributed_table('standalone', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+CREATE SCHEMA "Quoted Schema";
+CREATE TABLE "Quoted Schema"."MixedCase Table" (id int);
+SELECT create_distributed_table('"Quoted Schema"."MixedCase Table"', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
 CREATE PUBLICATION pub_partition_root_with_children
     FOR TABLE parent_with_children
     WITH (publish_via_partition_root = false);
 CREATE PUBLICATION pub_partition_root_without_children
     FOR TABLE parent_without_children
     WITH (publish_via_partition_root = false);
--- Worker catalogs should contain the explicitly published roots.
+CREATE PUBLICATION pub_partition_root_true
+    FOR TABLE parent_with_children
+    WITH (publish_via_partition_root = true);
+CREATE PUBLICATION pub_partition_root_leaf
+    FOR TABLE child_1
+    WITH (publish_via_partition_root = true);
+CREATE PUBLICATION pub_partition_root_mixed
+    FOR TABLE parent_with_children, standalone;
+CREATE PUBLICATION pub_partition_root_quoted
+    FOR TABLE "Quoted Schema"."MixedCase Table";
+-- Worker catalogs should contain the exact explicitly published relations.
 SELECT DISTINCT result
 FROM run_command_on_workers($$
-    SELECT array_agg(p.pubname || ':' || c.relname || ':' || p.pubviaroot
-                     ORDER BY p.pubname)::text
+    SELECT array_agg(format('%s:%I.%I:%s',
+                            p.pubname, n.nspname, c.relname, p.pubviaroot)
+                     ORDER BY p.pubname, n.nspname, c.relname)::text
     FROM pg_publication p
     JOIN pg_publication_rel pr ON pr.prpubid = p.oid
     JOIN pg_class c ON c.oid = pr.prrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE p.pubname LIKE 'pub_partition_root_%'
 $$)
 ORDER BY result;
-                                                             result
+                                                                                                                                                                                                                                                                result
 ---------------------------------------------------------------------
- {pub_partition_root_with_children:parent_with_children:false,pub_partition_root_without_children:parent_without_children:false}
+ {pub_partition_root_leaf:publication_partition_root.child_1:t,pub_partition_root_mixed:publication_partition_root.parent_with_children:f,pub_partition_root_mixed:publication_partition_root.standalone:f,"pub_partition_root_quoted:\"Quoted Schema\".\"MixedCase Table\":f",pub_partition_root_true:publication_partition_root.parent_with_children:t,pub_partition_root_with_children:publication_partition_root.parent_with_children:f,pub_partition_root_without_children:publication_partition_root.parent_without_children:f}
 (1 row)
 
--- PostgreSQL should retain its runtime leaf expansion semantics.
+-- PostgreSQL should retain its runtime expansion semantics.
 SELECT p.pubname,
-       COALESCE(string_agg(t.tablename, ', ' ORDER BY t.tablename), '<none>') AS tables
+       COALESCE(string_agg(format('%I.%I', t.schemaname, t.tablename), ', '
+                           ORDER BY t.schemaname, t.tablename)
+                FILTER (WHERE t.tablename IS NOT NULL), '<none>') AS tables
 FROM pg_publication p
 LEFT JOIN pg_publication_tables t USING (pubname)
 WHERE p.pubname LIKE 'pub_partition_root_%'
 GROUP BY p.pubname
 ORDER BY p.pubname;
-               pubname               |      tables
+               pubname               |                                                    tables
 ---------------------------------------------------------------------
- pub_partition_root_with_children    | child_1, child_2
+ pub_partition_root_leaf             | publication_partition_root.child_1
+ pub_partition_root_mixed            | publication_partition_root.child_1, publication_partition_root.child_2, publication_partition_root.standalone
+ pub_partition_root_quoted           | "Quoted Schema"."MixedCase Table"
+ pub_partition_root_true             | publication_partition_root.parent_with_children
+ pub_partition_root_with_children    | publication_partition_root.child_1, publication_partition_root.child_2
  pub_partition_root_without_children | <none>
-(2 rows)
+(6 rows)
 
 -- Node activation should reconstruct the roots, not expanded leaves.
 SELECT c
@@ -65,19 +98,26 @@ FROM unnest(activate_node_snapshot()) c
 WHERE c LIKE '%CREATE PUBLICATION%'
   AND c LIKE '%pub_partition_root_%'
 ORDER BY c;
-                                                                                                                              c
+                                                                                                                                              c
 ---------------------------------------------------------------------
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_leaf FOR TABLE publication_partition_root.child_1 WITH (publish_via_partition_root = ''true'', publish = ''insert, update, delete, truncate'')');
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_mixed FOR TABLE publication_partition_root.parent_with_children, TABLE publication_partition_root.standalone WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_quoted FOR TABLE "Quoted Schema"."MixedCase Table" WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
+ SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_true FOR TABLE publication_partition_root.parent_with_children WITH (publish_via_partition_root = ''true'', publish = ''insert, update, delete, truncate'')');
  SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_with_children FOR TABLE publication_partition_root.parent_with_children WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
  SELECT worker_create_or_replace_object('CREATE PUBLICATION pub_partition_root_without_children FOR TABLE publication_partition_root.parent_without_children WITH (publish_via_partition_root = ''false'', publish = ''insert, update, delete, truncate'')');
-(2 rows)
+(6 rows)
 
 DROP PUBLICATION pub_partition_root_with_children;
 DROP PUBLICATION pub_partition_root_without_children;
+DROP PUBLICATION pub_partition_root_true;
+DROP PUBLICATION pub_partition_root_leaf;
+DROP PUBLICATION pub_partition_root_mixed;
+DROP PUBLICATION pub_partition_root_quoted;
+SET client_min_messages TO ERROR;
 DROP SCHEMA publication_partition_root CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to function activate_node_snapshot()
-drop cascades to table parent_with_children
-drop cascades to table parent_without_children
+DROP SCHEMA "Quoted Schema" CASCADE;
+RESET client_min_messages;
 SELECT public.wait_for_resource_cleanup();
  wait_for_resource_cleanup
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/publication_partition_root.sql
+++ b/src/test/regress/sql/publication_partition_root.sql
@@ -17,28 +17,49 @@ SELECT create_distributed_table('parent_with_children', 'id');
 CREATE TABLE parent_without_children (id int) PARTITION BY RANGE (id);
 SELECT create_distributed_table('parent_without_children', 'id');
 
+CREATE TABLE standalone (id int);
+SELECT create_distributed_table('standalone', 'id');
+
+CREATE SCHEMA "Quoted Schema";
+CREATE TABLE "Quoted Schema"."MixedCase Table" (id int);
+SELECT create_distributed_table('"Quoted Schema"."MixedCase Table"', 'id');
+
 CREATE PUBLICATION pub_partition_root_with_children
     FOR TABLE parent_with_children
     WITH (publish_via_partition_root = false);
 CREATE PUBLICATION pub_partition_root_without_children
     FOR TABLE parent_without_children
     WITH (publish_via_partition_root = false);
+CREATE PUBLICATION pub_partition_root_true
+    FOR TABLE parent_with_children
+    WITH (publish_via_partition_root = true);
+CREATE PUBLICATION pub_partition_root_leaf
+    FOR TABLE child_1
+    WITH (publish_via_partition_root = true);
+CREATE PUBLICATION pub_partition_root_mixed
+    FOR TABLE parent_with_children, standalone;
+CREATE PUBLICATION pub_partition_root_quoted
+    FOR TABLE "Quoted Schema"."MixedCase Table";
 
--- Worker catalogs should contain the explicitly published roots.
+-- Worker catalogs should contain the exact explicitly published relations.
 SELECT DISTINCT result
 FROM run_command_on_workers($$
-    SELECT array_agg(p.pubname || ':' || c.relname || ':' || p.pubviaroot
-                     ORDER BY p.pubname)::text
+    SELECT array_agg(format('%s:%I.%I:%s',
+                            p.pubname, n.nspname, c.relname, p.pubviaroot)
+                     ORDER BY p.pubname, n.nspname, c.relname)::text
     FROM pg_publication p
     JOIN pg_publication_rel pr ON pr.prpubid = p.oid
     JOIN pg_class c ON c.oid = pr.prrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE p.pubname LIKE 'pub_partition_root_%'
 $$)
 ORDER BY result;
 
--- PostgreSQL should retain its runtime leaf expansion semantics.
+-- PostgreSQL should retain its runtime expansion semantics.
 SELECT p.pubname,
-       COALESCE(string_agg(t.tablename, ', ' ORDER BY t.tablename), '<none>') AS tables
+       COALESCE(string_agg(format('%I.%I', t.schemaname, t.tablename), ', '
+                           ORDER BY t.schemaname, t.tablename)
+                FILTER (WHERE t.tablename IS NOT NULL), '<none>') AS tables
 FROM pg_publication p
 LEFT JOIN pg_publication_tables t USING (pubname)
 WHERE p.pubname LIKE 'pub_partition_root_%'
@@ -54,6 +75,13 @@ ORDER BY c;
 
 DROP PUBLICATION pub_partition_root_with_children;
 DROP PUBLICATION pub_partition_root_without_children;
+DROP PUBLICATION pub_partition_root_true;
+DROP PUBLICATION pub_partition_root_leaf;
+DROP PUBLICATION pub_partition_root_mixed;
+DROP PUBLICATION pub_partition_root_quoted;
+SET client_min_messages TO ERROR;
 DROP SCHEMA publication_partition_root CASCADE;
+DROP SCHEMA "Quoted Schema" CASCADE;
+RESET client_min_messages;
 
 SELECT public.wait_for_resource_cleanup();

--- a/src/test/regress/sql/publication_partition_root.sql
+++ b/src/test/regress/sql/publication_partition_root.sql
@@ -1,0 +1,59 @@
+CREATE SCHEMA publication_partition_root;
+SET search_path TO publication_partition_root;
+SET citus.shard_replication_factor TO 1;
+
+CREATE FUNCTION activate_node_snapshot()
+    RETURNS text[]
+    LANGUAGE C STRICT
+    AS 'citus';
+
+CREATE TABLE parent_with_children (id int) PARTITION BY RANGE (id);
+CREATE TABLE child_1 PARTITION OF parent_with_children
+    FOR VALUES FROM (0) TO (10);
+CREATE TABLE child_2 PARTITION OF parent_with_children
+    FOR VALUES FROM (10) TO (20);
+SELECT create_distributed_table('parent_with_children', 'id');
+
+CREATE TABLE parent_without_children (id int) PARTITION BY RANGE (id);
+SELECT create_distributed_table('parent_without_children', 'id');
+
+CREATE PUBLICATION pub_partition_root_with_children
+    FOR TABLE parent_with_children
+    WITH (publish_via_partition_root = false);
+CREATE PUBLICATION pub_partition_root_without_children
+    FOR TABLE parent_without_children
+    WITH (publish_via_partition_root = false);
+
+-- Worker catalogs should contain the explicitly published roots.
+SELECT DISTINCT result
+FROM run_command_on_workers($$
+    SELECT array_agg(p.pubname || ':' || c.relname || ':' || p.pubviaroot
+                     ORDER BY p.pubname)::text
+    FROM pg_publication p
+    JOIN pg_publication_rel pr ON pr.prpubid = p.oid
+    JOIN pg_class c ON c.oid = pr.prrelid
+    WHERE p.pubname LIKE 'pub_partition_root_%'
+$$)
+ORDER BY result;
+
+-- PostgreSQL should retain its runtime leaf expansion semantics.
+SELECT p.pubname,
+       COALESCE(string_agg(t.tablename, ', ' ORDER BY t.tablename), '<none>') AS tables
+FROM pg_publication p
+LEFT JOIN pg_publication_tables t USING (pubname)
+WHERE p.pubname LIKE 'pub_partition_root_%'
+GROUP BY p.pubname
+ORDER BY p.pubname;
+
+-- Node activation should reconstruct the roots, not expanded leaves.
+SELECT c
+FROM unnest(activate_node_snapshot()) c
+WHERE c LIKE '%CREATE PUBLICATION%'
+  AND c LIKE '%pub_partition_root_%'
+ORDER BY c;
+
+DROP PUBLICATION pub_partition_root_with_children;
+DROP PUBLICATION pub_partition_root_without_children;
+DROP SCHEMA publication_partition_root CASCADE;
+
+SELECT public.wait_for_resource_cleanup();


### PR DESCRIPTION
## Summary
- reconstruct `CREATE PUBLICATION` from explicit `pg_publication_rel` root identities
- preserve PostgreSQL runtime leaf expansion when `publish_via_partition_root` is false
- cover worker propagation and node activation for populated and empty partition roots

## Root cause

Publication reconstruction selected `PUBLICATION_PART_LEAF` when `publish_via_partition_root=false`. PostgreSQL expanded a cataloged partition root to its leaves, but those leaves were absent from `pg_publication_rel`, so `BuildPublicationRelationObjSpec()` failed while reconstructing the publication.

Reconstruction now always uses `PUBLICATION_PART_ROOT`, matching explicit catalog identities. PostgreSQL runtime publication semantics remain unchanged.

## Validation
- PostgreSQL 17.10: `-Werror` build and focused schedule passed
- PostgreSQL 18.4: `-Werror` build and focused schedule passed
- PostgreSQL 19beta2: `-Werror` build and focused schedule passed

Closes #8742