### PR TITLE
Fix REASSIGN OWNED with keyword target roles

### DIFF
--- a/src/backend/distributed/commands/owned.c
+++ b/src/backend/distributed/commands/owned.c
@@ -161,11 +161,15 @@ PostprocessReassignOwnedStmt(Node *node, const char *queryString)
 
 /*
  * GetNewRoleAddress returns the ObjectAddress of the new role
+ *
+ * We use get_rolespec_oid() rather than get_role_oid() because the TO clause
+ * may hold a keyword role specification such as CURRENT_USER or SESSION_USER,
+ * in which case rolename is NULL.
  */
 static ObjectAddress *
 GetNewRoleAddress(ReassignOwnedStmt *stmt)
 {
-	Oid roleOid = get_role_oid(stmt->newrole->rolename, false);
+	Oid roleOid = get_rolespec_oid(stmt->newrole, false);
 	ObjectAddress *address = palloc0(sizeof(ObjectAddress));
 	ObjectAddressSet(*address, AuthIdRelationId, roleOid);
 	return address;

--- a/src/test/regress/expected/reassign_owned.out
+++ b/src/test/regress/expected/reassign_owned.out
@@ -190,5 +190,50 @@ WHERE
 
 (3 rows)
 
+--tests for reassign owned by to a keyword role specification (e.g. CURRENT_USER),
+--where RoleSpec->rolename is NULL
+CREATE ROLE keyword_source_role;
+GRANT CREATE ON SCHEMA public TO keyword_source_role;
+SET ROLE keyword_source_role;
+CREATE TABLE public.test_table5 (col1 int);
+RESET ROLE;
+SELECT create_distributed_table('test_table5', 'col1');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+set citus.log_remote_commands to on;
+set citus.grep_remote_commands = '%REASSIGN OWNED BY%';
+REASSIGN OWNED BY keyword_source_role TO CURRENT_USER;
+NOTICE:  issuing REASSIGN OWNED BY keyword_source_role TO postgres
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+NOTICE:  issuing REASSIGN OWNED BY keyword_source_role TO postgres
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+reset citus.grep_remote_commands;
+reset citus.log_remote_commands;
+SELECT result from run_command_on_all_nodes(
+  $$
+  SELECT jsonb_agg(to_jsonb(q2.*)) FROM (
+   SELECT
+    schemaname,
+    tablename,
+    tableowner
+   FROM
+    pg_tables
+   WHERE
+    tablename = 'test_table5'
+  ) q2
+  $$
+) ORDER BY result;
+                                      result
+---------------------------------------------------------------------
+ [{"tablename": "test_table5", "schemaname": "public", "tableowner": "postgres"}]
+ [{"tablename": "test_table5", "schemaname": "public", "tableowner": "postgres"}]
+ [{"tablename": "test_table5", "schemaname": "public", "tableowner": "postgres"}]
+(3 rows)
+
+DROP TABLE public.test_table5;
+DROP OWNED BY keyword_source_role;
 set client_min_messages to warning;
-drop role distributed_source_role1, "distributed_source_role-\!","distributed_target_role1-\!",local_target_role1,local_source_role1;
+drop role distributed_source_role1, "distributed_source_role-\!","distributed_target_role1-\!",local_target_role1,local_source_role1,keyword_source_role;

--- a/src/test/regress/sql/reassign_owned.sql
+++ b/src/test/regress/sql/reassign_owned.sql
@@ -137,5 +137,39 @@ WHERE
 ) ORDER BY result;
 
 
+--tests for reassign owned by to a keyword role specification (e.g. CURRENT_USER),
+--where RoleSpec->rolename is NULL
+CREATE ROLE keyword_source_role;
+GRANT CREATE ON SCHEMA public TO keyword_source_role;
+
+SET ROLE keyword_source_role;
+CREATE TABLE public.test_table5 (col1 int);
+RESET ROLE;
+SELECT create_distributed_table('test_table5', 'col1');
+
+set citus.log_remote_commands to on;
+set citus.grep_remote_commands = '%REASSIGN OWNED BY%';
+REASSIGN OWNED BY keyword_source_role TO CURRENT_USER;
+reset citus.grep_remote_commands;
+reset citus.log_remote_commands;
+
+SELECT result from run_command_on_all_nodes(
+  $$
+  SELECT jsonb_agg(to_jsonb(q2.*)) FROM (
+   SELECT
+    schemaname,
+    tablename,
+    tableowner
+   FROM
+    pg_tables
+   WHERE
+    tablename = 'test_table5'
+  ) q2
+  $$
+) ORDER BY result;
+
+DROP TABLE public.test_table5;
+DROP OWNED BY keyword_source_role;
+
 set client_min_messages to warning;
-drop role distributed_source_role1, "distributed_source_role-\!","distributed_target_role1-\!",local_target_role1,local_source_role1;
+drop role distributed_source_role1, "distributed_source_role-\!","distributed_target_role1-\!",local_target_role1,local_source_role1,keyword_source_role;


### PR DESCRIPTION
## Summary
- fix `REASSIGN OWNED BY ... TO CURRENT_USER` and other keyword target roles by resolving the complete `RoleSpec` with `get_rolespec_oid`
- avoid passing a NULL `RoleSpec->rolename` to `get_role_oid`, which caused the syscache hash path to segfault
- add regression coverage for keyword target roles plus a negative control that confirms an unrelated role remains unchanged

## Validation
- PostgreSQL 17 multi-node regression validation
- PostgreSQL 18 multi-node regression validation
- PostgreSQL 19 multi-node regression validation

## Scope
This is a general, PostgreSQL-version-independent fix. It is independent of the property-graph compatibility change and can be reviewed and backported on its own.

Closes #8745