### PR TITLE
Normalize PG19 unnamed insert-select subquery

### DIFF
--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -398,8 +398,9 @@ s/^([ ]{16}InitPlan) exists_1/\1 2/
 s/^([ ]{22}One-Time Filter: \(InitPlan) exists_1/\1 2/
 s/(InitPlan|SubPlan) (exists|expr|hashed)_([0-9]+)/\1 \3/g
 
-# PG19 renamed implicit ANY subqueries.
+# PG19 renamed implicit subqueries.
 # this rule can be removed when PG19 is the minimum supported version
+/^[[:space:]]*->[[:space:]]+Subquery Scan on / s/"\*SELECT\*"/"ANY_subquery"/
 s/\<unnamed_subquery\>/"ANY_subquery"/g
 
 # PG19 changed VACUUM PARALLEL option errors.

--- a/src/test/regress/expected/allow_unsafe_insert_select_pushdown.out
+++ b/src/test/regress/expected/allow_unsafe_insert_select_pushdown.out
@@ -248,7 +248,7 @@ $$, true);
    ->  Task
          Node: host=localhost port=xxxxx dbname=regression
          ->  Insert on res_14000004 citus_table_alias
-               ->  Subquery Scan on "*SELECT*"
+               ->  Subquery Scan on "ANY_subquery"
                      ->  WindowAgg
                            ->  Sort
                                  Sort Key: dist.text_col


### PR DESCRIPTION
## Summary

PostgreSQL 19 names this implicit INSERT/SELECT subquery `unnamed_subquery`, while PostgreSQL 17/18 emit `"*SELECT*"`. Extend the existing PG19 subquery-name normalization so both labels map to the established `"ANY_subquery"` canonical name.

The new rule is limited to `Subquery Scan` plan lines, preserving the rest of the plan structure and semantics as regression assertions.

## Validation

- Reproduced the exact PG19beta2 `allow_unsafe_insert_select_pushdown` mismatch.
- Focused PG19beta2 regression: 15/15 passed.
- Focused PostgreSQL 17.10 regression: 15/15 passed.
- Focused PostgreSQL 18.4 regression: 15/15 passed.
- Full PG19 `check-multi`: target test passed; local beta2 retained one unrelated `multi_orderby_limit_pushdown` planner-choice difference.
- Exhaustive expected-output normalization comparison affects only the intended line.

Closes #8747