### PR TITLE
Fix PG19 relation JSON COPY TO routing

### DIFF
--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -2992,12 +2992,14 @@ ProcessCopyStmt(CopyStmt *copyStatement, QueryCompletion *completionTag, const
 				return NULL;
 			}
 			else if (copyStatement->filename == NULL && !copyStatement->is_program &&
-					 !CopyStatementHasFormat(copyStatement, "binary"))
+					 !CopyStatementHasFormat(copyStatement, "binary") &&
+					 !CopyStatementHasFormat(copyStatement, "json"))
 			{
 				/*
 				 * COPY table TO STDOUT is handled by specialized logic to
 				 * avoid buffering the table on the coordinator. This enables
-				 * pg_dump of large tables.
+				 * pg_dump of large tables. Formats with coordinator-owned
+				 * framing use the query path, which may batch or spill rows.
 				 */
 				CitusCopyTo(copyStatement, completionTag);
 				return NULL;
@@ -3031,21 +3033,36 @@ CitusCopySelect(CopyStmt *copyStatement)
 	SelectStmt *selectStmt = makeNode(SelectStmt);
 	selectStmt->fromClause = list_make1(copyObject(copyStatement->relation));
 
-	Relation distributedRelation = table_openrv(copyStatement->relation, AccessShareLock);
-	TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
+	List *attributeNameList = copyStatement->attlist;
 	List *targetList = NIL;
 
-	for (int i = 0; i < tupleDescriptor->natts; i++)
+	if (attributeNameList == NIL)
 	{
-		Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, i);
+		Relation distributedRelation = table_openrv(copyStatement->relation, AccessShareLock);
+		TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
 
-		if (IsDroppedOrGenerated(attr))
+		for (int i = 0; i < tupleDescriptor->natts; i++)
 		{
-			continue;
+			Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, i);
+
+			if (IsDroppedOrGenerated(attr))
+			{
+				continue;
+			}
+
+			attributeNameList = lappend(attributeNameList,
+										makeString(pstrdup(attr->attname.data)));
 		}
 
+		table_close(distributedRelation, NoLock);
+	}
+
+	ListCell *attributeNameCell = NULL;
+	foreach(attributeNameCell, attributeNameList)
+	{
+		char *attributeName = strVal(lfirst(attributeNameCell));
 		ColumnRef *column = makeNode(ColumnRef);
-		column->fields = list_make1(makeString(pstrdup(attr->attname.data)));
+		column->fields = list_make1(makeString(pstrdup(attributeName)));
 		column->location = -1;
 
 		ResTarget *selectTarget = makeNode(ResTarget);
@@ -3056,8 +3073,6 @@ CitusCopySelect(CopyStmt *copyStatement)
 
 		targetList = lappend(targetList, selectTarget);
 	}
-
-	table_close(distributedRelation, NoLock);
 
 	selectStmt->targetList = targetList;
 	return selectStmt;

--- a/src/backend/distributed/commands/multi_copy.c
+++ b/src/backend/distributed/commands/multi_copy.c
@@ -3033,36 +3033,19 @@ CitusCopySelect(CopyStmt *copyStatement)
 	SelectStmt *selectStmt = makeNode(SelectStmt);
 	selectStmt->fromClause = list_make1(copyObject(copyStatement->relation));
 
-	List *attributeNameList = copyStatement->attlist;
+	Relation distributedRelation = table_openrv(copyStatement->relation, AccessShareLock);
+	TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
+	List *attributeNumberList = CopyGetAttnums(tupleDescriptor, distributedRelation,
+											   copyStatement->attlist);
 	List *targetList = NIL;
 
-	if (attributeNameList == NIL)
+	ListCell *attributeNumberCell = NULL;
+	foreach(attributeNumberCell, attributeNumberList)
 	{
-		Relation distributedRelation = table_openrv(copyStatement->relation, AccessShareLock);
-		TupleDesc tupleDescriptor = RelationGetDescr(distributedRelation);
-
-		for (int i = 0; i < tupleDescriptor->natts; i++)
-		{
-			Form_pg_attribute attr = TupleDescAttr(tupleDescriptor, i);
-
-			if (IsDroppedOrGenerated(attr))
-			{
-				continue;
-			}
-
-			attributeNameList = lappend(attributeNameList,
-										makeString(pstrdup(attr->attname.data)));
-		}
-
-		table_close(distributedRelation, NoLock);
-	}
-
-	ListCell *attributeNameCell = NULL;
-	foreach(attributeNameCell, attributeNameList)
-	{
-		char *attributeName = strVal(lfirst(attributeNameCell));
+		int attributeNumber = lfirst_int(attributeNumberCell);
+		Form_pg_attribute attribute = TupleDescAttr(tupleDescriptor, attributeNumber - 1);
 		ColumnRef *column = makeNode(ColumnRef);
-		column->fields = list_make1(makeString(pstrdup(attributeName)));
+		column->fields = list_make1(makeString(pstrdup(attribute->attname.data)));
 		column->location = -1;
 
 		ResTarget *selectTarget = makeNode(ResTarget);
@@ -3073,6 +3056,8 @@ CitusCopySelect(CopyStmt *copyStatement)
 
 		targetList = lappend(targetList, selectTarget);
 	}
+
+	table_close(distributedRelation, NoLock);
 
 	selectStmt->targetList = targetList;
 	return selectStmt;

--- a/src/test/regress/citus_tests/test/test_json_copy.py
+++ b/src/test/regress/citus_tests/test/test_json_copy.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+from psycopg import pq
+
+
+def copy_out(pgconn, command):
+    pgconn.send_query(command.encode())
+    copy_result = pgconn.get_result()
+    assert copy_result.status == pq.ExecStatus.COPY_OUT
+
+    chunks = []
+    while True:
+        size, data = pgconn.get_copy_data(0)
+        if size > 0:
+            chunks.append(bytes(data))
+        elif size == -1:
+            break
+        else:
+            raise AssertionError("COPY OUT failed")
+
+    command_result = pgconn.get_result()
+    assert command_result.status == pq.ExecStatus.COMMAND_OK
+    assert pgconn.get_result() is None
+    return copy_result, command_result, b"".join(chunks)
+
+
+def test_json_copy_protocol_and_routing(cluster):
+    coord = cluster.coordinator
+    if coord.sql_value("SELECT current_setting('server_version_num')::int") < 190000:
+        pytest.skip("JSON COPY is only available on PostgreSQL 19+")
+
+    coord.sql("CREATE TABLE json_copy (id int, payload text)")
+    coord.sql("""
+        SELECT create_distributed_table(
+            'json_copy', 'id', shard_count => 4, colocate_with => 'none')
+        """)
+    coord.sql("""
+        INSERT INTO json_copy
+        SELECT id, 'value-' || id
+        FROM (
+            SELECT DISTINCT ON (
+                get_shard_id_for_distribution_column('json_copy', id))
+                id
+            FROM generate_series(1, 100) id
+            ORDER BY get_shard_id_for_distribution_column('json_copy', id), id
+            LIMIT 2
+        ) distinct_shards
+        """)
+    assert coord.sql_value("""
+            SELECT count(DISTINCT
+                get_shard_id_for_distribution_column('json_copy', id))
+            FROM json_copy
+            """) == 2
+
+    with coord.conn() as conn:
+        direct_copy, direct_command, direct_data = copy_out(
+            conn.pgconn,
+            "COPY json_copy TO STDOUT (FORMAT json, FORCE_ARRAY true)",
+        )
+        query_copy, query_command, query_data = copy_out(
+            conn.pgconn,
+            "COPY (SELECT * FROM json_copy) TO STDOUT "
+            "(FORMAT json, FORCE_ARRAY true)",
+        )
+
+        assert direct_copy.nfields == query_copy.nfields == 1
+        assert direct_command.command_tuples == query_command.command_tuples == 2
+        assert sorted(json.loads(direct_data), key=lambda row: row["id"]) == sorted(
+            json.loads(query_data), key=lambda row: row["id"]
+        )
+
+        coord.sql("TRUNCATE json_copy")
+        empty_copy, empty_command, empty_data = copy_out(
+            conn.pgconn,
+            "COPY json_copy TO STDOUT (FORMAT json, FORCE_ARRAY true)",
+        )
+
+        assert empty_copy.nfields == 1
+        assert empty_command.command_tuples == 0
+        assert json.loads(empty_data) == []

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -626,6 +626,108 @@ $$);
 
 DROP PUBLICATION publication_all_except_conv;
 DROP TABLE publication_conv_excluded;
+-- JSON COPY framing and protocol state must be owned by one coordinator COPY.
+CREATE TABLE json_copy_dist (id int, payload text, optional text);
+SELECT create_distributed_table('json_copy_dist', 'id',
+                                shard_count => 4, colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO json_copy_dist
+SELECT id, E'quote" slash\\ newline\n', NULL
+FROM (
+    SELECT DISTINCT ON (get_shard_id_for_distribution_column('json_copy_dist', id))
+           id
+    FROM generate_series(1, 100) id
+    ORDER BY get_shard_id_for_distribution_column('json_copy_dist', id), id
+    LIMIT 2
+) distinct_shards;
+SELECT count(DISTINCT get_shard_id_for_distribution_column('json_copy_dist', id)) = 2
+       AS rows_on_distinct_shards
+FROM json_copy_dist;
+ rows_on_distinct_shards
+---------------------------------------------------------------------
+ t
+(1 row)
+
+COPY json_copy_dist (payload, optional) TO STDOUT
+    (FORMAT json, FORCE_ARRAY true);
+[
+ {"payload":"quote\" slash\\ newline\n","optional":null}
+,{"payload":"quote\" slash\\ newline\n","optional":null}
+]
+COPY json_copy_dist (payload) TO STDOUT
+    (FORMAT json, FORCE_ARRAY false);
+{"payload":"quote\" slash\\ newline\n"}
+{"payload":"quote\" slash\\ newline\n"}
+COPY json_copy_dist (payload) TO STDOUT
+    (FORMAT json, FORCE_ARRAY true, ENCODING 'UTF8', HEADER false);
+[
+ {"payload":"quote\" slash\\ newline\n"}
+,{"payload":"quote\" slash\\ newline\n"}
+]
+CREATE TABLE json_copy_empty (id int);
+SELECT create_distributed_table('json_copy_empty', 'id',
+                                shard_count => 4, colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+COPY json_copy_empty TO STDOUT (FORMAT json, FORCE_ARRAY true);
+[
+]
+CREATE TABLE json_copy_single_shard (id int, payload text);
+SELECT create_distributed_table('json_copy_single_shard', NULL,
+                                colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO json_copy_single_shard VALUES (1, 'single shard');
+COPY json_copy_single_shard TO STDOUT (FORMAT json, FORCE_ARRAY true);
+[
+ {"id":1,"payload":"single shard"}
+]
+CREATE TABLE json_copy_reference (id int PRIMARY KEY, payload text);
+SELECT create_reference_table('json_copy_reference');
+ create_reference_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO json_copy_reference VALUES (1, 'reference');
+COPY json_copy_reference TO STDOUT (FORMAT json, FORCE_ARRAY true);
+[
+ {"id":1,"payload":"reference"}
+]
+CREATE TABLE json_copy_local (id int, payload text);
+INSERT INTO json_copy_local VALUES (1, 'local');
+COPY json_copy_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
+[
+ {"id":1,"payload":"local"}
+]
+CREATE TABLE json_copy_citus_local (id int, payload text);
+SELECT citus_add_local_table_to_metadata('json_copy_citus_local');
+ citus_add_local_table_to_metadata
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO json_copy_citus_local VALUES (1, 'Citus local');
+COPY json_copy_citus_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
+[
+ {"id":1,"payload":"Citus local"}
+]
+COPY json_copy_dist TO STDOUT (FORMAT json, DELIMITER ',');
+ERROR:  cannot specify DELIMITER in JSON mode
+COPY json_copy_dist TO STDOUT (FORMAT json, HEADER true);
+ERROR:  cannot specify HEADER in JSON mode
+DROP TABLE json_copy_dist, json_copy_empty, json_copy_single_shard,
+           json_copy_reference, json_copy_local, json_copy_citus_local;
 SELECT citus_remove_node('localhost', :master_port);
  citus_remove_node
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -627,7 +627,13 @@ $$);
 DROP PUBLICATION publication_all_except_conv;
 DROP TABLE publication_conv_excluded;
 -- JSON COPY framing and protocol state must be owned by one coordinator COPY.
-CREATE TABLE json_copy_dist (id int, payload text, optional text);
+CREATE TABLE json_copy_dist
+(
+    id int,
+    payload text,
+    optional text,
+    generated text GENERATED ALWAYS AS (payload) STORED
+);
 SELECT create_distributed_table('json_copy_dist', 'id',
                                 shard_count => 4, colocate_with => 'none');
  create_distributed_table
@@ -704,12 +710,27 @@ COPY json_copy_reference TO STDOUT (FORMAT json, FORCE_ARRAY true);
 [
  {"id":1,"payload":"reference"}
 ]
-CREATE TABLE json_copy_local (id int, payload text);
+CREATE TABLE json_copy_local
+(
+    id int,
+    payload text,
+    generated text GENERATED ALWAYS AS (payload) STORED
+);
 INSERT INTO json_copy_local VALUES (1, 'local');
 COPY json_copy_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
 [
  {"id":1,"payload":"local"}
 ]
+COPY json_copy_local (generated) TO STDOUT (FORMAT json);
+ERROR:  column "generated" is a generated column
+DETAIL:  Generated columns cannot be used in COPY.
+COPY json_copy_dist (generated) TO STDOUT (FORMAT json);
+ERROR:  column "generated" is a generated column
+DETAIL:  Generated columns cannot be used in COPY.
+COPY json_copy_local (ctid) TO STDOUT (FORMAT json);
+ERROR:  column "ctid" of relation "json_copy_local" does not exist
+COPY json_copy_dist (ctid) TO STDOUT (FORMAT json);
+ERROR:  column "ctid" of relation "json_copy_dist" does not exist
 CREATE TABLE json_copy_citus_local (id int, payload text);
 SELECT citus_add_local_table_to_metadata('json_copy_citus_local');
  citus_add_local_table_to_metadata

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -477,7 +477,13 @@ DROP PUBLICATION publication_all_except_conv;
 DROP TABLE publication_conv_excluded;
 
 -- JSON COPY framing and protocol state must be owned by one coordinator COPY.
-CREATE TABLE json_copy_dist (id int, payload text, optional text);
+CREATE TABLE json_copy_dist
+(
+    id int,
+    payload text,
+    optional text,
+    generated text GENERATED ALWAYS AS (payload) STORED
+);
 SELECT create_distributed_table('json_copy_dist', 'id',
                                 shard_count => 4, colocate_with => 'none');
 INSERT INTO json_copy_dist
@@ -517,9 +523,19 @@ SELECT create_reference_table('json_copy_reference');
 INSERT INTO json_copy_reference VALUES (1, 'reference');
 COPY json_copy_reference TO STDOUT (FORMAT json, FORCE_ARRAY true);
 
-CREATE TABLE json_copy_local (id int, payload text);
+CREATE TABLE json_copy_local
+(
+    id int,
+    payload text,
+    generated text GENERATED ALWAYS AS (payload) STORED
+);
 INSERT INTO json_copy_local VALUES (1, 'local');
 COPY json_copy_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+COPY json_copy_local (generated) TO STDOUT (FORMAT json);
+COPY json_copy_dist (generated) TO STDOUT (FORMAT json);
+COPY json_copy_local (ctid) TO STDOUT (FORMAT json);
+COPY json_copy_dist (ctid) TO STDOUT (FORMAT json);
 
 CREATE TABLE json_copy_citus_local (id int, payload text);
 SELECT citus_add_local_table_to_metadata('json_copy_citus_local');

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -476,6 +476,62 @@ $$);
 DROP PUBLICATION publication_all_except_conv;
 DROP TABLE publication_conv_excluded;
 
+-- JSON COPY framing and protocol state must be owned by one coordinator COPY.
+CREATE TABLE json_copy_dist (id int, payload text, optional text);
+SELECT create_distributed_table('json_copy_dist', 'id',
+                                shard_count => 4, colocate_with => 'none');
+INSERT INTO json_copy_dist
+SELECT id, E'quote" slash\\ newline\n', NULL
+FROM (
+    SELECT DISTINCT ON (get_shard_id_for_distribution_column('json_copy_dist', id))
+           id
+    FROM generate_series(1, 100) id
+    ORDER BY get_shard_id_for_distribution_column('json_copy_dist', id), id
+    LIMIT 2
+) distinct_shards;
+
+SELECT count(DISTINCT get_shard_id_for_distribution_column('json_copy_dist', id)) = 2
+       AS rows_on_distinct_shards
+FROM json_copy_dist;
+
+COPY json_copy_dist (payload, optional) TO STDOUT
+    (FORMAT json, FORCE_ARRAY true);
+COPY json_copy_dist (payload) TO STDOUT
+    (FORMAT json, FORCE_ARRAY false);
+COPY json_copy_dist (payload) TO STDOUT
+    (FORMAT json, FORCE_ARRAY true, ENCODING 'UTF8', HEADER false);
+
+CREATE TABLE json_copy_empty (id int);
+SELECT create_distributed_table('json_copy_empty', 'id',
+                                shard_count => 4, colocate_with => 'none');
+COPY json_copy_empty TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+CREATE TABLE json_copy_single_shard (id int, payload text);
+SELECT create_distributed_table('json_copy_single_shard', NULL,
+                                colocate_with => 'none');
+INSERT INTO json_copy_single_shard VALUES (1, 'single shard');
+COPY json_copy_single_shard TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+CREATE TABLE json_copy_reference (id int PRIMARY KEY, payload text);
+SELECT create_reference_table('json_copy_reference');
+INSERT INTO json_copy_reference VALUES (1, 'reference');
+COPY json_copy_reference TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+CREATE TABLE json_copy_local (id int, payload text);
+INSERT INTO json_copy_local VALUES (1, 'local');
+COPY json_copy_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+CREATE TABLE json_copy_citus_local (id int, payload text);
+SELECT citus_add_local_table_to_metadata('json_copy_citus_local');
+INSERT INTO json_copy_citus_local VALUES (1, 'Citus local');
+COPY json_copy_citus_local TO STDOUT (FORMAT json, FORCE_ARRAY true);
+
+COPY json_copy_dist TO STDOUT (FORMAT json, DELIMITER ',');
+COPY json_copy_dist TO STDOUT (FORMAT json, HEADER true);
+
+DROP TABLE json_copy_dist, json_copy_empty, json_copy_single_shard,
+           json_copy_reference, json_copy_local, json_copy_citus_local;
+
 SELECT citus_remove_node('localhost', :master_port);
 RESET client_min_messages;
 


### PR DESCRIPTION
Fix PG19 relation JSON COPY TO routing.

## Problem

Relation `COPY ... TO STDOUT (FORMAT json)` used Citus's direct shard COPY
fast path. Concatenating shard-formatted JSON produced multiple arrays instead
of one valid JSON document for `FORCE_ARRAY true`. The fast path also reported
incorrect COPY protocol metadata and command tuple counts, especially for empty
results.

## Fix

- exclude `FORMAT json` from the direct `CitusCopyTo()` path so PostgreSQL
  formats one coordinator-owned JSON stream through `CitusCopySelect()`
- construct the coordinator SELECT from `CopyGetAttnums()` so explicit normal
  columns preserve order while generated, system, missing, and duplicate
  columns retain native relation COPY validation
- cover multi-shard, empty, single-shard, reference, local, Citus-local,
  streaming, explicit-column, escaping/null, encoding, option-error, and
  low-level libpq protocol behavior

This intentionally trades direct shard streaming for coordinator query
execution. Large JSON COPY operations may therefore use coordinator batching
or spill, but PostgreSQL must own the whole JSON document framing and protocol
state for correctness.

## Validation

- PostgreSQL 16.14, 17.10, 18.4, and 19beta2 builds with `CFLAGS=-Werror`
- `multi_copy` regression: 15/15 passed on PostgreSQL 16, 17, and 18
- combined `multi_copy` and `pg19` regression: 16/16 passed on PostgreSQL 19
- focused low-level libpq protocol/equivalence test: passed
- targeted Black, isort, flake8, `citus_indent`, and diff checks: passed

Closes #8760