### PR TITLE
Fix GRANTED BY ordering in propagated REVOKE statements

### DIFF
--- a/src/backend/distributed/deparser/citus_grantutils.c
+++ b/src/backend/distributed/deparser/citus_grantutils.c
@@ -106,7 +106,9 @@ AppendGrantSharedSuffix(StringInfo buf, GrantStmt *stmt)
 {
 	AppendGrantGrantees(buf, stmt);
 	AppendWithGrantOption(buf, stmt);
-	AppendGrantRestrictAndCascade(buf, stmt);
+
+	/* GRANTED BY must precede CASCADE/RESTRICT, per the GRANT/REVOKE grammar */
 	AppendGrantedByInGrant(buf, stmt);
+	AppendGrantRestrictAndCascade(buf, stmt);
 	appendStringInfo(buf, ";");
 }

--- a/src/test/regress/expected/grant_on_schema_propagation.out
+++ b/src/test/regress/expected/grant_on_schema_propagation.out
@@ -387,4 +387,30 @@ SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'public' ORDER BY nspna
 
 \c - - - :master_port
 DROP TABLE public_schema_table;
+-- GRANTED BY must be emitted before CASCADE/RESTRICT, otherwise the command
+-- sent to the workers is a syntax error
+CREATE SCHEMA granted_by_schema;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_1 WITH GRANT OPTION;
+SET ROLE role_1;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_2 GRANTED BY role_1;
+REVOKE USAGE ON SCHEMA granted_by_schema FROM role_2 GRANTED BY role_1 RESTRICT;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_3 GRANTED BY role_1;
+REVOKE USAGE ON SCHEMA granted_by_schema FROM role_3 GRANTED BY role_1 CASCADE;
+RESET ROLE;
+-- the grants above must be reflected on the workers as well
+SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'granted_by_schema' ORDER BY nspname;
+      nspname      |                  nspacl
+---------------------------------------------------------------------
+ granted_by_schema | {postgres=UC/postgres,role_1=U*/postgres}
+(1 row)
+
+\c - - - :worker_1_port
+SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'granted_by_schema' ORDER BY nspname;
+      nspname      |                  nspacl
+---------------------------------------------------------------------
+ granted_by_schema | {postgres=UC/postgres,role_1=U*/postgres}
+(1 row)
+
+\c - - - :master_port
+DROP SCHEMA granted_by_schema;
 DROP ROLE role_1, role_2, role_3;

--- a/src/test/regress/sql/grant_on_schema_propagation.sql
+++ b/src/test/regress/sql/grant_on_schema_propagation.sql
@@ -223,4 +223,23 @@ SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'public' ORDER BY nspna
 
 DROP TABLE public_schema_table;
 
+-- GRANTED BY must be emitted before CASCADE/RESTRICT, otherwise the command
+-- sent to the workers is a syntax error
+CREATE SCHEMA granted_by_schema;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_1 WITH GRANT OPTION;
+SET ROLE role_1;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_2 GRANTED BY role_1;
+REVOKE USAGE ON SCHEMA granted_by_schema FROM role_2 GRANTED BY role_1 RESTRICT;
+GRANT USAGE ON SCHEMA granted_by_schema TO role_3 GRANTED BY role_1;
+REVOKE USAGE ON SCHEMA granted_by_schema FROM role_3 GRANTED BY role_1 CASCADE;
+RESET ROLE;
+
+-- the grants above must be reflected on the workers as well
+SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'granted_by_schema' ORDER BY nspname;
+\c - - - :worker_1_port
+SELECT nspname, nspacl FROM pg_namespace WHERE nspname = 'granted_by_schema' ORDER BY nspname;
+\c - - - :master_port
+
+DROP SCHEMA granted_by_schema;
+
 DROP ROLE role_1, role_2, role_3;


### PR DESCRIPTION
## Summary

- emit `GRANTED BY` before `CASCADE`/`RESTRICT` when deparsing propagated shared-object GRANT/REVOKE statements
- cover both `RESTRICT` and `CASCADE` with schema privilege propagation checks on coordinator and worker

## Root cause

PostgreSQL grammar places `GRANTED BY grantor` before the optional `CASCADE`/`RESTRICT` behavior clause. `AppendGrantSharedSuffix()` emitted those clauses in the opposite order, producing worker SQL such as `REVOKE ... RESTRICT GRANTED BY ...`. The coordinator completed its local revoke, while workers rejected the propagated command with a syntax error, leaving privileges inconsistent.

The role path already had the correct ordering (`deparse_role_stmts.c`), which is what makes this an oversight in the shared-object path rather than a deliberate difference.

## Runtime negative control

With the one-line ordering change reverted and the harness re-run, the propagated statement is rejected by the worker:

```
 REVOKE USAGE ON SCHEMA granted_by_schema FROM role_2 GRANTED BY role_1 RESTRICT;
+ERROR:  syntax error at or near "GRANTED"
+CONTEXT:  while executing command on localhost:xxxxx
 REVOKE USAGE ON SCHEMA granted_by_schema FROM role_3 GRANTED BY role_1 CASCADE;
+ERROR:  syntax error at or near "GRANTED"
```

Because the worker rejects it, the whole `REVOKE` aborts and the privilege survives on both coordinator and worker. So unfixed, `REVOKE ... GRANTED BY ... CASCADE|RESTRICT` on a distributed shared object is not merely mis-ordered text — it is unexecutable. With the fix applied the same test passes with zero diff.

## Cross-version validation

A single `expected/grant_on_schema_propagation.out` satisfies all supported majors — no version-specific variants were needed:

| PostgreSQL | focused test |
|---|---|
| 16.14 | `ok - grant_on_schema_propagation` |
| 17.10 | `ok - grant_on_schema_propagation` |
| 18.4 | `ok - grant_on_schema_propagation` |

## Scope

This PR is limited to the shared-object deparser path (database, schema, function, sequence, and foreign server). Table grantor behavior is a separate defect with a separate fix and is intentionally out of scope here.
Tracks #8759.