### PR TITLE
Propagate GRANTED BY when deparsing table grants

### DIFF
--- a/src/backend/distributed/commands/grant.c
+++ b/src/backend/distributed/commands/grant.c
@@ -150,6 +150,18 @@ PreprocessGrantStmt(Node *node, const char *queryString,
 	}
 
 	/*
+	 * A grant may be attributed to a role other than the one we connect to the
+	 * workers as, in which case the workers would pick a grantor of their own
+	 * and end up with an ACL that differs from the one on the coordinator.
+	 */
+	const char *grantedBy = "";
+	if (grantStmt->grantor)
+	{
+		grantedBy = psprintf(" GRANTED BY %s",
+							 RoleSpecString(grantStmt->grantor, true));
+	}
+
+	/*
 	 * Deparse the target objects, and issue the deparsed statements to
 	 * workers, if applicable. That's so we easily can replicate statements
 	 * only to distributed relations.
@@ -170,9 +182,9 @@ PreprocessGrantStmt(Node *node, const char *queryString,
 				grantOption = " WITH GRANT OPTION";
 			}
 
-			appendStringInfo(&ddlString, "GRANT %s ON %s TO %s%s",
+			appendStringInfo(&ddlString, "GRANT %s ON %s TO %s%s%s",
 							 privsString.data, targetString.data, granteesString.data,
-							 grantOption);
+							 grantOption, grantedBy);
 		}
 		else
 		{
@@ -181,9 +193,9 @@ PreprocessGrantStmt(Node *node, const char *queryString,
 				grantOption = "GRANT OPTION FOR ";
 			}
 
-			appendStringInfo(&ddlString, "REVOKE %s%s ON %s FROM %s",
+			appendStringInfo(&ddlString, "REVOKE %s%s ON %s FROM %s%s",
 							 grantOption, privsString.data, targetString.data,
-							 granteesString.data);
+							 granteesString.data, grantedBy);
 
 			if (grantStmt->behavior == DROP_CASCADE)
 			{

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -637,3 +637,159 @@ SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;
 RESET search_path;
+--
+-- GRANTED BY on distributed tables.
+--
+-- PG19 (commit dd1398f1) lets a grant be attributed to any role whose
+-- privileges the current user inherits, instead of requiring the grantor to be
+-- current_user.  Citus must ship that grantor to the shards: without it every
+-- worker runs select_best_grantor() on its own and can pick a different
+-- eligible role, leaving shard ACLs that disagree with the coordinator.
+--
+-- Reproducing the divergence needs the named grantor to differ from the one a
+-- worker would pick by itself, so the table is owned by a third role and two
+-- separate roles hold SELECT WITH GRANT OPTION.
+--
+CREATE SCHEMA pg19_grantor;
+SET search_path TO pg19_grantor;
+SET citus.next_shard_id TO 1101000;
+SET citus.shard_count TO 2;
+SET citus.shard_replication_factor TO 1;
+CREATE ROLE pg19_owner;
+CREATE ROLE pg19_grantor_a;
+CREATE ROLE pg19_grantor_b;
+CREATE ROLE pg19_actor LOGIN;
+CREATE ROLE pg19_grantee;
+GRANT USAGE ON SCHEMA pg19_grantor TO pg19_actor;
+CREATE TABLE granted_by_test (a int, b int);
+SELECT create_distributed_table('granted_by_test', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+ALTER TABLE granted_by_test OWNER TO pg19_owner;
+GRANT SELECT ON granted_by_test TO pg19_grantor_a WITH GRANT OPTION;
+GRANT SELECT ON granted_by_test TO pg19_grantor_b WITH GRANT OPTION;
+GRANT pg19_grantor_a TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+GRANT pg19_grantor_b TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+-- name pg19_grantor_b explicitly; a worker left to itself picks pg19_grantor_a
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_b;
+RESET ROLE;
+SELECT DISTINCT a.grantor::regrole::text AS coordinator_grantor
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee';
+ coordinator_grantor
+---------------------------------------------------------------------
+ pg19_grantor_b
+(1 row)
+
+-- every shard must record the grantor the coordinator recorded
+SELECT DISTINCT result AS shard_grantor
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee'
+$cmd$);
+ shard_grantor
+---------------------------------------------------------------------
+ pg19_grantor_b
+(1 row)
+
+SET ROLE pg19_actor;
+REVOKE SELECT ON granted_by_test FROM pg19_grantee GRANTED BY pg19_grantor_b;
+RESET ROLE;
+-- grant twice under different grantors and revoke only one of them: the
+-- coordinator keeps the surviving grant, and the shards have to agree with it.
+-- Otherwise the grantee reads fine on the coordinator but is denied on the
+-- shards, so its queries fail with a permission error.
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_a;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_b;
+REVOKE SELECT ON granted_by_test FROM pg19_grantee GRANTED BY pg19_grantor_a;
+RESET ROLE;
+SELECT has_table_privilege('pg19_grantee', 'granted_by_test', 'SELECT') AS coordinator_privilege;
+ coordinator_privilege
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT DISTINCT result AS shard_privilege
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT has_table_privilege('pg19_grantee', '%s', 'SELECT')
+$cmd$);
+ shard_privilege
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- A grantor whose name needs quoting goes through RoleSpecString(..., true), and
+-- the grant option shares a slot with the grantor clause in both deparse paths:
+-- GRANTED BY follows WITH GRANT OPTION on a grant, and follows the grantee list
+-- on a revoke.  Exercise all of it on a worker.
+CREATE ROLE "Grant Owner";
+CREATE ROLE pg19_grantee2;
+GRANT SELECT ON granted_by_test TO "Grant Owner" WITH GRANT OPTION;
+GRANT "Grant Owner" TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee2
+    WITH GRANT OPTION GRANTED BY "Grant Owner";
+RESET ROLE;
+SELECT a.grantor::regrole::text AS coordinator_grantor,
+       a.is_grantable AS coordinator_grantable
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee2';
+ coordinator_grantor | coordinator_grantable
+---------------------------------------------------------------------
+ "Grant Owner"       | t
+(1 row)
+
+SELECT DISTINCT result AS shard_grant_option
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text || ', grantable=' || a.is_grantable::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee2'
+$cmd$);
+      shard_grant_option
+---------------------------------------------------------------------
+ "Grant Owner", grantable=true
+(1 row)
+
+-- dropping only the grant option has to reach the same ACL entry on the shards
+SET ROLE pg19_actor;
+REVOKE GRANT OPTION FOR SELECT ON granted_by_test
+    FROM pg19_grantee2 GRANTED BY "Grant Owner";
+RESET ROLE;
+SELECT a.grantor::regrole::text AS coordinator_grantor,
+       a.is_grantable AS coordinator_grantable
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee2';
+ coordinator_grantor | coordinator_grantable
+---------------------------------------------------------------------
+ "Grant Owner"       | f
+(1 row)
+
+SELECT DISTINCT result AS shard_grant_option
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text || ', grantable=' || a.is_grantable::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee2'
+$cmd$);
+       shard_grant_option
+---------------------------------------------------------------------
+ "Grant Owner", grantable=false
+(1 row)
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_grantor CASCADE;
+DROP ROLE pg19_owner, pg19_grantor_a, pg19_grantor_b, pg19_actor, pg19_grantee;
+DROP ROLE "Grant Owner", pg19_grantee2;
+RESET client_min_messages;
+RESET search_path;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -483,3 +483,136 @@ SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_repack CASCADE;
 RESET client_min_messages;
 RESET search_path;
+
+--
+-- GRANTED BY on distributed tables.
+--
+-- PG19 (commit dd1398f1) lets a grant be attributed to any role whose
+-- privileges the current user inherits, instead of requiring the grantor to be
+-- current_user.  Citus must ship that grantor to the shards: without it every
+-- worker runs select_best_grantor() on its own and can pick a different
+-- eligible role, leaving shard ACLs that disagree with the coordinator.
+--
+-- Reproducing the divergence needs the named grantor to differ from the one a
+-- worker would pick by itself, so the table is owned by a third role and two
+-- separate roles hold SELECT WITH GRANT OPTION.
+--
+CREATE SCHEMA pg19_grantor;
+SET search_path TO pg19_grantor;
+
+SET citus.next_shard_id TO 1101000;
+SET citus.shard_count TO 2;
+SET citus.shard_replication_factor TO 1;
+
+CREATE ROLE pg19_owner;
+CREATE ROLE pg19_grantor_a;
+CREATE ROLE pg19_grantor_b;
+CREATE ROLE pg19_actor LOGIN;
+CREATE ROLE pg19_grantee;
+
+GRANT USAGE ON SCHEMA pg19_grantor TO pg19_actor;
+
+CREATE TABLE granted_by_test (a int, b int);
+SELECT create_distributed_table('granted_by_test', 'a');
+ALTER TABLE granted_by_test OWNER TO pg19_owner;
+
+GRANT SELECT ON granted_by_test TO pg19_grantor_a WITH GRANT OPTION;
+GRANT SELECT ON granted_by_test TO pg19_grantor_b WITH GRANT OPTION;
+GRANT pg19_grantor_a TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+GRANT pg19_grantor_b TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+
+-- name pg19_grantor_b explicitly; a worker left to itself picks pg19_grantor_a
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_b;
+RESET ROLE;
+
+SELECT DISTINCT a.grantor::regrole::text AS coordinator_grantor
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee';
+
+-- every shard must record the grantor the coordinator recorded
+SELECT DISTINCT result AS shard_grantor
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee'
+$cmd$);
+
+SET ROLE pg19_actor;
+REVOKE SELECT ON granted_by_test FROM pg19_grantee GRANTED BY pg19_grantor_b;
+RESET ROLE;
+
+-- grant twice under different grantors and revoke only one of them: the
+-- coordinator keeps the surviving grant, and the shards have to agree with it.
+-- Otherwise the grantee reads fine on the coordinator but is denied on the
+-- shards, so its queries fail with a permission error.
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_a;
+GRANT SELECT ON granted_by_test TO pg19_grantee GRANTED BY pg19_grantor_b;
+REVOKE SELECT ON granted_by_test FROM pg19_grantee GRANTED BY pg19_grantor_a;
+RESET ROLE;
+
+SELECT has_table_privilege('pg19_grantee', 'granted_by_test', 'SELECT') AS coordinator_privilege;
+
+SELECT DISTINCT result AS shard_privilege
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT has_table_privilege('pg19_grantee', '%s', 'SELECT')
+$cmd$);
+
+-- A grantor whose name needs quoting goes through RoleSpecString(..., true), and
+-- the grant option shares a slot with the grantor clause in both deparse paths:
+-- GRANTED BY follows WITH GRANT OPTION on a grant, and follows the grantee list
+-- on a revoke.  Exercise all of it on a worker.
+CREATE ROLE "Grant Owner";
+CREATE ROLE pg19_grantee2;
+
+GRANT SELECT ON granted_by_test TO "Grant Owner" WITH GRANT OPTION;
+GRANT "Grant Owner" TO pg19_actor WITH INHERIT TRUE, ADMIN TRUE;
+
+SET ROLE pg19_actor;
+GRANT SELECT ON granted_by_test TO pg19_grantee2
+    WITH GRANT OPTION GRANTED BY "Grant Owner";
+RESET ROLE;
+
+SELECT a.grantor::regrole::text AS coordinator_grantor,
+       a.is_grantable AS coordinator_grantable
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee2';
+
+SELECT DISTINCT result AS shard_grant_option
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text || ', grantable=' || a.is_grantable::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee2'
+$cmd$);
+
+-- dropping only the grant option has to reach the same ACL entry on the shards
+SET ROLE pg19_actor;
+REVOKE GRANT OPTION FOR SELECT ON granted_by_test
+    FROM pg19_grantee2 GRANTED BY "Grant Owner";
+RESET ROLE;
+
+SELECT a.grantor::regrole::text AS coordinator_grantor,
+       a.is_grantable AS coordinator_grantable
+FROM pg_class c, aclexplode(c.relacl) a
+WHERE c.oid = 'granted_by_test'::regclass
+  AND a.grantee::regrole::text = 'pg19_grantee2';
+
+SELECT DISTINCT result AS shard_grant_option
+FROM run_command_on_shards('granted_by_test', $cmd$
+    SELECT DISTINCT a.grantor::regrole::text || ', grantable=' || a.is_grantable::text
+    FROM pg_class c, aclexplode(c.relacl) a
+    WHERE c.oid = '%s'::regclass
+      AND a.grantee::regrole::text = 'pg19_grantee2'
+$cmd$);
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_grantor CASCADE;
+DROP ROLE pg19_owner, pg19_grantor_a, pg19_grantor_b, pg19_actor, pg19_grantee;
+DROP ROLE "Grant Owner", pg19_grantee2;
+RESET client_min_messages;
+RESET search_path;


### PR DESCRIPTION
## Summary

Preserve a table `GRANT`/`REVOKE` statement's explicit `GRANTED BY` role when Citus deparses and propagates the command to physical shards.

This PR is intentionally limited to table-grantor serialization in `commands/grant.c`. It is separate from #8766, which fixes shared-object `REVOKE` clause ordering in the deparser. The two are complementary halves of the same report and must not be conflated.

Tracks #8759
Umbrella tracking: #8597

## Root cause

`PreprocessGrantStmt()` hand-builds the worker DDL string rather than routing through the deparser, and it never emitted `GrantStmt.grantor`. The explicit grantor was therefore silently dropped on the way to every worker.

PostgreSQL 19 (commit `dd1398f1`) widened `GRANTED BY` to accept **any role the acting role inherits**, not just `current_user`. Once the grantor is dropped from the worker command, each worker independently runs `select_best_grantor()` and can pick a different role than the coordinator did. The result is a coordinator/shard ACL divergence.

On PG16-18 the same statement requires `grantor = current_user`, so the omission is unobservable there. This is why the defect is only reachable, and only testable, on PG19.

## Impact

Once the ACLs diverge, a later `REVOKE` that names the coordinator's grantor matches nothing on the shards. Concretely, the coordinator reports the privilege as revoked while the physical shards still grant it — a silent privilege leak that `has_table_privilege()` on the coordinator will not reveal.

## Fix

`commands/grant.c` only, +16/-4. Builds a `grantedBy` fragment when `grantStmt->grantor` is set and appends it to both format strings. In `REVOKE` it lands after the grantee list and before `CASCADE`/`RESTRICT`, which is the same ordering #8766 establishes for shared objects, so the two scopes agree by construction.

`GrantStmt.grantor` has existed since PG14, so no version gate is needed; the code is inert on PG16-18 where the field cannot be set to anything but the current role.

## Test design

The scenario is deliberately discriminating. A third-party role owns the table and is **never named as grantor**, so the non-discriminating `owner == grantor` case cannot mask a failure. Two eligible grantors are inherited by the acting role, and the statement explicitly names the one the workers would *not* choose on their own.

Coverage:
- coordinator vs physical-shard `aclexplode(relacl).grantor` parity, read through `run_command_on_shards()`
- selective-revoke parity via `has_table_privilege()` on coordinator and shards
- a quoted grantor role name (`"Grant Owner"`), exercising `RoleSpecString(..., true)`
- `WITH GRANT OPTION` and the matching `REVOKE GRANT OPTION FOR`

Tests are gated on `server_version_ge_19` and are pure additions: zero removed lines in either `pg19.sql` or `pg19.out`.

## Negative control

Reverting `grant.c` to stock, rebuilding, reinstalling and re-running turns `pg19` red. Verified twice in independent cycles, the second time with a binary-level gate confirming the built `citus.so` actually matched the intended source in each phase (`strings citus.so | grep -c 'GRANT %s ON %s TO %s%s%s'` -> stock 0, fixed 1).

Four assertions flip, and **every one of them is shard-side**. All coordinator rows are byte-identical between the two runs and appear only as unchanged context:

| assertion | stock (broken) | with fix |
|---|---|---|
| shard grantor | `pg19_grantor_a` | `pg19_grantor_b` |
| shard privilege after selective revoke | `f` (coordinator reads `t`) | `t` |
| shard grant option after `GRANT ... WITH GRANT OPTION` | `pg19_grantor_a, grantable=true` | `"Grant Owner", grantable=true` |
| shard grant option after `REVOKE GRANT OPTION FOR` | `pg19_grantor_a, grantable=false` | `"Grant Owner", grantable=false` |

The sharpest single line is row 2: `coordinator_privilege = t` sits two lines above `shard_privilege = f` as unchanged context in the same diff hunk.

**Disclosed limitation, stated plainly:** rows 3 and 4 discriminate on grantor *identity* only, not on the `grantable` flag. Unfixed, the shard ACL entry and the un-attributed revoke both resolve to `pg19_grantor_a` and therefore coincide, so the grant option is still correctly dropped. Rows 1 and 2 carry the proof; rows 3 and 4 are corroborating.

## Validation

- base is exactly `origin/pg19-support` @ `db67cd7e2` with zero intervening delta, so the validated tree is the pushed tree
- 3 files, +305/-4; the two test files are append-only
- `citus_indent --check` clean (exit 0, no `FAIL` lines)
- full-cluster `pg19` regression on a 3-node PostgreSQL 19beta2 harness: `ok` with the fix, zero diff
- `expected/pg19.out` is harness-generated, never hand-written, and re-verified byte-identical to a freshly generated `results/pg19.out`
