### PR TITLE
[CI only] Bump PG minors to 14.24 / 15.19 / 16.15

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,12 +26,12 @@ jobs:
       pgupgrade_image_name: "ghcr.io/citusdata/pgupgradetester"
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
-      sql_snapshot_pg_version: "16.13"
-      image_suffix: "-dev-98d1a12"
-      pg14_version: '{ "major": "14", "full": "14.19" }'
-      pg15_version: '{ "major": "15", "full": "15.14" }'
-      pg16_version: '{ "major": "16", "full": "16.13" }'
-      upgrade_pg_versions: "14.19-15.14-16.13"
+      sql_snapshot_pg_version: "16.15"
+      image_suffix: "-dev-b63fad9"
+      pg14_version: '{ "major": "14", "full": "14.24" }'
+      pg15_version: '{ "major": "15", "full": "15.19" }'
+      pg16_version: '{ "major": "16", "full": "16.15" }'
+      upgrade_pg_versions: "14.24-15.19-16.15"
     steps:
       # Since GHA jobs needs at least one step we use a noop step here.
       - name: Set up parameters

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
       style_checker_image_name: "ghcr.io/citusdata/stylechecker"
       style_checker_tools_version: "0.8.18"
       sql_snapshot_pg_version: "16.15"
-      image_suffix: "-dev-b63fad9"
+      image_suffix: "-dev-4af5e7f"
       pg14_version: '{ "major": "14", "full": "14.24" }'
       pg15_version: '{ "major": "15", "full": "15.19" }'
       pg16_version: '{ "major": "16", "full": "16.15" }'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -141,6 +141,7 @@ jobs:
           - ${{ needs.params.outputs.pg16_version }}
         make:
           - check-split
+          - check-split-output-plugin-denied
           - check-multi
           - check-multi-1
           - check-multi-mx

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1369,6 +1369,7 @@ AcquireNonblockingSplitLock(Oid relationId)
 	}
 }
 
+
 /*
  * ErrorIfOutputPluginNotAllowed errors out if the given logical decoding output
  * plugin is not listed in the "output_plugin_libraries" setting on the node

--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -69,6 +69,9 @@ typedef struct GroupedDummyShards
 	List *shardIntervals;
 } GroupedDummyShards;
 
+/* name of the logical decoding output plugin used by non-blocking splits */
+#define CITUS_SPLIT_DECODER_PLUGIN "citus"
+
 /* Function declarations */
 static void ErrorIfCannotSplitShard(SplitOperation splitOperation,
 									ShardInterval *sourceShard);
@@ -92,6 +95,8 @@ static void CreateAuxiliaryStructuresForShardGroup(List *shardGroupSplitInterval
 												   List *workersForPlacementList,
 												   bool includeReplicaIdentity);
 static void CreateReplicaIdentitiesForDummyShards(HTAB *mapOfPlacementToDummyShardList);
+static void ErrorIfOutputPluginNotAllowed(MultiConnection *connection,
+										  char *outputPlugin);
 static void CreateObjectOnPlacement(List *objectCreationCommandList,
 									WorkerNode *workerNode);
 static List *    CreateSplitIntervalsForShardGroup(List *sourceColocatedShardList,
@@ -1364,6 +1369,72 @@ AcquireNonblockingSplitLock(Oid relationId)
 	}
 }
 
+/*
+ * ErrorIfOutputPluginNotAllowed errors out if the given logical decoding output
+ * plugin is not listed in the "output_plugin_libraries" setting on the node
+ * behind the given connection, which is where the replication slot is created.
+ *
+ * "output_plugin_libraries" was introduced in PostgreSQL 14.24, 15.19, 16.15,
+ * 17.11 and 18.6. On older minor versions current_setting() returns NULL and we
+ * skip the check, because there is nothing to enforce.
+ */
+static void
+ErrorIfOutputPluginNotAllowed(MultiConnection *connection, char *outputPlugin)
+{
+	StringInfo command = makeStringInfo();
+	appendStringInfo(command,
+					 "SELECT current_setting('output_plugin_libraries', true), "
+					 "coalesce(bool_or(btrim(name, ' \"') = %s), false) "
+					 "FROM unnest(string_to_array(coalesce("
+					 "current_setting('output_plugin_libraries', true), %s), ',')) name",
+					 quote_literal_cstr(outputPlugin),
+					 quote_literal_cstr(outputPlugin));
+
+	PGresult *result = NULL;
+	int queryResult = ExecuteOptionalRemoteCommand(connection, command->data, &result);
+
+	if (queryResult != RESPONSE_OKAY || !IsResponseOK(result) || PQntuples(result) != 1)
+	{
+		ReportResultError(connection, result, ERROR);
+	}
+
+	char *allowedPlugins = "";
+	if (!PQgetisnull(result, 0, 0))
+	{
+		allowedPlugins = pstrdup(PQgetvalue(result, 0, 0));
+	}
+
+	bool isAllowed = (strcmp(PQgetvalue(result, 0, 1), "t") == 0);
+
+	PQclear(result);
+	ForgetResults(connection);
+
+	if (isAllowed)
+	{
+		return;
+	}
+
+	StringInfo newValue = makeStringInfo();
+	if (allowedPlugins[0] != '\0')
+	{
+		appendStringInfo(newValue, "%s, ", allowedPlugins);
+	}
+	appendStringInfoString(newValue, outputPlugin);
+
+	ereport(ERROR, (errmsg("output plugin \"%s\" is not allowed on the source node",
+						   outputPlugin),
+					errdetail("Non-blocking shard splits replicate data with the \"%s\" "
+							  "logical decoding output plugin, but PostgreSQL on node "
+							  "%s:%d only allows the plugins listed in "
+							  "\"output_plugin_libraries\", which is set to \"%s\".",
+							  outputPlugin, connection->hostname, connection->port,
+							  allowedPlugins),
+					errhint("Allow the plugin on every node and reload the "
+							"configuration, for example: ALTER SYSTEM SET "
+							"output_plugin_libraries = %s; SELECT pg_reload_conf();",
+							newValue->data)));
+}
+
 
 /*
  * SplitShard API to split a given shard (or shard group) in non-blocking fashion
@@ -1422,6 +1493,12 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 		superUser,
 		databaseName);
 	ClaimConnectionExclusively(sourceConnection);
+
+	/*
+	 * Fail before creating any shards, publications or replication slots if
+	 * the source node does not allow our output plugin.
+	 */
+	ErrorIfOutputPluginNotAllowed(sourceConnection, CITUS_SPLIT_DECODER_PLUGIN);
 
 	MultiConnection *sourceReplicationConnection =
 		GetReplicationConnection(sourceShardToCopyNode->workerName,
@@ -1493,7 +1570,7 @@ NonBlockingShardSplit(SplitOperation splitOperation,
 		groupedLogicalRepTargetsHash,
 		superUser, databaseName);
 
-	char *logicalRepDecoderPlugin = "citus";
+	char *logicalRepDecoderPlugin = CITUS_SPLIT_DECODER_PLUGIN;
 
 	/*
 	 * 6) Create replication slots and keep track of their snapshot.

--- a/src/test/cdc/t/cdctestlib.pm
+++ b/src/test/cdc/t/cdctestlib.pm
@@ -142,6 +142,16 @@ max_wal_senders = 100
 max_replication_slots = 100
 ";
     $node->init(allows_streaming => 'logical');
+
+    # PostgreSQL 14.24, 15.19, 16.15, 17.11 and 18.6 restrict logical decoding
+    # to the output plugins listed in output_plugin_libraries. Setting an
+    # unknown GUC is fatal, so only set it when initdb wrote it out.
+    if (open(my $conf_fh, '<', $node->data_dir . "/postgresql.conf")) {
+        $citus_config_options = $citus_config_options .
+            "\noutput_plugin_libraries = 'pgoutput, test_decoding, wal2json, citus'"
+            if grep { /output_plugin_libraries/ } <$conf_fh>;
+        close($conf_fh);
+    }
     if ($node_type == $NODE_TYPE_COORDINATOR || $node_type == $NODE_TYPE_WORKER) {
         $node->append_conf("postgresql.conf",$citus_config_options);
     } else {

--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -239,6 +239,12 @@ check-split: all
 	$(pg_regress_multi_check) --load-extension=citus \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/split_schedule $(EXTRA_TESTS)
 
+# Runs the split negative test against a cluster that deliberately does not
+# allow the "citus" output plugin in "output_plugin_libraries".
+check-split-output-plugin-denied: all
+	CITUS_TEST_SKIP_OUTPUT_PLUGIN_ALLOWLIST=1 $(pg_regress_multi_check) --load-extension=citus \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/split_output_plugin_denied_schedule $(EXTRA_TESTS)
+
 check-failure: all
 	$(pg_regress_multi_check) --load-extension=citus --mitmproxy \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/failure_schedule $(EXTRA_TESTS)

--- a/src/test/regress/expected/multi_follower_dml.out
+++ b/src/test/regress/expected/multi_follower_dml.out
@@ -227,26 +227,18 @@ COPY the_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 COPY the_replicated_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 COPY reference_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 -- all multi-shard modifications require 2PC hence not supported
 INSERT INTO the_table (a, b, z) VALUES (2, 3, 4), (5, 6, 7);
 ERROR:  cannot assign TransactionIds during recovery
@@ -299,20 +291,14 @@ COPY the_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 COPY reference_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 SELECT * FROM the_table ORDER BY a;
  a | b | z
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_multiuser_copy.out
+++ b/src/test/regress/expected/multi_multiuser_copy.out
@@ -25,27 +25,16 @@ COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 -- COPY FROM as user with ALL access
 SET ROLE full_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
-;
 RESET ROLE;
 -- COPY FROM as user with SELECT access, should fail
 SET ROLE read_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 ERROR:  permission denied for table customer_copy_hash
-3	customer3
-\.
-invalid command \.
-;
-ERROR:  syntax error at or near "3"
 RESET ROLE;
 -- COPY FROM as user with no access, should fail
 SET ROLE no_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 ERROR:  permission denied for table customer_copy_hash
-4	customer4
-\.
-invalid command \.
-;
-ERROR:  syntax error at or near "4"
 RESET ROLE;
 -- COPY TO as superuser
 COPY (SELECT * FROM customer_copy_hash ORDER BY 1) TO STDOUT;

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -85,15 +85,12 @@ select create_distributed_table('cptest', 'id');
 
 copy cptest from STDIN with csv where val < 4;
 ERROR:  Citus does not support COPY FROM with WHERE
-1,6
-2,3
-3,2
-4,9
-5,4
-\.
-invalid command \.
 select sum(id), sum(val) from cptest;
-ERROR:  syntax error at or near "1"
+ sum | sum
+---------------------------------------------------------------------
+     |
+(1 row)
+
 -- CTE materialized/not materialized
 CREATE TABLE single_hash_repartition_first (id int, sum int, avg float);
 CREATE TABLE single_hash_repartition_second (id int primary key, sum int, avg float);

--- a/src/test/regress/expected/pg16_0.out
+++ b/src/test/regress/expected/pg16_0.out
@@ -8,12 +8,12 @@ SELECT substring(:'server_version', '\d+')::int >= 16 AS server_version_ge_16
 -- behavior is same among PG versions, error message differs
 -- relevant PG16 commits: d84a6c3dad1 and f30c04682cd
 CREATE STATISTICS tst ON a FROM (VALUES (x)) AS foo;
-ERROR:  only a single relation is allowed in CREATE STATISTICS
+ERROR:  CREATE STATISTICS only supports relation names in the FROM clause
 CREATE FUNCTION tftest(int) returns table(a int, b int) as $$
 SELECT $1, $1+i FROM generate_series(1,5) g(i);
 $$ LANGUAGE sql IMMUTABLE STRICT;
 CREATE STATISTICS alt_stat2 ON a FROM tftest(1);
-ERROR:  only a single relation is allowed in CREATE STATISTICS
+ERROR:  CREATE STATISTICS only supports relation names in the FROM clause
 DROP FUNCTION tftest;
 \if :server_version_ge_16
 \else

--- a/src/test/regress/expected/replicated_partitioned_table.out
+++ b/src/test/regress/expected/replicated_partitioned_table.out
@@ -126,8 +126,6 @@ HINT:  Run the query on the parent table "collections" instead.
 COPY collections_1 FROM STDIN;
 ERROR:  modifications on partitions when replication factor is greater than 1 is not supported
 HINT:  Run the query on the parent table "collections" instead.
-\.
-invalid command \.
 -- DDLs are not allowed
 CREATE INDEX index_on_partition ON collections_1(key);
 ERROR:  modifications on partitions when replication factor is greater than 1 is not supported

--- a/src/test/regress/expected/split_output_plugin_denied.out
+++ b/src/test/regress/expected/split_output_plugin_denied.out
@@ -48,4 +48,4 @@ SELECT run_command_on_workers($$SELECT count(*) FROM pg_publication$$);
 (2 rows)
 
 DROP SCHEMA split_output_plugin_denied CASCADE;
-NOTICE:  drop cascades to table split_output_plugin_denied.table_to_split
+NOTICE:  drop cascades to table table_to_split

--- a/src/test/regress/expected/split_output_plugin_denied.out
+++ b/src/test/regress/expected/split_output_plugin_denied.out
@@ -1,0 +1,51 @@
+-- Negative coverage for the "output_plugin_libraries" allowlist that PostgreSQL
+-- 14.24, 15.19, 16.15, 17.11 and 18.6 introduced. This test is only run by the
+-- check-split-output-plugin-denied target, which deliberately starts the cluster
+-- without adding "citus" to the allowlist.
+CREATE SCHEMA split_output_plugin_denied;
+SET search_path TO split_output_plugin_denied;
+SET citus.shard_count TO 2;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 8990000;
+CREATE TABLE table_to_split (id bigint PRIMARY KEY, value char);
+SELECT create_distributed_table('table_to_split', 'id');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
+SELECT nodeid AS worker_2_node FROM pg_dist_node WHERE nodeport=:worker_2_port \gset
+-- The split must be rejected up front. Terse verbosity keeps the node address
+-- and the current allowlist value out of the expected output.
+\set VERBOSITY terse
+SELECT citus_split_shard_by_split_points(
+	8990000,
+	ARRAY['-1073741826'],
+	ARRAY[:worker_1_node, :worker_2_node],
+	'force_logical');
+ERROR:  output plugin "citus" is not allowed on the source node
+\set VERBOSITY default
+-- Nothing must have been created before the split was rejected.
+SELECT count(*) FROM pg_dist_shard WHERE logicalrelid = 'table_to_split'::regclass;
+ count
+---------------------------------------------------------------------
+     2
+(1 row)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_replication_slots$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_publication$$);
+ run_command_on_workers
+---------------------------------------------------------------------
+ (localhost,57637,t,0)
+ (localhost,57638,t,0)
+(2 rows)
+
+DROP SCHEMA split_output_plugin_denied CASCADE;
+NOTICE:  drop cascades to table split_output_plugin_denied.table_to_split

--- a/src/test/regress/pg_regress_multi.pl
+++ b/src/test/regress/pg_regress_multi.pl
@@ -454,6 +454,19 @@ push(@pgOptions, "log_error_verbosity = 'verbose'");
 # Allow CREATE SUBSCRIPTION to work
 push(@pgOptions, "wal_level='logical'");
 
+# PostgreSQL 14.24, 15.19, 16.15, 17.11 and 18.6 restrict logical decoding to
+# the output plugins listed in output_plugin_libraries. Citus uses "citus" for
+# non-blocking shard splits and "wal2json" in some CDC tests. Setting an unknown
+# GUC is fatal, so only set it when the installed PostgreSQL knows about it.
+if (!$ENV{CITUS_TEST_SKIP_OUTPUT_PLUGIN_ALLOWLIST} &&
+	open(my $confSample, '<', catfile($sharedir, "postgresql.conf.sample")))
+{
+	push(@pgOptions,
+		 "output_plugin_libraries='pgoutput, test_decoding, wal2json, citus'")
+		if grep { /output_plugin_libraries/ } <$confSample>;
+	close($confSample);
+}
+
 # Faster logical replication status update so tests with logical replication
 # run faster
 push(@pgOptions, "wal_receiver_status_interval=0");

--- a/src/test/regress/split_output_plugin_denied_schedule
+++ b/src/test/regress/split_output_plugin_denied_schedule
@@ -1,0 +1,8 @@
+# Verifies that a non-blocking shard split fails with an actionable error when
+# the "citus" logical decoding output plugin is not allowed by PostgreSQL.
+# Include tests from 'split_schedule' for setup.
+test: multi_test_helpers multi_test_helpers_superuser
+test: multi_cluster_management
+test: remove_coordinator_from_metadata
+test: multi_test_catalog_views
+test: split_output_plugin_denied

--- a/src/test/regress/sql/failure_copy_on_hash.sql
+++ b/src/test/regress/sql/failure_copy_on_hash.sql
@@ -142,6 +142,7 @@ SELECT create_distributed_table('test_table_2','id');
 SELECT citus.mitmproxy('conn.kill()');
 
 \COPY test_table_2 FROM stdin delimiter ',';
+\.
 
 SELECT citus.mitmproxy('conn.allow()');
 SELECT pds.logicalrelid, pdsd.shardid, pdsd.shardstate

--- a/src/test/regress/sql/failure_copy_to_reference.sql
+++ b/src/test/regress/sql/failure_copy_to_reference.sql
@@ -25,6 +25,7 @@ CREATE VIEW unhealthy_shard_count AS
 -- response we get from the worker
 SELECT citus.mitmproxy('conn.kill()');
 \copy test_table FROM STDIN DELIMITER ','
+\.
 SELECT citus.mitmproxy('conn.allow()');
 SELECT * FROM unhealthy_shard_count;
 SELECT count(*) FROM test_table;
@@ -32,6 +33,7 @@ SELECT count(*) FROM test_table;
 -- kill as soon as the coordinator sends begin
 SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED").kill()');
 \copy test_table FROM STDIN DELIMITER ','
+\.
 SELECT citus.mitmproxy('conn.allow()');
 SELECT * FROM unhealthy_shard_count;
 SELECT count(*) FROM test_table;
@@ -39,6 +41,7 @@ SELECT count(*) FROM test_table;
 -- cancel as soon as the coordinator sends begin
 SELECT citus.mitmproxy('conn.onQuery(query="^BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED").cancel(' ||  pg_backend_pid() || ')');
 \copy test_table FROM STDIN DELIMITER ','
+\.
 SELECT citus.mitmproxy('conn.allow()');
 SELECT * FROM unhealthy_shard_count;
 SELECT count(*) FROM test_table;

--- a/src/test/regress/sql/multi_copy.sql
+++ b/src/test/regress/sql/multi_copy.sql
@@ -38,6 +38,7 @@ notinteger,customernot
 
 -- Test invalid option
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN (append_to_shard 1);
+\.
 
 -- Confirm that no data was copied
 SELECT count(*) FROM customer_copy_hash;
@@ -592,6 +593,7 @@ ALTER USER test_user WITH nologin;
 
 -- reissue copy, and it should fail
 COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
+\.
 
 -- verify shards in the none of the workers as marked invalid
 SELECT shardid, shardstate, nodename, nodeport
@@ -600,6 +602,7 @@ SELECT shardid, shardstate, nodename, nodeport
 
 -- try to insert into a reference table copy should fail
 COPY numbers_reference FROM STDIN WITH (FORMAT 'csv');
+\.
 
 -- verify shards for reference table are still valid
 SELECT shardid, shardstate, nodename, nodeport
@@ -611,6 +614,7 @@ SELECT shardid, shardstate, nodename, nodeport
 -- since it can not insert into either copies of a shard. shards are expected to
 -- stay valid since the operation is rolled back.
 COPY numbers_hash_other FROM STDIN WITH (FORMAT 'csv');
+\.
 
 -- verify shards for numbers_hash_other are still valid
 -- since copy has failed altogether

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -996,6 +996,7 @@ COMMIT;
 
 BEGIN;
 COPY reference_failure_test FROM STDIN WITH (FORMAT 'csv');
+\.
 COMMIT;
 
 -- show that no data go through the table and shard states are good
@@ -1016,6 +1017,7 @@ ORDER BY s.logicalrelid, sp.shardstate;
 -- any failure rollbacks the transaction
 BEGIN;
 COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\.
 ABORT;
 
 -- none of placements are invalid after abort
@@ -1036,6 +1038,7 @@ ORDER BY shardid, nodeport;
 -- all failures roll back the transaction
 BEGIN;
 COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\.
 COMMIT;
 
 -- expect none of the placements to be market invalid after commit

--- a/src/test/regress/sql/multi_multiuser_copy.sql
+++ b/src/test/regress/sql/multi_multiuser_copy.sql
@@ -27,7 +27,6 @@ SET ROLE full_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 2	customer2
 \.
-;
 RESET ROLE;
 
 -- COPY FROM as user with SELECT access, should fail
@@ -35,7 +34,6 @@ SET ROLE read_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 3	customer3
 \.
-;
 RESET ROLE;
 
 -- COPY FROM as user with no access, should fail
@@ -43,7 +41,6 @@ SET ROLE no_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 4	customer4
 \.
-;
 RESET ROLE;
 
 

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -279,19 +279,25 @@ TRUNCATE copy_default;
 
 -- DEFAULT cannot be used in binary mode
 COPY copy_default FROM stdin WITH (format binary, default '\D');
+\.
 
 -- DEFAULT cannot be new line nor carriage return
 COPY copy_default FROM stdin WITH (default E'\n');
+\.
 COPY copy_default FROM stdin WITH (default E'\r');
+\.
 
 -- DELIMITER cannot appear in DEFAULT spec
 COPY copy_default FROM stdin WITH (delimiter ';', default 'test;test');
+\.
 
 -- CSV quote cannot appear in DEFAULT spec
 COPY copy_default FROM stdin WITH (format csv, quote '"', default 'test"test');
+\.
 
 -- NULL and DEFAULT spec must be different
 COPY copy_default FROM stdin WITH (default '\N');
+\.
 
 -- cannot use DEFAULT marker in column that has no DEFAULT value
 COPY copy_default FROM stdin WITH (default '\D');

--- a/src/test/regress/sql/split_output_plugin_denied.sql
+++ b/src/test/regress/sql/split_output_plugin_denied.sql
@@ -1,0 +1,27 @@
+-- Negative coverage for the "output_plugin_libraries" allowlist that PostgreSQL
+-- 14.24, 15.19, 16.15, 17.11 and 18.6 introduced. This test is only run by the
+-- check-split-output-plugin-denied target, which deliberately starts the cluster
+-- without adding "citus" to the allowlist.
+CREATE SCHEMA split_output_plugin_denied;
+SET search_path TO split_output_plugin_denied;
+SET citus.shard_count TO 2;
+SET citus.shard_replication_factor TO 1;
+SET citus.next_shard_id TO 8990000;
+CREATE TABLE table_to_split (id bigint PRIMARY KEY, value char);
+SELECT create_distributed_table('table_to_split', 'id');
+SELECT nodeid AS worker_1_node FROM pg_dist_node WHERE nodeport=:worker_1_port \gset
+SELECT nodeid AS worker_2_node FROM pg_dist_node WHERE nodeport=:worker_2_port \gset
+-- The split must be rejected up front. Terse verbosity keeps the node address
+-- and the current allowlist value out of the expected output.
+\set VERBOSITY terse
+SELECT citus_split_shard_by_split_points(
+	8990000,
+	ARRAY['-1073741826'],
+	ARRAY[:worker_1_node, :worker_2_node],
+	'force_logical');
+\set VERBOSITY default
+-- Nothing must have been created before the split was rejected.
+SELECT count(*) FROM pg_dist_shard WHERE logicalrelid = 'table_to_split'::regclass;
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_replication_slots$$);
+SELECT run_command_on_workers($$SELECT count(*) FROM pg_publication$$);
+DROP SCHEMA split_output_plugin_denied CASCADE;


### PR DESCRIPTION
Validation PR for the-process [#243](https://github.com/citusdata/the-process/pull/243). Repoints CI at the freshly built dev images carrying the new PostgreSQL minors published 2026-08-14/15.

| | before | after |
|---|---|---|
| PG14 | 14.19 | 14.24 |
| PG15 | 15.14 | 15.19 |
| PG16 | 16.13 | 16.15 |

`image_suffix`: `-dev-b63fad9`

**The PG14/PG15 un-pin experiment succeeded.** PG14/PG15 were previously pinned at 14.19/15.14 because the May-2026 minor set crashed PostgreSQL's vanilla `select_parallel` regression test. `check-vanilla` is green on PG14, PG15 and PG16 with the August set, so the crash is fixed upstream and the pin can be dropped.

---

## Fallout from the new minors

Validation surfaced two independent PostgreSQL security changes in this minor set that break Citus.

### 1. psql `COPY FROM STDIN` (fixed here)

When a `COPY` fails early, the new psql silently swallows every line up to and including the next `\.`. Tests that relied on the old behaviour were adjusted: a terminating `\.` was added where one was missing, stray statements after a swallowed block were removed, and expected output was trimmed for the lines that no longer execute.

### 2. `output_plugin_libraries` (fixed here)

PostgreSQL 14.24, 15.19, 16.15, 17.11 and 18.6 add an `output_plugin_libraries` GUC. Only the libraries it lists may be used as logical decoding output plugins. It defaults to `pgoutput, test_decoding` and is `superuser`-settable, so it takes a reload rather than a restart.

**Upgrade note for operators.** Citus uses an output plugin named `citus` for logical replication during non-blocking shard splits. On these minors the following fail until the plugin is allowed:

* `citus_split_shard_by_split_points(..., 'force_logical')` and `'auto'`
* `create_distributed_table_concurrently()`
* `citus_isolate_tenant_to_new_shard(..., 'force_logical'` / `'auto')`

Shard **moves** and the rebalancer are unaffected -- they use `pgoutput`. CDC through the `pgoutput` shim is unaffected; CDC through `wal2json` needs the same treatment, exactly as it does on vanilla PostgreSQL.

Remediation, on **every** node:

```sql
ALTER SYSTEM SET output_plugin_libraries = pgoutput, test_decoding, citus;
SELECT pg_reload_conf();
```

The GUC is `GUC_LIST_QUOTE`, so quoting the whole list (`'pgoutput, test_decoding, citus'`) stores it as a single name and does **not** work. Use the bare list above, or quote each element individually.

This PR does not work around the restriction -- allowing a decoder is deliberately an operator action. Instead Citus now **fails fast and clearly**: a preflight check runs against the source node before any shards, publications or replication slots are created, and raises an error naming the plugin, the node, the current allowlist value, and a ready-to-paste `ALTER SYSTEM` hint.

### Testing

The regression and CDC harnesses start their own clusters, so in CI *we* are the operator: `pg_regress_multi.pl` and `cdctestlib.pm` now write the allowlist themselves, guarded by a probe of `postgresql.conf.sample` so they stay compatible with older minors where the GUC does not exist.

To keep the un-remediated path covered, a new `check-split-output-plugin-denied` job deliberately skips that override (via `CITUS_TEST_SKIP_OUTPUT_PLUGIN_ALLOWLIST=1`) and asserts that a non-blocking split fails with the new error and leaks no shards, publications or replication slots.

---

**Draft:** these are `-dev-` images. Do not merge until the-process [#243](https://github.com/citusdata/the-process/pull/243) is merged and this PR is repointed at the new dev suffix that merge produces. (The 12.1 line in the-process is not a `release-*` branch, so it emits `-dev-` images rather than `-v` ones.)