### PR TITLE
PG19 Beta3: adapt COPY regressions to psql input draining

### DIFF
--- a/src/test/regress/expected/multi_copy.out
+++ b/src/test/regress/expected/multi_copy.out
@@ -41,7 +41,7 @@ COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 ERROR:  invalid input syntax for type integer: "1,customer1"
 CONTEXT:  COPY customer_copy_hash, line 1, column c_custkey: "1,customer1"
 -- Test invalid option
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN (append_to_shard xxxxx);
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true' (append_to_shard xxxxx)
 ERROR:  append_to_shard is only valid for append-distributed tables
 -- Confirm that no data was copied
 SELECT count(*) FROM customer_copy_hash;
@@ -738,7 +738,7 @@ SET citus.enable_metadata_sync TO off;
 ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 -- reissue copy, and it should fail
-COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
 -- verify shards in the none of the workers as marked invalid
 SELECT shardid, shardstate, nodename, nodeport
@@ -757,7 +757,7 @@ SELECT shardid, shardstate, nodename, nodeport
 (8 rows)
 
 -- try to insert into a reference table copy should fail
-COPY numbers_reference FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_reference FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
 -- verify shards for reference table are still valid
 SELECT shardid, shardstate, nodename, nodeport
@@ -773,7 +773,7 @@ SELECT shardid, shardstate, nodename, nodeport
 -- try to insert into numbers_hash_other. copy should fail and rollback
 -- since it can not insert into either copies of a shard. shards are expected to
 -- stay valid since the operation is rolled back.
-COPY numbers_hash_other FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_other FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" is not permitted to log in
 -- verify shards for numbers_hash_other are still valid
 -- since copy has failed altogether

--- a/src/test/regress/expected/multi_follower_dml.out
+++ b/src/test/regress/expected/multi_follower_dml.out
@@ -223,30 +223,22 @@ ERROR:  cannot execute modification on a hot standby for a shard placement that 
 DETAIL:  citus.writable_standby_coordinator forwards writes to primary nodes, but the targeted shard has a placement on the local node, whose storage is read-only during recovery.
 HINT:  Place the affected shards on primary worker nodes only, or fail over this node to perform writes.
 -- COPY is not possible because Citus user 2PC
-COPY the_table (a, b, z) FROM STDIN WITH CSV;
+\copy the_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
-COPY the_replicated_table (a, b, z) FROM STDIN WITH CSV;
+\copy the_replicated_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
-COPY reference_table (a, b, z) FROM STDIN WITH CSV;
+\copy reference_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
-COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
+\copy citus_local_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 -- all multi-shard modifications require 2PC hence not supported
 INSERT INTO the_table (a, b, z) VALUES (2, 3, 4), (5, 6, 7);
 ERROR:  cannot assign TransactionIds during recovery
@@ -295,24 +287,18 @@ ERROR:  cannot execute modification on a hot standby for a shard placement that 
 DETAIL:  citus.writable_standby_coordinator forwards writes to primary nodes, but the targeted shard has a placement on the local node, whose storage is read-only during recovery.
 HINT:  Place the affected shards on primary worker nodes only, or fail over this node to perform writes.
 -- multi-shard COPY is not possible due to 2PC
-COPY the_table (a, b, z) FROM STDIN WITH CSV;
+\copy the_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
-COPY reference_table (a, b, z) FROM STDIN WITH CSV;
+\copy reference_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  writing to worker nodes is not currently allowed for replicated tables such as reference tables or hash distributed tables with replication factor greater than 1.
 DETAIL:  the database is read-only
 HINT:  All modifications to replicated tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
-COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
+\copy citus_local_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 ERROR:  COPY command to Citus tables is not allowed in read-only mode
 DETAIL:  the database is read-only
 HINT:  All COPY commands to citus tables happen via 2PC, and 2PC requires the database to be in a writable state.
-\.
-invalid command \.
 SELECT * FROM the_table ORDER BY a;
  a | b | z
 ---------------------------------------------------------------------

--- a/src/test/regress/expected/multi_modifying_xacts.out
+++ b/src/test/regress/expected/multi_modifying_xacts.out
@@ -1215,7 +1215,7 @@ INSERT INTO reference_failure_test VALUES (1, '1');
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 COMMIT;
 BEGIN;
-COPY reference_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy reference_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 COMMIT;
 -- show that no data go through the table and shard states are good
@@ -1241,7 +1241,7 @@ ORDER BY s.logicalrelid, sp.shardstate;
 
 -- any failure rollbacks the transaction
 BEGIN;
-COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 ABORT;
 -- none of placements are invalid after abort
@@ -1289,7 +1289,7 @@ ORDER BY shardid, nodeport;
 
 -- all failures roll back the transaction
 BEGIN;
-COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ERROR:  connection to the remote node test_user@localhost:xxxxx failed with the following error: FATAL:  role "test_user" does not exist
 COMMIT;
 -- expect none of the placements to be market invalid after commit

--- a/src/test/regress/expected/multi_multiuser_copy.out
+++ b/src/test/regress/expected/multi_multiuser_copy.out
@@ -25,27 +25,16 @@ COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 -- COPY FROM as user with ALL access
 SET ROLE full_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
-;
 RESET ROLE;
 -- COPY FROM as user with SELECT access, should fail
 SET ROLE read_access;
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true'
 ERROR:  permission denied for table customer_copy_hash
-3	customer3
-\.
-invalid command \.
-;
-ERROR:  syntax error at or near "3"
 RESET ROLE;
 -- COPY FROM as user with no access, should fail
 SET ROLE no_access;
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true'
 ERROR:  permission denied for table customer_copy_hash
-4	customer4
-\.
-invalid command \.
-;
-ERROR:  syntax error at or near "4"
 RESET ROLE;
 -- COPY TO as superuser
 COPY (SELECT * FROM customer_copy_hash ORDER BY 1) TO STDOUT;

--- a/src/test/regress/expected/pg12.out
+++ b/src/test/regress/expected/pg12.out
@@ -86,17 +86,14 @@ select create_distributed_table('cptest', 'id');
 
 (1 row)
 
-copy cptest from STDIN with csv where val < 4;
+\copy cptest from PROGRAM 'true' with csv where val < 4
 ERROR:  Citus does not support COPY FROM with WHERE
-1,6
-2,3
-3,2
-4,9
-5,4
-\.
-invalid command \.
 select sum(id), sum(val) from cptest;
-ERROR:  syntax error at or near "1"
+ sum | sum
+---------------------------------------------------------------------
+     |
+(1 row)
+
 -- CTE materialized/not materialized
 CREATE TABLE single_hash_repartition_first (id int, sum int, avg float);
 CREATE TABLE single_hash_repartition_second (id int primary key, sum int, avg float);

--- a/src/test/regress/expected/pg16.out
+++ b/src/test/regress/expected/pg16.out
@@ -481,21 +481,21 @@ SELECT * FROM copy_default ORDER BY id;
 
 TRUNCATE copy_default;
 -- DEFAULT cannot be used in binary mode
-COPY copy_default FROM stdin WITH (format binary, default '\D');
+\copy copy_default FROM PROGRAM 'true' WITH (format binary, default '\D')
 ERROR:  cannot specify DEFAULT in BINARY mode
 -- DEFAULT cannot be new line nor carriage return
-COPY copy_default FROM stdin WITH (default E'\n');
+\copy copy_default FROM PROGRAM 'true' WITH (default E'\n')
 ERROR:  COPY default representation cannot use newline or carriage return
-COPY copy_default FROM stdin WITH (default E'\r');
+\copy copy_default FROM PROGRAM 'true' WITH (default E'\r')
 ERROR:  COPY default representation cannot use newline or carriage return
 -- DELIMITER cannot appear in DEFAULT spec
-COPY copy_default FROM stdin WITH (delimiter ';', default 'test;test');
+\copy copy_default FROM PROGRAM 'true' WITH (delimiter ';', default 'test;test')
 ERROR:  COPY delimiter character must not appear in the DEFAULT specification
 -- CSV quote cannot appear in DEFAULT spec
-COPY copy_default FROM stdin WITH (format csv, quote '"', default 'test"test');
+\copy copy_default FROM PROGRAM 'true' WITH (format csv, quote '"', default 'test"test')
 ERROR:  CSV quote character must not appear in the DEFAULT specification
 -- NULL and DEFAULT spec must be different
-COPY copy_default FROM stdin WITH (default '\N');
+\copy copy_default FROM PROGRAM 'true' WITH (default '\N')
 ERROR:  NULL specification and DEFAULT specification cannot be the same
 -- cannot use DEFAULT marker in column that has no DEFAULT value
 COPY copy_default FROM stdin WITH (default '\D');

--- a/src/test/regress/expected/pg17.out
+++ b/src/test/regress/expected/pg17.out
@@ -1496,15 +1496,15 @@ SELECT create_distributed_table('check_ign_err', 'n');
 
 (1 row)
 
-COPY check_ign_err FROM STDIN WITH (on_error stop);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error stop)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (ON_ERROR ignore);
+\copy check_ign_err FROM PROGRAM 'true' WITH (ON_ERROR ignore)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (on_error ignore, log_verbosity verbose);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error ignore, log_verbosity verbose)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (log_verbosity verbose, on_error ignore);
+\copy check_ign_err FROM PROGRAM 'true' WITH (log_verbosity verbose, on_error ignore)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (log_verbosity verbose);
+\copy check_ign_err FROM PROGRAM 'true' WITH (log_verbosity verbose)
 ERROR:  Citus does not support COPY FROM with LOG_VERBOSITY option.
 -- End of Test for COPY ON_ERROR option
 -- Test FORCE_NOT_NULL and FORCE_NULL options

--- a/src/test/regress/expected/pg18.out
+++ b/src/test/regress/expected/pg18.out
@@ -1047,16 +1047,16 @@ SELECT create_distributed_table('check_ign_err', 'n');
 
 (1 row)
 
-COPY check_ign_err FROM STDIN WITH (on_error stop, reject_limit 5);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error stop, reject_limit 5)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (ON_ERROR ignore, REJECT_LIMIT 100);
+\copy check_ign_err FROM PROGRAM 'true' WITH (ON_ERROR ignore, REJECT_LIMIT 100)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (on_error ignore, log_verbosity verbose, reject_limit 50);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error ignore, log_verbosity verbose, reject_limit 50)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
-COPY check_ign_err FROM STDIN WITH (reject_limt 77, log_verbosity verbose, on_error ignore);
+\copy check_ign_err FROM PROGRAM 'true' WITH (reject_limt 77, log_verbosity verbose, on_error ignore)
 ERROR:  Citus does not support COPY FROM with ON_ERROR option.
 -- PG requires on_error when reject_limit is specified
-COPY check_ign_err FROM STDIN WITH (reject_limit 100);
+\copy check_ign_err FROM PROGRAM 'true' WITH (reject_limit 100)
 ERROR:  COPY REJECT_LIMIT requires ON_ERROR to be set to IGNORE
 -- PG18 Feature: COPY TABLE TO on a materialized view
 -- PG18 commit: https://github.com/postgres/postgres/commit/534874fac

--- a/src/test/regress/expected/replicated_partitioned_table.out
+++ b/src/test/regress/expected/replicated_partitioned_table.out
@@ -123,11 +123,9 @@ INSERT INTO collections_1 SELECT * FROM collections_1 OFFSET 0;
 ERROR:  modifications on partitions when replication factor is greater than 1 is not supported
 HINT:  Run the query on the parent table "collections" instead.
 -- COPY is not allowed
-COPY collections_1 FROM STDIN;
+\copy collections_1 FROM PROGRAM 'true'
 ERROR:  modifications on partitions when replication factor is greater than 1 is not supported
 HINT:  Run the query on the parent table "collections" instead.
-\.
-invalid command \.
 -- DDLs are not allowed
 CREATE INDEX index_on_partition ON collections_1(key);
 ERROR:  modifications on partitions when replication factor is greater than 1 is not supported

--- a/src/test/regress/sql/multi_copy.sql
+++ b/src/test/regress/sql/multi_copy.sql
@@ -47,7 +47,7 @@ notinteger,customernot
 \.
 
 -- Test invalid option
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN (append_to_shard 1);
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true' (append_to_shard 1)
 
 -- Confirm that no data was copied
 SELECT count(*) FROM customer_copy_hash;
@@ -601,7 +601,7 @@ ALTER USER test_user WITH nologin;
 \c - test_user - :master_port
 
 -- reissue copy, and it should fail
-COPY numbers_hash FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash FROM PROGRAM 'true' WITH (FORMAT 'csv')
 
 -- verify shards in the none of the workers as marked invalid
 SELECT shardid, shardstate, nodename, nodeport
@@ -609,7 +609,7 @@ SELECT shardid, shardstate, nodename, nodeport
 	WHERE logicalrelid = 'numbers_hash'::regclass order by shardid, nodeport;
 
 -- try to insert into a reference table copy should fail
-COPY numbers_reference FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_reference FROM PROGRAM 'true' WITH (FORMAT 'csv')
 
 -- verify shards for reference table are still valid
 SELECT shardid, shardstate, nodename, nodeport
@@ -620,7 +620,7 @@ SELECT shardid, shardstate, nodename, nodeport
 -- try to insert into numbers_hash_other. copy should fail and rollback
 -- since it can not insert into either copies of a shard. shards are expected to
 -- stay valid since the operation is rolled back.
-COPY numbers_hash_other FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_other FROM PROGRAM 'true' WITH (FORMAT 'csv')
 
 -- verify shards for numbers_hash_other are still valid
 -- since copy has failed altogether

--- a/src/test/regress/sql/multi_follower_dml.sql
+++ b/src/test/regress/sql/multi_follower_dml.sql
@@ -91,14 +91,10 @@ INSERT INTO reference_table (a, b, z) VALUES (2, 3, 4), (5, 6, 7);
 INSERT INTO citus_local_table (a, b, z) VALUES (2, 3, 4), (5, 6, 7);
 
 -- COPY is not possible because Citus user 2PC
-COPY the_table (a, b, z) FROM STDIN WITH CSV;
-\.
-COPY the_replicated_table (a, b, z) FROM STDIN WITH CSV;
-\.
-COPY reference_table (a, b, z) FROM STDIN WITH CSV;
-\.
-COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
-\.
+\copy the_table (a, b, z) FROM PROGRAM 'true' WITH CSV
+\copy the_replicated_table (a, b, z) FROM PROGRAM 'true' WITH CSV
+\copy reference_table (a, b, z) FROM PROGRAM 'true' WITH CSV
+\copy citus_local_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 
 -- all multi-shard modifications require 2PC hence not supported
 INSERT INTO the_table (a, b, z) VALUES (2, 3, 4), (5, 6, 7);
@@ -123,12 +119,9 @@ WITH del AS (DELETE FROM citus_local_table RETURNING *)
 SELECT * FROM del ORDER BY a;
 
 -- multi-shard COPY is not possible due to 2PC
-COPY the_table (a, b, z) FROM STDIN WITH CSV;
-\.
-COPY reference_table (a, b, z) FROM STDIN WITH CSV;
-\.
-COPY citus_local_table (a, b, z) FROM STDIN WITH CSV;
-\.
+\copy the_table (a, b, z) FROM PROGRAM 'true' WITH CSV
+\copy reference_table (a, b, z) FROM PROGRAM 'true' WITH CSV
+\copy citus_local_table (a, b, z) FROM PROGRAM 'true' WITH CSV
 SELECT * FROM the_table ORDER BY a;
 SELECT * FROM reference_table ORDER BY a;
 SELECT * FROM citus_local_table ORDER BY a;

--- a/src/test/regress/sql/multi_modifying_xacts.sql
+++ b/src/test/regress/sql/multi_modifying_xacts.sql
@@ -997,7 +997,7 @@ INSERT INTO reference_failure_test VALUES (1, '1');
 COMMIT;
 
 BEGIN;
-COPY reference_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy reference_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 COMMIT;
 
 -- show that no data go through the table and shard states are good
@@ -1017,7 +1017,7 @@ ORDER BY s.logicalrelid, sp.shardstate;
 
 -- any failure rollbacks the transaction
 BEGIN;
-COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 ABORT;
 
 -- none of placements are invalid after abort
@@ -1037,7 +1037,7 @@ ORDER BY shardid, nodeport;
 
 -- all failures roll back the transaction
 BEGIN;
-COPY numbers_hash_failure_test FROM STDIN WITH (FORMAT 'csv');
+\copy numbers_hash_failure_test FROM PROGRAM 'true' WITH (FORMAT 'csv')
 COMMIT;
 
 -- expect none of the placements to be market invalid after commit

--- a/src/test/regress/sql/multi_multiuser_copy.sql
+++ b/src/test/regress/sql/multi_multiuser_copy.sql
@@ -27,23 +27,16 @@ SET ROLE full_access;
 COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
 2	customer2
 \.
-;
 RESET ROLE;
 
 -- COPY FROM as user with SELECT access, should fail
 SET ROLE read_access;
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
-3	customer3
-\.
-;
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true'
 RESET ROLE;
 
 -- COPY FROM as user with no access, should fail
 SET ROLE no_access;
-COPY customer_copy_hash (c_custkey,c_name) FROM STDIN;
-4	customer4
-\.
-;
+\copy customer_copy_hash (c_custkey,c_name) FROM PROGRAM 'true'
 RESET ROLE;
 
 

--- a/src/test/regress/sql/pg12.sql
+++ b/src/test/regress/sql/pg12.sql
@@ -49,13 +49,7 @@ vacuum (index_cleanup 1) gen1;
 -- COPY FROM
 create table cptest (id int, val int);
 select create_distributed_table('cptest', 'id');
-copy cptest from STDIN with csv where val < 4;
-1,6
-2,3
-3,2
-4,9
-5,4
-\.
+\copy cptest from PROGRAM 'true' with csv where val < 4
 select sum(id), sum(val) from cptest;
 
 -- CTE materialized/not materialized

--- a/src/test/regress/sql/pg16.sql
+++ b/src/test/regress/sql/pg16.sql
@@ -258,20 +258,20 @@ SELECT * FROM copy_default ORDER BY id;
 TRUNCATE copy_default;
 
 -- DEFAULT cannot be used in binary mode
-COPY copy_default FROM stdin WITH (format binary, default '\D');
+\copy copy_default FROM PROGRAM 'true' WITH (format binary, default '\D')
 
 -- DEFAULT cannot be new line nor carriage return
-COPY copy_default FROM stdin WITH (default E'\n');
-COPY copy_default FROM stdin WITH (default E'\r');
+\copy copy_default FROM PROGRAM 'true' WITH (default E'\n')
+\copy copy_default FROM PROGRAM 'true' WITH (default E'\r')
 
 -- DELIMITER cannot appear in DEFAULT spec
-COPY copy_default FROM stdin WITH (delimiter ';', default 'test;test');
+\copy copy_default FROM PROGRAM 'true' WITH (delimiter ';', default 'test;test')
 
 -- CSV quote cannot appear in DEFAULT spec
-COPY copy_default FROM stdin WITH (format csv, quote '"', default 'test"test');
+\copy copy_default FROM PROGRAM 'true' WITH (format csv, quote '"', default 'test"test')
 
 -- NULL and DEFAULT spec must be different
-COPY copy_default FROM stdin WITH (default '\N');
+\copy copy_default FROM PROGRAM 'true' WITH (default '\N')
 
 -- cannot use DEFAULT marker in column that has no DEFAULT value
 COPY copy_default FROM stdin WITH (default '\D');

--- a/src/test/regress/sql/pg17.sql
+++ b/src/test/regress/sql/pg17.sql
@@ -844,11 +844,11 @@ ALTER INDEX tbl_idx ALTER COLUMN 2 SET STATISTICS -1;
 CREATE TABLE check_ign_err (n int, m int[], k int);
 SELECT create_distributed_table('check_ign_err', 'n');
 
-COPY check_ign_err FROM STDIN WITH (on_error stop);
-COPY check_ign_err FROM STDIN WITH (ON_ERROR ignore);
-COPY check_ign_err FROM STDIN WITH (on_error ignore, log_verbosity verbose);
-COPY check_ign_err FROM STDIN WITH (log_verbosity verbose, on_error ignore);
-COPY check_ign_err FROM STDIN WITH (log_verbosity verbose);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error stop)
+\copy check_ign_err FROM PROGRAM 'true' WITH (ON_ERROR ignore)
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error ignore, log_verbosity verbose)
+\copy check_ign_err FROM PROGRAM 'true' WITH (log_verbosity verbose, on_error ignore)
+\copy check_ign_err FROM PROGRAM 'true' WITH (log_verbosity verbose)
 
 -- End of Test for COPY ON_ERROR option
 

--- a/src/test/regress/sql/pg18.sql
+++ b/src/test/regress/sql/pg18.sql
@@ -612,12 +612,12 @@ INSERT INTO temporal_fk_rng2rng VALUES
 CREATE TABLE check_ign_err (n int, m int[], k int);
 SELECT create_distributed_table('check_ign_err', 'n');
 
-COPY check_ign_err FROM STDIN WITH (on_error stop, reject_limit 5);
-COPY check_ign_err FROM STDIN WITH (ON_ERROR ignore, REJECT_LIMIT 100);
-COPY check_ign_err FROM STDIN WITH (on_error ignore, log_verbosity verbose, reject_limit 50);
-COPY check_ign_err FROM STDIN WITH (reject_limt 77, log_verbosity verbose, on_error ignore);
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error stop, reject_limit 5)
+\copy check_ign_err FROM PROGRAM 'true' WITH (ON_ERROR ignore, REJECT_LIMIT 100)
+\copy check_ign_err FROM PROGRAM 'true' WITH (on_error ignore, log_verbosity verbose, reject_limit 50)
+\copy check_ign_err FROM PROGRAM 'true' WITH (reject_limt 77, log_verbosity verbose, on_error ignore)
 -- PG requires on_error when reject_limit is specified
-COPY check_ign_err FROM STDIN WITH (reject_limit 100);
+\copy check_ign_err FROM PROGRAM 'true' WITH (reject_limit 100)
 
 -- PG18 Feature: COPY TABLE TO on a materialized view
 -- PG18 commit: https://github.com/postgres/postgres/commit/534874fac

--- a/src/test/regress/sql/replicated_partitioned_table.sql
+++ b/src/test/regress/sql/replicated_partitioned_table.sql
@@ -94,8 +94,7 @@ INSERT INTO collections_1 SELECT * FROM collections_1;
 INSERT INTO collections_1 SELECT * FROM collections_1 OFFSET 0;
 
 -- COPY is not allowed
-COPY collections_1 FROM STDIN;
-\.
+\copy collections_1 FROM PROGRAM 'true'
 
 -- DDLs are not allowed
 CREATE INDEX index_on_partition ON collections_1(key);


### PR DESCRIPTION
## Summary

PostgreSQL 19 Beta3 psql commit `d6ab88d` changed how input is drained after a server-side COPY command is rejected before entering COPY_IN. The affected regression scripts could consequently consume following SQL as COPY data or desynchronize.

This clean-room rebuild:

- fixes all 34 COPY sites proven by pristine PG19 Beta3 schedule output to reject before COPY_IN
- uses unconditional zero-row client input via `\copy ... FROM PROGRAM 'true'` while preserving each server-side COPY command, error, and downstream assertion
- preserves the successful data-bearing `multi_multiuser_copy` COPY commands and their `customer1` / `customer2` rows unchanged
- removes only the independently proven redundant standalone `;` after the successful `full_access` COPY
- uses canonical harness-generated expected output only: no psql version probes, COPY-specific `\if` gates, or new alternative expected files
- changes 18 files with 73 insertions and 124 deletions

The distinct nested child-psql case was split into #8793 and merged into `pg19-support` through #8795. The current base also includes the follower topology fix merged to `main` through #8796 and then normally merged into `pg19-support`.

## Affected schedules

- `check-multi`
- `check-multi-1`
- `check-multi-1-create-citus`
- `check-enterprise`
- `check-follower-cluster`

## Validation

The exact clean-room patch was built and exercised in isolated WSL roots against PostgreSQL 19 Beta3, 19 Beta2, 18.4, 17.10, and 16.14.

| PostgreSQL | `check-multi` | `check-multi-1` | `check-multi-1-create-citus` | `check-enterprise` | `check-follower-cluster` |
|---|---:|---:|---:|---:|---:|
| 19 Beta3 | 194/194 | 211/211 | 35/35 | 33/33 | 8/8 |
| 19 Beta2 | 194/194 | 211/211 | 35/35 | 33/33 | 8/8 |
| 18.4 | 194/194 | 211/211 | 35/35 | 33/33 | 8/8 |
| 17.10 | 194/194 | 211/211 | 35/35 | 33/33 | 8/8 |
| 16.14 | 194/194 | 211/211 | 35/35 | 33/33 | 8/8 |

- all 34 changed commands retain canonical ECHO=all coverage
- no new expected-output alternatives are introduced
- style, expected-output normalization, diff checks, clean-root checks, and reserved-port cleanup pass
- stable COPY patch ID: `31e51d9a48b6ca0e7ca7f3ee095188ba572cad5e`

Closes #8781