### PR TITLE
Fix whole schedule line dependencies

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -73,6 +73,8 @@ def parse_arguments():
 
 
 class TestDeps:
+    # None means this test requires no prerequisite setup schedule. Other tests
+    # on the same schedule line can still require one.
     schedule: Optional[str]
     direct_extra_tests: list[str]
 
@@ -566,10 +568,7 @@ def merge_test_dependencies(dependencies):
     )
 
     if len(schedules) > 1:
-        compatible_schedule_families = (
-            ("minimal_schedule", "base_schedule"),
-            ("mx_minimal_schedule", "mx_base_schedule"),
-        )
+        compatible_schedule_families = (("minimal_schedule", "base_schedule"),)
         for schedule_family in compatible_schedule_families:
             if set(schedules).issubset(schedule_family):
                 schedules = [

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -512,6 +512,18 @@ def find_test_schedule_and_line(test_name, args):
 
 
 def test_dependencies(test_name, test_schedule, schedule_line, args):
+    if args["use_whole_schedule_line"]:
+        test_names = schedule_line.split()[1:]
+        dependencies = [
+            single_test_dependencies(name, test_schedule, schedule_line, args)
+            for name in test_names
+        ]
+        return merge_test_dependencies(dependencies)
+
+    return single_test_dependencies(test_name, test_schedule, schedule_line, args)
+
+
+def single_test_dependencies(test_name, test_schedule, schedule_line, args):
     if test_name in DEPS:
         return DEPS[test_name]
 
@@ -542,6 +554,50 @@ def test_dependencies(test_name, test_schedule, schedule_line, args):
         repeatable = True
 
     return TestDeps(default_base_schedule(test_schedule, args), repeatable=repeatable)
+
+
+def merge_test_dependencies(dependencies):
+    schedules = list(
+        OrderedDict.fromkeys(
+            dependency.schedule
+            for dependency in dependencies
+            if dependency.schedule is not None
+        )
+    )
+
+    if len(schedules) > 1:
+        compatible_schedule_families = (
+            ("minimal_schedule", "base_schedule"),
+            ("mx_minimal_schedule", "mx_base_schedule"),
+        )
+        for schedule_family in compatible_schedule_families:
+            if set(schedules).issubset(schedule_family):
+                schedules = [
+                    schedule
+                    for schedule in reversed(schedule_family)
+                    if schedule in schedules
+                ]
+                break
+        else:
+            raise Exception(
+                f"Tests on the same schedule line require incompatible setup schedules: "
+                f"{', '.join(schedules)}"
+            )
+
+    extra_tests = OrderedDict()
+    for dependency in dependencies:
+        for extra_test in dependency.direct_extra_tests:
+            extra_tests[extra_test] = True
+
+    return TestDeps(
+        schedules[0] if schedules else None,
+        list(extra_tests.keys()),
+        repeatable=all(dependency.repeatable for dependency in dependencies),
+        worker_count=max(dependency.worker_count for dependency in dependencies),
+        citus_upgrade_infra=any(
+            dependency.citus_upgrade_infra for dependency in dependencies
+        ),
+    )
 
 
 # Returns true if given test_schedule_line is of the form:
@@ -582,7 +638,7 @@ def tmp_schedule(test_name, dependencies, schedule_line, args):
 
 
 def needed_worker_count(test_name, dependencies):
-    worker_count = worker_count_for(test_name)
+    worker_count = max(worker_count_for(test_name), dependencies.worker_count)
     for dependency in dependencies.extra_tests():
         worker_count = max(worker_count_for(dependency), worker_count)
     return worker_count

--- a/src/test/regress/citus_tests/test/test_run_test.py
+++ b/src/test/regress/citus_tests/test/test_run_test.py
@@ -27,6 +27,7 @@ def test_whole_schedule_line_merges_dependencies():
 
 def test_merged_dependencies_include_all_requirements():
     dependencies = [
+        Dependencies(None),
         Dependencies("minimal_schedule", ["first_setup"], worker_count=3),
         Dependencies(
             "base_schedule",

--- a/src/test/regress/citus_tests/test/test_run_test.py
+++ b/src/test/regress/citus_tests/test/test_run_test.py
@@ -1,0 +1,44 @@
+from run_test import TestDeps as Dependencies
+from run_test import merge_test_dependencies, needed_worker_count
+from run_test import test_dependencies as get_test_dependencies
+
+
+def test_whole_schedule_line_merges_dependencies():
+    args = {
+        "use_base_schedule": False,
+        "use_whole_schedule_line": False,
+    }
+    schedule_line = (
+        "test: multi_deparse_shard_query multi_distributed_transaction_id "
+        "intermediate_results limit_intermediate_size\n"
+    )
+
+    dependencies = get_test_dependencies(
+        "intermediate_results", "multi_schedule", schedule_line, args
+    )
+    assert dependencies.schedule == "minimal_schedule"
+
+    args["use_whole_schedule_line"] = True
+    dependencies = get_test_dependencies(
+        "intermediate_results", "multi_schedule", schedule_line, args
+    )
+    assert dependencies.schedule == "base_schedule"
+
+
+def test_merged_dependencies_include_all_requirements():
+    dependencies = [
+        Dependencies("minimal_schedule", ["first_setup"], worker_count=3),
+        Dependencies(
+            "base_schedule",
+            ["second_setup"],
+            repeatable=False,
+            worker_count=5,
+        ),
+    ]
+
+    merged_dependencies = merge_test_dependencies(dependencies)
+
+    assert merged_dependencies.schedule == "base_schedule"
+    assert merged_dependencies.direct_extra_tests == ["first_setup", "second_setup"]
+    assert not merged_dependencies.repeatable
+    assert needed_worker_count("unconfigured_test", merged_dependencies) == 5


### PR DESCRIPTION
Fix flakiness detector dependencies for whole schedule lines

## Root cause

`run_test.py` selected dependencies only for the initially requested test, even when `--use-whole-schedule-line` executed every test on the selected schedule line.

In `multi_schedule`, `intermediate_results` shares a line with `limit_intermediate_size`. The former defaults to `minimal_schedule`, while the latter explicitly requires `base_schedule`. Selecting `intermediate_results` therefore omitted the base setup that creates `users_table` and `events_table`, causing all flakiness shards to fail with missing-relation errors before reaching the expected size-limit checks.

## Fix

When whole-line mode is active, resolve and merge dependency requirements for every test on the selected line. This honors stronger setup schedules, explicit extra tests, repeatability constraints, worker counts, and upgrade-infrastructure requirements. Incompatible setup schedule families fail closed.

## Validation

- Reproduced pre-fix selection as `minimal_schedule`.
- Confirmed post-fix selection as `base_schedule`.
- Confirmed the generated schedule starts with `base_schedule` and contains eight whole-line repetitions.
- Focused pytest coverage passes (`2 passed`).
- Black, isort, flake8, and compileall checks pass.
- Dependency merging succeeds across all 701 existing schedule lines.

## Backports

The latent harness pattern also exists on `pg19-support`, `release-14.0`, and `release-13.2`. After this lands on `main`, backports to the supported release branches are recommended; `pg19-support` should take the main fix if it remains independently active.

Closes #8786