### PR TITLE
Fix flaky single_node_enterprise multi-shard connection race

### DIFF
--- a/src/test/regress/expected/single_node_enterprise.out
+++ b/src/test/regress/expected/single_node_enterprise.out
@@ -459,6 +459,9 @@ SELECT * FROM view_created_before_shard_moves;
 
 -- and make sure that all the shards are remote
 BEGIN;
+	-- pin the pool size, otherwise the executor may open extra connections
+	-- for the multi-shard command below, making the output non-deterministic
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
 NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');

--- a/src/test/regress/sql/single_node_enterprise.sql
+++ b/src/test/regress/sql/single_node_enterprise.sql
@@ -292,6 +292,9 @@ SELECT * FROM view_created_before_shard_moves;
 
 -- and make sure that all the shards are remote
 BEGIN;
+	-- pin the pool size, otherwise the executor may open extra connections
+	-- for the multi-shard command below, making the output non-deterministic
+	SET LOCAL citus.max_adaptive_executor_pool_size TO 1;
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
 	INSERT INTO test(x,y) VALUES (102,100);


### PR DESCRIPTION
`single_node_enterprise` asserts on the exact set of `NOTICE: issuing ...` lines produced by a
6-shard multi-shard SELECT. That output is racy by design.

## Why

`CalculateNewConnectionCount()` (`adaptive_executor.c:2734`) decides on the executor's first cycle to
open 3 additional connections beyond the first:

- `maxNewConnectionCount = targetPoolSize - initiatedConnectionCount` (`:2772`)
- `newConnectionsForReadyTasks = Max(0, readyTaskCount - usableConnectionCount)` (`:2781`)
- the slow-start cap at `:2784` is inside `if (ExecutorSlowStartInterval != SLOW_START_DISABLED)`, and
  the regression harness sets `citus.executor_slow_start_interval = 0ms`
  (`pg_regress_multi.pl:641`), so it is skipped
- `Min(4, 3) = 3` at `:2794`
- the cost guard at `:2843` cannot fire on the first cycle

So **3 extra connections are started on every run, including every green one.** The decision is
deterministic; what is not deterministic is whether any of those connections completes TCP connect
plus authentication before the 6 very small sequential queries have already drained. When one wins,
its `BEGIN` is emitted into the notice stream and the diff appears.

Because there is exactly one *last* task, a winning connection can insert its `BEGIN` in exactly one
place — which is why every observed failure diff is byte-identical. That is the signature of this
race, not evidence against one.

## Fix

Pin `citus.max_adaptive_executor_pool_size` to 1 for the duration of the block, so no extra
connection is ever started and the notice stream is fully determined.

**+6/−0, zero deletions.** The zero-deletion count is the load-bearing verification: if pinning the
pool had altered execution in any way, existing `NOTICE: issuing ...` lines would have had to change.
They did not. No baseline was re-recorded to make this pass.

The test occupies its own `test:` line in both `enterprise_minimal_schedule` and
`enterprise_schedule`, and there is no parallel-schedule variant, so only external load can win the
race — consistent with it being seen on shared CI runners and rarely locally.

## History

This has been failing intermittently for two years. #7671 reports it with the identical hunk header
`@@ -465,28 +465,30 @@`, and #8348 lists it as item 2 of the unstable-test tracker.

Fixes #7671
Refs #8348 (unstable test list, item 2)
Refs #8776
