### PR TITLE
Make rebalance colocation-group representative selection deterministic

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -2016,6 +2016,13 @@ NonColocatedDistRelationIdList(void)
 	List *allCitusTablesList = CitusTableTypeIdList(ANY_CITUS_TABLE_TYPE);
 	Oid tableId = InvalidOid;
 
+	/*
+	 * CitusTableTypeIdList scans pg_dist_partition unordered, so the first-wins
+	 * de-duplication below would pick an arbitrary representative per colocation
+	 * group. Sort by oid to keep the rebalance plan reproducible.
+	 */
+	list_sort(allCitusTablesList, list_oid_cmp);
+
 	/* allocate sufficient capacity for O(1) expected look-up time */
 	int capacity = (int) (list_length(allCitusTablesList) / 0.75) + 1;
 	int flags = HASH_ELEM | HASH_CONTEXT | HASH_BLOBS;


### PR DESCRIPTION
This is a **product defect**, not a test flake. It was found via a nightly `background_rebalance_parallel_reference_tables`
failure, but the test was reporting the bug correctly.

## Root cause

`NonColocatedDistRelationIdList()` (`shard_rebalancer.c:2013-2058`) builds its list from
`CitusTableTypeIdList()` and then keeps the **first** table seen per `colocationId` (the dedup
`continue` at `:2050`).

`CitusTableTypeIdList()` scans `pg_dist_partition` with an **unordered** `systable_beginscan`
(`metadata_cache.c:5078-5080`). So the representative table for each colocation group is whichever
tuple physical order happens to yield — it can change after a HOT update, a vacuum, or any other
storage-level churn, with no schema or data change at all.

Two consequences:

1. The representative relation name is printed in `DEBUG1` output.
2. The shard IDs emitted in the rebalance plan are those of whichever table won.

The second is the serious one, and it also exposes the sibling test `background_rebalance_parallel`,
which is only shielded from the first because it never raises `client_min_messages` to `DEBUG1`. That
ruled out a test-only fix.

## Reproduced on demand

Two arms on a fresh 3-node cluster with a forced HOT update on `pg_dist_partition`, differing only in
the installed library (verified binary-identical to the intended build at both ends of each arm):

| Library | representative before churn | after churn |
|---|---|---|
| Unpatched | `table1_colg1` | **`table2_colg1`** ← bug reproduces |
| Patched | `table1_colg1` | **`table1_colg1`** ← fixed |

Measured OIDs: `17320 table1_colg1` < `17326 table2_colg1`.

## Fix

Sort by OID before the de-duplication. Lowest OID is creation order, which is exactly what the
existing committed baselines already assert — so this converts an incidental property into a
guaranteed one rather than changing behaviour.

The sort is in-place on a list built fresh per call, and needs no new `#include`.

## Validation

- Full `check-operations` — **17/17 pass**, with the installed library MD5-verified against the build
  tree both before and after the run.
- **Zero expected-output churn.** `git status --porcelain -- src/test/regress/` is empty; no `.out` and
  no `.sql` file is touched by this PR. That is the actual evidence this is a real fix and not
  test-shaping.
- Six-call-site audit of `NonColocatedDistRelationIdList()` consumers (`:1138`, `:1179`, `:1334`,
  `:1445`, `:3787`, `:4051`) — all clean; none depends on the previous arbitrary order.

## Deliberately not changed

`CitusTableTypeIdList()` in `metadata_cache.c` is left unordered. Sorting at the source would impose
cost on every caller; the rebalancer is the one that needs the ordering guarantee.

Refs #8776
