### PR TITLE
Only cancel the distributed transaction that was found deadlocked

### DIFF
--- a/src/backend/distributed/transaction/backend_data.c
+++ b/src/backend/distributed/transaction/backend_data.c
@@ -1214,7 +1214,7 @@ GetBackendDataForProc(PGPROC *proc, BackendData *result)
  * data with this information.
  */
 void
-CancelTransactionDueToDeadlock(PGPROC *proc)
+CancelTransactionDueToDeadlock(PGPROC *proc, DistributedTransactionId *transactionId)
 {
 	BackendData *backendData = &backendManagementShmemData->backends[getProcNo_compat(
 																		 proc)];
@@ -1227,8 +1227,29 @@ CancelTransactionDueToDeadlock(PGPROC *proc)
 
 	SpinLockAcquire(&backendData->mutex);
 
-	/* send a SIGINT only if the process is still in a distributed transaction */
-	if (backendData->transactionId.transactionNumber != 0)
+	DistributedTransactionId *backendXactId = &backendData->transactionId;
+
+	/*
+	 * Send a SIGINT only if the backend is still running the very distributed
+	 * transaction that we found to be part of the deadlock. The caller walks the
+	 * whole deadlock cycle to pick a victim after it looks the backend up, so the
+	 * backend may have finished that transaction and started an unrelated one in
+	 * between, and cancelling that one would be wrong.
+	 *
+	 * The initiator node has to be compared as well, because transaction numbers are
+	 * only unique per node. A transaction initiated on another node can therefore
+	 * share a number with a local one, and
+	 * AssociateDistributedTransactionWithBackendProc() matches on the number alone.
+	 *
+	 * The timestamp is not compared, even though DistributedTransactionIdCompare()
+	 * does consider it. That comparison sorts ids gathered from all nodes, whereas
+	 * we only compare against a single live backend: its transaction numbers come
+	 * from a monotonic counter, so a new transaction on it necessarily has a
+	 * different number, and reusing one requires a restart, which invalidates
+	 * this proc.
+	 */
+	if (backendXactId->transactionNumber == transactionId->transactionNumber &&
+		backendXactId->initiatorNodeIdentifier == transactionId->initiatorNodeIdentifier)
 	{
 		backendData->cancelledDueToDeadlock = true;
 		SpinLockRelease(&backendData->mutex);

--- a/src/backend/distributed/transaction/distributed_deadlock_detection.c
+++ b/src/backend/distributed/transaction/distributed_deadlock_detection.c
@@ -208,7 +208,8 @@ CheckForDistributedDeadlocks(void)
 			/* we found the deadlock and its associated proc exists */
 			if (youngestAliveTransaction)
 			{
-				CancelTransactionDueToDeadlock(youngestAliveTransaction->initiatorProc);
+				CancelTransactionDueToDeadlock(youngestAliveTransaction->initiatorProc,
+											   &youngestAliveTransaction->transactionId);
 				LogCancellingBackend(youngestAliveTransaction);
 
 				hash_seq_term(&status);

--- a/src/include/distributed/backend_data.h
+++ b/src/include/distributed/backend_data.h
@@ -66,7 +66,8 @@ extern uint64 ExtractGlobalPID(const char *applicationName);
 extern int ExtractNodeIdFromGlobalPID(uint64 globalPID, bool missingOk);
 extern int ExtractProcessIdFromGlobalPID(uint64 globalPID);
 extern void GetBackendDataForProc(PGPROC *proc, BackendData *result);
-extern void CancelTransactionDueToDeadlock(PGPROC *proc);
+extern void CancelTransactionDueToDeadlock(PGPROC *proc,
+										   DistributedTransactionId *transactionId);
 extern bool MyBackendGotCancelledDueToDeadlock(bool clearState);
 extern List * ActiveDistributedTransactionNumbers(void);
 extern LocalTransactionId GetMyProcLocalTransactionId(void);


### PR DESCRIPTION
This is a **product defect** in the distributed deadlock detector. It was found while investigating a
nightly `statement_cancel_error_message` failure, but see the honest framing at the bottom — it is
**not** proven to be the cause of that failure.

## The defect

`CheckForDistributedDeadlocks` associates graph nodes with live backends and then SIGINTs the victim.
Association matches on the **transaction number alone**
(`distributed_deadlock_detection.c:398-402`); the initiating node is never compared. The `Assert` at
`:411` checks the *live backend's* initiator field, which was bound from that same backend at
`:396-397`, so it is structurally incapable of catching a graph-node/live-backend mismatch.

The old cancel-side guard only checked `transactionNumber != 0`. Two ways that is insufficient:

- **(a) TOCTOU.** The victim's distributed transaction can change between association at `:183` and
  the `kill()` at `:211`, so the SIGINT lands on a different transaction than the one found
  deadlocked.
- **(b) Cross-node transaction-number collision.** `nextTransactionNumber` is initialised to `1`
  **per node** (`backend_data.c:564`) and bumped locally (`:862`). Every node's counter starts at 1,
  so a transaction initiated on node 1 can be matched to a same-numbered *local* transaction and
  SIGINT an innocent backend.

## Fix

The cancel path now verifies both the transaction number **and** the initiating node — i.e. it
enforces at cancel time the invariant that association should already guarantee but does not.

**3 files, +28/−5.** No test file and no expected output is touched by this PR.

## Why this is safe to merge independently of causation

The change is **monotonic**: the new guard fires on a strict subset of the occasions the old one did,
so the rate of stray SIGINTs under this patch is less than or equal to the rate without it. It cannot
make any cancellation-related failure more likely. The proof is four short steps, all local:

1. The old guard is `backendData->transactionId.transactionNumber != 0`. That expression is
   character-for-character the body of `IsInDistributedTransaction()`
   (`lock_graph.c:974`).
2. The victim can only reach the `kill()` if
   `AssociateDistributedTransactionWithBackendProc()` returned true for it — non-associated nodes
   `continue` at `distributed_deadlock_detection.c:190`, and `youngestAliveTransaction` is
   assigned only after that filter (`:193-205`).
3. That function returns true only after passing `IsInDistributedTransaction()` at `:390` **and**
   transaction-number equality at `:398-402`. So the transaction id handed to the new guard always
   has a non-zero number.
4. The new guard requires `backendData` to carry *that same* non-zero number. Satisfying it
   therefore satisfies the old one automatically. New implies old; the converse does not hold.

The residual difference between the two is exactly the bug: the old test passes whenever the victim
holds *any* distributed transaction, so it accepts a victim that finished the deadlocked transaction
and began an unrelated one. The new test does not.

The cost of a false suppression is bounded and self-healing: the detector re-runs on the next cycle
and re-detects the same cycle, so the worst case is a delayed resolution rather than an orphaned
deadlock. Nothing is orphaned by the extra rejection in any case — the DFS starts only from the
node's own transactions (`distributed_deadlock_detection.c:146`), so a foreign node's deadlock is
resolved by that node's own detector.


## What is left open, deliberately

A third mechanism was found and is **reproduced but not fixed here**: the daemon can issue a second
SIGINT for a transaction that has not finished unwinding. Under an amplified detector, 14 of 20
iterations issued two SIGINTs to the same backend for the same transaction number about 1 ms apart.

It is left out of this PR because the obvious fix is wrong: skipping when the `cancelledDueToDeadlock`
flag is set does not work, because that flag is **cleared on read** by the error-message hook. It is
also pre-existing and, per the analysis below, benign in practice. It will be tracked separately.

## Honest framing

This closes two real mis-cancellation holes. It is **not** proven to be the cause of the PG16 nightly
failure in #8776, and both routes we proposed from this fix to that failure have since been refuted —
one by the shape of the detector code, one by PostgreSQL source. Recording both so they are not
re-derived:

1. **A pending cancel cannot leak across a statement boundary.** In PG16
   `src/backend/tcop/postgres.c`, `:3365` sets `QueryCancelPending = false` unconditionally at the top
   of the block, and `:3421` guards the generic error with `!DoingCommandRead`, commented *"If we are
   reading a command from the client, just ignore the cancel request."* This also explains why the
   repeat SIGINT above fired 14 times and converted zero times.
2. **Widening `deadlock_timeout` cannot expose the mis-cancellation.** A sweep over
   100 ms / 200 ms / 500 ms / 1 s produced 60 cancels, all correctly matched, zero mismatched. That
   null is structural, not a small sample: only an association-matched node reaches the `kill()` at
   `:211` (non-matches `continue` at `:190`), so a correct match is true *by construction*. The only
   route to a mismatch is the narrow window between `:183` and `:211`, which `deadlock_timeout` does
   not widen — it controls the interval *between* detector cycles.

Refs #8776

