### PR TITLE
Fix nested psql COPY on PostgreSQL 19

### DIFF
--- a/src/test/regress/expected/intermediate_results.out
+++ b/src/test/regress/expected/intermediate_results.out
@@ -240,7 +240,7 @@ END;
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM
-  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int); END;"$$
+  $$psql -h localhost -p 57636 -U postgres -d regression -1 -c "COPY squares FROM STDIN WITH (format result)" -c "CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int)"$$
 WITH (FORMAT text);
 SELECT * FROM squares ORDER BY x;
  x | x2

--- a/src/test/regress/sql/intermediate_results.sql
+++ b/src/test/regress/sql/intermediate_results.sql
@@ -127,7 +127,7 @@ END;
 -- pipe query output into a result file and create a table to check the result
 COPY (SELECT s, s*s FROM generate_series(1,5) s)
 TO PROGRAM
-  $$psql -h localhost -p 57636 -U postgres -d regression -c "BEGIN; COPY squares FROM STDIN WITH (format result); CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int); END;"$$
+  $$psql -h localhost -p 57636 -U postgres -d regression -1 -c "COPY squares FROM STDIN WITH (format result)" -c "CREATE TABLE intermediate_results.squares AS SELECT * FROM read_intermediate_result('squares', 'text') AS res(x int, x2 int)"$$
 WITH (FORMAT text);
 
 SELECT * FROM squares ORDER BY x;


### PR DESCRIPTION
DESCRIPTION: Fixes nested psql COPY transactions on PostgreSQL 19

Closes #8793.

PostgreSQL 19 Beta3 child psql exits 2 when one `-c` contains
`BEGIN; COPY ... FROM STDIN; CREATE TABLE ...; END;`. The outer
`COPY (...) TO PROGRAM` consequently fails and `squares` is absent.

This differs from #8781: that issue concerns draining inline COPY data after
startup rejection. Here COPY mode is entered, but Beta3 rejects the remaining
statements in the same `-c` after the COPY protocol exchange.

Invoke child psql unconditionally with `-1` and two `-c` arguments instead.
COPY still consumes stdin, CREATE TABLE runs in the same process, and `-1`
preserves transaction atomicity across supported PostgreSQL versions.

Validation:
- PostgreSQL 19 Beta3: focused 7/7; check-multi 191/194, with only the three
  unrelated COPY-draining failures fixed by #8785
- PostgreSQL 19 Beta2: focused 7/7; check-multi 194/194
- PostgreSQL 18.4: focused 7/7; check-multi 194/194
- PostgreSQL 17.10: focused 7/7; check-multi 194/194
- PostgreSQL 16.14: focused 7/7; check-multi 194/194