### PR TITLE
Fix follower topology in flaky test runner

### DIFF
--- a/src/test/regress/Makefile
+++ b/src/test/regress/Makefile
@@ -132,6 +132,10 @@ check-custom-schedule: all
 	$(pg_regress_multi_check) --load-extension=citus --worker-count=$(WORKERCOUNT) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
 
+check-follower-custom-schedule: all
+	$(pg_regress_multi_check) --load-extension=citus --follower-cluster --worker-count=$(WORKERCOUNT) \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
+
 check-failure-custom-schedule: all
 	$(pg_regress_multi_check) --load-extension=citus --mitmproxy --worker-count=$(WORKERCOUNT) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
@@ -142,6 +146,12 @@ check-isolation-custom-schedule: all  $(isolation_test_files)
 
 check-custom-schedule-vg: all
 	$(pg_regress_multi_check) --load-extension=citus \
+	--valgrind --pg_ctl-timeout=360 --connection-timeout=500000 --worker-count=$(WORKERCOUNT) \
+	--valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
+	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)
+
+check-follower-custom-schedule-vg: all
+	$(pg_regress_multi_check) --load-extension=citus --follower-cluster \
 	--valgrind --pg_ctl-timeout=360 --connection-timeout=500000 --worker-count=$(WORKERCOUNT) \
 	--valgrind-path=valgrind --valgrind-log-file=$(CITUS_VALGRIND_LOG_FILE) \
 	-- $(MULTI_REGRESS_OPTS) --schedule=$(citus_abs_srcdir)/$(SCHEDULE) $(EXTRA_TESTS)

--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -85,12 +85,14 @@ class TestDeps:
         repeatable=True,
         worker_count=2,
         citus_upgrade_infra=False,
+        follower_cluster=False,
     ):
         self.schedule = schedule
         self.direct_extra_tests = extra_tests or []
         self.repeatable = repeatable
         self.worker_count = worker_count
         self.citus_upgrade_infra = citus_upgrade_infra
+        self.follower_cluster = follower_cluster
 
     def extra_tests(self):
         all_deps = OrderedDict()
@@ -138,6 +140,11 @@ DEPS = {
     ),
     "multi_add_node_from_backup_sequences": TestDeps(
         None, ["multi_add_node_from_backup_negative"], worker_count=5, repeatable=False
+    ),
+    # Prepares coordinator metadata and registers follower workers as secondaries.
+    "multi_follower_dml": TestDeps(
+        None,
+        ["follower_single_node", "multi_follower_select_statements"],
     ),
     "single_node": TestDeps(None, ["multi_test_helpers"]),
     "single_node_truncate": TestDeps(None),
@@ -400,7 +407,9 @@ def run_schedule_with_multiregress(test_name, schedule, dependencies, args):
     worker_count = needed_worker_count(test_name, dependencies)
 
     # find suitable make recipe
-    if dependencies.schedule == "base_isolation_schedule" or test_name.startswith(
+    if dependencies.follower_cluster:
+        make_recipe = "check-follower-custom-schedule"
+    elif dependencies.schedule == "base_isolation_schedule" or test_name.startswith(
         "isolation"
     ):
         make_recipe = "check-isolation-custom-schedule"
@@ -433,6 +442,9 @@ def run_schedule_with_multiregress(test_name, schedule, dependencies, args):
 
 
 def default_base_schedule(test_schedule, args):
+    if test_schedule == "multi_follower_schedule":
+        return None
+
     if "isolation" in test_schedule:
         if "columnar" in test_schedule:
             # we don't have pre-requisites for columnar isolation tests
@@ -520,9 +532,15 @@ def test_dependencies(test_name, test_schedule, schedule_line, args):
             single_test_dependencies(name, test_schedule, schedule_line, args)
             for name in test_names
         ]
-        return merge_test_dependencies(dependencies)
+    else:
+        dependencies = [
+            single_test_dependencies(test_name, test_schedule, schedule_line, args)
+        ]
 
-    return single_test_dependencies(test_name, test_schedule, schedule_line, args)
+    if test_schedule == "multi_follower_schedule":
+        dependencies.append(TestDeps(None, follower_cluster=True))
+
+    return merge_test_dependencies(dependencies)
 
 
 def single_test_dependencies(test_name, test_schedule, schedule_line, args):
@@ -595,6 +613,9 @@ def merge_test_dependencies(dependencies):
         worker_count=max(dependency.worker_count for dependency in dependencies),
         citus_upgrade_infra=any(
             dependency.citus_upgrade_infra for dependency in dependencies
+        ),
+        follower_cluster=any(
+            dependency.follower_cluster for dependency in dependencies
         ),
     )
 

--- a/src/test/regress/citus_tests/test/test_run_test.py
+++ b/src/test/regress/citus_tests/test/test_run_test.py
@@ -1,5 +1,9 @@
 from run_test import TestDeps as Dependencies
-from run_test import merge_test_dependencies, needed_worker_count
+from run_test import (
+    merge_test_dependencies,
+    needed_worker_count,
+    run_schedule_with_multiregress,
+)
 from run_test import test_dependencies as get_test_dependencies
 
 
@@ -34,6 +38,7 @@ def test_merged_dependencies_include_all_requirements():
             ["second_setup"],
             repeatable=False,
             worker_count=5,
+            follower_cluster=True,
         ),
     ]
 
@@ -43,3 +48,34 @@ def test_merged_dependencies_include_all_requirements():
     assert merged_dependencies.direct_extra_tests == ["first_setup", "second_setup"]
     assert not merged_dependencies.repeatable
     assert needed_worker_count("unconfigured_test", merged_dependencies) == 5
+    assert merged_dependencies.follower_cluster
+
+
+def test_follower_schedule_selects_follower_custom_target(monkeypatch):
+    args = {
+        "use_base_schedule": False,
+        "use_whole_schedule_line": False,
+        "valgrind": False,
+    }
+    dependencies = get_test_dependencies(
+        "multi_follower_dml",
+        "multi_follower_schedule",
+        "test: multi_follower_dml\n",
+        args,
+    )
+    commands = []
+    monkeypatch.setattr("run_test.run", commands.append)
+
+    run_schedule_with_multiregress(
+        "multi_follower_dml", "tmp_schedule", dependencies, args
+    )
+
+    assert dependencies.follower_cluster
+    assert dependencies.schedule is None
+    assert dependencies.extra_tests() == [
+        "follower_single_node",
+        "multi_follower_select_statements",
+    ]
+    assert "check-follower-custom-schedule" in commands[0]
+    assert "WORKERCOUNT=2" in commands[0]
+    assert "SCHEDULE='tmp_schedule'" in commands[0]

--- a/src/test/regress/expected/multi_follower_dml.out
+++ b/src/test/regress/expected/multi_follower_dml.out
@@ -500,10 +500,12 @@ BEGIN;
 	LOCK TABLE local IN SHARE ROW EXCLUSIVE MODE;
 COMMIT;
 \c -reuse-previous=off regression - - :master_port
+DROP TABLE the_replicated_table;
 DROP TABLE the_table;
 DROP TABLE reference_table;
 DROP TABLE citus_local_table;
 DROP TABLE dist_on_coord;
+DROP TABLE local;
 SELECT master_remove_node('localhost', :master_port);
  master_remove_node
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/multi_follower_dml.sql
+++ b/src/test/regress/sql/multi_follower_dml.sql
@@ -216,8 +216,10 @@ BEGIN;
 COMMIT;
 
 \c -reuse-previous=off regression - - :master_port
+DROP TABLE the_replicated_table;
 DROP TABLE the_table;
 DROP TABLE reference_table;
 DROP TABLE citus_local_table;
 DROP TABLE dist_on_coord;
+DROP TABLE local;
 SELECT master_remove_node('localhost', :master_port);


### PR DESCRIPTION
Closes #8794.

This fixes follower-cluster regression tests in the flakiness runner by preserving their required topology instead of excluding them.

The bug has been latent since the flakiness runner was introduced in e2a73ad8 on 2022-12-12. Follower topology support already existed separately in `check-follower-cluster`, but `run_test.py` sent generated schedules through the generic `check-custom-schedule` target. The abandoned attempt in #7563 never merged, leaving follower tests without their coordinator/worker replicas, follower ports, and replication settings during flakiness runs.

The root fix models follower topology as a `TestDeps` requirement derived from `multi_follower_schedule`, preserves it when whole-line dependencies are merged, and selects a follower-aware custom-schedule target. It does not add a blanket exclusion.

The exact five-file change is:

- `src/test/regress/citus_tests/run_test.py`: model/merge follower topology, avoid the generic base schedule for follower tests, select the follower target, and prepare the focused prerequisite chain.
- `src/test/regress/citus_tests/test/test_run_test.py`: cover direct target selection and merged topology requirements.
- `src/test/regress/Makefile`: add regular and valgrind follower custom-schedule targets with `--follower-cluster`, worker count, and generated schedule.
- `src/test/regress/sql/multi_follower_dml.sql`: clean up two tables left by the test so repetition is valid.
- `src/test/regress/expected/multi_follower_dml.out`: match that cleanup.

Validation:

- Focused pytest: 3 passed.
- Black, isort, and flake8 passed for the touched Python files.
- PostgreSQL 18 WSL build/install validation under `/home/ihalatci/Development`.
- Actual `multi_follower_dml -r 5` run invoked `--follower-cluster --worker-count=2`, created the six-server topology, and passed 7/7 tests: two prerequisites plus five repetitions.

Backport to `release-14.0` and `release-13.2` only after this merges to `main`, validating each branch independently with its focused Python checks and repeated follower run.