### PR TITLE
Match SplitGUCList semantics when parsing output_plugin_libraries

### DIFF
--- a/src/backend/distributed/operations/shard_split.c
+++ b/src/backend/distributed/operations/shard_split.c
@@ -1385,9 +1385,12 @@ ErrorIfOutputPluginNotAllowed(MultiConnection *connection, char *outputPlugin)
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
 					 "SELECT current_setting('output_plugin_libraries', true), "
-					 "coalesce(bool_or(btrim(name, ' \"') = %s), false) "
-					 "FROM unnest(string_to_array(coalesce("
-					 "current_setting('output_plugin_libraries', true), %s), ',')) name",
+					 "coalesce(bool_or(CASE WHEN name LIKE '\"%%\"' THEN "
+					 "replace(substring(name, 2, length(name) - 2), '\"\"', '\"') "
+					 "ELSE name END = %s), false) "
+					 "FROM (SELECT btrim(elem, E' \\t\\n\\r\\f') AS name FROM unnest("
+					 "string_to_array(coalesce(current_setting("
+					 "'output_plugin_libraries', true), %s), ',')) elem) s",
 					 quote_literal_cstr(outputPlugin),
 					 quote_literal_cstr(outputPlugin));
 


### PR DESCRIPTION
DESCRIPTION: Match SplitGUCList semantics parsing output_plugin_libraries

Backport of the SQL tightening from #8777, addressing @onurctirtir's review
comment there.

### What was wrong

`ErrorIfOutputPluginNotAllowed()` parsed `output_plugin_libraries` with
`btrim(name, ' "')`, which strips spaces and double quotes from either end in
any combination. PostgreSQL's real parser is `SplitGUCList` (`guc.c`), which:

* splits on commas,
* trims **all** whitespace (space, `\t`, `\n`, `\r`, `\f`) from each element,
* removes the surrounding quotes **only** when an element is *fully* quoted,
  collapsing interior `""` to `"` and preserving interior whitespace.

The two disagreed in **both** directions:

| `output_plugin_libraries` | PostgreSQL | old SQL | consequence |
|---|---|---|---|
| `" citus "` | ` citus ` -> no match | `citus` -> match | **false positive**: preflight passes, the split fails later anyway |
| `pgoutput,<TAB>citus` | `citus` -> match | `<TAB>citus` -> no match | **false negative**: we block a split PostgreSQL would have allowed |

`current_setting()` does not normalize the tab away, so the false negative is
reachable.

### The fix

Trim `E' \t\n\r\f'` per element, then unwrap a fully-quoted element and
collapse doubled inner quotes -- i.e. exactly what `SplitGUCList` does.

```sql
coalesce(bool_or(CASE WHEN name LIKE '"%"' THEN
  replace(substring(name, 2, length(name) - 2), '""', '"')
  ELSE name END = 'citus'), false)
FROM (SELECT btrim(elem, E' \t\n\r\f') AS name
      FROM unnest(string_to_array(coalesce(
        current_setting('output_plugin_libraries', true), 'citus'), ',')) elem) s
```

Note `\v` is deliberately excluded: `scanner_isspace` does not treat it as
whitespace, so a POSIX `[[:space:]]` class would over-trim.

### Verification

The expression was extracted straight out of the compiled `appendStringInfo`
format string and run against PostgreSQL 16.15, using
`pg_create_logical_replication_slot` as ground truth. All probed cases agree,
including tab and newline separators, quoted elements with interior spaces, and
doubled inner quotes.

### Known, deliberate limitation

A comma *inside* a quoted element (`"a,b"`) still splits incorrectly, because
`string_to_array` is comma-blind. Unreachable for the name `citus`; left alone
to keep the change minimal.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>