### PR TITLE
Fix multiuser COPY flakiness setup

### DIFF
--- a/src/test/regress/citus_tests/run_test.py
+++ b/src/test/regress/citus_tests/run_test.py
@@ -253,6 +253,10 @@ DEPS = {
         ["multi_create_table", "multi_create_users", "multi_multiuser_load_data"],
         repeatable=False,
     ),
+    "multi_multiuser_copy": TestDeps(
+        "enterprise_minimal_schedule",
+        ["multi_create_table", "multi_create_users"],
+    ),
     "multi_prepare_plsql": TestDeps("base_schedule"),
     "multi_utility_statements": TestDeps("base_schedule"),
     "pg15": TestDeps("base_schedule"),

--- a/src/test/regress/citus_tests/test/test_run_test.py
+++ b/src/test/regress/citus_tests/test/test_run_test.py
@@ -5,6 +5,7 @@ from run_test import (
     run_schedule_with_multiregress,
 )
 from run_test import test_dependencies as get_test_dependencies
+from run_test import tmp_schedule
 
 
 def test_whole_schedule_line_merges_dependencies():
@@ -79,3 +80,51 @@ def test_follower_schedule_selects_follower_custom_target(monkeypatch):
     assert "check-follower-custom-schedule" in commands[0]
     assert "WORKERCOUNT=2" in commands[0]
     assert "SCHEDULE='tmp_schedule'" in commands[0]
+
+
+def test_multiuser_copy_uses_required_enterprise_setup():
+    args = {
+        "use_base_schedule": False,
+        "use_whole_schedule_line": True,
+    }
+    dependencies = get_test_dependencies(
+        "multi_multiuser_copy",
+        "enterprise_schedule",
+        "test: multi_multiuser_copy\n",
+        args,
+    )
+
+    assert dependencies.schedule == "enterprise_minimal_schedule"
+    assert dependencies.extra_tests() == ["multi_create_table", "multi_create_users"]
+    assert dependencies.repeatable
+
+
+def test_multiuser_copy_setup_precedes_repetitions(tmp_path, monkeypatch):
+    args = {
+        "use_base_schedule": False,
+        "use_whole_schedule_line": True,
+        "repeat": 8,
+    }
+    dependencies = get_test_dependencies(
+        "multi_multiuser_copy",
+        "enterprise_schedule",
+        "test: multi_multiuser_copy\n",
+        args,
+    )
+    monkeypatch.setattr("run_test.REGRESS_DIR", tmp_path)
+    (tmp_path / "enterprise_minimal_schedule").write_text("test: enterprise_setup\n")
+
+    with tmp_schedule(
+        "multi_multiuser_copy",
+        dependencies,
+        "test: multi_multiuser_copy\n",
+        args,
+    ) as schedule:
+        schedule_lines = (tmp_path / schedule).read_text().splitlines()
+
+    assert schedule_lines == [
+        "test: enterprise_setup",
+        "test: multi_create_table",
+        "test: multi_create_users",
+        *(["test: multi_multiuser_copy"] * 8),
+    ]

--- a/src/test/regress/citus_tests/test/test_run_test.py
+++ b/src/test/regress/citus_tests/test/test_run_test.py
@@ -5,7 +5,9 @@ from run_test import (
     run_schedule_with_multiregress,
 )
 from run_test import test_dependencies as get_test_dependencies
-from run_test import tmp_schedule
+from run_test import (
+    tmp_schedule,
+)
 
 
 def test_whole_schedule_line_merges_dependencies():

--- a/src/test/regress/expected/multi_multiuser_copy.out
+++ b/src/test/regress/expected/multi_multiuser_copy.out
@@ -1,6 +1,10 @@
 --
 -- MULTI_MULTIUSER_COPY
 --
+-- Make this test re-runnable within the same cluster.
+SET client_min_messages TO WARNING;
+DROP TABLE IF EXISTS customer_copy_hash;
+RESET client_min_messages;
 -- Create a new hash-partitioned table into which to COPY
 CREATE TABLE customer_copy_hash (
         c_custkey integer,

--- a/src/test/regress/sql/multi_multiuser_copy.sql
+++ b/src/test/regress/sql/multi_multiuser_copy.sql
@@ -2,6 +2,11 @@
 -- MULTI_MULTIUSER_COPY
 --
 
+-- Make this test re-runnable within the same cluster.
+SET client_min_messages TO WARNING;
+DROP TABLE IF EXISTS customer_copy_hash;
+RESET client_min_messages;
+
 -- Create a new hash-partitioned table into which to COPY
 CREATE TABLE customer_copy_hash (
         c_custkey integer,


### PR DESCRIPTION
## Summary

- add the missing enterprise setup dependencies for `multi_multiuser_copy`: `enterprise_minimal_schedule`, `multi_create_table`, and `multi_create_users`
- make repeated executions start clean by narrowly dropping `customer_copy_hash` at the start of the test while suppressing the expected first-run notice
- add focused dependency and schedule-order tests and update the canonical expected output

The flakiness runner previously reached `multi_multiuser_copy` without the required tables and `full_access`, `read_access`, and `no_access` roles. Repetitions also retained `customer_copy_hash` and its rows. No load-data prerequisite is needed by this test.

**Diff:** 4 files, 62 insertions.

## Validation

- `pytest -q citus_tests/test/test_run_test.py` — 5 passed
- Black, isort, and Flake8 — clean
- exact `run_test.py multi_multiuser_copy --repeat 8 --use-whole-schedule-line` — 8/8 repetitions passed
- normal enterprise regression schedule — 32/32 tests passed