### PR TITLE
Stabilize single-node remote command notices

### DIFF
--- a/src/test/regress/expected/single_node_enterprise.out
+++ b/src/test/regress/expected/single_node_enterprise.out
@@ -366,9 +366,9 @@ INSERT INTO ref SELECT i, i*2 FROM generate_series(100,150)i;
 -- the first insert goes to a shard on the worker
 -- the second insert goes to a shard on the coordinator
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
-NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730501 (x, y) VALUES (101, 100)
 	INSERT INTO test(x,y) VALUES (102,100);
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730502 (x, y) VALUES (102, 100)
@@ -386,13 +386,12 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM single_nod
 (1 row)
 
 ROLLBACK;
-NOTICE:  issuing ROLLBACK
 -- the first insert goes to a shard on the coordinator
 -- the second insert goes to a shard on the worker
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (102,100);
-NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730502 (x, y) VALUES (102, 100)
 	INSERT INTO test(x,y) VALUES (101,100);
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730501 (x, y) VALUES (101, 100)
@@ -410,7 +409,6 @@ NOTICE:  executing the command locally: SELECT count(*) AS count FROM single_nod
 (1 row)
 
 ROLLBACK;
-NOTICE:  issuing ROLLBACK
 SET citus.shard_replication_factor TO 1;
 -- now, lets move all the shards of distributed tables out of the coordinator
 -- block writes is much faster for the sake of the test timings we prefer it
@@ -459,9 +457,9 @@ SELECT * FROM view_created_before_shard_moves;
 
 -- and make sure that all the shards are remote
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
-NOTICE:  issuing BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;SELECT assign_distributed_transaction_id(xx, xx, 'xxxxxxx');
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730501 (x, y) VALUES (101, 100)
 	INSERT INTO test(x,y) VALUES (102,100);
 NOTICE:  issuing INSERT INTO single_node_ent.test_90730502 (x, y) VALUES (102, 100)
@@ -479,7 +477,6 @@ NOTICE:  issuing SELECT count(*) AS count FROM single_node_ent.test_90731506 tes
 (1 row)
 
 ROLLBACK;
-NOTICE:  issuing ROLLBACK
 -- should fail as only read access is allowed
 SET ROLE read_access_single_node;
 INSERT INTO test VALUES (1, 1, (95, 'citus9.5')::new_type);

--- a/src/test/regress/sql/single_node_enterprise.sql
+++ b/src/test/regress/sql/single_node_enterprise.sql
@@ -253,6 +253,7 @@ INSERT INTO ref SELECT i, i*2 FROM generate_series(100,150)i;
 -- the first insert goes to a shard on the worker
 -- the second insert goes to a shard on the coordinator
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
 	INSERT INTO test(x,y) VALUES (102,100);
@@ -264,6 +265,7 @@ ROLLBACK;
 -- the first insert goes to a shard on the coordinator
 -- the second insert goes to a shard on the worker
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (102,100);
 	INSERT INTO test(x,y) VALUES (101,100);
@@ -292,6 +294,7 @@ SELECT * FROM view_created_before_shard_moves;
 
 -- and make sure that all the shards are remote
 BEGIN;
+	SET LOCAL citus.grep_remote_commands TO '%single_node_ent.test_%';
 	SET LOCAL citus.log_remote_commands TO ON;
 	INSERT INTO test(x,y) VALUES (101,100);
 	INSERT INTO test(x,y) VALUES (102,100);


### PR DESCRIPTION
## Root cause

`single_node_enterprise` logs exact remote commands around multi-shard `SELECT count(*) FROM test` assertions. The adaptive executor may establish optional connections while the existing connection drains the small shard tasks. Whether a new connection finishes connect/auth in time is nondeterministic, so its connection-local `BEGIN TRANSACTION ... assign_distributed_transaction_id(...)` and matching `ROLLBACK` notices may appear with timing-dependent count and order.

These transaction-control notices do not indicate different shard routing or query results.

## Fix

Set transaction-local `citus.grep_remote_commands` to `%single_node_ent.test_%` in the three affected blocks.

This narrowly excludes connection-local transaction-control chatter while preserving every meaningful shard-operation notice:

- remote shard `INSERT` commands
- all multi-shard `SELECT` commands
- local-versus-remote execution evidence

No executor behavior and no broad output normalization changes.

## Diff

- 2 files changed
- 6 insertions, 6 deletions
- `src/test/regress/sql/single_node_enterprise.sql`
- `src/test/regress/expected/single_node_enterprise.out`

## Validation

Validated from a clean PostgreSQL 18 WSL build:

- focused normal run: 1/1 passed
- CI-equivalent `--use-whole-schedule-line`: 32/32 repetitions passed with zero regression diffs
- `ci/fix_style.sh`: passed; patch unchanged
- `git diff --check`: passed

## Residual risk

This test no longer asserts connection-local transaction-control notices. If those protocol messages need coverage, they should be tested separately under deterministic connection conditions. The intended shard routing and command execution coverage remains intact.

Fixes #7671
Refs #8348