### PR TITLE
Make multi_partitioning_utils repeatable

### DIFF
--- a/src/test/regress/expected/multi_partitioning_utils.out
+++ b/src/test/regress/expected/multi_partitioning_utils.out
@@ -431,5 +431,17 @@ SELECT master_get_table_ddl_events('capitals');
 ERROR:  capitals is not a regular, foreign or partitioned table
 SELECT master_get_table_ddl_events('cities');
 ERROR:  cities is not a regular, foreign or partitioned table
--- dropping parents frop the partitions
-DROP TABLE date_partitioned_table, multi_column_partitioned, list_partitioned, partition_parent_schema.parent_table, cities, capitals;
+-- clean up all objects created by this test
+DROP TABLE date_partitioned_table, date_partitioned_table_100, date_partition_2007_100,
+	multi_column_partitioned, list_partitioned, partition_parent_schema.parent_table,
+	cities, capitals;
+DROP SCHEMA partition_parent_schema, partition_child_1_schema, partition_child_2_schema;
+DROP FUNCTION generate_alter_table_detach_partition_command(regclass),
+	generate_alter_table_attach_partition_command(regclass),
+	generate_partition_information(regclass),
+	print_partitions(regclass),
+	table_inherits(regclass),
+	table_inherited(regclass),
+	detach_and_attach_partition(regclass, regclass),
+	drop_and_recreate_partitioned_table(regclass),
+	some_function(text);

--- a/src/test/regress/sql/multi_partitioning_utils.sql
+++ b/src/test/regress/sql/multi_partitioning_utils.sql
@@ -297,5 +297,17 @@ SELECT table_inherited('date_partitioned_table');
 SELECT master_get_table_ddl_events('capitals');
 SELECT master_get_table_ddl_events('cities');
 
--- dropping parents frop the partitions
-DROP TABLE date_partitioned_table, multi_column_partitioned, list_partitioned, partition_parent_schema.parent_table, cities, capitals;
+-- clean up all objects created by this test
+DROP TABLE date_partitioned_table, date_partitioned_table_100, date_partition_2007_100,
+	multi_column_partitioned, list_partitioned, partition_parent_schema.parent_table,
+	cities, capitals;
+DROP SCHEMA partition_parent_schema, partition_child_1_schema, partition_child_2_schema;
+DROP FUNCTION generate_alter_table_detach_partition_command(regclass),
+	generate_alter_table_attach_partition_command(regclass),
+	generate_partition_information(regclass),
+	print_partitions(regclass),
+	table_inherits(regclass),
+	table_inherited(regclass),
+	detach_and_attach_partition(regclass, regclass),
+	drop_and_recreate_partitioned_table(regclass),
+	some_function(text);


### PR DESCRIPTION
## Root cause

`multi_partitioning_utils` performed incomplete cleanup. Test-local functions, relations, and schemas survived its first execution, so whole-schedule-line repetitions 2-8 collided with duplicate-object errors even though `replicated_partitioned_table` itself remained stable.

## Fix

Clean up every test-local object created by `multi_partitioning_utils`, preserving genuine whole-line repeatability instead of clamping the requested flakiness coverage to one execution.

- 2 files changed
- 28 insertions, 4 deletions

## Validation

- Exact whole-line detector: `multi_partitioning_utils` 8/8 and `replicated_partitioned_table` 8/8
- Normal `check-multi`: 194/194
- `tdigest_aggregate_support` whole-line tail: 8/8
- Focused pytest and repository-pinned Black, isort, and flake8 checks pass