### PR TITLE
PG19: propagate EXPLAIN IO to worker nodes

### DIFF
--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -113,6 +113,9 @@ typedef struct
 	ExplainSerializeOption serialize;
 #endif
 	ExplainFormat format;
+#if PG_VERSION_NUM >= PG_VERSION_19
+	bool io;
+#endif
 } ExplainOptions;
 
 
@@ -939,7 +942,10 @@ RemoteExplain(Task *task, ExplainState *es, ParamListInfo params)
 {
 	/*
 	 * For EXPLAIN EXECUTE we still use the old method, so task->fetchedExplainAnalyzePlan
-	 * can be NULL for some cases of es->analyze == true.
+	 * can be NULL for some cases of es->analyze == true.  The same is true for a
+	 * distributed subplan: its saved output is keyed by task id and consumed once when
+	 * replayed into a freshly planned task list, so a task without a matching entry
+	 * falls through to a live remote EXPLAIN here.
 	 */
 	if (es->analyze && task->fetchedExplainAnalyzePlan)
 	{
@@ -1240,6 +1246,9 @@ BuildRemoteExplainQuery(char *queryString, ExplainState *es)
 #if PG_VERSION_NUM >= PG_VERSION_17
 					 "MEMORY %s, SERIALIZE %s, "
 #endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+					 "IO %s, "
+#endif
 					 "FORMAT %s) %s",
 					 es->analyze ? "TRUE" : "FALSE",
 					 es->verbose ? "TRUE" : "FALSE",
@@ -1251,6 +1260,9 @@ BuildRemoteExplainQuery(char *queryString, ExplainState *es)
 #if PG_VERSION_NUM >= PG_VERSION_17
 					 es->memory ? "TRUE" : "FALSE",
 					 serializeStr,
+#endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+					 es->io ? "TRUE" : "FALSE",
 #endif
 					 formatStr,
 					 queryString);
@@ -1393,6 +1405,9 @@ worker_save_query_explain_analyze(PG_FUNCTION_ARGS)
 	es->memory = ExtractFieldBoolean(explainOptions, "memory", es->memory);
 	es->serialize = ExtractFieldExplainSerialize(explainOptions, "serialize",
 												 es->serialize);
+#endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+	es->io = ExtractFieldBoolean(explainOptions, "io", es->io);
 #endif
 
 	TupleDesc tupleDescriptor = NULL;
@@ -1640,6 +1655,9 @@ CitusExplainOneQuery(Query *query, int cursorOptions, IntoClause *into,
 #if PG_VERSION_NUM >= PG_VERSION_17
 	CurrentDistributedQueryExplainOptions.memory = es->memory;
 	CurrentDistributedQueryExplainOptions.serialize = es->serialize;
+#endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+	CurrentDistributedQueryExplainOptions.io = es->io;
 #endif
 
 	/* rest is copied from ExplainOneQuery() */
@@ -2066,6 +2084,9 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc,
 #if PG_VERSION_NUM >= PG_VERSION_17
 					 "\"memory\": %s, \"serialize\": \"%s\", "
 #endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+					 "\"io\": %s, "
+#endif
 					 "\"timing\": %s, \"summary\": %s, \"format\": \"%s\"}",
 					 CurrentDistributedQueryExplainOptions.verbose ? "true" : "false",
 					 CurrentDistributedQueryExplainOptions.costs ? "true" : "false",
@@ -2074,6 +2095,9 @@ WrapQueryForExplainAnalyze(const char *queryString, TupleDesc tupleDesc,
 #if PG_VERSION_NUM >= PG_VERSION_17
 					 CurrentDistributedQueryExplainOptions.memory ? "true" : "false",
 					 ExplainSerializeStr(CurrentDistributedQueryExplainOptions.serialize),
+#endif
+#if PG_VERSION_NUM >= PG_VERSION_19
+					 CurrentDistributedQueryExplainOptions.io ? "true" : "false",
 #endif
 					 CurrentDistributedQueryExplainOptions.timing ? "true" : "false",
 					 CurrentDistributedQueryExplainOptions.summary ? "true" : "false",
@@ -2362,6 +2386,11 @@ ExplainWorkerPlan(PlannedStmt *plannedstmt, DistributedSubPlan *subPlan, DestRec
 
 	if (es->wal)
 		instrument_option |= INSTRUMENT_WAL;
+
+#if PG_VERSION_NUM >= PG_VERSION_19
+	if (es->io)
+		instrument_option |= INSTRUMENT_IO;
+#endif
 
 	/*
 	 * We always collect timing for the entire statement, even when node-level

--- a/src/test/regress/bin/normalize.sed
+++ b/src/test/regress/bin/normalize.sed
@@ -468,3 +468,9 @@ s/local_table_5_col_1_fkey_([0-9]+)/local_table_5_col_1_fkey1_\1/g
 # these rules can be removed when PG19 is the minimum supported version
 /^([[:space:]]*)139264$/ s/139264$/131072/
 /^([[:space:]]*[0-9]+[[:space:]]+[|][[:space:]]+)139264$/ s/139264$/131072/
+
+# PG19 adds the IO option to EXPLAIN. Citus spells every option out, so remote
+# EXPLAIN commands carry a no-op "IO FALSE" that earlier versions do not send.
+# these rules can be removed when PG19 is the minimum supported version
+s/, IO FALSE,/,/g
+s/"io": false, //g

--- a/src/test/regress/expected/pg19.out
+++ b/src/test/regress/expected/pg19.out
@@ -1073,3 +1073,88 @@ SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_eager_agg CASCADE;
 RESET client_min_messages;
 RESET search_path;
+--
+-- EXPLAIN (ANALYZE, IO) has to reach the worker nodes (#8770).  PG19 added the
+-- IO option; Citus forwards a fixed set of options to the workers, so without
+-- explicit support the distributed plan silently comes back with no IO info.
+--
+CREATE SCHEMA pg19_explain_io;
+SET search_path TO pg19_explain_io;
+-- only assert on the presence of the IO section: the prefetch numbers depend on
+-- effective_io_concurrency and on the host
+CREATE FUNCTION explain_has_prefetch(explain_command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+	query_plan text;
+BEGIN
+	FOR query_plan IN EXECUTE explain_command LOOP
+		IF query_plan ILIKE '%Prefetch:%' THEN
+			RETURN true;
+		END IF;
+	END LOOP;
+	RETURN false;
+END; $$ LANGUAGE plpgsql;
+CREATE TABLE explain_io(a int, b int);
+SELECT create_distributed_table('explain_io', 'a');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO explain_io SELECT g, g FROM generate_series(1, 10) g;
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, IO, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	SELECT count(*) FROM explain_io $$);
+ explain_has_prefetch
+---------------------------------------------------------------------
+ t
+(1 row)
+
+-- without IO the worker plans must not contain the section
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	SELECT count(*) FROM explain_io $$);
+ explain_has_prefetch
+---------------------------------------------------------------------
+ f
+(1 row)
+
+-- EXPLAIN ANALYZE of a distributed subplan makes Citus build the remote EXPLAIN
+-- statement itself instead of reusing a plan saved by the worker, so IO has to
+-- be forwarded on that path as well.  The plan of the INSERT tasks reads nothing
+-- and therefore has no IO section, the assertion here is the logged command.
+SET citus.shard_count TO 2;
+SET citus.next_shard_id TO 8770000;
+CREATE TABLE explain_io_mod(a int, b int);
+INSERT INTO explain_io_mod VALUES (1, 11);
+SELECT create_distributed_table('explain_io_mod', 'a');
+NOTICE:  Copying data from local table...
+NOTICE:  copying the data has completed
+DETAIL:  The local data in the table is no longer visible, but is still on disk.
+HINT:  To remove the local data, run: SELECT truncate_local_data_after_distributing_table($$pg19_explain_io.explain_io_mod$$)
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+SET citus.explain_all_tasks TO on;
+SET citus.log_remote_commands TO on;
+SET citus.grep_remote_commands TO '%IO TRUE%';
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, IO, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	WITH cte_1 AS (INSERT INTO explain_io_mod VALUES (6,66),(7,77),(8,88) RETURNING *)
+	SELECT * FROM cte_1 $$);
+NOTICE:  issuing EXPLAIN (ANALYZE TRUE, VERBOSE FALSE, COSTS FALSE, BUFFERS TRUE, WAL FALSE, TIMING FALSE, SUMMARY FALSE, MEMORY FALSE, SERIALIZE none, IO TRUE, FORMAT TEXT) INSERT INTO pg19_explain_io.explain_io_mod_8770001 AS citus_table_alias (a, b) VALUES (6,66) RETURNING citus_table_alias.a, citus_table_alias.b
+DETAIL:  on server postgres@localhost:xxxxx connectionId: xxxxxxx
+CONTEXT:  PL/pgSQL function explain_has_prefetch(text) line XX at FOR over EXECUTE statement
+ explain_has_prefetch
+---------------------------------------------------------------------
+ f
+(1 row)
+
+RESET citus.log_remote_commands;
+RESET citus.grep_remote_commands;
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_explain_io CASCADE;
+RESET client_min_messages;
+RESET search_path;

--- a/src/test/regress/sql/pg19.sql
+++ b/src/test/regress/sql/pg19.sql
@@ -791,3 +791,63 @@ SET client_min_messages TO WARNING;
 DROP SCHEMA pg19_eager_agg CASCADE;
 RESET client_min_messages;
 RESET search_path;
+
+--
+-- EXPLAIN (ANALYZE, IO) has to reach the worker nodes (#8770).  PG19 added the
+-- IO option; Citus forwards a fixed set of options to the workers, so without
+-- explicit support the distributed plan silently comes back with no IO info.
+--
+CREATE SCHEMA pg19_explain_io;
+SET search_path TO pg19_explain_io;
+
+-- only assert on the presence of the IO section: the prefetch numbers depend on
+-- effective_io_concurrency and on the host
+CREATE FUNCTION explain_has_prefetch(explain_command text)
+RETURNS BOOLEAN AS $$
+DECLARE
+	query_plan text;
+BEGIN
+	FOR query_plan IN EXECUTE explain_command LOOP
+		IF query_plan ILIKE '%Prefetch:%' THEN
+			RETURN true;
+		END IF;
+	END LOOP;
+	RETURN false;
+END; $$ LANGUAGE plpgsql;
+
+CREATE TABLE explain_io(a int, b int);
+SELECT create_distributed_table('explain_io', 'a');
+INSERT INTO explain_io SELECT g, g FROM generate_series(1, 10) g;
+
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, IO, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	SELECT count(*) FROM explain_io $$);
+
+-- without IO the worker plans must not contain the section
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	SELECT count(*) FROM explain_io $$);
+
+-- EXPLAIN ANALYZE of a distributed subplan makes Citus build the remote EXPLAIN
+-- statement itself instead of reusing a plan saved by the worker, so IO has to
+-- be forwarded on that path as well.  The plan of the INSERT tasks reads nothing
+-- and therefore has no IO section, the assertion here is the logged command.
+SET citus.shard_count TO 2;
+SET citus.next_shard_id TO 8770000;
+CREATE TABLE explain_io_mod(a int, b int);
+INSERT INTO explain_io_mod VALUES (1, 11);
+SELECT create_distributed_table('explain_io_mod', 'a');
+SET citus.explain_all_tasks TO on;
+SET citus.log_remote_commands TO on;
+SET citus.grep_remote_commands TO '%IO TRUE%';
+SELECT explain_has_prefetch($$
+	EXPLAIN (ANALYZE, IO, COSTS OFF, TIMING OFF, SUMMARY OFF)
+	WITH cte_1 AS (INSERT INTO explain_io_mod VALUES (6,66),(7,77),(8,88) RETURNING *)
+	SELECT * FROM cte_1 $$);
+RESET citus.log_remote_commands;
+RESET citus.grep_remote_commands;
+
+SET client_min_messages TO WARNING;
+DROP SCHEMA pg19_explain_io CASCADE;
+RESET client_min_messages;
+RESET search_path;


### PR DESCRIPTION
Draft fix for #8770.

This propagates PostgreSQL 19 EXPLAIN IO state through Citus worker EXPLAIN generation and normalizes the resulting version-varying output in regression tests.

Stack: depends on #8771 draft branch to avoid pg19.sql/pg19.out conflicts.