### PR TITLE
Report unsupported ALTER CONSTRAINT explicitly

### DIFF
--- a/src/backend/distributed/commands/table.c
+++ b/src/backend/distributed/commands/table.c
@@ -3813,8 +3813,11 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 			case AT_DetachPartitionFinalize:
 			{
-				ereport(ERROR, (errmsg("ALTER TABLE .. DETACH PARTITION .. FINALIZE "
-									   "commands are currently unsupported.")));
+				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								errmsg("ALTER TABLE ... DETACH PARTITION ... FINALIZE "
+									   "commands are currently unsupported"),
+								errdetail("Citus does not propagate detached partition "
+										  "finalization to shards.")));
 				break;
 			}
 
@@ -3834,7 +3837,8 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 
 				if (partitionCommand->concurrent)
 				{
-					ereport(ERROR, (errmsg("ALTER TABLE .. DETACH PARTITION .. "
+					ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+									errmsg("ALTER TABLE .. DETACH PARTITION .. "
 										   "CONCURRENTLY commands are currently "
 										   "unsupported.")));
 				}
@@ -3917,6 +3921,16 @@ ErrorIfUnsupportedAlterTableStmt(AlterTableStmt *alterTableStatement)
 				 * ALTER TABLE .. VALIDATE CONSTRAINT ..
 				 * ALTER TABLE .. ALTER COLUMN .. SET COMPRESSION ..
 				 */
+				break;
+			}
+
+			case AT_AlterConstraint:
+			{
+				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								errmsg("ALTER TABLE ... ALTER CONSTRAINT commands "
+									   "are currently unsupported"),
+								errdetail("Citus does not propagate constraint "
+										  "property changes to shards.")));
 				break;
 			}
 

--- a/src/test/regress/expected/partitioning_issue_3970.out
+++ b/src/test/regress/expected/partitioning_issue_3970.out
@@ -120,8 +120,8 @@ SET search_path = test_3970;
 ALTER TABLE part_table RENAME CONSTRAINT my_seq TO my_seq_check;
 ERROR:  renaming constraints belonging to distributed tables is currently unsupported
 ALTER TABLE part_table ALTER CONSTRAINT my_seq DEFERRABLE;
-ERROR:  alter table command is currently unsupported
-DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP|VALIDATE CONSTRAINT, SET (), RESET (), ENABLE|DISABLE|NO FORCE|FORCE ROW LEVEL SECURITY, ATTACH|DETACH PARTITION and TYPE subcommands are supported.
+ERROR:  ALTER TABLE ... ALTER CONSTRAINT commands are currently unsupported
+DETAIL:  Citus does not propagate constraint property changes to shards.
 -- verify that we can drop the constraints on partitioned tables
 ALTER TABLE part_table DROP CONSTRAINT my_seq;
 DROP TABLE part_table, dist CASCADE;

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -238,6 +238,7 @@ ALTER TABLE par DETACH PARTITION par_2 CONCURRENTLY;
 ERROR:  ALTER TABLE .. DETACH PARTITION .. CONCURRENTLY commands are currently unsupported.
 ALTER TABLE par DETACH PARTITION par_2 FINALIZE;
 ERROR:  ALTER TABLE ... DETACH PARTITION ... FINALIZE commands are currently unsupported
+DETAIL:  Citus does not propagate detached partition finalization to shards.
 -- test column compression propagation in distribution
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE col_compression (a TEXT COMPRESSION pglz, b TEXT);

--- a/src/test/regress/expected/pg14.out
+++ b/src/test/regress/expected/pg14.out
@@ -237,7 +237,7 @@ SELECT create_distributed_table('par','a');
 ALTER TABLE par DETACH PARTITION par_2 CONCURRENTLY;
 ERROR:  ALTER TABLE .. DETACH PARTITION .. CONCURRENTLY commands are currently unsupported.
 ALTER TABLE par DETACH PARTITION par_2 FINALIZE;
-ERROR:  ALTER TABLE .. DETACH PARTITION .. FINALIZE commands are currently unsupported.
+ERROR:  ALTER TABLE ... DETACH PARTITION ... FINALIZE commands are currently unsupported
 -- test column compression propagation in distribution
 SET citus.shard_replication_factor TO 1;
 CREATE TABLE col_compression (a TEXT COMPRESSION pglz, b TEXT);

--- a/src/test/regress/expected/pg18.out
+++ b/src/test/regress/expected/pg18.out
@@ -1567,8 +1567,8 @@ SELECT * FROM contacts ORDER BY contact_id;
 -- ALTER TABLE .. ALTER CONSTRAINT is not supported in Citus,
 -- so the following command should fail
 ALTER TABLE contacts ALTER CONSTRAINT fk_customer ENFORCED;
-ERROR:  alter table command is currently unsupported
-DETAIL:  Only ADD|DROP COLUMN, SET|DROP NOT NULL, SET|DROP DEFAULT, ADD|DROP|VALIDATE CONSTRAINT, SET (), RESET (), ENABLE|DISABLE|NO FORCE|FORCE ROW LEVEL SECURITY, ATTACH|DETACH PARTITION and TYPE subcommands are supported.
+ERROR:  ALTER TABLE ... ALTER CONSTRAINT commands are currently unsupported
+DETAIL:  Citus does not propagate constraint property changes to shards.
 -- PG18 Feature: ENFORCED / NOT ENFORCED check constraints
 -- PG18 commit: https://github.com/postgres/postgres/commit/ca87c415e
 -- In Citus, CHECK constraints are propagated on promoting a postgres table


### PR DESCRIPTION
Draft partial fix for #8758.

This makes ALTER TABLE ... ALTER CONSTRAINT fail with a stable FEATURE_NOT_SUPPORTED error and detail explaining that Citus does not propagate constraint property changes to shards. It also tags the existing unsupported DETACH PARTITION CONCURRENTLY/FINALIZE paths with FEATURE_NOT_SUPPORTED.

Important limitation: I did not include MERGE PARTITIONS / SPLIT PARTITION cases because this post-merge source checkout has no corresponding AT_* enum identifiers or grammar strings. That part needs to be rechecked against the exact PostgreSQL 19 parser API before adding cases.