### PR TITLE
[release-12.1] Quote EXTRACT fields in PG14-16 ruleutils

### DIFF
--- a/src/backend/distributed/deparser/ruleutils_14.c
+++ b/src/backend/distributed/deparser/ruleutils_14.c
@@ -6817,7 +6817,8 @@ get_func_sql_syntax(FuncExpr *expr, deparse_context *context)
 				Assert(IsA(con, Const) &&
 					   con->consttype == TEXTOID &&
 					   !con->constisnull);
-				appendStringInfoString(buf, TextDatumGetCString(con->constvalue));
+				appendStringInfoString(buf,
+									   quote_identifier(TextDatumGetCString(con->constvalue)));
 			}
 			appendStringInfoString(buf, " FROM ");
 			get_rule_expr((Node *) lsecond(expr->args), context, false);

--- a/src/backend/distributed/deparser/ruleutils_15.c
+++ b/src/backend/distributed/deparser/ruleutils_15.c
@@ -7050,7 +7050,8 @@ get_func_sql_syntax(FuncExpr *expr, deparse_context *context)
 				Assert(IsA(con, Const) &&
 					   con->consttype == TEXTOID &&
 					   !con->constisnull);
-				appendStringInfoString(buf, TextDatumGetCString(con->constvalue));
+				appendStringInfoString(buf,
+									   quote_identifier(TextDatumGetCString(con->constvalue)));
 			}
 			appendStringInfoString(buf, " FROM ");
 			get_rule_expr((Node *) lsecond(expr->args), context, false);

--- a/src/backend/distributed/deparser/ruleutils_16.c
+++ b/src/backend/distributed/deparser/ruleutils_16.c
@@ -7157,7 +7157,8 @@ get_func_sql_syntax(FuncExpr *expr, deparse_context *context)
 				Assert(IsA(con, Const) &&
 					   con->consttype == TEXTOID &&
 					   !con->constisnull);
-				appendStringInfoString(buf, TextDatumGetCString(con->constvalue));
+				appendStringInfoString(buf,
+									   quote_identifier(TextDatumGetCString(con->constvalue)));
 			}
 			appendStringInfoString(buf, " FROM ");
 			get_rule_expr((Node *) lsecond(expr->args), context, false);

--- a/src/test/regress/expected/extract_deparse.out
+++ b/src/test/regress/expected/extract_deparse.out
@@ -1,0 +1,40 @@
+--
+-- EXTRACT_DEPARSE
+--
+CREATE SCHEMA extract_deparse;
+SET search_path TO extract_deparse;
+CREATE TABLE extract_deparse_source (id int, ts timestamp);
+SELECT create_distributed_table('extract_deparse_source', 'id',
+								shard_count => 1, colocate_with => 'none');
+ create_distributed_table
+---------------------------------------------------------------------
+
+(1 row)
+
+INSERT INTO extract_deparse_source VALUES (1, timestamp '2026-01-01');
+-- EXTRACT accepts any string as its field name. Verify Citus quotes that field
+-- when deparsing task SQL, so text resembling a second statement remains data.
+-- PG19 has equivalent coverage in pg19.sql.
+DO $$
+BEGIN
+	IF current_setting('server_version_num')::int < 190000 THEN
+		PERFORM EXTRACT('year FROM timestamp ''2000-01-01''); CREATE TABLE injected(); --' FROM ts)
+		FROM extract_deparse_source
+		WHERE id = 1;
+	END IF;
+EXCEPTION
+	WHEN invalid_parameter_value THEN NULL;
+END
+$$;
+SELECT bool_and(result::boolean) AS extract_field_injection_blocked
+FROM run_command_on_workers($$
+	SELECT to_regclass('extract_deparse.injected') IS NULL
+$$);
+ extract_field_injection_blocked
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA extract_deparse CASCADE;
+RESET client_min_messages;

--- a/src/test/regress/multi_1_schedule
+++ b/src/test/regress/multi_1_schedule
@@ -359,6 +359,7 @@ test: check_mx
 # deparsing logic tests
 # ---------
 test: multi_deparse_function multi_deparse_procedure
+test: extract_deparse
 
 # --------
 # cannot be run in parallel with any other tests as it checks

--- a/src/test/regress/sql/extract_deparse.sql
+++ b/src/test/regress/sql/extract_deparse.sql
@@ -1,0 +1,35 @@
+--
+-- EXTRACT_DEPARSE
+--
+
+CREATE SCHEMA extract_deparse;
+SET search_path TO extract_deparse;
+
+CREATE TABLE extract_deparse_source (id int, ts timestamp);
+SELECT create_distributed_table('extract_deparse_source', 'id',
+								shard_count => 1, colocate_with => 'none');
+INSERT INTO extract_deparse_source VALUES (1, timestamp '2026-01-01');
+
+-- EXTRACT accepts any string as its field name. Verify Citus quotes that field
+-- when deparsing task SQL, so text resembling a second statement remains data.
+-- PG19 has equivalent coverage in pg19.sql.
+DO $$
+BEGIN
+	IF current_setting('server_version_num')::int < 190000 THEN
+		PERFORM EXTRACT('year FROM timestamp ''2000-01-01''); CREATE TABLE injected(); --' FROM ts)
+		FROM extract_deparse_source
+		WHERE id = 1;
+	END IF;
+EXCEPTION
+	WHEN invalid_parameter_value THEN NULL;
+END
+$$;
+
+SELECT bool_and(result::boolean) AS extract_field_injection_blocked
+FROM run_command_on_workers($$
+	SELECT to_regclass('extract_deparse.injected') IS NULL
+$$);
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA extract_deparse CASCADE;
+RESET client_min_messages;


### PR DESCRIPTION
## Summary

Backport the focused EXTRACT identifier quoting parity fix from [#8804](https://github.com/citusdata/citus/pull/8804) to `release-12.1` for PostgreSQL 14, 15, and 16.

- quote EXTRACT field identifiers in the copied PG14/PG15/PG16 `ruleutils` implementations
- add one shared, repeat-safe `extract_deparse` regression covering every supported PostgreSQL major
- run it from release-12's existing current-library `multi_1_schedule`; this branch predates the N-1 mixed-library schedule split
- preserve the existing shard-aware Citus deparser changes

Fixes [#8803](https://github.com/citusdata/citus/issues/8803).

Main PR: [#8804](https://github.com/citusdata/citus/pull/8804)

## Validation

- `-Werror` builds against PostgreSQL 14.24, 15.19, and 16.15
- shared `extract_deparse` regression: 8/8 repetitions on each supported PostgreSQL major
- expected output generated with the release-12 regression runner
- shared SQL matches the main-branch test byte-for-byte; expected output matches the proven release runner output
- relevant style, schedule, SQL snapshot, and diff checks