### PR TITLE
Fix intermediate result row count type

### DIFF
--- a/src/include/distributed/intermediate_results.h
+++ b/src/include/distributed/intermediate_results.h
@@ -35,7 +35,7 @@ typedef struct DistributedResultFragment
 	uint32 nodeId;
 
 	/* number of rows in the result file */
-	int rowCount;
+	int64 rowCount;
 
 	/*
 	 * The fragment contains the rows which match the partitioning method


### PR DESCRIPTION
DistributedResultFragment.rowCount was declared as int, while the row count is read as int64.

Use int64 for the struct field as well to avoid a narrowing conversion and preserve the full row count value.