### PR TITLE
Fix rebalance background job ID type

### DIFF
--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1201,7 +1201,7 @@ citus_rebalance_start(PG_FUNCTION_ARGS)
 		.rebalanceStrategy = strategy,
 		.improvementThreshold = strategy->improvementThreshold,
 	};
-	int jobId = RebalanceTableShardsBackground(&options, shardTransferModeOid,
+	int64 jobId = RebalanceTableShardsBackground(&options, shardTransferModeOid,
 											   ParallelTransferReferenceTables,
 											   ParallelTransferColocatedShards);
 

--- a/src/backend/distributed/operations/shard_rebalancer.c
+++ b/src/backend/distributed/operations/shard_rebalancer.c
@@ -1202,8 +1202,8 @@ citus_rebalance_start(PG_FUNCTION_ARGS)
 		.improvementThreshold = strategy->improvementThreshold,
 	};
 	int64 jobId = RebalanceTableShardsBackground(&options, shardTransferModeOid,
-											   ParallelTransferReferenceTables,
-											   ParallelTransferColocatedShards);
+											     ParallelTransferReferenceTables,
+											     ParallelTransferColocatedShards);
 
 	if (jobId == 0)
 	{


### PR DESCRIPTION
RebalanceTableShardsBackground() returns an int64, while its result was stored in an int.
Store the returned job ID in an int64 to avoid narrowing the value.