### PR TITLE
Align nightly cassert with main: 17.11 / 18.6 / 19beta3, drop PG16

### DIFF
--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -35,9 +35,9 @@ jobs:
     name: Initialize parameters
     runs-on: ubuntu-latest
     outputs:
-      pg_versions: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.9" }, { "major": "18", "full": "18.3" }]'
-      pg_upgrade_pairs: '[{ "old": "16", "old_full": "16.13", "new": "17", "new_full": "17.9" }, { "old": "17", "old_full": "17.9", "new": "18", "new_full": "18.3" }]'
-      citus_upgrade_pg: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.9" }]'
+      pg_versions: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }]'
+      pg_upgrade_pairs: '[{ "old": "16", "old_full": "16.13", "new": "17", "new_full": "17.11" }, { "old": "17", "old_full": "17.11", "new": "18", "new_full": "18.6" }]'
+      citus_upgrade_pg: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.11" }]'
       citus_old_version: "v14.0.1"  # 14.0-1 chains to MASTER (15.0); 14.1 has no path to 15.0 yet
     steps:
       - name: Set up parameters

--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -1,7 +1,7 @@
 name: Nightly cassert
 run-name: Nightly cassert (${{ github.ref_name }})
 
-# Full-suite Citus run against an --enable-cassert PostgreSQL build (PG 16/17/18).
+# Full-suite Citus run against an --enable-cassert PostgreSQL build (PG 17/18).
 # Purpose: surface PG-core asserts and Citus's own Assert() that the normal PGDG-image PR
 # pipeline cannot catch. First runs are EXPECTED to be RED across all majors as pre-existing
 # asserts surface -- that is the intended signal, not a regression gate.
@@ -35,9 +35,9 @@ jobs:
     name: Initialize parameters
     runs-on: ubuntu-latest
     outputs:
-      pg_versions: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }]'
-      pg_upgrade_pairs: '[{ "old": "16", "old_full": "16.13", "new": "17", "new_full": "17.11" }, { "old": "17", "old_full": "17.11", "new": "18", "new_full": "18.6" }]'
-      citus_upgrade_pg: '[{ "major": "16", "full": "16.13" }, { "major": "17", "full": "17.11" }]'
+      pg_versions: '[{ "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }]'
+      pg_upgrade_pairs: '[{ "old": "17", "old_full": "17.11", "new": "18", "new_full": "18.6" }]'
+      citus_upgrade_pg: '[{ "major": "17", "full": "17.11" }]'
       citus_old_version: "v14.0.1"  # 14.0-1 chains to MASTER (15.0); 14.1 has no path to 15.0 yet
     steps:
       - name: Set up parameters

--- a/.github/workflows/nightly_cassert.yml
+++ b/.github/workflows/nightly_cassert.yml
@@ -1,14 +1,13 @@
 name: Nightly cassert
 run-name: Nightly cassert (${{ github.ref_name }})
 
-# Full-suite Citus run against an --enable-cassert PostgreSQL build (PG 17/18).
+# Full-suite Citus run against an --enable-cassert PostgreSQL build (PG 17/18/19).
 # Purpose: surface PG-core asserts and Citus's own Assert() that the normal PGDG-image PR
 # pipeline cannot catch. First runs are EXPECTED to be RED across all majors as pre-existing
 # asserts surface -- that is the intended signal, not a regression gate.
 #
 # The version matrix lives in the `params` job below (single source of truth, mirroring
-# build_and_test.yml). The `pg19-support` branch adapts this by adding the 19beta1 row + the
-# 18->19 upgrade pair, the same way 19 support is layered onto the other test suites.
+# build_and_test.yml's params job, which pins 17.11 / 18.6 / 19beta3 and no longer builds PG16).
 
 on:
   schedule:
@@ -35,9 +34,9 @@ jobs:
     name: Initialize parameters
     runs-on: ubuntu-latest
     outputs:
-      pg_versions: '[{ "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }]'
-      pg_upgrade_pairs: '[{ "old": "17", "old_full": "17.11", "new": "18", "new_full": "18.6" }]'
-      citus_upgrade_pg: '[{ "major": "17", "full": "17.11" }]'
+      pg_versions: '[{ "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }, { "major": "19", "full": "19beta3" }]'
+      pg_upgrade_pairs: '[{ "old": "17", "old_full": "17.11", "new": "18", "new_full": "18.6" }, { "old": "18", "old_full": "18.6", "new": "19", "new_full": "19beta3" }, { "old": "17", "old_full": "17.11", "new": "19", "new_full": "19beta3" }]'
+      citus_upgrade_pg: '[{ "major": "17", "full": "17.11" }, { "major": "18", "full": "18.6" }]'
       citus_old_version: "v14.0.1"  # 14.0-1 chains to MASTER (15.0); 14.1 has no path to 15.0 yet
     steps:
       - name: Set up parameters


### PR DESCRIPTION
## What

Realigns `.github/workflows/nightly_cassert.yml` with `main`. Its `params` job is meant to be a mirror of `build_and_test.yml`, but it had drifted in **both** directions:

- it still built **PG16**, which `main` no longer compiles against, and
- it was missing **PG19**, which `main` does test.

`main`'s params job currently pins `17.11` / `18.6` / `19beta3` and declares **no `pg16_version` at all**.

## Changes

| Output | Before | After |
|---|---|---|
| `pg_versions` | 16.13, 17.9, 18.3 | **17.11, 18.6, 19beta3** |
| `pg_upgrade_pairs` | 16→17, 17→18 | **17→18, 18→19, 17→19** |
| `citus_upgrade_pg` | 16.13, 17.9 | **17.11, 18.6** |

Plus the file header comment, which advertised `PG 16/17/18` and referenced a `pg19-support` branch that no longer exists (PG19 landed in `main`). `citus_old_version` is untouched.

## Why PG16 comes out

Citus `main` no longer compiles against PostgreSQL 16 — `configure` aborts with:

```
configure: error: Citus is not compatible with the detected PostgreSQL version 16.
```

Every PG16 job was therefore guaranteed to fail regardless of minor. In [run 34182646836](https://github.com/citusdata/citus/actions/runs/34182646836) (2026-09-08), **all 14 PG16 jobs were red**:

```
cassert PG16 - regress / isolation / columnar / tap / failure /
               generator / citus-upgrade / arbitrary-configs-0..5
cassert PG16-PG17 - pg-upgrade
```

That is categorically different from a normal cassert failure: it is a build that cannot start, so it drowns out the assert signal this nightly exists to surface.

## Why PG19 goes in

`main` already runs PG19 (`19beta3`), so the nightly should too. Unlike PG16, PG19 **does** build, so any redness it produces is real assert signal — exactly what this workflow is for, per its own header note that runs are expected to be red as pre-existing asserts surface.

`citus_upgrade_pg` deliberately stays at 17 + 18, mirroring `main`'s `test-citus-upgrade` matrix: the older Citus versions used by that suite do not run on PG19.

## Verification

The three `params` outputs are JSON-in-YAML strings, so they were checked by parsing rather than by eye. A script YAML-loads this workflow **and fetches `build_and_test.yml` from `main`**, then asserts the nightly mirrors it:

- majors match main's `pg*_version` set exactly (`17, 18, 19`), and every `full` equals main's
- `pg_upgrade_pairs` equals main's `test-pg-upgrade` include set exactly (`17→18, 18→19, 17→19`), with each `old_full`/`new_full` resolved from main
- `citus_upgrade_pg` majors equal main's `test-citus-upgrade` matrix (`17, 18`)
- no `16` / `16.13` token remains anywhere in the file, and no stale `pg19-support` reference

Result: `MIRRORS MAIN EXACTLY - ALL ASSERTIONS PASSED`.

The PG builds are from source via pgenv (`setup_cassert_pg`), whose input is documented as accepting betas (`e.g. 17.10 / 18.4 / 19beta1`). The `19beta3` source tarball is published (`postgresql-19beta3.tar.bz2`, HTTP 200), so the build is viable.

## Notes

Companion to [citus#8816](https://github.com/citusdata/citus/pull/8816) (`nightly_arm64.yml`). If that workflow has the same PG16/PG19 drift, it is best fixed there.

Refs [citus#8804](https://github.com/citusdata/citus/issues/8804).
