### PR TITLE
Backport #8821: harden extract_deparse security regression test (release-12.1)

### DIFF
--- a/src/test/regress/expected/extract_deparse.out
+++ b/src/test/regress/expected/extract_deparse.out
@@ -26,9 +26,20 @@ EXCEPTION
 	WHEN invalid_parameter_value THEN NULL;
 END
 $$;
-SELECT bool_and(result::boolean) AS extract_field_injection_blocked
+-- Positive control: the same expression with a valid field must still be
+-- pushed down, so the check below cannot pass merely because the expression
+-- stopped reaching the workers.
+SELECT EXTRACT('year' FROM ts) = 2026 AS extract_field_pushdown_works
+FROM extract_deparse_source
+WHERE id = 1;
+ extract_field_pushdown_works
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT bool_and(result::int = 0) AS extract_field_injection_blocked
 FROM run_command_on_workers($$
-	SELECT to_regclass('extract_deparse.injected') IS NULL
+	SELECT count(*) FROM pg_class WHERE relname = 'injected'
 $$);
  extract_field_injection_blocked
 ---------------------------------------------------------------------

--- a/src/test/regress/sql/extract_deparse.sql
+++ b/src/test/regress/sql/extract_deparse.sql
@@ -25,9 +25,16 @@ EXCEPTION
 END
 $$;
 
-SELECT bool_and(result::boolean) AS extract_field_injection_blocked
+-- Positive control: the same expression with a valid field must still be
+-- pushed down, so the check below cannot pass merely because the expression
+-- stopped reaching the workers.
+SELECT EXTRACT('year' FROM ts) = 2026 AS extract_field_pushdown_works
+FROM extract_deparse_source
+WHERE id = 1;
+
+SELECT bool_and(result::int = 0) AS extract_field_injection_blocked
 FROM run_command_on_workers($$
-	SELECT to_regclass('extract_deparse.injected') IS NULL
+	SELECT count(*) FROM pg_class WHERE relname = 'injected'
 $$);
 
 SET client_min_messages TO ERROR;


### PR DESCRIPTION
DESCRIPTION: Backport extract_deparse security regression test hardening to release-12.1

Backport of #8821 (merged to `main` as 2cfa425c2) to `release-12.1`.

The `extract_deparse` security regression test — which guards the EXTRACT
identifier-quoting fix — had two silent-pass paths:

1. It checked `to_regclass('extract_deparse.injected') IS NULL`, but the deparser
   fully-qualifies task SQL and Citus sends no `SET search_path` for SELECT task
   execution, so a successful injection would create `injected` in the worker's
   default `public` schema. The assertion therefore passed even when the
   injection succeeded. Replaced with a schema-agnostic
   `count(*) FROM pg_class WHERE relname = 'injected'`, matching the existing
   idiom in `citus_internal_distribute_object.sql`.

2. If a planner change stopped pushing the expression down, nothing would run on
   a worker and the test would still pass. Added a positive control asserting the
   same expression with a valid field is still pushed down.

Test-only change, +22/-4 across `sql/extract_deparse.sql` and
`expected/extract_deparse.out`. The `pg19.*` half of #8821 is intentionally
excluded — those files do not exist on this branch.

Note: `extract_deparse` runs under `check-multi-1` on this branch
(`multi_1_schedule`), not `check-multi-1-create-citus` as on release-13.2/14.0.

Prior CI on this branch (manual dispatch, run 33889067381): 95 jobs, 0 failures.