### PR TITLE
[release-13.2] Add aggregate CI/Packaging gate jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -555,3 +555,36 @@ jobs:
       if: always()
       with:
         folder: test_flakyness_parallel_${{ matrix.id }}
+  # Single aggregate gate for branch protection. Its name is deliberately
+  # constant across main and every release branch, so that the required status
+  # check list never has to be updated when the Postgres matrix changes.
+  #
+  # Only blocking jobs belong in "needs". Advisory jobs (flakyness detection,
+  # benchmarks, N-1 suites) are intentionally left out: they still run and stay
+  # visible, but they must not gate a merge.
+  #
+  # NOTE: adding a new blocking job to this workflow requires adding it here too,
+  # otherwise it will not be enforced by branch protection.
+  ci-gate:
+    name: CI
+    if: always()
+    needs:
+    - params
+    - check-sql-snapshots
+    - check-style
+    - build
+    - test-citus
+    - test-citus-failure
+    - test-citus-cdc
+    - test-arbitrary-configs
+    - test-pg-upgrade
+    - test-citus-upgrade
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show results of required jobs
+      run: echo '${{ toJSON(needs) }}'
+    - name: Fail if any required job did not succeed
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      run: |
+        echo "At least one required job did not succeed." >&2
+        exit 1

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -175,3 +175,24 @@ jobs:
         run: |
           echo "Postgres version: ${POSTGRES_VERSION}"
           ./.github/packaging/validate_build_output.sh "deb"
+
+  # Single aggregate gate for branch protection. See the "CI" job in
+  # build_and_test.yml for the rationale; the name is kept constant across
+  # main and every release branch so that the required status check list does
+  # not depend on the Postgres matrix.
+  packaging-gate:
+    name: Packaging
+    if: always()
+    needs:
+      - get_postgres_versions_from_file
+      - rpm_build_tests
+      - deb_build_tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show results of required jobs
+        run: echo '${{ toJSON(needs) }}'
+      - name: Fail if any required job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "At least one required job did not succeed." >&2
+          exit 1


### PR DESCRIPTION
Backport of #8815 to `release-13.2`, cherry-picked with `-x` from the final merged squash commit `4ae7278827991688daeff887c1f364b1bfee1bdd`.

Adds constant-name `CI` and `Packaging` aggregate gates. Each runs with `always()` and fails when any required dependency fails, is cancelled, or is skipped. The exact source patch adds 54 lines across two workflows without modifying existing jobs.

All four N-1 suites, flakiness detection, and benchmarks remain enabled under their existing conditions and outside the blocking dependencies. Including `check-style` in `CI` intentionally makes it required on `release-13.2` once the future gate-based protection is activated. This PR does not edit repository protection or rulesets.

Validation: exact source patch identity; YAML/job dependencies and unchanged existing job definitions; all dependency result combinations and failure-step exit status. Actionlint 1.7.7 reports no new findings: packaging is clean, and the build workflow retains only its two existing `azure/login@v1` runner warnings.