### PR TITLE
Fix cassert crash on columnar CREATE INDEX CONCURRENTLY

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -2483,13 +2483,17 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 		CheckCitusColumnarAlterExtensionStmt(parsetree);
 	}
 
-	int saveNestLevel = -1;
+	/*
+	 * We cannot use a GUC nest level here: CREATE INDEX CONCURRENTLY and
+	 * REINDEX CONCURRENTLY commit and restart the transaction internally,
+	 * which resets GUCNestLevel.  That both discards the override and makes
+	 * the matching AtEOXact_GUC() call trip its nest-level assertion.  Save
+	 * and restore the variable directly instead.
+	 */
+	int saveMaintenanceWorkers = max_parallel_maintenance_workers;
 	if (indexBuildOnColumnar)
 	{
-		saveNestLevel = NewGUCNestLevel();
-		set_config_option("max_parallel_maintenance_workers", "0",
-						  PGC_USERSET, PGC_S_SESSION,
-						  GUC_ACTION_SAVE, true, 0, false);
+		max_parallel_maintenance_workers = 0;
 	}
 
 	PG_TRY();
@@ -2499,9 +2503,9 @@ ColumnarProcessUtility(PlannedStmt *pstmt,
 	}
 	PG_FINALLY();
 	{
-		if (saveNestLevel >= 0)
+		if (indexBuildOnColumnar)
 		{
-			AtEOXact_GUC(true, saveNestLevel);
+			max_parallel_maintenance_workers = saveMaintenanceWorkers;
 		}
 	}
 	PG_END_TRY();


### PR DESCRIPTION
DESCRIPTION: Fixes a crash on `CREATE INDEX CONCURRENTLY` / `REINDEX CONCURRENTLY` against columnar tables in assertion-enabled builds

Fixes https://github.com/citusdata/citus/issues/8833.

Clears all six failing nightly-cassert jobs (`columnar` and `isolation` on PG17, PG18, PG19), red every night since 2026-08-28 — see https://github.com/citusdata/citus/issues/8812, https://github.com/citusdata/citus/issues/8817, https://github.com/citusdata/citus/issues/8832.

## Problem

`ColumnarProcessUtility()` forced `max_parallel_maintenance_workers = 0` for index builds on columnar tables by opening a GUC nest level and closing it with `AtEOXact_GUC()` in `PG_FINALLY`.

A GUC nest level cannot span a utility statement that commits internally. `DefineIndex()` on the CONCURRENTLY path runs `CommitTransactionCommand(); StartTransactionCommand();` three times (PG17 `indexcmds.c:1618, 1690, 1750`), and `ReindexRelationConcurrently()` does the same. Each internal commit resets `GUCNestLevel` to 1, so the trailing `AtEOXact_GUC(true, saveNestLevel)` ran with `saveNestLevel == 2 > GUCNestLevel == 1` and `isCommit == true`, aborting the backend:

```
TRAP: failed Assert("nestLevel > 0 && (nestLevel <= GUCNestLevel ||
      (nestLevel == GUCNestLevel + 1 && !isCommit))"), File: "guc.c", Line: 2273
... CREATE INDEX(ExceptionalCondition+0x6e)
... CREATE INDEX(AtEOXact_GUC+0x77)
/home/runner/.pgenv/pgsql-17.11/lib/citus_columnar.so(+0x16a3a)
... ProcessUtility
server process was terminated by signal 6: Aborted
DETAIL:  Failed process was running: create index CONCURRENTLY t_idx on t(a, b);
```

`addr2line` resolves that frame to `ColumnarProcessUtility` at `columnar_tableam.c:2504` — the `AtEOXact_GUC()` call.

Introduced by `ca8e66a3a` (#8753); `git log -S "AtEOXact_GUC" -- src/backend/columnar/columnar_tableam.c` returns that commit alone. The affected tests are long pre-existing, so new code broke old tests.

**Severity:** CI-blocking only. Non-cassert builds were unaffected — without assertions `AtEOXact_GUC()` ends with `GUCNestLevel = nestLevel - 1`, the value it already holds, so it degenerates to a no-op.

## Fix

`max_parallel_maintenance_workers` is a plain `int` (`extern PGDLLIMPORT` in `miscadmin.h`, already included), so save and restore it directly. That survives the internal commits and involves no nest-level bookkeeping.

This also makes the override *effective* during concurrent builds, which the nest-level version never was — it was silently discarded at the first internal commit, leaving the guarantee to rest solely on the planner hook (`ColumnarGetRelationInfoHook` / `ColumnarBuildSimpleRelHook` setting `rel->rel_parallel_workers = 0`).

The `indexBuildOnColumnar` guard on the restore is required: every `SET` statement also passes through this hook, so an unconditional restore reverts plain `SET max_parallel_maintenance_workers = ...`. The `guc_restore_test` block added by #8753 catches exactly that.

## Testing

Built `--enable-cassert` PostgreSQL 17.10 and reproduced the crash on unpatched `main`, then re-ran with the fix:

| Suite | Before | After |
|---|---|---|
| `check-columnar` | `columnar_indexes` crash | `columnar_indexes` passes, 0 `TRAP`s |
| `check-columnar-isolation` | crash in `columnar_index_concurrency` | All 5 tests passed, 0 `TRAP`s |

No new tests: the existing `columnar_indexes` and `columnar_index_concurrency` tests both crash without this change and pass with it.