### PR TITLE
[release-14.0] Retire Debian Bullseye from packaging CI

### DIFF
--- a/.github/packaging/packaging_ignore.yml
+++ b/.github/packaging/packaging_ignore.yml
@@ -1,3 +1,4 @@
 base:
   - ".* warning: ignoring old recipe for target [`']check'"
   - ".* warning: overriding recipe for target [`']check'"
+  - ".*: warning: no previous declaration for '.*' \\[-Wmissing-variable-declarations\\]"

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -120,14 +120,11 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - ubuntu-focal-all
+          - debian-trixie-all
           - ubuntu-jammy-all
+          - ubuntu-noble-all
 
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
-        exclude:
-          # PG18 is not supported on Ubuntu focal
-          - packaging_docker_image: ubuntu-focal-all
-            POSTGRES_VERSION: 18
 
     container:
       image: citus/packaging:${{ matrix.packaging_docker_image }}

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -120,7 +120,6 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - debian-bullseye-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
 


### PR DESCRIPTION
Retire Debian Bullseye and modernize the Debian-based packaging CI targets on `release-14.0`.

The matrix now tests:

- Debian Bookworm and Trixie
- Ubuntu Jammy and Noble

This removes Ubuntu Focal and its PG18 exclusion while preserving PostgreSQL coverage and the aggregate `Packaging` gate.