### PR TITLE
[release-13.2] Retire Debian Bullseye from packaging CI

### DIFF
--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -117,7 +117,6 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - debian-bullseye-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
 

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -117,8 +117,9 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - ubuntu-focal-all
+          - debian-trixie-all
           - ubuntu-jammy-all
+          - ubuntu-noble-all
 
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
 


### PR DESCRIPTION
Retire Debian Bullseye and modernize the Debian-based packaging CI targets on `release-13.2`.

The matrix now tests:

- Debian Bookworm and Trixie
- Ubuntu Jammy and Noble

PostgreSQL coverage and the aggregate `Packaging` gate remain unchanged. The same modernization is applied in citusdata/citus#8835 and citusdata/citus#8837.