### PR TITLE
Retire Debian Bullseye from packaging CI

### DIFF
--- a/.github/packaging/packaging_ignore.yml
+++ b/.github/packaging/packaging_ignore.yml
@@ -1,3 +1,4 @@
 base:
   - ".* warning: ignoring old recipe for target [`']check'"
   - ".* warning: overriding recipe for target [`']check'"
+  - ".*: warning: no previous declaration for '.*' \\[-Wmissing-variable-declarations\\]"

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -125,7 +125,6 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - debian-bullseye-all
           - ubuntu-focal-all
           - ubuntu-jammy-all
 

--- a/.github/workflows/packaging-test-pipelines.yml
+++ b/.github/workflows/packaging-test-pipelines.yml
@@ -125,16 +125,11 @@ jobs:
         # PG_CONFIG variable in each of those runs.
         packaging_docker_image:
           - debian-bookworm-all
-          - ubuntu-focal-all
+          - debian-trixie-all
           - ubuntu-jammy-all
+          - ubuntu-noble-all
 
         POSTGRES_VERSION: ${{ fromJson(needs.get_postgres_versions_from_file.outputs.pg_versions) }}
-        exclude:
-          # PG18 and PG19 are not supported on Ubuntu focal
-          - packaging_docker_image: ubuntu-focal-all
-            POSTGRES_VERSION: 18
-          - packaging_docker_image: ubuntu-focal-all
-            POSTGRES_VERSION: 19
 
     container:
       image: citus/packaging:${{ matrix.packaging_docker_image }}


### PR DESCRIPTION
Retire Debian Bullseye and modernize the Debian-based packaging CI targets on `main`.

The matrix now tests:

- Debian Bookworm and Trixie
- Ubuntu Jammy and Noble

This removes Ubuntu Focal and its obsolete PG18/PG19 exclusions while preserving PostgreSQL coverage and the aggregate `Packaging` gate.

Companion release-branch PRs:
- citusdata/citus#8835 (`release-14.0`)
- citusdata/citus#8836 (`release-13.2`)

Rollout order: update consumers before rolling out citusdata/packaging#1234.