### PR TITLE
Advance mitmproxy pin to unblock security dependency sync

### DIFF
--- a/.devcontainer/src/test/regress/Pipfile
+++ b/.devcontainer/src/test/regress/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [packages]
 pyasn1 = ">=0.6.4"
-mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "321e6d203cf31e36d59ba8e4f9c6a3c4a5d6ddf0"}
+mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "a16444362cc0393ccf7329f50fc909b711729de7"}
 "aioquic" = ">=1.2.0,<1.3.0"
 "mitmproxy-rs" = ">=0.12.6,<0.13.0"
 argon2-cffi = ">=23.1.0"

--- a/.devcontainer/src/test/regress/Pipfile.lock
+++ b/.devcontainer/src/test/regress/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "63eaa480757d61b4951dcbef6687f5a385031e8e336544ac9630b6d7b7c631c6"
+            "sha256": "37590aa1c1766e1647b8d1d967c8cbd4422fb9f77ab88dc3ad2dc5964dc74e5e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -683,7 +683,7 @@
         "mitmproxy": {
             "git": "https://github.com/citusdata/mitmproxy.git",
             "markers": "python_version >= '3.12'",
-            "ref": "321e6d203cf31e36d59ba8e4f9c6a3c4a5d6ddf0"
+            "ref": "a16444362cc0393ccf7329f50fc909b711729de7"
         },
         "mitmproxy-linux": {
             "hashes": [

--- a/src/test/regress/Pipfile
+++ b/src/test/regress/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [packages]
 pyasn1 = ">=0.6.4"
-mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "321e6d203cf31e36d59ba8e4f9c6a3c4a5d6ddf0"}
+mitmproxy = {git = "https://github.com/citusdata/mitmproxy.git", ref = "a16444362cc0393ccf7329f50fc909b711729de7"}
 "aioquic" = ">=1.2.0,<1.3.0"
 "mitmproxy-rs" = ">=0.12.6,<0.13.0"
 argon2-cffi = ">=23.1.0"

--- a/src/test/regress/Pipfile.lock
+++ b/src/test/regress/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "63eaa480757d61b4951dcbef6687f5a385031e8e336544ac9630b6d7b7c631c6"
+            "sha256": "37590aa1c1766e1647b8d1d967c8cbd4422fb9f77ab88dc3ad2dc5964dc74e5e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -683,7 +683,7 @@
         "mitmproxy": {
             "git": "https://github.com/citusdata/mitmproxy.git",
             "markers": "python_version >= '3.12'",
-            "ref": "321e6d203cf31e36d59ba8e4f9c6a3c4a5d6ddf0"
+            "ref": "a16444362cc0393ccf7329f50fc909b711729de7"
         },
         "mitmproxy-linux": {
             "hashes": [


### PR DESCRIPTION
## Summary

Advance the Citus mitmproxy fork pin to the commit from https://github.com/citusdata/mitmproxy/pull/5 in both regression-test Pipfiles and their lock metadata.

The updated fork adds cap support for:

- `cryptography==50.0.0`
- `h2==4.4.1`
- `tornado==6.5.8`
- OpenSSL 4 unsupported-protocol probe compatibility

This is intentionally a metadata-only minimal change: current package versions remain pinned. Once this PR merges, run `dependency-security-sync` in `citusdata/the-process` to generate the actual patched Citus lockfiles and test-image requirements as coordinated PRs.

## Validation

The current `.github/scripts/security_sync.py` from `citusdata/the-process` was run against all 14 current Citus Dependabot alerts in WSL Ubuntu 22.04 with Python 3.12, resolving the unpublished fork commit locally through a temporary Git URL rewrite.

- `tornado`, `h2`, and `cryptography` all reported `['applied', 'applied']`
- All alerts were addressed with `blocked=[]`
- Paired generated lockfiles were identical
- `pipenv verify` succeeded
- Full generated consumer development dependencies installed; `pip check` succeeded
- `mitmdump --version` started successfully with OpenSSL 4.0.1
- The fork's targeted seven-file suite passed with baseline and exact patched dependencies: 199 passed and 1 platform skip in each run

No workflow code, package versions, tests, or build tools are changed here.