### PR TITLE
Fix incorrect results from nested recurring outer joins

### DIFF
--- a/src/backend/distributed/planner/multi_physical_planner.c
+++ b/src/backend/distributed/planner/multi_physical_planner.c
@@ -178,7 +178,6 @@ static uint32 HashPartitionCount(void);
 static Job * BuildJobTreeTaskList(Job *jobTree,
 								  PlannerRestrictionContext *plannerRestrictionContext);
 static bool IsInnerTableOfOuterJoin(RelationRestriction *relationRestriction,
-									Bitmapset *distributedTables,
 									bool *outerPartHasDistributedTable);
 static void ErrorIfUnsupportedShardDistribution(Query *query);
 static Task * QueryPushdownTaskCreate(Query *originalQuery, int shardIndex,
@@ -2277,7 +2276,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 	int minShardOffset = INT_MAX;
 	int prevShardCount = 0;
 	Bitmapset *taskRequiredForShardIndex = NULL;
-	Bitmapset *distributedTableIndex = NULL;
+	bool hasDistributedTable = false;
 
 	/* error if shards are not co-partitioned */
 	ErrorIfUnsupportedShardDistribution(query);
@@ -2294,10 +2293,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 	RelationRestriction *relationRestriction = NULL;
 	List *prunedShardList = NULL;
 
-	/* First loop, gather the indexes of distributed tables
-	 *  this is required to decide whether we can skip shards
-	 *  from inner tables of outer joins
-	 */
+	/* first check that distributed tables have the same shard count */
 	foreach_declared_ptr(relationRestriction,
 						 relationRestrictionContext->relationRestrictionList)
 	{
@@ -2320,14 +2316,13 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		}
 		prevShardCount = cacheEntry->shardIntervalArrayLength;
 
-		distributedTableIndex = bms_add_member(distributedTableIndex,
-											   relationRestriction->index);
+		hasDistributedTable = true;
 	}
 
 	/* In the second loop, populate taskRequiredForShardIndex */
 	bool updateQualsForOuterJoin = false;
 	bool outerPartHasDistributedTable = false;
-	bool noDistTables = bms_is_empty(distributedTableIndex);
+	bool noDistTables = !hasDistributedTable;
 	bool hasRefOrSchemaShardedTable = false;
 	forboth_ptr(prunedShardList, prunedRelationShardList,
 				relationRestriction, relationRestrictionContext->relationRestrictionList)
@@ -2382,7 +2377,7 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
 		 * the table is part of the non-outer side of the join and the outer side has a
 		 * distributed table.
 		 */
-		if (IsInnerTableOfOuterJoin(relationRestriction, distributedTableIndex,
+		if (IsInnerTableOfOuterJoin(relationRestriction,
 									&outerPartHasDistributedTable))
 		{
 			if (outerPartHasDistributedTable)
@@ -2490,7 +2485,6 @@ QueryPushdownSqlTaskList(Query *query, uint64 jobId,
  */
 static bool
 IsInnerTableOfOuterJoin(RelationRestriction *relationRestriction,
-						Bitmapset *distributedTables,
 						bool *outerPartHasDistributedTable)
 {
 	RestrictInfo *joinInfo = NULL;
@@ -2511,10 +2505,25 @@ IsInnerTableOfOuterJoin(RelationRestriction *relationRestriction,
 									   joinInfo->outer_relids);
 		if (!isInOuter)
 		{
-			/* this table is joined in the inner part of an outer join */
-			/* set if the outer part has a distributed relation */
-			*outerPartHasDistributedTable = bms_overlap(joinInfo->outer_relids,
-														distributedTables);
+			/*
+			 * Range table indexes are local to each query level. Resolve the
+			 * outer relations in this restriction's PlannerInfo, not against
+			 * distributed table indexes collected from other subqueries.
+			 */
+			PlannerInfo *plannerInfo = relationRestriction->plannerInfo;
+			*outerPartHasDistributedTable = false;
+			int outerRelationIndex = -1;
+			while ((outerRelationIndex = bms_next_member(joinInfo->outer_relids,
+														 outerRelationIndex)) >= 0)
+			{
+				RangeTblEntry *outerRte =
+					plannerInfo->simple_rte_array[outerRelationIndex];
+				if (IsTableWithDistKeyRTE((Node *) outerRte))
+				{
+					*outerPartHasDistributedTable = true;
+					break;
+				}
+			}
 
 			/* this is an inner table of an outer join  */
 			return true;

--- a/src/test/regress/expected/recurring_join_pushdown.out
+++ b/src/test/regress/expected/recurring_join_pushdown.out
@@ -980,4 +980,32 @@ DEBUG:  Creating router plan
 (1 row)
 
 SET client_min_messages TO ERROR;
+-- Query-local range table indexes must not make the reference side of the
+-- nested outer join look distributed, causing every shard task to be skipped.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM d1 RIGHT JOIN r1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d1 USING (a);
+ count | count
+---------------------------------------------------------------------
+    57 |    54
+(1 row)
+
+-- A different distributed table at the outer query level has the same issue.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM d1 RIGHT JOIN r1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d2 USING (a);
+ count | count
+---------------------------------------------------------------------
+    57 |    54
+(1 row)
+
+-- The equivalent LEFT JOIN spelling must return the same duplicate and NULL rows.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM r1 LEFT JOIN d1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d2 USING (a);
+ count | count
+---------------------------------------------------------------------
+    57 |    54
+(1 row)
+
 DROP SCHEMA recurring_join_pushdown CASCADE;

--- a/src/test/regress/sql/recurring_join_pushdown.sql
+++ b/src/test/regress/sql/recurring_join_pushdown.sql
@@ -139,4 +139,21 @@ ORDER BY sq.a
 LIMIT 1;
 
 SET client_min_messages TO ERROR;
+
+-- Query-local range table indexes must not make the reference side of the
+-- nested outer join look distributed, causing every shard task to be skipped.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM d1 RIGHT JOIN r1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d1 USING (a);
+
+-- A different distributed table at the outer query level has the same issue.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM d1 RIGHT JOIN r1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d2 USING (a);
+
+-- The equivalent LEFT JOIN spelling must return the same duplicate and NULL rows.
+SELECT count(*), count(s.a)
+FROM (SELECT d1.a FROM r1 LEFT JOIN d1 USING (a) ORDER BY d1.a) s
+LEFT JOIN d2 USING (a);
+
 DROP SCHEMA recurring_join_pushdown CASCADE;


### PR DESCRIPTION
DESCRIPTION: Fix incorrect empty results from nested recurring outer joins

Fixes #8838.

## Root cause

`QueryPushdownSqlTaskList()` combined distributed range-table indexes from different query levels into one bitmap. `IsInnerTableOfOuterJoin()` could therefore mistake a nested reference table for an outer-level distributed table with the same index, skip every shard task, and incorrectly return no rows.

## Changes

- Resolve each outer-side relation in its owning `PlannerInfo->simple_rte_array`, using the existing distributed-table predicate.
- Replace the cross-query index bitmap with a boolean where only the presence of distributed tables is needed.
- Cover nested RIGHT JOINs with the same and distinct outer distributed tables, plus the equivalent LEFT JOIN, including duplicate and unmatched rows.

The CTE reuse, `NOT IN`, and `LIMIT 0` in the original generator query are incidental; the reduced reproducer only needs a nested recurring outer join.

## Validation

- Exact saved CI query 239 and fixture: distributed and local PostgreSQL both return `count=4, avg=0` after the fix (PostgreSQL 17.11).
- Original generator seed `1788923688918`: passes on PostgreSQL 17.11 and assertion-enabled PostgreSQL 17.10.
- Focused recurring outer-join, reference outer-join, CTE, and recursive-planning suites: pass on PostgreSQL 18.6, 19beta3, and assertion-enabled 17.10; initial focused subset also passes on 17.11.
- Existing Citus formatting check passes.