### PR TITLE
Fix CDC decoder crash from translated tuples outliving the publish call

### DIFF
--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -272,38 +272,46 @@ TranslateAndPublishRelationForCDC(LogicalDecodingContext *ctx, ReorderBufferTXN 
 	HeapTuple originalNewTuple = change->data.tp.newtuple;
 	HeapTuple originalOldTuple = change->data.tp.oldtuple;
 
-	/*
-	 * Check if there has been a schema change (such as a dropped column), by comparing
-	 * the number of attributes in the shard table and the shell table.
-	 */
-	TranslateChangesIfSchemaChanged(relation, targetRelation, change);
-
-	/*
-	 * Publish the change to the shard table as the change in the distributed table,
-	 * so that the CDC client can see the change in the distributed table,
-	 * instead of the shard table, by calling the pgoutput's callback function.
-	 */
-	ouputPluginChangeCB(ctx, txn, targetRelation, change);
-
-	/*
-	 * Free the translated tuples and put the original ones back. A field that
-	 * was not translated still holds its original pointer, so it is left alone.
-	 */
-	if (change->data.tp.newtuple != originalNewTuple &&
-		change->data.tp.newtuple != NULL)
+	PG_TRY();
 	{
-		heap_freetuple(change->data.tp.newtuple);
-		change->data.tp.newtuple = originalNewTuple;
-	}
+		/*
+		 * Check if there has been a schema change (such as a dropped column), by comparing
+		 * the number of attributes in the shard table and the shell table.
+		 */
+		TranslateChangesIfSchemaChanged(relation, targetRelation, change);
 
-	if (change->data.tp.oldtuple != originalOldTuple &&
-		change->data.tp.oldtuple != NULL)
+		/*
+		 * Publish the change to the shard table as the change in the distributed table,
+		 * so that the CDC client can see the change in the distributed table,
+		 * instead of the shard table, by calling the pgoutput's callback function.
+		 */
+		ouputPluginChangeCB(ctx, txn, targetRelation, change);
+	}
+	PG_FINALLY();
 	{
-		heap_freetuple(change->data.tp.oldtuple);
-		change->data.tp.oldtuple = originalOldTuple;
-	}
+		/*
+		 * Free the translated tuples and put the original ones back. A field that
+		 * was not translated still holds its original pointer, so it is left alone.
+		 * This also has to happen when the callback throws, because the reorder
+		 * buffer cleans the transaction up before the error propagates further.
+		 */
+		if (change->data.tp.newtuple != originalNewTuple &&
+			change->data.tp.newtuple != NULL)
+		{
+			heap_freetuple(change->data.tp.newtuple);
+			change->data.tp.newtuple = originalNewTuple;
+		}
 
-	RelationClose(targetRelation);
+		if (change->data.tp.oldtuple != originalOldTuple &&
+			change->data.tp.oldtuple != NULL)
+		{
+			heap_freetuple(change->data.tp.oldtuple);
+			change->data.tp.oldtuple = originalOldTuple;
+		}
+
+		RelationClose(targetRelation);
+	}
+	PG_END_TRY();
 }
 
 

--- a/src/backend/distributed/cdc/cdc_decoder.c
+++ b/src/backend/distributed/cdc/cdc_decoder.c
@@ -263,6 +263,16 @@ TranslateAndPublishRelationForCDC(LogicalDecodingContext *ctx, ReorderBufferTXN 
 	Relation targetRelation = RelationIdGetRelation(targetRelationid);
 
 	/*
+	 * Remember the tuples that the reorder buffer handed us. Any tuple that we
+	 * substitute below is allocated by us, but the reorder buffer frees both
+	 * tuple fields of the change when the transaction is cleaned up, assuming
+	 * they were allocated from its own tuple context. Restoring the original
+	 * pointers after publishing keeps each allocator freeing only what it owns.
+	 */
+	HeapTuple originalNewTuple = change->data.tp.newtuple;
+	HeapTuple originalOldTuple = change->data.tp.oldtuple;
+
+	/*
 	 * Check if there has been a schema change (such as a dropped column), by comparing
 	 * the number of attributes in the shard table and the shell table.
 	 */
@@ -274,6 +284,25 @@ TranslateAndPublishRelationForCDC(LogicalDecodingContext *ctx, ReorderBufferTXN 
 	 * instead of the shard table, by calling the pgoutput's callback function.
 	 */
 	ouputPluginChangeCB(ctx, txn, targetRelation, change);
+
+	/*
+	 * Free the translated tuples and put the original ones back. A field that
+	 * was not translated still holds its original pointer, so it is left alone.
+	 */
+	if (change->data.tp.newtuple != originalNewTuple &&
+		change->data.tp.newtuple != NULL)
+	{
+		heap_freetuple(change->data.tp.newtuple);
+		change->data.tp.newtuple = originalNewTuple;
+	}
+
+	if (change->data.tp.oldtuple != originalOldTuple &&
+		change->data.tp.oldtuple != NULL)
+	{
+		heap_freetuple(change->data.tp.oldtuple);
+		change->data.tp.oldtuple = originalOldTuple;
+	}
+
 	RelationClose(targetRelation);
 }
 


### PR DESCRIPTION
## The crash

`cdc_decoder.c` segfaults the walsender. Proven stack from a local core dump:

```text
SlabFree
ReorderBufferFreeChange
ReorderBufferCleanupTXN
ReorderBufferProcessTXN
xact_decode
LogicalDecodingProcessRecord
XLogSendLogical
WalSndLoop
```

```text
LOG:  client backend (PID ...) was terminated by signal 11: Segmentation fault
DETAIL:  Failed process was running: START_REPLICATION SLOT "cdc_replication_slot" LOGICAL 0/0
```

Core inspection pinned the faulting free to the field at struct offset `0x38` of a
`REORDER_BUFFER_CHANGE_UPDATE` change — confirmed via DWARF to be `data.tp.newtuple` —
and showed the pointer is the Citus-translated tuple, not PostgreSQL's own. Its chunk
header selects allocator ID 5, from which `SlabFree` derives a bogus context pointer
(`0x1000000`) and faults.

## Root cause: ownership / lifetime mismatch

- `GetTupleForTargetSchemaForCdc()` builds a replacement tuple with `heap_form_tuple()`
  in the *current* memory context.
- `TranslateChangesIfSchemaChanged()` assigns it to `change->data.tp.newtuple` (and to
  `oldtuple` for `UPDATE` with `REPLICA IDENTITY FULL`, and for `DELETE`), and never
  restores the original pointers.
- `TranslateAndPublishRelationForCDC()` called `ouputPluginChangeCB()` and returned with
  both fields still pointing at Citus-allocated memory.
- PostgreSQL then frees both fields in `ReorderBufferFreeChange()` during
  `ReorderBufferCleanupTXN()`, expecting memory allocated from the reorder buffer's own
  tuple context. It frees a foreign chunk and faults.

This is **not** a concurrency race and **not** a regression from any recent PR. It is a
pre-existing latent bug that surfaces intermittently because it depends on memory reuse,
which is why it has looked like a flaky test rather than a crash.

## The fix

Scope the tuple substitution strictly to the publish call, so PostgreSQL only ever sees —
and therefore only ever frees — pointers it allocated itself.

In `TranslateAndPublishRelationForCDC()`:

1. Remember `change->data.tp.newtuple` / `oldtuple` before translating.
2. After `ouputPluginChangeCB()` returns, for each field: if it no longer holds the
   original pointer, `heap_freetuple()` the tuple Citus allocated and restore the original.

Using "differs from the original" as the test makes restoration automatically correct on
every translated path — `INSERT` (newtuple only), `UPDATE` with and without a non-NULL
`oldtuple`, and `DELETE` (oldtuple only) — and a strict no-op when `HasSchemaChanged()`
returned false and nothing was replaced.

Deliberately minimal: 29 added lines in one function, roughly half of them comments.
No signature changes, no change to `GetTupleForTargetSchemaForCdc()`'s translation logic,
no new memory contexts, no change to the pgoutput callback contract, and no
version `#ifdef` — the minimum supported version is PG 17 and `data.tp.newtuple` is a
plain `HeapTuple` on 17/18/19, which is why the surrounding code already assigns it
unguarded.

## Testing

`src/test/cdc/t/006_cdc_schema_change_and_move.pl` exercises exactly this path: it
combines `DROP COLUMN`, a `force_logical` shard move, and a subsequent `UPDATE`, which is
what drives translation and therefore the bad free. CI will validate it.

Locally, the extension was built against PostgreSQL 18.6: `citus.so`, `citus_columnar.so`,
`citus_pgoutput.so`, and `citus_wal2json.so` all compile and link cleanly, with no new
compiler warnings under the project's `-Wall -Wextra` flags. `cdc_decoder.c` is clean under
`uncrustify` with the repo's `citus-style.cfg`.

## Follow-up (not in this PR)

`.github/actions/save_logs_and_results` does not upload `src/test/cdc/log/`, so when the
walsender crashes, CI shows only a `poll_query_until` catch-up timeout with "connection
refused" and the real server log is lost. Worth fixing separately to make future CDC
crashes diagnosable — intentionally left out here to keep this change to the fix itself.

Fixes #8844