### PR TITLE
Fix search_path quoting in citus_schema_move test

### DIFF
--- a/src/test/regress/expected/citus_schema_move.out
+++ b/src/test/regress/expected/citus_schema_move.out
@@ -91,7 +91,7 @@ ERROR:  cannot move shard to the same node
 CREATE OR REPLACE FUNCTION get_non_coord_candidate_node_for_schema_move(
     schema_id regnamespace)
 RETURNS TABLE (nodeid integer, nodename text, nodeport integer)
-SET search_path TO 'pg_catalog, public'
+SET search_path TO pg_catalog, public
 AS $func$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_dist_schema WHERE schemaid = schema_id)

--- a/src/test/regress/sql/citus_schema_move.sql
+++ b/src/test/regress/sql/citus_schema_move.sql
@@ -70,7 +70,7 @@ WHERE noderole = 'primary' AND table_name = 's1.t1'::regclass;
 CREATE OR REPLACE FUNCTION get_non_coord_candidate_node_for_schema_move(
     schema_id regnamespace)
 RETURNS TABLE (nodeid integer, nodename text, nodeport integer)
-SET search_path TO 'pg_catalog, public'
+SET search_path TO pg_catalog, public
 AS $func$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_dist_schema WHERE schemaid = schema_id)


### PR DESCRIPTION
The test helper quotes `pg_catalog, public` as a single schema name.
Remove the quotes so search_path contains both schemas, and update the expected output.

Fixes #7951
