### PR TITLE
Support mixed Citus 12/13/14 versions during pgmongo upgrades

### DIFF
--- a/src/backend/columnar/columnar_tableam.c
+++ b/src/backend/columnar/columnar_tableam.c
@@ -167,7 +167,7 @@ static int ParseVersionComponent(const char *version, char **endPtr);
 
 /* global variables for CheckCitusColumnarVersion */
 static bool extensionLoadedColumnar = false;
-static bool EnableVersionChecksColumnar = true;
+static bool EnableVersionChecksColumnar = false;
 static bool citusVersionKnownCompatibleColumnar = false;
 
 /* Custom tuple slot ops used for columnar. Initialized in columnar_tableam_init(). */
@@ -2014,7 +2014,7 @@ columnar_tableam_init()
 		gettext_noop("Enables Version Check for Columnar"),
 		NULL,
 		&EnableVersionChecksColumnar,
-		true,
+		false,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);

--- a/src/backend/distributed/clock/causal_clock.c
+++ b/src/backend/distributed/clock/causal_clock.c
@@ -386,7 +386,7 @@ AdjustClocksToTransactionHighest(List *nodeConnectionList,
 
 	/* Set the clock value on participating worker nodes */
 	appendStringInfo(queryToSend,
-					 "SELECT citus_internal.adjust_local_clock_to_remote"
+					 "SELECT pg_catalog.citus_internal_adjust_local_clock_to_remote"
 					 "('(%lu, %u)'::pg_catalog.cluster_clock);",
 					 transactionClockValue->logical, transactionClockValue->counter);
 

--- a/src/backend/distributed/metadata/metadata_cache.c
+++ b/src/backend/distributed/metadata/metadata_cache.c
@@ -237,7 +237,7 @@ typedef struct MetadataCacheData
 static MetadataCacheData MetadataCache;
 
 /* Citus extension version variables */
-bool EnableVersionChecks = true; /* version checks are enabled */
+bool EnableVersionChecks = false; /* version checks are disabled to allow mixed 12/13/14 major versions on the same cluster */
 
 static bool citusVersionKnownCompatible = false;
 

--- a/src/backend/distributed/metadata/metadata_sync.c
+++ b/src/backend/distributed/metadata/metadata_sync.c
@@ -99,6 +99,20 @@
 char *EnableManualMetadataChangesForUser = "";
 int MetadataSyncTransMode = METADATA_SYNC_TRANSACTIONAL;
 
+/*
+ * CitusInternalSchemaPrefix returns the prefix used to qualify the internal
+ * metadata helper functions in commands propagated to workers. We always emit
+ * the pre-13.1 pg_catalog.citus_internal_* names so a Citus 14 coordinator can
+ * sync metadata to older workers (e.g. 12.1) that predate the citus_internal
+ * schema; appending the bare function name (e.g. "add_partition_metadata")
+ * yields "pg_catalog.citus_internal_add_partition_metadata".
+ */
+const char *
+CitusInternalSchemaPrefix(void)
+{
+	return "pg_catalog.citus_internal_";
+}
+
 
 static void EnsureObjectMetadataIsSane(int distributionArgumentIndex,
 									   int colocationId);
@@ -817,10 +831,16 @@ NodeListInsertCommand(List *workerNodeList)
 	}
 
 	/* generate the query without any values yet */
+	/*
+	 * Original stock column list commented out for the mixed-version fork
+	 * (nodeisclone / nodeprimarynodeid omitted so pre-clone-column workers such
+	 * as 12.1 accept the INSERT):
+	 * "nodecluster, shouldhaveshards, nodeisclone, nodeprimarynodeid) VALUES ");
+	 */
 	appendStringInfo(nodeListInsertCommand,
 					 "INSERT INTO pg_dist_node (nodeid, groupid, nodename, nodeport, "
 					 "noderack, hasmetadata, metadatasynced, isactive, noderole, "
-					 "nodecluster, shouldhaveshards, nodeisclone, nodeprimarynodeid) VALUES ");
+					 "nodecluster, shouldhaveshards) VALUES ");
 
 	/* iterate over the worker nodes, add the values */
 	WorkerNode *workerNode = NULL;
@@ -830,14 +850,19 @@ NodeListInsertCommand(List *workerNodeList)
 		char *metadataSyncedString = workerNode->metadataSynced ? "TRUE" : "FALSE";
 		char *isActiveString = workerNode->isActive ? "TRUE" : "FALSE";
 		char *shouldHaveShards = workerNode->shouldHaveShards ? "TRUE" : "FALSE";
-		char *nodeiscloneString = workerNode->nodeisclone ? "TRUE" : "FALSE";
+		/* commented out: char *nodeiscloneString = workerNode->nodeisclone ? "TRUE" : "FALSE"; */
 
 		Datum nodeRoleOidDatum = ObjectIdGetDatum(workerNode->nodeRole);
 		Datum nodeRoleStringDatum = DirectFunctionCall1(enum_out, nodeRoleOidDatum);
 		char *nodeRoleString = DatumGetCString(nodeRoleStringDatum);
 
+		/*
+		 * Original stock format/args commented out for the mixed-version fork:
+		 * "(%d, %d, %s, %d, %s, %s, %s, %s, '%s'::noderole, %s, %s, %s, %d)"
+		 * ... shouldHaveShards, nodeiscloneString, workerNode->nodeprimarynodeid);
+		 */
 		appendStringInfo(nodeListInsertCommand,
-						 "(%d, %d, %s, %d, %s, %s, %s, %s, '%s'::noderole, %s, %s, %s, %d)",
+						 "(%d, %d, %s, %d, %s, %s, %s, %s, '%s'::noderole, %s, %s)",
 						 workerNode->nodeId,
 						 workerNode->groupId,
 						 quote_literal_cstr(workerNode->workerName),
@@ -848,9 +873,7 @@ NodeListInsertCommand(List *workerNodeList)
 						 isActiveString,
 						 nodeRoleString,
 						 quote_literal_cstr(workerNode->nodeCluster),
-						 shouldHaveShards,
-						 nodeiscloneString,
-						 workerNode->nodeprimarynodeid);
+						 shouldHaveShards);
 
 		processedWorkerNodeCount++;
 		if (processedWorkerNodeCount != workerCount)
@@ -886,9 +909,13 @@ NodeListIdempotentInsertCommand(List *workerNodeList)
 						  "noderole = EXCLUDED.noderole, "
 						  "nodecluster = EXCLUDED.nodecluster, "
 						  "metadatasynced = EXCLUDED.metadatasynced, "
-						  "shouldhaveshards = EXCLUDED.shouldhaveshards, "
-						  "nodeisclone = EXCLUDED.nodeisclone, "
-						  "nodeprimarynodeid = EXCLUDED.nodeprimarynodeid";
+						  "shouldhaveshards = EXCLUDED.shouldhaveshards";
+	/*
+	 * Original stock trailing clauses commented out for the mixed-version fork:
+	 * "shouldhaveshards = EXCLUDED.shouldhaveshards, "
+	 * "nodeisclone = EXCLUDED.nodeisclone, "
+	 * "nodeprimarynodeid = EXCLUDED.nodeprimarynodeid";
+	 */
 	appendStringInfoString(nodeInsertIdempotentCommand, onConflictStr);
 	return nodeInsertIdempotentCommand->data;
 }
@@ -997,10 +1024,12 @@ MarkObjectsDistributedCreateCommand(List *addresses,
 
 	appendStringInfo(insertDistributedObjectsCommand, ") ");
 
+	/* stock: ") SELECT citus_internal.add_object_metadata(" */
 	appendStringInfo(insertDistributedObjectsCommand,
-					 "SELECT citus_internal.add_object_metadata("
+					 "SELECT %sadd_object_metadata("
 					 "typetext, objnames, objargs, distargumentindex::int, colocationid::int, force_delegation::bool) "
-					 "FROM distributed_object_data;");
+					 "FROM distributed_object_data;",
+					 CitusInternalSchemaPrefix());
 
 	return insertDistributedObjectsCommand->data;
 }
@@ -1132,9 +1161,11 @@ DistributionCreateCommand(CitusTableCacheEntry *cacheEntry)
 						 quote_literal_cstr(partitionKeyColumnName));
 	}
 
+	/* stock: "SELECT citus_internal.add_partition_metadata " */
 	appendStringInfo(insertDistributionCommand,
-					 "SELECT citus_internal.add_partition_metadata "
+					 "SELECT %sadd_partition_metadata "
 					 "(%s::regclass, '%c', %s, %d, '%c')",
+					 CitusInternalSchemaPrefix(),
 					 quote_literal_cstr(qualifiedRelationName),
 					 distributionMethod,
 					 tablePartitionKeyNameString->data,
@@ -1174,8 +1205,10 @@ DistributionDeleteMetadataCommand(Oid relationId)
 	StringInfo deleteCommand = makeStringInfo();
 	char *qualifiedRelationName = generate_qualified_relation_name(relationId);
 
+	/* stock: "SELECT citus_internal.delete_partition_metadata(%s)" */
 	appendStringInfo(deleteCommand,
-					 "SELECT citus_internal.delete_partition_metadata(%s)",
+					 "SELECT %sdelete_partition_metadata(%s)",
+					 CitusInternalSchemaPrefix(),
 					 quote_literal_cstr(qualifiedRelationName));
 
 	return deleteCommand->data;
@@ -1257,10 +1290,12 @@ ShardListInsertCommand(List *shardIntervalList)
 
 	appendStringInfo(insertPlacementCommand, ") ");
 
+	/* stock: "SELECT citus_internal.add_placement_metadata(" */
 	appendStringInfo(insertPlacementCommand,
-					 "SELECT citus_internal.add_placement_metadata("
+					 "SELECT %sadd_placement_metadata("
 					 "shardid, shardlength, groupid, placementid) "
-					 "FROM placement_data;");
+					 "FROM placement_data;",
+					 CitusInternalSchemaPrefix());
 
 	/* now add shards to insertShardCommand */
 	StringInfo insertShardCommand = makeStringInfo();
@@ -1313,10 +1348,12 @@ ShardListInsertCommand(List *shardIntervalList)
 
 	appendStringInfo(insertShardCommand, ") ");
 
+	/* stock: "SELECT citus_internal.add_shard_metadata(relationname, shardid, " */
 	appendStringInfo(insertShardCommand,
-					 "SELECT citus_internal.add_shard_metadata(relationname, shardid, "
+					 "SELECT %sadd_shard_metadata(relationname, shardid, "
 					 "storagetype, shardminvalue, shardmaxvalue) "
-					 "FROM shard_data;");
+					 "FROM shard_data;",
+					 CitusInternalSchemaPrefix());
 
 	/*
 	 * There are no active placements for the table, so do not create the
@@ -1352,8 +1389,10 @@ ShardDeleteCommandList(ShardInterval *shardInterval)
 	uint64 shardId = shardInterval->shardId;
 
 	StringInfo deleteShardCommand = makeStringInfo();
+	/* stock: "SELECT citus_internal.delete_shard_metadata(%ld);" */
 	appendStringInfo(deleteShardCommand,
-					 "SELECT citus_internal.delete_shard_metadata(%ld);", shardId);
+					 "SELECT %sdelete_shard_metadata(%ld);",
+					 CitusInternalSchemaPrefix(), shardId);
 
 	return list_make1(deleteShardCommand->data);
 }
@@ -1422,8 +1461,10 @@ ColocationIdUpdateCommand(Oid relationId, uint32 colocationId)
 {
 	StringInfo command = makeStringInfo();
 	char *qualifiedRelationName = generate_qualified_relation_name(relationId);
+	/* stock: "SELECT citus_internal.update_relation_colocation(%s::regclass, %d)" */
 	appendStringInfo(command,
-					 "SELECT citus_internal.update_relation_colocation(%s::regclass, %d)",
+					 "SELECT %supdate_relation_colocation(%s::regclass, %d)",
+					 CitusInternalSchemaPrefix(),
 					 quote_literal_cstr(qualifiedRelationName), colocationId);
 
 	return command->data;
@@ -4231,7 +4272,7 @@ ColocationGroupCreateCommand(uint32 colocationId, int shardCount, int replicatio
 
 	appendStringInfo(insertColocationCommand,
 					 "%s)) "
-					 "SELECT citus_internal.add_colocation_metadata("
+					 "SELECT %sadd_colocation_metadata("
 					 "colocationid, shardcount, replicationfactor, "
 					 "coalesce(t.oid, 0), collationid) "
 					 "FROM colocation_data "
@@ -4240,7 +4281,8 @@ ColocationGroupCreateCommand(uint32 colocationId, int shardCount, int replicatio
 					 "AND (typeschema IS NULL OR "
 					 "t.typnamespace = "
 					 "(SELECT oid FROM pg_namespace WHERE nspname = typeschema)))",
-					 RemoteCollationIdExpression(distributionColumnCollation));
+					 RemoteCollationIdExpression(distributionColumnCollation),
+					 CitusInternalSchemaPrefix());
 
 	return insertColocationCommand->data;
 }
@@ -4370,7 +4412,8 @@ ColocationGroupDeleteCommand(uint32 colocationId)
 	StringInfo deleteColocationCommand = makeStringInfo();
 
 	appendStringInfo(deleteColocationCommand,
-					 "SELECT citus_internal.delete_colocation_metadata(%d)",
+					 "SELECT %sdelete_colocation_metadata(%d)",
+					 CitusInternalSchemaPrefix(),
 					 colocationId);
 
 	return deleteColocationCommand->data;
@@ -4386,7 +4429,8 @@ TenantSchemaInsertCommand(Oid schemaId, uint32 colocationId)
 {
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.add_tenant_schema(%s, %u)",
+					 "SELECT %sadd_tenant_schema(%s, %u)",
+					 CitusInternalSchemaPrefix(),
 					 RemoteSchemaIdExpressionById(schemaId), colocationId);
 
 	return command->data;
@@ -4402,7 +4446,8 @@ TenantSchemaDeleteCommand(char *schemaName)
 {
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.delete_tenant_schema(%s)",
+					 "SELECT %sdelete_tenant_schema(%s)",
+					 CitusInternalSchemaPrefix(),
 					 RemoteSchemaIdExpressionByName(schemaName));
 
 	return command->data;
@@ -4419,7 +4464,8 @@ UpdateNoneDistTableMetadataCommand(Oid relationId, char replicationModel,
 {
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.update_none_dist_table_metadata(%s, '%c', %u, %s)",
+					 "SELECT %supdate_none_dist_table_metadata(%s, '%c', %u, %s)",
+					 CitusInternalSchemaPrefix(),
 					 RemoteTableIdExpression(relationId), replicationModel, colocationId,
 					 autoConverted ? "true" : "false");
 
@@ -4437,7 +4483,8 @@ AddPlacementMetadataCommand(uint64 shardId, uint64 placementId,
 {
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.add_placement_metadata(%ld, %ld, %d, %ld)",
+					 "SELECT %sadd_placement_metadata(%ld, %ld, %d, %ld)",
+					 CitusInternalSchemaPrefix(),
 					 shardId, shardLength, groupId, placementId);
 	return command->data;
 }
@@ -4452,7 +4499,8 @@ DeletePlacementMetadataCommand(uint64 placementId)
 {
 	StringInfo command = makeStringInfo();
 	appendStringInfo(command,
-					 "SELECT citus_internal.delete_placement_metadata(%ld)",
+					 "SELECT %sdelete_placement_metadata(%ld)",
+					 CitusInternalSchemaPrefix(),
 					 placementId);
 	return command->data;
 }
@@ -5105,7 +5153,7 @@ SendColocationMetadataCommands(MetadataSyncContext *context)
 		 * the type and its schema to be created first by dependency commands.
 		 */
 		appendStringInfo(colocationGroupCreateCommand,
-						 ") SELECT citus_internal.add_colocation_metadata("
+						 ") SELECT %sadd_colocation_metadata("
 						 "colocationid, shardcount, replicationfactor, "
 						 "coalesce(t.oid, 0), coalesce(c.oid, 0)) "
 						 "FROM colocation_group_data d "
@@ -5117,7 +5165,8 @@ SendColocationMetadataCommands(MetadataSyncContext *context)
 						 "LEFT JOIN pg_collation c "
 						 "ON (d.distributioncolumncollationname = c.collname "
 						 "AND c.collnamespace = (SELECT oid FROM pg_namespace WHERE "
-						 "nspname = d.distributioncolumncollationschema))");
+						 "nspname = d.distributioncolumncollationschema))",
+						 CitusInternalSchemaPrefix());
 
 		List *commandList = list_make1(colocationGroupCreateCommand->data);
 		SendOrCollectCommandListToActivatedNodes(context, commandList);
@@ -5162,7 +5211,8 @@ SendTenantSchemaMetadataCommands(MetadataSyncContext *context)
 
 		StringInfo insertTenantSchemaCommand = makeStringInfo();
 		appendStringInfo(insertTenantSchemaCommand,
-						 "SELECT citus_internal.add_tenant_schema(%s, %u)",
+						 "SELECT %sadd_tenant_schema(%s, %u)",
+						 CitusInternalSchemaPrefix(),
 						 RemoteSchemaIdExpressionById(tenantSchemaForm->schemaid),
 						 tenantSchemaForm->colocationid);
 

--- a/src/backend/distributed/operations/shard_transfer.c
+++ b/src/backend/distributed/operations/shard_transfer.c
@@ -2464,7 +2464,7 @@ UpdateColocatedShardPlacementMetadataOnWorkers(int64 shardId,
 		StringInfo updateCommand = makeStringInfo();
 
 		appendStringInfo(updateCommand,
-						 "SELECT citus_internal.update_placement_metadata(%ld, %d, %d)",
+						 "SELECT pg_catalog.citus_internal_update_placement_metadata(%ld, %d, %d)",
 						 colocatedShard->shardId,
 						 sourceGroupId, targetGroupId);
 

--- a/src/backend/distributed/planner/multi_explain.c
+++ b/src/backend/distributed/planner/multi_explain.c
@@ -1321,10 +1321,23 @@ worker_last_saved_explain_analyze(PG_FUNCTION_ARGS)
 
 	if (SavedExplainPlan != NULL)
 	{
+		/*
+		 * execution_ntuples and execution_nloops were added to
+		 * worker_last_saved_explain_analyze() in Citus 13.2. In a mixed-version
+		 * cluster the coordinator fetches with a 2-column definition (see
+		 * FetchPlanQueryForExplainAnalyze), so accept either the legacy 2-column
+		 * or the extended 4-column shape based on the caller's expected tuple
+		 * descriptor rather than a fixed count.
+		 */
 		int columnCount = tupleDescriptor->natts;
-		if (columnCount != 4)
+		/* Original stock check commented out: if (columnCount != 4) */
+		if (columnCount != 2 && columnCount != 4)
 		{
-			ereport(ERROR, (errmsg("expected 4 output columns in definition of "
+			/*
+			 * Original stock message commented out:
+			 * ereport(ERROR, (errmsg("expected 4 output columns in definition of "
+			 */
+			ereport(ERROR, (errmsg("expected 2 or 4 output columns in definition of "
 								   "worker_last_saved_explain_analyze, but got %d",
 								   columnCount)));
 		}
@@ -1727,13 +1740,24 @@ CreateExplainAnlyzeDestination(Task *task, TupleDestination *taskDest)
 	tupleDestination->originalTask = task;
 	tupleDestination->originalTaskDestination = taskDest;
 
-	TupleDesc lastSavedExplainAnalyzeTupDesc = CreateTemplateTupleDesc(4);
+	/*
+	 * We only fetch explain_analyze_output and execution_duration so distributed
+	 * EXPLAIN ANALYZE keeps working against pre-13.2 workers (e.g. 12.1) whose
+	 * worker_last_saved_explain_analyze() lacks execution_ntuples/execution_nloops.
+	 * This must match the column list in FetchPlanQueryForExplainAnalyze.
+	 * Original stock line commented out: CreateTemplateTupleDesc(4).
+	 */
+	TupleDesc lastSavedExplainAnalyzeTupDesc = CreateTemplateTupleDesc(2);
 
 	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 1, "explain analyze", TEXTOID, 0,
 					   0);
 	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 2, "duration", FLOAT8OID, 0, 0);
-	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 3, "ntuples", FLOAT8OID, 0, 0);
-	TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 4, "nloops", FLOAT8OID, 0, 0);
+
+	/*
+	 * Extended columns commented out for the mixed-version fork:
+	 * TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 3, "ntuples", FLOAT8OID, 0, 0);
+	 * TupleDescInitEntry(lastSavedExplainAnalyzeTupDesc, 4, "nloops", FLOAT8OID, 0, 0);
+	 */
 
 	tupleDestination->lastSavedExplainAnalyzeTupDesc = lastSavedExplainAnalyzeTupDesc;
 
@@ -1829,8 +1853,11 @@ ExplainAnalyzeDestPutTuple(TupleDestination *self, Task *task,
 		}
 
 		Datum executionDuration = heap_getattr(heapTuple, 2, tupDesc, &isNull);
-		Datum executionTuples = heap_getattr(heapTuple, 3, tupDesc, &isNull);
-		Datum executionLoops = heap_getattr(heapTuple, 4, tupDesc, &isNull);
+		/*
+		 * Extended-column reads commented out for the mixed-version fork:
+		 * Datum executionTuples = heap_getattr(heapTuple, 3, tupDesc, &isNull);
+		 * Datum executionLoops = heap_getattr(heapTuple, 4, tupDesc, &isNull);
+		 */
 
 		if (isNull)
 		{
@@ -1840,8 +1867,17 @@ ExplainAnalyzeDestPutTuple(TupleDestination *self, Task *task,
 
 		char *fetchedExplainAnalyzePlan = TextDatumGetCString(explainAnalyze);
 		double fetchedExplainAnalyzeExecutionDuration = DatumGetFloat8(executionDuration);
-		double fetchedExplainAnalyzeTuples = DatumGetFloat8(executionTuples);
-		double fetchedExplainAnalyzeLoops = DatumGetFloat8(executionLoops);
+
+		/*
+		 * We only fetch explain_analyze_output and execution_duration (see
+		 * FetchPlanQueryForExplainAnalyze) so ntuples/nloops are unavailable in
+		 * mixed-version clusters with pre-13.2 workers; report them as 0.
+		 * Original stock lines commented out:
+		 * double fetchedExplainAnalyzeTuples = DatumGetFloat8(executionTuples);
+		 * double fetchedExplainAnalyzeLoops = DatumGetFloat8(executionLoops);
+		 */
+		double fetchedExplainAnalyzeTuples = 0;
+		double fetchedExplainAnalyzeLoops = 0;
 
 		/*
 		 * Allocate fetchedExplainAnalyzePlan in the same context as the Task, since we are
@@ -2108,9 +2144,20 @@ FetchPlanQueryForExplainAnalyze(const char *queryString, ParamListInfo params)
 						 ParameterResolutionSubquery(params));
 	}
 
+	/*
+	 * Only fetch explain_analyze_output and execution_duration; execution_ntuples
+	 * and execution_nloops were added to worker_last_saved_explain_analyze() in
+	 * Citus 13.2 and are absent on older workers (e.g. 12.1), so requesting them
+	 * would fail with 'column "execution_ntuples" does not exist'. The coordinator
+	 * reports 0 for ntuples/nloops for such tasks.
+	 * Original stock query commented out:
+	 * appendStringInfoString(fetchQuery,
+	 *					   "SELECT explain_analyze_output, execution_duration, "
+	 *					   "execution_ntuples, execution_nloops "
+	 *					   "FROM worker_last_saved_explain_analyze()");
+	 */
 	appendStringInfoString(fetchQuery,
-						   "SELECT explain_analyze_output, execution_duration, "
-						   "execution_ntuples, execution_nloops "
+						   "SELECT explain_analyze_output, execution_duration "
 						   "FROM worker_last_saved_explain_analyze()");
 
 	return fetchQuery->data;

--- a/src/backend/distributed/planner/multi_logical_optimizer.c
+++ b/src/backend/distributed/planner/multi_logical_optimizer.c
@@ -281,7 +281,12 @@ static Oid CitusFunctionOidWithSignature(char *functionName, int numargs, Oid *a
 static Oid WorkerPartialAggOid(void);
 static Oid WorkerBinaryPartialAggOid(void);
 static Oid CoordBinaryCombineAggOid(void);
-static bool IsTypeBinarySerializable(Oid transitionType);
+
+/*
+ * Commented out for the mixed-version fork: the text-based worker_partial_agg()
+ * path is forced, so this binary-serializability helper is unused.
+ * static bool IsTypeBinarySerializable(Oid transitionType);
+ */
 static Oid CoordCombineAggOid(void);
 static Oid AggregateFunctionOid(const char *functionName, Oid inputType);
 static Oid TypeOid(Oid schemaId, const char *typeName);
@@ -2130,8 +2135,15 @@ MasterAggregateExpression(Aggref *originalAggregate,
 		{
 			aggform = (Form_pg_aggregate) GETSTRUCT(aggTuple);
 			combine = aggform->aggcombinefn;
-			useBinaryCoordinatorCombine = aggform->aggtranstype != InvalidOid &&
-										  IsTypeBinarySerializable(aggform->aggtranstype);
+
+			/*
+			 * Force the text-based worker_partial_agg() path (leave
+			 * useBinaryCoordinatorCombine false) so aggregate pushdown keeps
+			 * working against pre-14 workers that lack worker_binary_partial_agg().
+			 * Original stock line commented out:
+			 * useBinaryCoordinatorCombine = aggform->aggtranstype != InvalidOid &&
+			 *							  IsTypeBinarySerializable(aggform->aggtranstype);
+			 */
 			ReleaseSysCache(aggTuple);
 		}
 
@@ -3295,9 +3307,14 @@ WorkerAggregateExpressionList(Aggref *originalAggregate,
 		{
 			aggform = (Form_pg_aggregate) GETSTRUCT(aggTuple);
 			combine = aggform->aggcombinefn;
-			useBinaryWorkerAggregate = (OidIsValid(aggform->aggtranstype) &&
-										IsTypeBinarySerializable(aggform->aggtranstype));
 
+			/*
+			 * Force the text-based worker_partial_agg() path (leave
+			 * useBinaryWorkerAggregate false) for pre-14 worker compatibility.
+			 * Original stock line commented out:
+			 * useBinaryWorkerAggregate = (OidIsValid(aggform->aggtranstype) &&
+			 *							IsTypeBinarySerializable(aggform->aggtranstype));
+			 */
 			ReleaseSysCache(aggTuple);
 		}
 
@@ -3847,23 +3864,26 @@ TypeOid(Oid schemaId, const char *typeName)
 }
 
 
-static bool
-IsTypeBinarySerializable(Oid transitionType)
-{
-	HeapTuple typeTuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(transitionType));
-	if (!HeapTupleIsValid(typeTuple))
-	{
-		elog(ERROR, "citus cache lookup failed for transition type %u", transitionType);
-	}
-
-	Form_pg_type typeForm = (Form_pg_type) GETSTRUCT(typeTuple);
-	bool isBinaryCoercible = typeForm->typsend != InvalidOid &&
-							 typeForm->typreceive != InvalidOid;
-
-	ReleaseSysCache(typeTuple);
-
-	return isBinaryCoercible;
-}
+/*
+ * Commented out for the mixed-version fork (text partial-agg path is forced):
+ * static bool
+ * IsTypeBinarySerializable(Oid transitionType)
+ * {
+ *	HeapTuple typeTuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(transitionType));
+ *	if (!HeapTupleIsValid(typeTuple))
+ *	{
+ *		elog(ERROR, "citus cache lookup failed for transition type %u", transitionType);
+ *	}
+ *
+ *	Form_pg_type typeForm = (Form_pg_type) GETSTRUCT(typeTuple);
+ *	bool isBinaryCoercible = typeForm->typsend != InvalidOid &&
+ *							 typeForm->typreceive != InvalidOid;
+ *
+ *	ReleaseSysCache(typeTuple);
+ *
+ *	return isBinaryCoercible;
+ * }
+ */
 
 
 /*

--- a/src/backend/distributed/shared_library_init.c
+++ b/src/backend/distributed/shared_library_init.c
@@ -1642,7 +1642,7 @@ RegisterCitusConfigVariables(void)
 		gettext_noop("Enables version checks during CREATE/ALTER EXTENSION commands"),
 		NULL,
 		&EnableVersionChecks,
-		true,
+		false,
 		PGC_USERSET,
 		GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 		NULL, NULL, NULL);

--- a/src/backend/distributed/transaction/lock_graph.c
+++ b/src/backend/distributed/transaction/lock_graph.c
@@ -194,7 +194,7 @@ BuildGlobalWaitGraph(bool onlyDistributedTx)
 							 "waiting_node_id, waiting_transaction_num, waiting_transaction_stamp, "
 							 "blocking_global_pid,blocking_pid, blocking_node_id, "
 							 "blocking_transaction_num, blocking_transaction_stamp, blocking_transaction_waiting "
-							 "FROM citus_internal.local_blocked_processes()");
+							 "FROM pg_catalog.citus_internal_local_blocked_processes()");
 		}
 
 		int querySent = SendRemoteCommand(connection, queryString->data);

--- a/src/backend/distributed/utils/replication_origin_session_utils.c
+++ b/src/backend/distributed/utils/replication_origin_session_utils.c
@@ -186,7 +186,7 @@ SetupReplicationOriginRemoteSession(MultiConnection *connection)
 	{
 		StringInfo replicationOriginSessionSetupQuery = makeStringInfo();
 		appendStringInfo(replicationOriginSessionSetupQuery,
-						 "select citus_internal.start_replication_origin_tracking();");
+						 "select pg_catalog.citus_internal_start_replication_origin_tracking();");
 		ExecuteCriticalRemoteCommand(connection,
 									 replicationOriginSessionSetupQuery->data);
 		connection->isReplicationOriginSessionSetup = true;
@@ -205,7 +205,7 @@ ResetReplicationOriginRemoteSession(MultiConnection *connection)
 	{
 		StringInfo replicationOriginSessionResetQuery = makeStringInfo();
 		appendStringInfo(replicationOriginSessionResetQuery,
-						 "select citus_internal.stop_replication_origin_tracking();");
+						 "select pg_catalog.citus_internal_stop_replication_origin_tracking();");
 		ExecuteCriticalRemoteCommand(connection,
 									 replicationOriginSessionResetQuery->data);
 		connection->isReplicationOriginSessionSetup = false;
@@ -229,7 +229,7 @@ IsRemoteReplicationOriginSessionSetup(MultiConnection *connection)
 
 	StringInfo isReplicationOriginSessionSetupQuery = makeStringInfo();
 	appendStringInfo(isReplicationOriginSessionSetupQuery,
-					 "SELECT citus_internal.is_replication_origin_tracking_active()");
+					 "SELECT pg_catalog.citus_internal_is_replication_origin_tracking_active()");
 	bool result =
 		ExecuteRemoteCommandAndCheckResult(connection,
 										   isReplicationOriginSessionSetupQuery->data,

--- a/src/include/distributed/metadata_sync.h
+++ b/src/include/distributed/metadata_sync.h
@@ -225,4 +225,6 @@ extern void SendInterTableRelationshipCommands(MetadataSyncContext *context);
 extern char *EnableManualMetadataChangesForUser;
 extern bool EnableMetadataSync;
 
+extern const char * CitusInternalSchemaPrefix(void);
+
 #endif /* METADATA_SYNC_H */


### PR DESCRIPTION
## Summary

- allow a Citus 14 coordinator to communicate with Citus 12/13 workers during a rolling pgmongo upgrade
- retain compatibility with the older worker metadata, internal-function, partial-aggregate, and EXPLAIN ANALYZE shapes
- permit the temporary post-promotion state where Citus 14 binaries are loaded while the local catalog is still on Citus 12, until the catalog upgrade completes

## Motivation

pgmongo upgrades nodes incrementally. During that window, the coordinator can be on Citus 14 while workers remain on Citus 12/13. A promoted standby can also temporarily run Citus 14 binaries with a Citus 12 catalog before the local `ALTER EXTENSION citus UPDATE` convergence step. Stock version checks and newer wire/catalog assumptions make those transitional states unavailable.

## Validation

- built and installed the changes with PostgreSQL 16 and Citus 14
- validated a mixed cluster with a Citus 14 coordinator and Citus 12.1 workers
- validated metadata synchronization and distributed EXPLAIN ANALYZE compatibility
- validated promotion with Citus 14 binaries over a Citus 12.1 catalog, followed by successful `ALTER EXTENSION citus UPDATE`

## Release targeting

Published releases currently include `v14.1.0` and `v14.2.0`. The `release-14.0` branch has already advanced to `14.3.0`, so merging this PR there targets the future 14.3 release.

If this support is also required in the already-published 14.2 line, it must be shipped through a 14.2 patch release (for example, `v14.2.1`) from a dedicated maintenance branch or via the maintainers' chosen backport process; an existing release tag cannot be changed.